### PR TITLE
refactor: Clean up dead code and document stub methods

### DIFF
--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -171,12 +171,6 @@ pub(crate) trait RenderPlanBuilder {
         schema: &GraphSchema,
     ) -> RenderPlanBuilderResult<RenderPlan>;
 
-    fn build_simple_relationship_render_plan(
-        &self,
-        distinct_override: Option<bool>,
-        schema: &GraphSchema,
-    ) -> RenderPlanBuilderResult<RenderPlan>;
-
     fn to_render_plan(&self, schema: &GraphSchema) -> RenderPlanBuilderResult<RenderPlan>;
 }
 
@@ -1248,27 +1242,32 @@ impl RenderPlanBuilder for LogicalPlan {
     }
 
     fn extract_having(&self) -> RenderPlanBuilderResult<Option<RenderExpr>> {
-        // TODO: Implement HAVING clause extraction
+        // Note: HAVING clauses are handled by LogicalPlan::GroupBy nodes in to_render_plan().
+        // This method returns None for GraphJoins/GraphRel which don't directly have HAVING.
         Ok(None)
     }
 
     fn extract_order_by(&self) -> RenderPlanBuilderResult<Vec<OrderByItem>> {
-        // TODO: Implement ORDER BY extraction
+        // Note: ORDER BY is handled by LogicalPlan::OrderBy nodes in to_render_plan().
+        // This method returns empty for GraphJoins/GraphRel which don't directly have ORDER BY.
         Ok(vec![])
     }
 
     fn extract_limit(&self) -> Option<i64> {
-        // TODO: Implement LIMIT extraction
+        // Note: LIMIT is handled by LogicalPlan::Limit nodes in to_render_plan().
+        // This method returns None for GraphJoins/GraphRel which don't directly have LIMIT.
         None
     }
 
     fn extract_skip(&self) -> Option<i64> {
-        // TODO: Implement SKIP extraction
+        // Note: SKIP is handled by LogicalPlan::Skip nodes in to_render_plan().
+        // This method returns None for GraphJoins/GraphRel which don't directly have SKIP.
         None
     }
 
     fn extract_union(&self, _schema: &GraphSchema) -> RenderPlanBuilderResult<Option<Union>> {
-        // TODO: Implement UNION extraction
+        // Note: UNION is handled by LogicalPlan::Union nodes in to_render_plan().
+        // This method returns None for GraphJoins/GraphRel which don't directly have UNION.
         Ok(None)
     }
 
@@ -1278,17 +1277,6 @@ impl RenderPlanBuilder for LogicalPlan {
     ) -> RenderPlanBuilderResult<RenderPlan> {
         // Delegate to JoinBuilder
         <LogicalPlan as JoinBuilder>::try_build_join_based_plan(self, schema)
-    }
-
-    fn build_simple_relationship_render_plan(
-        &self,
-        _distinct_override: Option<bool>,
-        _schema: &GraphSchema,
-    ) -> RenderPlanBuilderResult<RenderPlan> {
-        // TODO: Implement simple relationship render plan building
-        Err(RenderBuildError::InvalidRenderPlan(
-            "Simple relationship render plan not implemented".to_string(),
-        ))
     }
 
     fn to_render_plan(&self, schema: &GraphSchema) -> RenderPlanBuilderResult<RenderPlan> {


### PR DESCRIPTION
# refactor: Phase 2 Final Cleanup - Document stub methods and remove dead code

##Phase 2 Module Extraction COMPLETE ✅

## Changes
- Remove unused build_simple_relationship_render_plan() method (returns error, never called)
- Document that [extract_having/order_by/limit/skip/union] intentionally return empty values
- These are handled by their respective LogicalPlan nodes in [to_render_plan()]
- GraphJoins/GraphRel don't directly have these clauses - they pass through

## Why This Matters
The stub methods aren't dead code - they're called from GraphJoins/GraphRel rendering but correctly return empty. The actual ORDER BY/LIMIT/SKIP/HAVING logic lives in the dedicated LogicalPlan nodes (OrderBy, Limit, Skip, GroupBy) which handle their own clauses in [to_render_plan()].

## Testing
✅ All 770 unit tests passing (100%)
✅ 12/17 integration tests passing (71% - same as before, pre-existing failures)
✅ No regressions introduced

## Phase 2 Final Stats
- [plan_builder.rs]: Reduced from 2,490 to 1,516 lines (39% reduction)
- 4 modules extracted: 3,149 lines total
  -[join_builder.rs] (1,790 lines)
  -select_builder.rs (131 lines)
  -[from_builder.rs] (864 lines)
  -[group_by_builder.rs] (364 lines)

## 🎉 Phase 2 modularization complete!