### PR TITLE
docs: Add AGENTS.md files for all src modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ docs1/
 !DEV_QUICK_START.md
 !TESTING.md
 
+# Agent documentation for AI-assisted development
+!**/AGENTS.md
+
 # Development assistants
 .claude/
 agent-os/

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,120 @@
+# Top-Level Source Files — Agent Guide
+
+> **Purpose**: Application entry point, crate root, and configuration.
+> These three files wire everything together.
+
+## File Overview
+
+```
+src/
+├── lib.rs    (40 lines)  ← Crate root: module declarations, debug macros
+├── main.rs   (74 lines)  ← Binary entry point: CLI parsing, server startup
+└── config.rs (191 lines) ← Server configuration: CLI, env vars, validation
+```
+
+**Total**: ~305 lines
+
+## Key Files
+
+### lib.rs — Crate Root
+
+Declares all top-level modules and provides debug macros:
+
+```rust
+pub mod utils;
+pub mod clickhouse_query_generator;
+pub mod config;
+pub mod graph_catalog;
+pub mod open_cypher_parser;
+pub mod packstream;
+pub mod procedures;
+pub mod query_planner;
+pub mod render_plan;
+pub mod server;
+```
+
+**Debug macros**:
+- `debug_print!(...)` — `eprintln!` only in debug builds, zero-cost in release
+- `debug_println!(...)` — `println!` only in debug builds, zero-cost in release
+
+**Note**: The `testing` module is NOT declared here — it's only reachable from
+test code within submodules.
+
+### main.rs — Binary Entry Point
+
+Uses `clap` for CLI argument parsing:
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--http-host` | `0.0.0.0` | HTTP server bind address |
+| `--http-port` | `8080` | HTTP server port |
+| `--disable-bolt` | `false` | Disable Bolt protocol server |
+| `--bolt-host` | `0.0.0.0` | Bolt server bind address |
+| `--bolt-port` | `7687` | Bolt server port |
+| `--max-cte-depth` | `100` | Max recursive CTE depth for variable-length paths |
+| `--validate-schema` | `false` | Validate YAML schema against ClickHouse on startup |
+| `--daemon` | `false` | Run as background daemon |
+
+**Flow**: Parse CLI → Convert to `CliConfig` → Build `ServerConfig` → `server::run_with_config()`
+
+**Logger**: `env_logger` with default level `debug`, overridable via `RUST_LOG` env var.
+
+### config.rs — Server Configuration
+
+`ServerConfig` struct with validation via `validator` crate:
+- Port range validation (1-65535)
+- Non-empty host validation
+- CTE depth range (1-1000)
+
+**Configuration sources** (in priority order):
+1. CLI arguments (`from_cli()`)
+2. Environment variables (`from_env()`)
+3. YAML file (`from_yaml_file()`)
+4. Default values
+
+**Environment variables**:
+| Variable | Default | Maps to |
+|----------|---------|---------|
+| `CLICKGRAPH_HOST` | `0.0.0.0` | `http_host` |
+| `CLICKGRAPH_PORT` | `8080` | `http_port` |
+| `CLICKGRAPH_BOLT_HOST` | `0.0.0.0` | `bolt_host` |
+| `CLICKGRAPH_BOLT_PORT` | `7687` | `bolt_port` |
+| `CLICKGRAPH_BOLT_ENABLED` | `true` | `bolt_enabled` |
+| `CLICKGRAPH_MAX_CTE_DEPTH` | `100` | `max_cte_depth` |
+| `CLICKGRAPH_VALIDATE_SCHEMA` | `false` | `validate_schema` |
+
+**Error handling**: Uses `thiserror` with `ConfigError` enum covering env var errors,
+parse errors, and validation errors.
+
+## Critical Invariants
+
+### 1. Bolt Enabled by Default
+The CLI uses `--disable-bolt` (inverted flag). `bolt_enabled = !cli.disable_bolt`.
+The config struct stores the positive `bolt_enabled: bool`.
+
+### 2. Module Declaration Order
+The module declaration order in `lib.rs` doesn't affect compilation, but `utils`
+is declared first because other modules depend on it.
+
+### 3. Config Validation
+`ServerConfig` is validated after construction from any source. Invalid configs
+cause the server to exit with error code 1 (in `main.rs`).
+
+## Dependencies
+
+**What these files use**:
+- `clap` — CLI argument parsing (main.rs)
+- `env_logger` — logging initialization (main.rs)
+- `validator` — struct validation (config.rs)
+- `serde` / `serde_yaml` — YAML config deserialization (config.rs)
+- `thiserror` — error types (config.rs)
+
+**What uses these files**:
+- `config::ServerConfig` is used by `server::run_with_config()`
+- `lib.rs` macros (`debug_print!`, `debug_println!`) are used throughout the crate
+
+## Testing Guidance
+
+- `config.rs` has 4 unit tests: default validation, invalid port, invalid CTE depth, empty host
+- `main.rs` has no tests (integration tested via server startup)
+- Run with: `cargo test --lib config`

--- a/src/graph_catalog/AGENTS.md
+++ b/src/graph_catalog/AGENTS.md
@@ -1,0 +1,308 @@
+# graph_catalog Module — Agent Guide
+
+> **Purpose**: Core schema foundation for ClickGraph. Loads YAML configuration files,
+> builds runtime `GraphSchema` structures, and provides O(1) lookup APIs consumed by
+> every downstream module (query_planner, render_plan, clickhouse_query_generator, server).
+> This module defines the "shape of the graph" that all query translation depends on.
+
+## Module Architecture
+
+```
+YAML config file(s)
+    │
+    ▼
+config.rs                 ← Parse YAML → GraphSchemaConfig → build GraphSchema
+    │                        Two paths: sync (no DB) / async (auto-discovery + engine detection)
+    │
+    ├─ schema_types.rs       ← Database-agnostic type system (Int, String, DateTime, etc.)
+    ├─ engine_detection.rs   ← ClickHouse MergeTree family detection for FINAL keyword
+    ├─ column_info.rs        ← Query system.columns for auto-discovery
+    ├─ expression_parser.rs  ← nom-based parser for computed property expressions
+    ├─ filter_parser.rs      ← nom-based parser for schema-level WHERE filters
+    ├─ constraint_compiler.rs← Compile edge constraints (from.prop/to.prop) to SQL
+    ├─ schema_validator.rs   ← Validate YAML definitions against actual ClickHouse tables
+    │
+    ▼
+graph_schema.rs           ← Runtime data structures: GraphSchema, NodeSchema, RelationshipSchema
+    │                        O(1) lookups via rel_type_index, edge pattern classification
+    │
+    ├─ composite_key_utils.rs ← TYPE::FROM::TO composite key parsing & matching
+    ├─ node_classification.rs ← Denormalized node detection utilities
+    ├─ element_id.rs          ← Neo4j-compatible elementId generation/parsing
+    │
+    ▼
+pattern_schema.rs         ← PatternSchemaContext: unified pattern analysis abstraction
+                             Computes NodeAccessStrategy + EdgeAccessStrategy + JoinStrategy
+                             for a (left_node, edge, right_node) triple ONCE
+```
+
+## Key Files & Line Counts
+
+| File | Lines | Role |
+|------|------:|------|
+| config.rs | 2,899 | YAML loading, parsing, GraphSchema construction |
+| graph_schema.rs | 2,572 | Core runtime types (NodeSchema, RelationshipSchema, GraphSchema) + ~900 lines tests |
+| pattern_schema.rs | 1,651 | Unified pattern analysis (access strategies, join strategies) |
+| expression_parser.rs | 768 | nom parser for ClickHouse scalar expressions in property mappings |
+| filter_parser.rs | 681 | nom parser for SQL WHERE clause filters in schema definitions |
+| element_id.rs | 564 | Neo4j elementId generation and parsing |
+| schema_types.rs | 532 | Database-agnostic type enum with dialect-specific SQL literal generation |
+| engine_detection.rs | 481 | MergeTree engine family detection, FINAL keyword support |
+| composite_key_utils.rs | 318 | `TYPE::FROM::TO` composite key building, parsing, matching |
+| constraint_compiler.rs | 289 | Edge constraint expressions → SQL compilation |
+| node_classification.rs | 222 | Consolidated denormalized node property detection |
+| schema_validator.rs | 145 | Validate graph views against ClickHouse table schemas |
+| errors.rs | 121 | Error types with context helpers (thiserror) |
+| column_info.rs | 108 | ClickHouse `system.columns` metadata querying |
+| mod.rs | 49 | Module declarations and public re-exports |
+
+**Test files** (~784 lines total): `testing/mock_clickhouse.rs` (64), `tests/mock_clickhouse.rs` (146),
+`tests/mock_clickhouse_enhanced.rs` (191), `tests/schema_validator_tests.rs` (104),
+`tests/view_validation_tests.rs` (113), `tests/view_demo.rs` (69), `composite_id_tests.rs` (69),
+`schema_validator/tests.rs` (28)
+
+## Critical Invariants
+
+### 1. Composite Key Format for Relationships
+Relationships are stored in `GraphSchema.relationships` HashMap with composite keys:
+```
+TYPE::FROM_NODE::TO_NODE
+```
+Example: `FOLLOWS::User::User`, `AUTHORED::User::Post`
+
+This disambiguates the same relationship type connecting different node pairs.
+The `rel_type_index` provides O(1) lookup from type name → list of composite keys.
+
+**NEVER** use raw type name as HashMap key. Always use `build_composite_key()` or
+`get_rel_schema_with_nodes()` for lookups. For type-only lookups, use `rel_schemas_for_type()`.
+
+### 2. Property Mappings: Cypher Name → ClickHouse Column
+`NodeSchema.property_mappings` maps Cypher property names to `PropertyValue`:
+- `PropertyValue::Column(col)` — simple column reference
+- `PropertyValue::Expression(expr)` — computed ClickHouse expression
+
+Example: Cypher `u.name` → `PropertyValue::Column("full_name")` → SQL `alias.full_name`
+
+**NEVER** assume Cypher property name == ClickHouse column name. Always resolve through
+`property_mappings`. The `to_sql(alias)` method handles both Column and Expression variants.
+
+### 3. Denormalized Node Properties Live on the NODE Definition
+For denormalized schemas (node properties embedded in edge table), the property mappings
+for each side are stored on the `NodeSchema` as `from_properties` and `to_properties`,
+NOT on the `RelationshipSchema`.
+
+```yaml
+# ✅ CORRECT: from_properties on the node definition
+nodes:
+  Airport:
+    from_properties:
+      code: origin_code
+      city: origin_city
+    to_properties:
+      code: dest_code
+      city: dest_city
+```
+
+The `RelationshipSchema` also carries `from_node_properties` / `to_node_properties` as a
+mirror copy built during `config.rs` construction for downstream convenience.
+
+### 4. PatternSchemaContext: Compute Once, Use Everywhere
+`PatternSchemaContext::analyze()` computes all schema decisions for a graph pattern triple.
+It returns `NodeAccessStrategy`, `EdgeAccessStrategy`, and `JoinStrategy` — these should be
+queried from the context, NEVER re-derived by downstream code.
+
+Previously, schema detection logic was scattered across ~4800 lines in `graph_join_inference.rs`.
+`PatternSchemaContext` consolidates this into a single analysis point.
+
+### 5. GraphSchema.build() Constructs rel_type_index
+The `GraphSchema::build()` constructor (not `new()`) automatically builds the `rel_type_index`
+secondary index. **Always use `build()`** — `new()` is only for direct struct construction in
+tests that don't need type-based lookups.
+
+### 6. Polymorphic Edges Use `$any` Sentinel
+When a polymorphic edge definition uses `from_label_column` / `to_label_column`, the
+endpoint node labels are dynamically determined. The sentinel value `$any` in
+`from_label_values` / `to_label_values` means "match any label in this column."
+
+### 7. Two Conversion Paths in config.rs
+- **`to_graph_schema()`** — Sync, no DB connection. Used in tests and simple configs.
+- **`to_graph_schema_with_client()`** — Async, queries ClickHouse for auto-discovery
+  (`system.columns`) and engine detection (`system.tables`). Used in production startup.
+
+Auto-discovery populates `column_names` on schemas and detects MergeTree engine variants.
+`exclude_columns` and `naming_convention` only apply during auto-discovery.
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| Wrong relationship lookup | "No relationship schema found" | Using type name instead of composite key `TYPE::FROM::TO` |
+| Property not resolved | "Column not found" or wrong column | Bypassed `property_mappings`, used Cypher name as SQL column |
+| Denormalized props missing | Node properties NULL in results | Looked at `property_mappings` (empty) instead of `from_properties`/`to_properties` |
+| Schema not found at runtime | "No node schema for label X" | Using `GLOBAL_SCHEMAS` directly instead of task-local `get_current_schema()` |
+| Engine detection fails | Missing FINAL keyword | `to_graph_schema()` used instead of `to_graph_schema_with_client()` (no engine info) |
+| Filter not applied | Schema filter ignored in SQL | Filter parsed but not propagated to SQL generator via `SchemaFilter::to_sql(alias)` |
+| Expression precedence wrong | Incorrect computed property SQL | Missing parentheses in `expression_parser.rs` precedence levels |
+| Composite key mismatch | Generic rel lookup returns wrong edge | `expand_generic_relationship_type()` not called for untyped `[r]` patterns |
+
+## Dependencies
+
+### Upstream (graph_catalog imports from)
+- `crate::server::models::SqlDialect` — dialect enum for SQL literal generation in `schema_types.rs`
+- `crate::query_planner::plan_ctx::PlanCtx` — used only in `pattern_schema.rs` factory method
+
+### Downstream (who imports graph_catalog)
+- **server/** — `graph_catalog.rs` (schema admin), `mod.rs` (init), `query_context.rs` (task-local),
+  `bolt_protocol/id_rewriter.rs`, `bolt_protocol/result_transformer.rs`
+- **query_planner/** — `plan_ctx/`, `logical_expr/`, `translator/`, `optimizer/`,
+  `logical_plan/` (match_clause, mod)
+- **clickhouse_query_generator/** — `json_builder.rs`, `variable_length_cte.rs`, `pagerank.rs`,
+  `multi_type_vlp_joins.rs`, `to_sql_query.rs`
+- **render_plan/** — `plan_builder_helpers.rs`, `plan_builder_utils.rs`, `join_builder.rs`,
+  `cte_extraction.rs`, `cte_generation.rs`, `cte_manager/`
+
+### Key External Crates
+- `serde` / `serde_yaml` — YAML configuration deserialization
+- `nom` — Parser combinators for expression_parser.rs and filter_parser.rs
+- `thiserror` — Error type derivation
+- `clickhouse` — Async ClickHouse client (column_info.rs, engine_detection.rs, schema_validator.rs)
+- `log` — Structured logging throughout
+
+## Testing After Changes
+
+```bash
+# Must pass ALL of these:
+cargo test --lib graph_catalog       # All graph_catalog unit tests
+cargo test                           # Full suite (995+ tests)
+
+# Specific test groups:
+cargo test composite_key             # Composite key parsing/matching
+cargo test test_detect               # Edge table pattern classification
+cargo test test_coupled              # Coupled edge detection (Zeek DNS pattern)
+cargo test schema_validator          # Schema validation against ClickHouse
+cargo test expression_parser         # Expression parsing
+cargo test filter_parser             # Filter parsing
+cargo test element_id                # Neo4j elementId generation/parsing
+cargo test engine_detection          # MergeTree family detection
+
+# If changing config.rs YAML parsing:
+cargo test config                    # Config loading tests
+# Then manually test with benchmark schema:
+export GRAPH_CONFIG_PATH="./benchmarks/social_network/schemas/social_benchmark.yaml"
+cargo run --bin clickgraph
+```
+
+## Schema Variation Awareness
+
+Every downstream consumer of graph_catalog may behave differently based on schema type.
+When modifying any schema structure, verify all 5 patterns still work:
+
+### Schema Patterns
+
+1. **Standard** — Separate node tables + separate edge table. Traditional 3-way JOIN.
+   - Example: `users` table + `follows` table + `users` table
+   - `is_denormalized = false`, `is_fk_edge = false`
+
+2. **FK-Edge** — Edge is a foreign key column on a node table. No separate edge table.
+   - `RelationshipSchema.is_fk_edge = true`
+   - Edge table = node table, `from_id` or `to_id` is FK column
+
+3. **Denormalized** — Node properties embedded in edge table. Node has no own table.
+   - `NodeSchema.is_denormalized = true`, `from_properties` / `to_properties` populated
+   - `property_mappings` is empty or minimal (≤2 entries)
+   - Example: Airport properties stored on flights table
+
+4. **Polymorphic** — Single edge table with `type_column` discriminator for multiple rel types.
+   - `RelationshipSchema.type_column = Some("rel_type")`
+   - `from_label_column` / `to_label_column` for dynamic node resolution
+   - `$any` sentinel for wildcard label matching
+
+5. **Composite ID** — Multi-column node identity (e.g., `(database, table)` tuple).
+   - `NodeIdSchema::Composite { columns, types }`
+   - elementId uses `|` separator: `"Label:id1|id2"`
+
+### Strategy Enums (from pattern_schema.rs)
+
+```
+NodeAccessStrategy:
+  OwnTable           — Node has dedicated table (standard)
+  EmbeddedInEdge      — Node properties stored in edge table (denormalized)
+  Virtual             — Node has no physical storage
+
+EdgeAccessStrategy:
+  SeparateTable       — Standard edge table
+  Polymorphic         — Type-discriminated edge table
+  FkEdge              — Foreign key on node table
+
+JoinStrategy:
+  Traditional         — Standard 3-way JOIN (node-edge-node)
+  SingleTableScan     — All data in one table (fully denormalized)
+  MixedAccess         — One node denormalized, other traditional
+  EdgeToEdge          — No node tables, edge-only pattern
+  CoupledSameRow      — Two edges from same table row (Zeek DNS pattern)
+  FkEdgeJoin          — FK-based join (no separate edge table)
+```
+
+### Schema Compatibility Matrix
+
+| Feature / Area                              | Standard | FK-edge | Denormalized | Polymorphic | Composite ID |
+|---------------------------------------------|:--------:|:-------:|:------------:|:-----------:|:------------:|
+| YAML config loading                         |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Property mapping resolution                 |    ✅    |   ✅    |      ⚠️      |     ✅      |      ✅      |
+| Relationship lookup (composite key)         |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Edge table pattern classification           |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| PatternSchemaContext analysis               |    ✅    |   ✅    |      ✅      |     ✅      |      ⚠️      |
+| Neo4j elementId generation                  |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Engine detection / FINAL                    |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Schema-level filters                        |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Expression-based properties                 |    ✅    |   ✅    |      ✅      |     ✅      |      ✅      |
+| Coupled edge detection                      |    ✅    |   N/A   |      ✅      |     ⚠️      |      ✅      |
+
+✅ = fully supported and tested. ⚠️ = works but edge cases need care. N/A = not applicable.
+
+**Denormalized property resolution** (⚠️): Must use `from_properties`/`to_properties`, not
+`property_mappings`. Every new consumer of NodeSchema must handle this distinction.
+
+## Public API Summary
+
+### Core Types (from graph_schema.rs)
+- `GraphSchema` — Container: `nodes: HashMap<label, NodeSchema>`, `relationships: HashMap<composite_key, RelationshipSchema>`, `rel_type_index`
+- `NodeSchema` — Node definition: `table_name`, `node_id`, `property_mappings`, `is_denormalized`, `from_properties`, `to_properties`, `filter`, `engine`
+- `RelationshipSchema` — Edge definition: `from_node`/`to_node` (labels), `from_id`/`to_id` (columns), `property_mappings`, `is_fk_edge`, `type_column`, `constraints`
+- `NodeIdSchema` — `Single { column, dtype }` | `Composite { columns, types }`
+- `Direction` — `Outgoing` | `Incoming` | `Both`
+- `EdgeTablePattern` — `Traditional` | `FullyDenormalized` | `Mixed { from_denormalized, to_denormalized }`
+
+### Lookup Methods (on GraphSchema)
+- `node_schema(label)` → `Option<&NodeSchema>`
+- `get_rel_schema(composite_key)` → `Option<&RelationshipSchema>`
+- `get_rel_schema_with_nodes(type, from, to)` → builds composite key and looks up
+- `rel_schemas_for_type(type_name)` → `Vec<(&String, &RelationshipSchema)>` via `rel_type_index`
+- `expand_generic_relationship_type(from, to)` → finds all matching rel types for node pair
+- `are_edges_coupled(type1, type2)` → `bool` (same table + shared node)
+- `get_coupled_edge_info(type1, type2)` → `Option<CoupledEdgeInfo>`
+
+### Pattern Analysis (from pattern_schema.rs)
+- `PatternSchemaContext::analyze(left_node, edge, right_node, schema)` → computes strategies
+- `PatternSchemaContext::from_graph_rel_dyn(graph_rel, schema)` → factory from query planner types
+- `.left_node_strategy()`, `.right_node_strategy()`, `.edge_strategy()`, `.join_strategy()`
+- `.get_node_property(alias, prop, schema)` → resolves property to SQL column
+- `.get_edge_property(prop, schema)` → resolves edge property to SQL column
+
+### Expression & Filter (from expression_parser.rs, filter_parser.rs)
+- `PropertyValue::Column(col)` | `PropertyValue::Expression(expr)` — property mapping value
+- `PropertyValue::to_sql(alias)` → prefixed SQL column/expression
+- `SchemaFilter::new(sql_str)` → parsed filter with validation
+- `SchemaFilter::to_sql(alias)` → aliased SQL WHERE predicate
+
+### Element IDs (from element_id.rs)
+- `generate_node_element_id(label, id_values)` → `"Label:id"` or `"Label:id1|id2"`
+- `parse_node_element_id(element_id)` → `(label, id_values)`
+- `generate_relationship_element_id(type, from_id, to_id)` → `"Type:from->to"`
+- `parse_relationship_element_id(element_id)` → `(type, from_id, to_id)`
+
+### Composite Keys (from composite_key_utils.rs)
+- `build_composite_key(type, from, to)` → `"TYPE::FROM::TO"`
+- `CompositeKey::parse(key)` → `Result<CompositeKey>`
+- `is_composite_key(key)` → `bool` (contains `::`)
+- `extract_type_name(key)` → type portion before first `::`

--- a/src/open_cypher_parser/AGENTS.md
+++ b/src/open_cypher_parser/AGENTS.md
@@ -1,0 +1,297 @@
+# open_cypher_parser Module — Agent Guide
+
+> **Purpose**: Parses OpenCypher query strings into a typed AST (`OpenCypherQueryAst`).
+> This is the first stage of the query pipeline — all downstream modules depend on correct parsing.
+> Uses the [nom](https://docs.rs/nom) parser combinator library. Zero-copy: AST nodes borrow from the input `&str`.
+
+## Module Architecture
+
+```
+Cypher query string (&str)
+    │
+    ├─ common::strip_comments()     ← Pre-processing: remove --, //, /* */ comments
+    │                                  (respects string literals and relationship patterns like -->)
+    │
+    ▼
+mod.rs::parse_cypher_statement()    ← Top-level entry point
+    │
+    ├─ Standalone CALL?  → standalone_procedure_call.rs → CypherStatement::ProcedureCall
+    │
+    └─ Regular query     → parse_query_with_nom()       → CypherStatement::Query
+         │
+         ├─ use_clause.rs          → UseClause
+         ├─ match_clause.rs        → MatchClause  (with path_pattern.rs + where_clause.rs)
+         ├─ optional_match_clause  → OptionalMatchClause
+         ├─ where_clause.rs        → WhereClause (standalone, after MATCH clauses)
+         ├─ call_clause.rs         → CallClause (CALL ... YIELD)
+         ├─ unwind_clause.rs       → UnwindClause
+         ├─ with_clause.rs         → WithClause (recursive: can nest MATCH, WITH, UNWIND)
+         ├─ create_clause.rs       → CreateClause  ← parsed but out of scope (read-only engine)
+         ├─ set_clause.rs          → SetClause     ← parsed but out of scope
+         ├─ remove_clause.rs       → RemoveClause  ← parsed but out of scope
+         ├─ delete_clause.rs       → DeleteClause  ← parsed but out of scope
+         ├─ return_clause.rs       → ReturnClause
+         └─ order_by_and_page.rs   → ORDER BY + SKIP + LIMIT (unified)
+              ├─ order_by_clause.rs
+              ├─ skip_clause.rs
+              └─ limit_clause.rs
+
+Shared infrastructure:
+  ├─ ast.rs              ← All AST types (Expression, PathPattern, NodePattern, etc.)
+  ├─ expression.rs       ← Expression parser: operators, functions, literals, comprehensions
+  ├─ path_pattern.rs     ← Graph pattern parser: nodes, relationships, shortest path
+  ├─ common.rs           ← ws(), identifiers, string parsing, comment stripping
+  └─ errors.rs           ← OpenCypherParsingError (nom-compatible)
+```
+
+## Key Files with Line Counts
+
+| File | Lines | Responsibility |
+|------|------:|----------------|
+| mod.rs | 1,734 | Top-level parsers (`parse_cypher_statement`, `parse_query_with_nom`, `parse_query`), UNION support, extensive integration tests |
+| ast.rs | 706 | All AST type definitions — the contract between parser and downstream modules |
+| expression.rs | 1,596 | Expression parsing: precedence climbing, operators, functions, CASE, EXISTS, reduce, pattern comprehension, lambda, map/list literals, property access, label expressions |
+| path_pattern.rs | 1,537 | Node/relationship/connected pattern parsing, variable-length specs (`*1..3`), `shortestPath()`/`allShortestPaths()`, multi-label support, inline properties, depth limit (50 hops) |
+| common.rs | 481 | `strip_comments()` (comment removal respecting strings/relationship patterns), `ws()` combinator, identifier parsers |
+| return_clause.rs | 403 | RETURN item parsing with `original_text` capture for Neo4j-compatible default aliases |
+| with_clause.rs | 332 | WITH clause with ORDER BY/SKIP/LIMIT/WHERE, recursive nesting (subsequent MATCH, UNWIND, WITH) |
+| match_clause.rs | 282 | MATCH clause parsing with optional path variable (`p = ...`), WHERE per MATCH |
+| where_clause.rs | 257 | WHERE clause → delegates to `expression::parse_expression` |
+| order_by_clause.rs | 211 | ORDER BY items with ASC/DESC |
+| set_clause.rs | 179 | SET parsing (out of scope for runtime) |
+| optional_match_clause.rs | 177 | OPTIONAL MATCH with two-word keyword parsing |
+| order_by_and_page_clause.rs | 156 | Unified ORDER BY + SKIP + LIMIT per OpenCypher spec order |
+| standalone_procedure_call.rs | 156 | `CALL db.labels()`, `CALL dbms.components()` with YIELD |
+| remove_clause.rs | 156 | REMOVE parsing (out of scope for runtime) |
+| delete_clause.rs | 150 | DELETE / DETACH DELETE (out of scope for runtime) |
+| unwind_clause.rs | 136 | UNWIND expression AS alias |
+| skip_clause.rs | 132 | SKIP integer |
+| create_clause.rs | 129 | CREATE parsing (out of scope for runtime) |
+| limit_clause.rs | 127 | LIMIT integer |
+| call_clause.rs | 125 | In-query CALL with named arguments (`key: value` or `key => value`) |
+| use_clause.rs | 107 | USE database_name (schema selection) |
+| errors.rs | 44 | `OpenCypherParsingError` struct implementing nom's `ParseError` and `ContextError` traits |
+| **Total** | **9,308** | |
+
+## Public API
+
+### Entry Points (exposed via `mod.rs`)
+
+```rust
+// Primary entry point — handles regular queries, UNION, and standalone CALL
+pub fn parse_cypher_statement(input: &str)
+    -> IResult<&str, CypherStatement<'_>, OpenCypherParsingError<'_>>
+
+// Legacy single-query parser (backward compatibility)
+pub fn parse_statement(input: &str)
+    -> IResult<&str, OpenCypherQueryAst<'_>, OpenCypherParsingError<'_>>
+
+// Convenience wrapper that checks all input is consumed
+pub fn parse_query(input: &str) -> Result<OpenCypherQueryAst<'_>, OpenCypherParsingError<'_>>
+
+// Pre-processing: strip comments before parsing
+pub fn strip_comments(input: &str) -> String
+```
+
+### Key Public Types (from `ast.rs`)
+
+- `CypherStatement<'a>` — top-level: `Query { query, union_clauses }` or `ProcedureCall`
+- `OpenCypherQueryAst<'a>` — the full query: match/optional match/with/where/return/order/skip/limit clauses
+- `Expression<'a>` — recursive enum: `Literal`, `Variable`, `PropertyAccessExp`, `FunctionCallExp`, `OperatorApplicationExp`, `PathPattern`, `Case`, `ExistsExpression`, `ReduceExp`, `MapLiteral`, `LabelExpression`, `Lambda`, `PatternComprehension`, `List`, `ArraySubscript`, `ArraySlicing`, `Parameter`
+- `PathPattern<'a>` — `Node`, `ConnectedPattern`, `ShortestPath`, `AllShortestPaths`
+- `NodePattern<'a>` — name, labels (multi-label via `|`), inline properties
+- `RelationshipPattern<'a>` — name, direction, labels (multi-type via `|`), properties, variable_length
+- `VariableLengthSpec` — min/max hops with validation
+- `ConnectedPattern<'a>` — uses `Rc<RefCell<NodePattern>>` for node sharing in chains
+
+## AST Structure
+
+```
+CypherStatement
+├── Query                          OR   ProcedureCall (standalone CALL)
+│   ├── query: OpenCypherQueryAst
+│   └── union_clauses: Vec<UnionClause>
+│
+OpenCypherQueryAst
+├── use_clause: Option<UseClause>           "USE dbname"
+├── match_clauses: Vec<MatchClause>         legacy separate list
+├── optional_match_clauses: Vec<OptionalMatchClause>  legacy separate list
+├── reading_clauses: Vec<ReadingClause>     unified, preserves order (preferred)
+├── call_clause: Option<CallClause>         "CALL proc(args) YIELD ..."
+├── unwind_clauses: Vec<UnwindClause>       "UNWIND expr AS alias"
+├── with_clause: Option<WithClause>         "WITH items ORDER BY SKIP LIMIT WHERE"
+│   └── (recursive sub-structure)           subsequent_match, subsequent_with, etc.
+├── where_clause: Option<WhereClause>       standalone WHERE (after WITH)
+├── create/set/remove/delete_clause         parsed but out of scope
+├── return_clause: Option<ReturnClause>     "RETURN [DISTINCT] items"
+├── order_by_clause: Option<OrderByClause>
+├── skip_clause: Option<SkipClause>
+└── limit_clause: Option<LimitClause>
+
+Expression (recursive)
+├── Literal(Integer|Float|Boolean|String|Null)
+├── Variable(&str)
+├── Parameter(&str)                         $param
+├── PropertyAccessExp { base, key }         n.name
+├── FunctionCallExp { name, args }          count(*), toUpper(n.name)
+├── OperatorApplicationExp { op, operands } a + b, NOT x, x IS NULL
+├── List(Vec<Expression>)                   [1, 2, 3]
+├── MapLiteral(Vec<(key, Expression)>)      {days: 5}
+├── Case { expr, when_then, else_expr }
+├── ExistsExpression(ExistsSubquery)        EXISTS { (n)-[:REL]->() }
+├── ReduceExp(ReduceExpression)             reduce(acc=0, x IN list | acc+x)
+├── LabelExpression { variable, label }     n:Person
+├── Lambda(LambdaExpression)                x -> x > 5
+├── PatternComprehension                    [(a)-[:REL]->(b) | b.name]
+├── PathPattern(PathPattern)                (a)-[]->(b) used in expressions
+├── ArraySubscript { array, index }         list[0]
+└── ArraySlicing { array, from, to }        list[1..5]
+```
+
+## Critical Invariants
+
+### 1. Zero-Copy Parsing
+All `&'a str` references in the AST borrow from the original input string.
+**Never** modify or deallocate the input string while the AST is alive.
+`FunctionCall.name` is the exception — it's `String` (owned) because dotted names like `ch.arrayFilter` are joined from parts.
+
+### 2. Operator Precedence (expression.rs)
+The expression parser implements standard precedence via recursive descent:
+```
+Lowest  → parse_logical_or      (OR)
+          parse_logical_and     (AND)
+          parse_not_expression  (NOT)
+          parse_comparison      (= <> < > <= >= =~ IN STARTS WITH ENDS WITH CONTAINS)
+          parse_additive        (+ -)
+          parse_multiplicative  (* / %)
+          parse_unary           (unary - , DISTINCT)
+Highest → parse_postfix         (IS NULL, IS NOT NULL, [index], [from..to])
+          parse_primary         (literals, variables, function calls, CASE, EXISTS, reduce, etc.)
+```
+**OR must not consume ORDER**: `parse_logical_or` uses `terminated(tag_no_case("OR"), not(peek(alphanumeric1)))` to avoid matching the "OR" in "ORDER".
+
+### 3. ConnectedPattern Node Sharing
+In multi-hop patterns like `(a)-[]->(b)-[]->(c)`, the intermediate node `(b)` is shared between consecutive `ConnectedPattern` entries via `Rc<RefCell<NodePattern>>`. The second pattern's `start_node` is `clone()` of the first pattern's `end_node`.
+
+### 4. WITH Clause Recursive Nesting
+`WithClause` can contain `subsequent_match`, `subsequent_unwind`, and `subsequent_with` (boxed). This represents chained patterns:
+```cypher
+-- This becomes nested WithClause structs:
+MATCH (a) WITH a MATCH (a)-[]->(b) WITH a, b RETURN a, b
+```
+
+### 5. WHERE Clause Placement
+WHERE can appear in multiple positions per OpenCypher spec:
+- **Per MATCH**: `MatchClause.where_clause` — after that specific MATCH's patterns
+- **After WITH**: `WithClause.where_clause` — filters WITH results
+- **Standalone**: `OpenCypherQueryAst.where_clause` — after all MATCH clauses (overridden if WHERE after WITH exists)
+
+### 6. Reading Clause Ordering
+`reading_clauses: Vec<ReadingClause>` preserves interleaving order of MATCH and OPTIONAL MATCH.
+When populated, this takes precedence over the legacy `match_clauses` / `optional_match_clauses` vectors (which are still populated for backward compatibility).
+
+### 7. Comment Stripping Safety
+`strip_comments()` must NOT strip:
+- `-->`, `<--`, `--(`, `--[` — these are Cypher relationship patterns, not comments
+- Content inside single quotes `'`, double quotes `"`, or backticks `` ` `` — these are string literals/identifiers
+
+### 8. Relationship Chain Depth Limit
+`MAX_RELATIONSHIP_CHAIN_DEPTH = 50` in path_pattern.rs. Chains longer than this cause a `TooLarge` parse error. This prevents stack overflow on adversarial inputs.
+
+### 9. Binary Operator Keywords as Variables
+`is_binary_operator_keyword()` blocks `AND`, `OR`, `XOR` from being parsed as variable names at expression start. This prevents `WHERE AND x = 1` from treating `AND` as a variable. `NOT` is intentionally not blocked (it's a valid unary prefix operator).
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| WHERE consumes too much | RETURN clause not found | Expression parser doesn't stop at clause boundaries; `parse_expression` must naturally terminate before keywords |
+| OR matches ORDER | "ORDER BY" parsed as "OR DER BY..." | Missing `not(peek(alphanumeric1))` guard after "OR" |
+| `--` parsed as comment | Relationship pattern `(a)--(b)` disappears | `strip_comments` didn't check for `(` or `[` after `--` |
+| Pattern comprehension vs list | `[(a)--() | 1]` fails to parse or parsed as list | Pattern comprehension must be tried before list literal in `alt()` chain |
+| AS keyword consumed by expression | `RETURN x AS alias` — `AS` treated as variable | Expression parser must stop at clause boundary keywords; keyword sensitivity is managed by what the callers (return_clause, with_clause) handle |
+| STARTS WITH/ENDS WITH | Multi-word operators misparsed | Must be parsed before single-word `IN` in the `alt()` chain |
+| NOT IN vs IN | `NOT IN` parsed as NOT + IN separately | `NOT IN` must appear before `IN` in operator alternatives |
+| Identifiers starting with keywords | `ORDER_date` parsed as ORDER keyword | Identifiers use `take_while1(is_identifier_char)` which includes `_`, so `ORDER_date` is consumed as one token, but `ORDER ` triggers the keyword |
+
+## Dependencies
+
+### External Crates
+- **nom** (parser combinators) — core parsing machinery (`IResult`, `tag`, `alt`, `many0`, etc.)
+- **serde** — `Serialize`/`Deserialize` on `Direction` (for serialization in plans)
+
+### Internal: What This Module Depends On
+- `crate::debug_print!` macro — used in `VariableLengthSpec::validate()` for warnings
+
+### Internal: What Depends On This Module
+
+| Consumer Module | What It Uses |
+|----------------|--------------|
+| `server/handlers.rs` | `parse_cypher_statement()`, `strip_comments()` — HTTP query entry point |
+| `server/bolt_protocol/handler.rs` | `parse_cypher_statement()` — Bolt protocol entry point |
+| `query_planner/ast_transform/` | AST types for query rewriting |
+| `query_planner/logical_plan/` | AST types for logical plan building (MatchClause, WithClause, ReturnClause, Expression, etc.) |
+| `query_planner/logical_expr/` | `Expression`, `Operator`, `Literal` for logical expression modeling |
+| `query_planner/analyzer/` | `Expression`, `WhereClause` for property extraction, match type inference |
+| `query_planner/optimizer/` | AST types for union pruning, filter pushdown |
+| `render_plan/` | `Direction` for SQL generation |
+| `procedures/executor.rs` | `CypherStatement`, `StandaloneProcedureCall` for procedure dispatch |
+| `procedures/return_evaluator.rs` | `Expression`, `ReturnClause` for evaluating RETURN on procedure results |
+
+## Testing Guidance
+
+### Running Tests
+```bash
+# All parser unit tests (~150+ tests across all files)
+cargo test --lib open_cypher_parser
+
+# Specific file's tests
+cargo test --lib open_cypher_parser::expression::tests
+cargo test --lib open_cypher_parser::path_pattern::tests
+cargo test --lib open_cypher_parser::mod::tests
+
+# Full query integration tests (in mod.rs)
+cargo test --lib test_parse_full_read_query
+cargo test --lib test_parse_full_query
+cargo test --lib test_parse_cypher_statement_union
+
+# All tests (includes downstream consumers that will break if parser changes)
+cargo test
+```
+
+### What to Test After Changes
+
+- **Changed expression.rs**: Run all expression tests + `test_parse_full_read_query` + `test_parse_where_*` tests. Also run downstream: `cargo test --lib query_planner` and `cargo test --lib render_plan`.
+- **Changed path_pattern.rs**: Run path pattern tests + `test_parse_match_clause_*` + shortest path tests.
+- **Changed a clause parser** (return/with/match/etc.): Run that file's tests + `mod.rs` integration tests.
+- **Changed ast.rs**: Run the full `cargo test` — every downstream module uses these types.
+- **Changed common.rs**: Run `test_strip_comments` + full parser suite (comment stripping affects everything).
+
+### Test Structure
+Each clause file has its own `#[cfg(test)] mod tests` with:
+1. Happy path tests (simple input)
+2. Edge cases (whitespace, case sensitivity)
+3. Error cases (missing keywords, invalid input)
+4. Integration with related clauses (e.g., MATCH with WHERE)
+
+`mod.rs` has comprehensive integration tests parsing complete multi-clause queries and asserting the full AST structure.
+
+## Design Decisions & Gotchas
+
+### Why `Rc<RefCell<NodePattern>>` in ConnectedPattern?
+Node sharing in multi-hop paths. In `(a)-[]->(b)-[]->(c)`, node `b` appears as `end_node` of the first pattern and `start_node` of the second. Using `Rc<RefCell<>>` avoids cloning while allowing the same node to be referenced from both positions.
+
+### Why are CREATE/SET/DELETE/REMOVE parsed?
+Historical: the parser was originally part of a full Cypher engine. These clauses are parsed into AST nodes but never executed — ClickGraph is read-only. They remain for grammar completeness and potential future use.
+
+### Why two representations for reading clauses?
+`reading_clauses: Vec<ReadingClause>` preserves the exact order of MATCH and OPTIONAL MATCH.
+`match_clauses` and `optional_match_clauses` are separate vectors for backward compatibility with older code that processes them independently. New code should use `reading_clauses`.
+
+### Why `FunctionCall.name` is `String` not `&str`?
+Dotted function names like `ch.arrayFilter` are parsed as separate identifier parts joined by `.`. The joined result is an owned `String` because it doesn't correspond to any contiguous slice in the original input.
+
+### Temporal Accessor Desugaring
+`$param.year` or `n.date.month` are desugared into `FunctionCall` nodes during parsing:
+`n.registration_date.year` → `FunctionCallExp { name: "year", args: [PropertyAccess(n, registration_date)] }`
+This simplifies downstream handling since temporal accessors behave like function calls.

--- a/src/packstream/AGENTS.md
+++ b/src/packstream/AGENTS.md
@@ -1,0 +1,131 @@
+# packstream Module — Agent Guide
+
+> **Purpose**: PackStream binary serialization/deserialization for the Neo4j Bolt protocol.
+> Vendored from [neo4rs](https://github.com/neo4j-labs/neo4rs) (MIT license).
+> This is a **wire format codec** — do not modify unless fixing Bolt protocol bugs.
+
+## Module Architecture
+
+```
+packstream/
+├── mod.rs        (640 lines) ← Public API: from_bytes(), to_bytes(), Data wrapper,
+│                                RawBytes, BoltBytesBuilder (test-only), Dbg (debug-only)
+├── de.rs         (573 lines) ← Deserializer: bytes → Rust types via serde
+└── ser/
+    ├── mod.rs    (1144 lines) ← Serializer: Rust types → bytes via serde
+    └── map.rs    (1044 lines) ← Map serialization helpers (AsMap, key validation)
+```
+
+**Total**: ~3,400 lines (including ~600 lines of tests)
+
+## Key Files
+
+### mod.rs — Public API & Data Types
+- `from_bytes<T>(Bytes) → Result<T, de::Error>` — deserialize PackStream bytes to any serde type
+- `to_bytes<T>(&T) → Result<Bytes, ser::Error>` — serialize any serde type to PackStream bytes
+- `Data` — wrapper around `Bytes` with reset/keep-alive semantics for multi-pass parsing
+- `RawBytes` — deserializes raw byte pointer for zero-copy access
+- `BoltBytesBuilder` — test-only fluent builder for constructing PackStream byte sequences
+- `Dbg` — debug-only pretty-printer for PackStream byte streams
+
+### de.rs — Deserializer
+Implements `serde::Deserializer` for the PackStream binary format.
+
+Key design: uses a `Visitation` enum to control parsing behavior:
+- `Default` — standard deserialization
+- `BytesAsBytes` — deserialize byte sequences as borrowed bytes
+- `RawBytes` — return raw unconsumed bytes (for `RawBytes` newtype)
+- `MapAsSeq` — deserialize maps as sequences of key-value pairs
+- `SeqAsTuple(n)` — deserialize lists as fixed-size tuples
+
+Internal types:
+- `ItemsParser` — shared iterator for list/map/struct field parsing
+- `StructParser` — handles Bolt struct (tag + fields) as serde enum
+- `SharedBytes` — unsafe shared mutable reference for progressive parsing
+
+### ser/mod.rs — Serializer
+Implements `serde::Serializer` for PackStream encoding.
+
+Key encoding rules (PackStream spec):
+- Integers: compact encoding (tiny_int -16..127 = 1 byte, up to int64 = 9 bytes)
+- Strings: length-prefixed (tiny 0-15, string8/16/32)
+- Lists: length-prefixed (tiny 0-15, list8/16/32)
+- Maps: length-prefixed with string-only keys
+- Structs: tag byte + fields (for Bolt protocol messages)
+
+Notable: `MapSerializer` supports unknown-length maps by backpatching the header.
+
+### ser/map.rs — Map Serialization Helpers
+- `AsMap<T>` — wrapper to serialize tuples/sequences as PackStream maps
+- `AsMapSerializer` — converts sequences of key-value pairs into map entries
+- `InnerMapSerializer` — alternating key/value state machine
+- `StringKeySerializer` — enforces string-only map keys
+- `SpecialKeySerializer`/`SpecialValueSerializer` — internal protocol for map size hints
+
+## Critical Invariants
+
+### 1. PackStream Marker Bytes
+The format uses specific marker byte ranges — these are part of the Neo4j spec:
+- `0x00-0x7F`: Tiny positive int
+- `0x80-0x8F`: Tiny string (length in low nibble)
+- `0x90-0x9F`: Tiny list
+- `0xA0-0xAF`: Tiny map
+- `0xB0-0xBF`: Struct (length in low nibble, followed by tag byte)
+- `0xC0`: Null, `0xC1`: Float64, `0xC2`: False, `0xC3`: True
+- `0xC8-0xCB`: Int8/16/32/64
+- `0xCC-0xCE`: Bytes8/16/32
+- `0xD0-0xD2`: String8/16/32
+- `0xD4-0xD6`: List8/16/32
+- `0xD8-0xDA`: Map8/16/32
+
+**Do not change marker byte assignments** — they must match the Neo4j PackStream specification.
+
+### 2. Unsafe Code
+- `SharedBytes::get()` uses `unsafe` for shared mutable reference (progressive byte consumption)
+- `parse_string()` and `parse_bytes()` use `unsafe` for zero-copy borrowed slices
+- These are vendored patterns from neo4rs — change only with extreme caution
+
+### 3. Roundtrip Guarantee
+All PackStream types must roundtrip: `from_bytes(to_bytes(x)) == x`. Tests verify this for
+all primitive types, collections, and Bolt structures.
+
+## Dependencies
+
+**What this module uses**:
+- `bytes` crate (`Bytes`, `BytesMut`, `BufMut`, `Buf`) — buffer management
+- `serde` — serialization framework (Serialize/Deserialize traits)
+- `thiserror` — error type definitions
+
+**What uses this module**:
+- `server/bolt_protocol/connection.rs` — Bolt message encoding/decoding
+  - `packstream::from_bytes()` for deserializing Bolt message fields
+  - `packstream::to_bytes()` for serializing response values
+
+## Public API
+
+```rust
+// Deserialize PackStream bytes
+pub fn from_bytes<T: DeserializeOwned>(bytes: Bytes) -> Result<T, de::Error>;
+
+// Serialize to PackStream bytes
+pub fn to_bytes<T: Serialize>(value: &T) -> Result<Bytes, ser::Error>;
+
+// Internal (crate-visible)
+pub(crate) fn from_bytes_ref<T>(bytes: &mut Data) -> Result<T, de::Error>;
+pub(crate) fn from_bytes_seed<S>(bytes: &mut Data, seed: S) -> Result<S::Value, de::Error>;
+```
+
+## Testing Guidance
+
+- Tests are extensive (~200 lines in `mod.rs`, ~160 lines in `ser/map.rs`)
+- Use `BoltBytesBuilder` (`bolt()` function) to construct test PackStream bytes
+- All tests verify roundtrip: deserialize → re-serialize → compare bytes
+- Run with: `cargo test --lib packstream`
+- Debug mode enables `Dbg` pretty-printer for inspecting byte streams
+
+## When to Modify
+
+- **Bolt protocol bugs**: If Neo4j clients send/receive unexpected bytes
+- **New Bolt message types**: If adding new struct tags to the protocol
+- **Never**: Change encoding rules — they're part of the PackStream specification
+- **Caution**: This is vendored code — prefer minimal, targeted changes

--- a/src/procedures/AGENTS.md
+++ b/src/procedures/AGENTS.md
@@ -1,0 +1,174 @@
+# procedures Module — Agent Guide
+
+> **Purpose**: Neo4j-compatible metadata procedure execution.
+> Handles `CALL db.labels()`, `CALL dbms.components()`, etc.
+> These **bypass the query planner entirely** — they read from GraphSchema directly.
+
+## Module Architecture
+
+```
+procedures/
+├── mod.rs                          (170 lines) ← ProcedureRegistry, type aliases, re-exports
+├── executor.rs                     (501 lines) ← Routing, execution, UNION handling, detection
+├── return_evaluator.rs             (449 lines) ← RETURN clause evaluation (COLLECT, maps, slicing)
+├── db_labels.rs                    (81 lines)  ← db.labels() → all node labels
+├── db_property_keys.rs             (86 lines)  ← db.propertyKeys() → all Cypher property names
+├── db_relationship_types.rs        (81 lines)  ← db.relationshipTypes() → all edge types
+├── db_schema_node_type_properties.rs (112 lines) ← db.schema.nodeTypeProperties() → per-label props
+├── db_schema_rel_type_properties.rs  (110 lines) ← db.schema.relTypeProperties() → per-type props
+├── dbms_components.rs              (76 lines)  ← dbms.components() → ClickGraph version/edition
+└── dbms_stubs.rs                   (63 lines)  ← Browser compatibility stubs (clientConfig, etc.)
+```
+
+**Total**: ~1,730 lines
+
+## Execution Flow
+
+```
+Cypher query "CALL db.labels()"
+    │
+    ▼
+Parser → CypherStatement::ProcedureCall or CypherStatement::Query with call_clause
+    │
+    ▼
+Handler (HTTP or Bolt) detects procedure-only query
+    │  uses is_procedure_only_statement() / is_procedure_union_query()
+    ▼
+executor.rs routes to ProcedureRegistry
+    │
+    ▼
+Specific procedure function (e.g., db_labels::execute)
+    │  receives &GraphSchema, returns Vec<HashMap<String, JsonValue>>
+    ▼
+If RETURN clause present → return_evaluator.rs transforms results
+    │  handles COLLECT(), map literals, array slicing
+    ▼
+Results formatted as JSON (HTTP) or Bolt records (Bolt protocol)
+```
+
+## Key Files
+
+### mod.rs — Registry & Types
+- `ProcedureRegistry` — HashMap of procedure name → function pointer
+- Registers 10 built-in procedures (6 core + 4 stubs)
+- `ProcedureResult = Result<Vec<HashMap<String, JsonValue>>, String>`
+- `ProcedureFn = Arc<dyn Fn(&GraphSchema) -> ProcedureResult + Send + Sync>`
+
+### executor.rs — Execution Engine
+**Detection functions** (used by handlers to decide execution path):
+- `is_procedure_only_statement(&CypherStatement)` — main routing decision
+- `is_procedure_only_query(&OpenCypherQueryAst)` — checks single query
+- `is_procedure_union_query(&CypherStatement)` — detects CALL UNION ALL CALL
+
+**Execution functions**:
+- `execute_procedure_by_name()` — core executor, gets schema, calls procedure fn
+- `execute_procedure()` — variant taking parsed AST
+- `execute_procedure_query()` — handles CALL + RETURN (applies return_evaluator)
+- `execute_procedure_union()` — executes multiple procedures, combines results
+- `execute_procedure_union_with_return()` — UNION with per-branch RETURN evaluation
+
+**Schema access**: Uses task-local `get_current_schema()` first, falls back to `GLOBAL_SCHEMAS`.
+
+### return_evaluator.rs — RETURN Clause Processing
+Handles the transformation of procedure results through RETURN expressions:
+- `apply_return_clause()` — entry point, detects aggregation vs row-by-row
+- `evaluate_aggregation_expr()` — handles COLLECT, COUNT, map literals with aggregations
+- `evaluate_expr()` — non-aggregation: variables, literals, property access, maps
+- `apply_array_slicing()` — `COLLECT(label)[..1000]` support
+- `EvalContext` — variable bindings for expression evaluation
+
+### Procedure Implementations (db_*.rs, dbms_*.rs)
+Each follows the same pattern:
+```rust
+pub fn execute(schema: &GraphSchema) -> Result<Vec<HashMap<String, JsonValue>>, String>
+```
+
+Key details:
+- **db.labels()** — extracts labels from `schema.all_node_schemas()`, handles `::` namespacing
+- **db.relationshipTypes()** — extracts from `schema.get_relationships_schemas()`
+- **db.propertyKeys()** — collects all Cypher property names (mapping keys, not column names)
+- **db.schema.nodeTypeProperties()** — returns per-label property metadata (name, type, mandatory)
+- **db.schema.relTypeProperties()** — returns per-type property metadata
+- **dbms.components()** — returns `{"name":"ClickGraph","versions":[CARGO_PKG_VERSION],"edition":"community"}`
+- **dbms_stubs** — minimal responses for Browser compatibility (clientConfig, showCurrentUser, etc.)
+
+## Critical Invariants
+
+### 1. Procedures NEVER Touch SQL
+Procedures read directly from `GraphSchema` metadata. They do **not** generate SQL,
+do **not** query ClickHouse, and do **not** go through the query planner.
+
+### 2. Schema Source Priority
+`executor::get_schema()` uses:
+1. Task-local `get_current_schema()` (set by HTTP/Bolt handlers)
+2. Fallback: `GLOBAL_SCHEMAS` lookup by `schema_name` parameter
+
+### 3. Property Keys Are Cypher Names
+`db.propertyKeys()` returns keys from `property_mappings` (Cypher-side names),
+**not** the underlying ClickHouse column names. This is correct behavior.
+
+### 4. UNION Detection Requirements
+`is_procedure_union_query()` requires ALL of:
+- Main query has `call_clause`, no `match_clauses`, no `where_clause`, no `with_clause`
+- All union branches have the same constraints
+- All unions are `UNION ALL` (not DISTINCT)
+
+### 5. Aggregation Detection
+`return_evaluator` checks for aggregation functions recursively in RETURN expressions.
+If **any** return item contains COLLECT/COUNT/SUM/AVG/MIN/MAX, the entire result set
+is aggregated into a single output record.
+
+## Dependencies
+
+**What this module uses**:
+- `graph_catalog::graph_schema::GraphSchema` — schema metadata
+- `open_cypher_parser` — AST types and parsing (for detection functions)
+- `server::query_context` — task-local schema access
+- `server::GLOBAL_SCHEMAS` — fallback schema access
+- `serde_json` — result value types
+
+**What uses this module**:
+- `server/handlers.rs` — HTTP query handler (procedure detection + execution)
+- `server/bolt_protocol/handler.rs` — Bolt query handler (procedure detection + execution)
+
+## Public API
+
+```rust
+// Detection (re-exported from mod.rs)
+pub fn is_procedure_only_statement(stmt: &CypherStatement) -> bool;
+pub fn is_procedure_only_query(query: &OpenCypherQueryAst) -> bool;
+pub fn is_procedure_union_query(stmt: &CypherStatement) -> bool;
+
+// Execution (re-exported from mod.rs)
+pub fn execute_procedure_query(...) -> ProcedureResult;
+pub fn execute_procedure_union(...) -> ProcedureResult;
+pub fn execute_procedure_union_with_return(...) -> ProcedureResult;
+pub fn extract_procedure_names_from_union(query: &str) -> Result<Vec<String>, String>;
+
+// RETURN evaluation (re-exported from mod.rs)
+pub fn apply_return_clause(results, return_clause) -> ProcedureResult;
+
+// Registry
+pub struct ProcedureRegistry { ... }
+impl ProcedureRegistry {
+    pub fn new() -> Self;        // creates with all built-ins
+    pub fn get(&self, name: &str) -> Option<&ProcedureFn>;
+    pub fn contains(&self, name: &str) -> bool;
+    pub fn names(&self) -> Vec<&str>;
+}
+```
+
+## Testing Guidance
+
+- Each `db_*.rs` has unit tests with empty schema (format validation)
+- `executor.rs` has tests for statement detection (procedure-only, union, mixed)
+- `return_evaluator.rs` has tests for COLLECT, map+COLLECT, variable passthrough
+- Run with: `cargo test --lib procedures`
+- Integration testing: requires running server with loaded schema, use curl/Bolt client
+
+## When to Modify
+
+- **Adding a new procedure**: Create `new_procedure.rs`, register in `ProcedureRegistry::new()`
+- **YIELD clause filtering**: Currently not implemented (TODO in executor.rs)
+- **New aggregation functions**: Add to `has_aggregation_in_expr()` match and `evaluate_aggregation_expr()`
+- **Schema changes**: If `GraphSchema` API changes, update all `db_*.rs` implementations

--- a/src/query_planner/AGENTS.md
+++ b/src/query_planner/AGENTS.md
@@ -1,0 +1,443 @@
+# query_planner Module — Agent Guide
+
+> **Purpose**: Transforms parsed Cypher AST into an optimized `LogicalPlan` + `PlanCtx` ready for SQL generation.
+> This is the brain of ClickGraph — **schema inference, type resolution, JOIN planning, filter optimization, and variable scoping** all happen here.
+> Total: ~51,700 lines across 80+ files.
+
+## Module Architecture
+
+```
+Cypher AST (from open_cypher_parser)
+    │
+    ▼
+mod.rs                   ← Entry points: evaluate_read_query(), evaluate_read_statement()
+    │                       Orchestrates the 3-phase pipeline: initial → intermediate → final
+    │
+    ├─ logical_plan/     ← LogicalPlan enum + clause-to-plan translation
+    │   plan_builder.rs     builds plan from AST clause-by-clause
+    │   match_clause/       MATCH pattern → ViewScan/GraphNode/GraphRel
+    │   with_clause.rs      WITH → WithClause (scope boundary + CTE)
+    │   return_clause.rs    RETURN → Projection
+    │   where_clause.rs     WHERE → Filter
+    │   order_by_clause.rs  ORDER BY → OrderBy
+    │   ...
+    │
+    ├─ analyzer/         ← Multi-pass analysis pipeline (schema, types, JOINs, filters)
+    │   mod.rs              initial_analyzing() → intermediate_analyzing() → final_analyzing()
+    │   graph_join/         Graph pattern → SQL JOIN inference (largest sub-module, 6.7K lines)
+    │   filter_tagging.rs   WHERE pushdown and property mapping (3.1K)
+    │   type_inference.rs   Infer missing labels/types from schema (1.5K)
+    │   schema_inference.rs Label-to-table/ViewScan resolution (1.3K)
+    │   ...
+    │
+    ├─ optimizer/        ← Plan optimization passes (filter pushdown, projection pruning)
+    │   mod.rs              initial_optimization() → final_optimization()
+    │   filter_into_graph_rel.rs   Embed filters into GraphRel nodes (1.1K)
+    │   cartesian_join_extraction.rs  Cross-pattern filter → JOIN condition (765)
+    │   ...
+    │
+    ├─ plan_ctx/         ← Planning context: variables, scoping, table metadata
+    │   mod.rs (1.7K)       PlanCtx: scope chain, TableCtx map, CTE tracking, VLP endpoints
+    │   table_ctx.rs (333)  Per-alias metadata: labels, properties, CTE references
+    │   builder.rs (289)    PlanCtx constructors
+    │
+    ├─ translator/       ← Graph→SQL property resolution boundary
+    │   property_resolver.rs  Unified property mapping (standard/denormalized/polymorphic)
+    │
+    ├─ logical_expr/     ← Expression IR between AST and SQL
+    │   mod.rs (944)        LogicalExpr enum: Literal, Column, Operator, PropertyAccess, etc.
+    │   ast_conversion.rs   AST Expression → LogicalExpr conversion
+    │   expression_rewriter.rs  Property mapping and transformation
+    │   visitors.rs         Visitor pattern for expression traversal
+    │   combinators.rs      AND/OR predicate composition
+    │
+    ├─ ast_transform/    ← Pre-planning AST transformations
+    │   mod.rs (943)        id() function rewriting, UNION splitting by labels
+    │   id_function.rs      IdFunctionTransformer for Bolt protocol encoded IDs
+    │   string_arena.rs     Arena allocator for transformed string lifetimes
+    │
+    ├─ join_context.rs   ← VLP naming conventions + JOIN state tracking
+    ├─ typed_variable.rs ← Unified variable type system (Node/Rel/Scalar/Path/Collection)
+    ├─ transformed.rs    ← Transformed<T> enum: Yes(T) | No(T) for pass results
+    ├─ types.rs          ← QueryType enum (Read, Call, Procedure, etc.)
+    └─ errors.rs         ← Top-level QueryPlannerError
+```
+
+## Data Flow: The 3-Phase Pipeline
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │           evaluate_read_statement()          │
+                    └────────────────────┬────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                            Phase 0: Plan Building                    │
+    │  logical_plan::evaluate_cypher_statement()                          │
+    │    → plan_builder::build_logical_plan()                             │
+    │    Processes MATCH → OPTIONAL → UNWIND → WHERE → WITH → RETURN     │
+    │    Result: Raw LogicalPlan + PlanCtx                                │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                    Phase 1: initial_analyzing()                      │
+    │  1. SchemaInference        → label → table/ViewScan                 │
+    │  2. TypeInference          → infer missing node/edge types          │
+    │  3. PatternResolver        → UNION ALL for ambiguous types          │
+    │  4. VlpTransitivityCheck   → validate VLP patterns                  │
+    │  5. CteSchemaResolver      → register CTE schemas                   │
+    │  6. BidirectionalUnion     → undirected → UNION ALL (both dirs)     │
+    │  7. GraphJoinInference     → graph patterns → SQL JOINs             │
+    │  8. ProjectedColumnsResolver → pre-compute projected columns        │
+    │  9. QueryValidation        → validate query structure               │
+    │ 10. FilterTagging          → property mapping + filter pushdown     │
+    │ 11. CartesianJoinExtraction → cross-pattern filter → ON clause      │
+    │ 12. ProjectionTagging      → expand RETURN *, tag columns           │
+    │ 13. GroupByBuilding        → aggregation → GROUP BY                 │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                    Phase 1.5: initial_optimization()                 │
+    │  1. CartesianJoinExtraction → cross-pattern filters to join_condition│
+    │  2. FilterIntoGraphRel      → push filters into GraphRel nodes     │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                    Phase 2: intermediate_analyzing()                 │
+    │  1. GraphTraversalPlanning → query plan for traversals              │
+    │  2. SchemaInference (push) → push table names to scans             │
+    │  3. DuplicateScansRemoving → dedup repeated alias scans            │
+    │  4. VariableResolver       → resolve property → column references  │
+    │  5. CteReferencePopulator  → populate cte_references on WithClause │
+    │  6. CteColumnResolver      → resolve CTE column references         │
+    │  7. UnwindTupleEnricher    → tuple structure for UNWIND             │
+    │  8. CollectUnwindElimination → remove no-op collect+UNWIND         │
+    │  9. TrivialWithElimination → remove pass-through WITH clauses      │
+    │ 10. PropertyRequirementsAnalyzer → track needed properties         │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                    Phase 2.5: final_optimization()                   │
+    │  1. ProjectionPushDown      → eliminate unused columns              │
+    │  2. CleanupViewScanFilters  → remove duplicate filters on ViewScans│
+    │  3. FilterPushDown          → push filters closer to scans         │
+    │  4. ViewOptimizer           → schema-aware view optimizations      │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+    ┌────────────────────────────────────┼─────────────────────────────────┐
+    │                    Phase 3: final_analyzing()                        │
+    │  1. PlanSanitization        → final plan cleanup                   │
+    │  2. UnwindPropertyRewriter  → tuple index rewriting                │
+    └────────────────────────────────────┬─────────────────────────────────┘
+                                         │
+                                         ▼
+                            (LogicalPlan, PlanCtx) → render_plan → SQL
+```
+
+## Key Types and Public API
+
+### Entry Points (mod.rs)
+
+| Function | Purpose |
+|----------|---------|
+| `evaluate_read_query()` | Single query → (LogicalPlan, PlanCtx) |
+| `evaluate_read_statement()` | Statement with UNION → (LogicalPlan, PlanCtx) |
+| `evaluate_call_query()` | CALL procedure → LogicalPlan (PageRank) |
+| `get_query_type()` | Classify query: Read, Call, Delete, Update |
+| `get_statement_query_type()` | Classify CypherStatement |
+
+### Core Types
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `LogicalPlan` | `logical_plan/mod.rs` | Main plan enum: 16 variants |
+| `PlanCtx` | `plan_ctx/mod.rs` | Planning context with scope chain |
+| `TableCtx` | `plan_ctx/table_ctx.rs` | Per-alias metadata |
+| `LogicalExpr` | `logical_expr/mod.rs` | Expression IR: 20+ variants |
+| `TypedVariable` | `typed_variable.rs` | Unified variable type system |
+| `VariableRegistry` | `typed_variable.rs` | Variable name → type mapping |
+| `JoinContext` | `join_context.rs` | JOIN state during traversal |
+| `Transformed<T>` | `transformed.rs` | Yes(T)/No(T) for pass results |
+| `PropertyResolver` | `translator/property_resolver.rs` | Graph property → SQL column |
+
+### LogicalPlan Variants
+
+```rust
+LogicalPlan::Empty              // No-op (filtered UNION branches)
+LogicalPlan::ViewScan(Arc<ViewScan>)  // Table scan with optional predicates
+LogicalPlan::GraphNode(GraphNode)     // Node in graph pattern
+LogicalPlan::GraphRel(GraphRel)       // Relationship pattern (left/center/right)
+LogicalPlan::GraphJoins(GraphJoins)   // Computed JOINs from graph patterns
+LogicalPlan::Filter(Filter)           // WHERE predicate
+LogicalPlan::Projection(Projection)   // RETURN clause
+LogicalPlan::GroupBy(GroupBy)          // GROUP BY + HAVING
+LogicalPlan::OrderBy(OrderBy)         // ORDER BY
+LogicalPlan::Skip(Skip)               // SKIP n
+LogicalPlan::Limit(Limit)             // LIMIT n
+LogicalPlan::Cte(Cte)                 // Common Table Expression
+LogicalPlan::Union(Union)             // UNION / UNION ALL
+LogicalPlan::WithClause(WithClause)   // WITH scope boundary + CTE materialization
+LogicalPlan::CartesianProduct(CartesianProduct)  // CROSS/LEFT JOIN for disconnected patterns
+LogicalPlan::Unwind(Unwind)           // ARRAY JOIN
+LogicalPlan::PageRank(PageRank)       // PageRank algorithm
+```
+
+### Pass Traits
+
+```rust
+// analyzer/analyzer_pass.rs
+trait AnalyzerPass {
+    fn analyze(&self, plan: Arc<LogicalPlan>, ctx: &mut PlanCtx)
+        -> AnalyzerResult<Transformed<Arc<LogicalPlan>>>;
+    fn analyze_with_graph_schema(&self, plan, ctx, schema)
+        -> AnalyzerResult<Transformed<Arc<LogicalPlan>>>;
+}
+
+// optimizer/optimizer_pass.rs
+trait OptimizerPass {
+    fn optimize(&self, plan: Arc<LogicalPlan>, ctx: &mut PlanCtx)
+        -> OptimizerResult<Transformed<Arc<LogicalPlan>>>;
+}
+```
+
+## Key Files with Line Counts
+
+### Top-Level (query_planner/)
+| File | Lines | Purpose |
+|------|------:|---------|
+| `mod.rs` | 260 | Entry points, pipeline orchestration, PageRank eval |
+| `errors.rs` | 27 | QueryPlannerError enum |
+| `join_context.rs` | 387 | VLP naming constants, JoinContext struct, VlpEndpointInfo |
+| `typed_variable.rs` | 1,062 | TypedVariable enum, VariableRegistry, 5 variable types |
+| `transformed.rs` | 20 | Transformed<T> enum |
+| `types.rs` | 11 | QueryType enum |
+
+### logical_plan/ (5,870 lines total)
+| File | Lines | Purpose |
+|------|------:|---------|
+| `mod.rs` | 1,940 | LogicalPlan enum, all node structs, evaluate_cypher_statement |
+| `match_clause/traversal.rs` | 1,669 | Core MATCH → plan translation |
+| `match_clause/tests.rs` | 1,581 | Unit tests for match clause |
+| `match_clause/view_scan.rs` | 974 | ViewScan generation |
+| `return_clause.rs` | 745 | RETURN → Projection |
+| `match_clause/helpers.rs` | 663 | Scan helpers, property conversion |
+| `with_clause.rs` | 579 | WITH → WithClause scope boundary |
+| `plan_builder.rs` | 479 | build_logical_plan() orchestrator |
+| `view_scan.rs` | 306 | ViewScan struct definition |
+| `where_clause.rs` | 260 | WHERE → Filter |
+| `optional_match_clause.rs` | 245 | OPTIONAL MATCH → CartesianProduct |
+| `unwind_clause.rs` | 171 | UNWIND → Unwind node |
+| `match_clause/schema_filter.rs` | 138 | Schema-based filtering |
+
+### analyzer/ (17,900 lines total — largest sub-module)
+| File | Lines | Purpose |
+|------|------:|---------|
+| `graph_join/inference.rs` | 4,048 | **Core JOIN inference** — THE largest file |
+| `filter_tagging.rs` | 3,121 | Filter pushdown + property mapping |
+| `type_inference.rs` | 1,527 | Infer missing labels/types from schema |
+| `graph_join/tests.rs` | 1,373 | JOIN inference tests |
+| `variable_resolver.rs` | 1,334 | Property access → column resolution |
+| `projection_tagging.rs` | 1,326 | RETURN * expansion, column tagging |
+| `schema_inference.rs` | 1,308 | Label → table resolution |
+| `bidirectional_union.rs` | 1,235 | Undirected patterns → UNION ALL |
+| `pattern_resolver.rs` | 1,228 | Multi-type pattern enumeration |
+| `property_requirements_analyzer.rs` | 1,094 | Track needed properties (optimization) |
+| `graph_traversal_planning.rs` | 849 | Graph traversal planning |
+| `match_type_inference.rs` | 759 | MATCH-specific type inference |
+| `graph_join/cross_branch.rs` | 755 | Cross-branch shared node detection |
+| `multi_type_vlp_expansion.rs` | 686 | VLP multi-type UNION expansion |
+| `mod.rs` | 614 | Pipeline orchestration (3 analysis phases) |
+| `group_by_building.rs` | 613 | Aggregation → GROUP BY |
+| `cte_column_resolver.rs` | 494 | CTE column reference resolution |
+| `graph_join/helpers.rs` | 493 | JOIN inference utilities |
+| `property_requirements.rs` | 461 | PropertyRequirements data structure |
+| `duplicate_scans_removing.rs` | 458 | Dedup repeated alias scans |
+| `graph_context.rs` | 389 | Graph execution context |
+| `graph_join/metadata.rs` | 379 | Pattern index: PatternNodeInfo/EdgeInfo |
+| `projected_columns_resolver.rs` | 376 | Pre-compute projected columns |
+| `vlp_transitivity_check.rs` | 374 | VLP transitivity validation |
+| `unwind_property_rewriter.rs` | 374 | Tuple index rewriting |
+| `unwind_tuple_enricher.rs` | 363 | Tuple metadata for UNWIND |
+| `query_validation.rs` | 342 | Query structure validation |
+| `test_multi_type_vlp_auto_inference.rs` | 341 | VLP auto-inference tests |
+| `where_property_extractor.rs` | 281 | WHERE-based property extraction |
+| `cte_schema_resolver.rs` | 222 | CTE schema registration |
+| `view_resolver.rs` | 197 | View resolution |
+| `plan_sanitization.rs` | 194 | Plan cleanup |
+| `cte_reference_populator.rs` | 192 | Populate cte_references on WithClause |
+| `view_resolver_tests.rs` | 138 | View resolver tests |
+| `errors.rs` | 108 | AnalyzerError enum |
+
+### optimizer/ (3,440 lines total)
+| File | Lines | Purpose |
+|------|------:|---------|
+| `filter_into_graph_rel.rs` | 1,148 | Embed filters into GraphRel nodes |
+| `cartesian_join_extraction.rs` | 765 | Cross-pattern filter → JOIN condition |
+| `collect_unwind_elimination.rs` | 571 | Remove no-op collect+UNWIND patterns |
+| `cleanup_viewscan_filters.rs` | 339 | Remove duplicate ViewScan filters |
+| `view_optimizer.rs` | 348 | Schema-aware view optimizations |
+| `trivial_with_elimination.rs` | 295 | Remove pass-through WITH clauses |
+| `union_pruning.rs` | 224 | Prune empty UNION branches |
+| `mod.rs` | 181 | Pipeline orchestration |
+| `filter_push_down.rs` | 168 | Push filters toward scans |
+| `projection_push_down.rs` | 151 | Eliminate unused columns |
+| `optimizer_pass.rs` | 34 | OptimizerPass trait |
+| `errors.rs` | 40 | OptimizerError enum |
+
+### Other Sub-modules
+| File | Lines | Purpose |
+|------|------:|---------|
+| `plan_ctx/mod.rs` | 1,673 | PlanCtx struct + scope chain logic |
+| `plan_ctx/table_ctx.rs` | 333 | TableCtx: per-alias metadata |
+| `plan_ctx/builder.rs` | 289 | PlanCtx constructors |
+| `translator/property_resolver.rs` | 765 | Unified property resolution |
+| `ast_transform/mod.rs` | 943 | id() function rewriting |
+| `ast_transform/id_function.rs` | 577 | IdFunctionTransformer |
+| `logical_expr/mod.rs` | 944 | LogicalExpr enum definitions |
+| `logical_expr/ast_conversion.rs` | 524 | AST → LogicalExpr |
+| `logical_expr/expression_rewriter.rs` | 441 | Property mapping transforms |
+| `logical_expr/visitors.rs` | 408 | Expression visitor pattern |
+| `tests/integration_tests.rs` | 192 | Integration tests |
+
+## Critical Invariants
+
+### 1. GraphRel Left/Right Convention
+`left` is ALWAYS the **source** node (connects to `from_id`), `right` is ALWAYS the **target** (connects to `to_id`). For incoming arrows `(a)<-[:R]-(b)`, nodes are SWAPPED during parsing so left=b, right=a. **Never** use `direction` field for from_id/to_id selection in JOIN logic.
+
+### 2. WITH Clause = Scope Barrier
+WITH clauses create variable scope boundaries. `PlanCtx.is_with_scope=true` means variable lookup stops here. Only `exported_aliases` are visible downstream. Analyzers like BidirectionalUnion must NOT cross WithClause boundaries.
+
+### 3. VLP Naming Conventions (Single Source of Truth)
+Constants in `join_context.rs`:
+- `VLP_CTE_FROM_ALIAS = "t"` — FROM alias for VLP CTEs
+- `VLP_START_ID_COLUMN = "start_id"` — start node ID column
+- `VLP_END_ID_COLUMN = "end_id"` — end node ID column
+
+All code generating/referencing VLP CTEs MUST use these constants. VLP CTE names follow: `vlp_{start_alias}_{end_alias}`.
+
+### 4. Analysis Phase Ordering
+Many passes depend on prior passes. Key dependencies:
+- **SchemaInference** must run before TypeInference (needs table mappings)
+- **TypeInference** must run before VlpTransitivityCheck (needs relationship types)
+- **BidirectionalUnion** must run before GraphJoinInference (needs expanded patterns)
+- **FilterTagging** must run before CartesianJoinExtraction (needs property-mapped predicates)
+- **VariableResolver** must run before CteReferencePopulator (needs resolved references)
+- **CteReferencePopulator** must run before CteColumnResolver
+- **PropertyRequirementsAnalyzer** must run LAST (needs all property references stable)
+- **UnwindPropertyRewriter** must run at VERY END (after all transformations)
+
+### 5. Schema Access Pattern
+Query-processing code MUST access schema via task-local `QueryContext` or the `PlanCtx.schema()` method, never directly from `GLOBAL_SCHEMAS`. See `server/query_context.rs`.
+
+### 6. Transformed<T> Protocol
+Every pass returns `Transformed::Yes(plan)` if it modified the plan, `Transformed::No(plan)` if not. Callers use `.get_plan()` to extract the plan regardless. This enables optimization tracking.
+
+### 7. PlanCtx Dual Registration
+`PlanCtx::insert_table_ctx()` registers variables in BOTH the legacy `alias_table_ctx_map` AND the new `VariableRegistry`. Both systems must stay in sync during the migration period.
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| Filter lost across WITH | WHERE clause disappears in SQL | TrivialWithElimination removes WithClause containing filter |
+| Variable amnesia after WITH | "alias not found" errors | Variable not exported from WithClause.exported_aliases |
+| Wrong property mapping | Column not found in ClickHouse | FilterTagging maps property with wrong schema context |
+| Duplicate filters | Same WHERE condition appears twice | FilterIntoGraphRel runs twice, or CleanupViewScanFilters missed |
+| VLP endpoint wrong column | JOIN uses `u2.user_id` instead of `t.end_id` | JoinContext not marking VLP endpoint correctly |
+| GraphRel left/right swapped | FROM/TO IDs reversed | Using `direction` field instead of left/right convention |
+| CTE column resolution fail | `a_name` not found | CteColumnResolver didn't run, or CTE schema not registered |
+| Cross-pattern filter in wrong place | Filter pushed into single GraphRel | CartesianJoinExtraction didn't run before FilterIntoGraphRel |
+| Type inference explosion | Too many UNION branches | `max_inferred_types` not set, PatternResolver generates N² combinations |
+| Scope leak | Variable from parent scope visible | `is_with_scope` not set on new PlanCtx scope |
+
+## Dependencies
+
+### Upstream (inputs to this module)
+| Module | What It Provides |
+|--------|-----------------|
+| `open_cypher_parser` | `OpenCypherQueryAst`, `CypherStatement`, `Expression`, pattern types |
+| `graph_catalog` | `GraphSchema`, `NodeSchema`, `RelationshipSchema`, `PatternSchemaContext` |
+| `server::query_context` | Task-local schema access |
+
+### Downstream (consumers of this module's output)
+| Module | What It Consumes |
+|--------|-----------------|
+| `render_plan` | `LogicalPlan` + `PlanCtx` → `RenderPlan` (SQL-ready IR) |
+| `clickhouse_query_generator` | Indirect — depends on render_plan's output |
+| `server::handlers` | Calls `evaluate_read_statement()` |
+
+## Testing Guidance
+
+### Unit Tests (in-module)
+```bash
+# Run all query_planner tests
+cargo test --lib query_planner
+
+# Specific sub-module tests
+cargo test --lib graph_join           # JOIN inference (largest test suite)
+cargo test --lib match_clause         # MATCH pattern tests
+cargo test --lib filter_tagging       # Filter pushdown tests
+cargo test --lib type_inference       # Type inference tests
+cargo test --lib vlp_transitivity     # VLP validation tests
+cargo test --lib view_resolver        # View resolution tests
+```
+
+### Integration Tests
+```bash
+# Tests in src/query_planner/tests/integration_tests.rs
+cargo test --lib integration_tests
+
+# Full test suite (includes render_plan + SQL generation)
+cargo test
+```
+
+### Manual Smoke Testing
+```bash
+# Set schema and start server
+export GRAPH_CONFIG_PATH="./benchmarks/social_network/schemas/social_benchmark.yaml"
+cargo run --bin clickgraph
+
+# Test basic query planning (sql_only skips ClickHouse execution)
+curl -X POST localhost:8080/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User)-[:FOLLOWS]->(f:User) RETURN u.name, f.name LIMIT 5", "sql_only": true}'
+```
+
+### Key Test Patterns to Verify
+When modifying this module, ensure these patterns work:
+- [ ] Simple node: `MATCH (u:User) RETURN u.name`
+- [ ] Single-hop: `MATCH (u:User)-[:FOLLOWS]->(f:User) RETURN u.name, f.name`
+- [ ] Multi-hop: `MATCH (a)-[:FOLLOWS]->(b)-[:FOLLOWS]->(c) RETURN a.name, c.name`
+- [ ] VLP: `MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN a.name, b.name`
+- [ ] WITH scope: `MATCH (u:User) WITH u MATCH (u)-[:FOLLOWS]->(f) RETURN f.name`
+- [ ] OPTIONAL MATCH: `MATCH (u:User) OPTIONAL MATCH (u)-[:FOLLOWS]->(f) RETURN u.name, f.name`
+- [ ] Aggregation: `MATCH (u:User)-[:FOLLOWS]->(f) RETURN u.name, count(f) AS cnt`
+- [ ] Untyped nodes: `MATCH (n) RETURN n LIMIT 10`
+- [ ] Undirected: `MATCH (a:User)--(b) RETURN a.name, b.name`
+
+## Sub-modules That Deserve Their Own AGENTS.md
+
+### 1. `analyzer/` (~17,900 lines)
+The largest and most complex sub-module. Contains 30+ files spanning schema inference, type inference, JOIN generation, filter optimization, CTE resolution, and variable scoping. The `graph_join/` sub-sub-module alone is 6,700 lines with its own internal architecture (phased approach: metadata → schema context → join generation → cross-branch detection).
+
+### 2. `logical_plan/` (~5,870 lines)
+Core data structures + clause processing. The `match_clause/` sub-module (3,500+ lines) handles the most complex AST-to-plan translation including variable-length paths, shortest paths, and view-aware scans. The `mod.rs` alone is 1,940 lines with all plan node structs.
+
+### 3. `plan_ctx/` (~2,300 lines)
+The PlanCtx is the most-touched data structure in the codebase. Understanding its scope chain, dual registration (TableCtx + VariableRegistry), CTE tracking, and VLP endpoint management is essential for any query planner work.
+
+### 4. `logical_expr/` (~2,600 lines)
+The expression IR layer. While simpler than analyzer, the 20+ LogicalExpr variants and expression rewriting logic are important for anyone working on filter handling or property mapping.
+
+## Schema Variation Awareness
+
+The query planner generates different plan structures based on schema type:
+
+| Schema Type | Plan Differences |
+|-------------|-----------------|
+| **Standard** | Separate ViewScans for nodes + edges, 3-way GraphRel |
+| **FK-edge** | No separate edge table, relationship = FK column on node |
+| **Denormalized** | Node properties on edge table, GraphNode.is_denormalized=true |
+| **Polymorphic** | Single edge table + type_column, type filters in ViewScan |
+| **Composite ID** | Multi-column node identity, affects JOIN conditions |
+
+When modifying the planner, always ask: does this work for all 5 schema variations?

--- a/src/query_planner/analyzer/AGENTS.md
+++ b/src/query_planner/analyzer/AGENTS.md
@@ -1,0 +1,496 @@
+# query_planner/analyzer Module — Agent Guide
+
+> **Purpose**: The analyzer transforms parsed Cypher AST (`LogicalPlan`) into an optimized,
+> fully-resolved logical plan ready for SQL generation. It runs a configurable pipeline of
+> ~20 analysis and optimization passes — resolving labels to tables, inferring types,
+> mapping properties to columns, generating JOINs, building GROUP BYs, and pruning
+> unnecessary data — all producing a plan the renderer can translate "dumbly" to SQL.
+>
+> **This is the largest sub-module (~28,200 lines)** and where most semantic bugs originate.
+> Read this before touching any file here.
+
+## Module Architecture
+
+```
+LogicalPlan (from open_cypher_parser + plan_builder)
+    │
+    ▼
+mod.rs                       ← Pipeline orchestrator: initial → intermediate → final
+    │                           3 entry points, each runs ordered analysis passes
+    │
+    ├─ analyzer_pass.rs (29)     ← AnalyzerPass trait definition (2 methods)
+    ├─ errors.rs (108)           ← AnalyzerError enum, Pass enum for error attribution
+    │
+    ├─── Phase 1: Initial Analysis ──────────────────────────────────────────
+    │ schema_inference.rs (1,309)     ← Labels → tables, ViewScan creation
+    │ type_inference.rs (1,528)       ← Infer missing node labels & edge types
+    │ pattern_resolver.rs (1,229)     ← Untyped nodes → UNION ALL of typed branches
+    │ pattern_resolver_config.rs (60) ← Max combinations config (default: 38)
+    │ vlp_transitivity_check.rs (375) ← Validate VLP patterns are transitive
+    │ cte_schema_resolver.rs (223)    ← Register WITH CTE schemas in PlanCtx
+    │ bidirectional_union.rs (1,236)  ← Undirected (a)--(b) → UNION ALL of both directions
+    │ graph_join/ (inference)         ← Graph pattern → JOINs (runs early for PatternSchemaContext)
+    │ projected_columns_resolver.rs (377) ← Pre-compute GraphNode.projected_columns
+    │ query_validation.rs (343)       ← Validate relationship patterns against schema
+    │ filter_tagging.rs (3,122)       ← Property mapping, filter extraction, id() decoding
+    │ projection_tagging.rs (1,327)   ← RETURN * expansion, column tagging
+    │ group_by_building.rs (614)      ← Detect aggregates, create GROUP BY
+    │
+    ├─── Phase 2: Intermediate Analysis ─────────────────────────────────────
+    │ graph_traversal_planning.rs (850) ← Multi-hop & [:TYPE1|TYPE2] → CTE/UNION
+    │ duplicate_scans_removing.rs (459) ← Deduplicate same-alias table scans
+    │ variable_resolver.rs (1,335)      ← Resolve TableAlias → CTE PropertyAccess
+    │ cte_reference_populator.rs (193)  ← Populate GraphRel.cte_references
+    │ cte_column_resolver.rs (495)      ← Resolve property names → CTE column names
+    │ unwind_tuple_enricher.rs (364)    ← Enrich Unwind with tuple index metadata
+    │ property_requirements_analyzer.rs (1,095) ← Determine needed properties per alias
+    │ property_requirements.rs (462)    ← PropertyRequirements data structure
+    │
+    ├─── Phase 3: Final Analysis ────────────────────────────────────────────
+    │ plan_sanitization.rs (195)        ← Final plan cleanup
+    │ unwind_property_rewriter.rs (375) ← Rewrite user.name → user.5 (tuple index)
+    │
+    ├─── Supporting Modules ─────────────────────────────────────────────────
+    │ graph_context.rs (390)            ← GraphContext struct for pattern analysis
+    │ view_resolver.rs (198)            ← Schema lookups for nodes/relationships
+    │ view_scan_handling.rs (13)        ← ViewScan leaf node helper
+    │ match_type_inference.rs (760)     ← Type inference for MATCH clause processing
+    │ multi_type_vlp_expansion.rs (687) ← Enumerate valid multi-type VLP paths
+    │ where_property_extractor.rs (282) ← Extract property refs from WHERE (AST-level)
+    │
+    └─── graph_join/ Sub-Module (5,731 lines total) ─────────────────────────
+      mod.rs (57)             ← Public API, re-exports
+      inference.rs (4,049)    ← Core JOIN generation (THE BEAST)
+      metadata.rs (380)       ← PatternGraphMetadata builder
+      helpers.rs (494)        ← Join dedup, column resolution, utilities
+      cross_branch.rs (756)   ← Cross-branch JOIN detection, uniqueness constraints
+      tests.rs (1,374)        ← Comprehensive unit tests
+```
+
+## Complete File List
+
+| File | Lines | Responsibility |
+|------|------:|----------------|
+| graph_join/inference.rs | 4,049 | Core JOIN generation from graph patterns — THE most complex file |
+| filter_tagging.rs | 3,122 | Property→column mapping, filter extraction, id() decoding |
+| type_inference.rs | 1,528 | Infer node labels & edge types from schema context |
+| graph_join/tests.rs | 1,374 | Unit tests for graph join inference |
+| variable_resolver.rs | 1,335 | Resolve variable references to CTE sources |
+| projection_tagging.rs | 1,327 | RETURN * expansion, property tagging |
+| schema_inference.rs | 1,309 | Label→table resolution, ViewScan creation |
+| bidirectional_union.rs | 1,236 | Undirected patterns → UNION ALL |
+| pattern_resolver.rs | 1,229 | Untyped vars → systematic UNION ALL expansion |
+| property_requirements_analyzer.rs | 1,095 | Determine required properties for pruning |
+| graph_traversal_planning.rs | 850 | Multi-hop CTE planning, [:A\|B] UNION |
+| match_type_inference.rs | 760 | MATCH clause type inference helpers |
+| graph_join/cross_branch.rs | 756 | Cross-branch JOIN detection, uniqueness constraints |
+| multi_type_vlp_expansion.rs | 687 | Multi-type VLP path enumeration |
+| mod.rs | 614 | Pipeline orchestrator (initial/intermediate/final) |
+| group_by_building.rs | 614 | GROUP BY clause creation from aggregates |
+| cte_column_resolver.rs | 495 | Resolve PropertyAccess → CTE column names |
+| graph_join/helpers.rs | 494 | Join deduplication, column resolution |
+| property_requirements.rs | 462 | PropertyRequirements data structure |
+| duplicate_scans_removing.rs | 459 | Deduplicate same-alias ViewScans |
+| graph_context.rs | 390 | GraphContext struct for pattern analysis |
+| graph_join/metadata.rs | 380 | PatternGraphMetadata types & builder |
+| projected_columns_resolver.rs | 377 | Pre-compute projected_columns for GraphNodes |
+| vlp_transitivity_check.rs | 375 | Validate VLP transitivity |
+| unwind_property_rewriter.rs | 375 | Rewrite property access → tuple indices |
+| unwind_tuple_enricher.rs | 364 | Enrich Unwind nodes with tuple metadata |
+| query_validation.rs | 343 | Validate relationship patterns against schema |
+| test_multi_type_vlp_auto_inference.rs | 341 | Tests for multi-type VLP auto-inference |
+| where_property_extractor.rs | 282 | Extract property refs from WHERE (AST-level) |
+| cte_schema_resolver.rs | 223 | Register WITH CTE schemas in PlanCtx |
+| view_resolver.rs | 198 | Schema lookups for nodes/relationships |
+| plan_sanitization.rs | 195 | Final plan cleanup, PropertyAccess→Column |
+| cte_reference_populator.rs | 193 | Populate GraphRel.cte_references |
+| view_resolver_tests.rs | 138 | Tests for ViewResolver |
+| errors.rs | 108 | AnalyzerError enum |
+| pattern_resolver_config.rs | 60 | Max combinations config |
+| graph_join/mod.rs | 57 | Public API, re-exports |
+| analyzer_pass.rs | 29 | AnalyzerPass trait definition |
+| view_scan_handling.rs | 13 | ViewScan leaf helper |
+
+## The 3-Phase Analysis Pipeline
+
+The analyzer is invoked in 3 phases from `mod.rs`. Each phase is a separate function
+called sequentially from `query_planner/mod.rs`. **Pass ordering within each phase is critical.**
+
+### Phase 1: `initial_analyzing()` — Schema Resolution & Pattern Analysis
+
+Resolves types, validates patterns, maps properties, and generates JOINs.
+
+```
+Step 1:  SchemaInference         — Labels → tables, ViewScan creation
+Step 2:  TypeInference           — Infer missing labels/types from schema
+Step 2.1: PatternResolver        — Untyped nodes → UNION ALL branches
+Step 2.5: VlpTransitivityCheck   — Validate VLP patterns are transitive
+Step 3:  CteSchemaResolver       — Register WITH CTE schemas in PlanCtx
+Step 3.5: BidirectionalUnion     — (a)--(b) → UNION ALL (MUST be before GraphJoinInference!)
+Step 4:  GraphJoinInference      — Graph patterns → JOIN trees + PatternSchemaContext
+Step 5:  ProjectedColumnsResolver — Pre-compute GraphNode.projected_columns
+Step 6:  QueryValidation         — Validate relationship patterns
+Step 7:  FilterTagging           — Property→column mapping, filter extraction
+Step 3.5*: CartesianJoinExtraction — Cross-pattern filters → join_condition (optimizer pass)
+Step 4*: ProjectionTagging       — RETURN * expansion, column tagging
+Step 5*: GroupByBuilding         — Detect aggregates → GROUP BY
+```
+
+*Note: Step numbers in code comments are historical and don't match sequential order.*
+
+### Phase 2: `intermediate_analyzing()` — Traversal Planning & Resolution
+
+Plans complex traversals, resolves variables, manages CTEs, optimizes.
+
+```
+Step 1:  GraphTraversalPlanning      — Multi-hop/[:A|B] → CTE/UNION
+Step 2:  SchemaInference (push)      — Push inferred table names to ViewScans
+Step 3:  DuplicateScansRemoving      — Deduplicate same-alias scans
+Step 4:  VariableResolver            — TableAlias("cnt") → PropertyAccess("cte", "cnt")
+Step 5:  CteReferencePopulator       — Populate GraphRel.cte_references
+Step 6:  CteColumnResolver           — PropertyAccess("p","firstName") → ("p","p_firstName")
+Step 7:  UnwindTupleEnricher         — Enrich Unwind with tuple structure metadata
+Step 8:  CollectUnwindElimination    — Remove no-op collect+UNWIND patterns (optimizer)
+Step 9:  TrivialWithElimination      — Remove pass-through WITH clauses (optimizer)
+Step 10: PropertyRequirementsAnalyzer — Determine needed properties per alias
+```
+
+### Phase 3: `final_analyzing()` — Cleanup & Last-Mile Rewriting
+
+```
+Step 1: PlanSanitization           — Final plan cleanup, PropertyAccess→Column
+Step 2: UnwindPropertyRewriter     — user.name → user.5 (tuple index access)
+```
+
+## The `graph_join/` Sub-Module Architecture
+
+This is the most complex sub-module (5,731 lines). It converts Cypher graph patterns
+into SQL JOINs.
+
+### Core Data Flow
+
+```
+GraphRel tree                                     GraphJoins { joins: Vec<Join> }
+    │                                                 ▲
+    ▼                                                 │
+build_pattern_metadata()                         build_graph_joins()
+    │  (Phase 0: pre-compute index)                   │
+    ▼                                                 │
+PatternGraphMetadata                             collected_graph_joins
+    │  (nodes, edges, references, appearances)        ▲
+    ▼                                                 │
+collect_graph_joins()  ──── infer_graph_join() ──────┘
+    │                       │
+    │                       ├─ Standard pattern: FROM(a) + edge(r) + TO(b) → 2 JOINs
+    │                       ├─ FK-edge pattern: node + FK column → 1 JOIN
+    │                       ├─ Denormalized pattern: edge embeds node → 0-1 JOINs
+    │                       └─ VLP pattern: mark endpoints in JoinContext
+    │
+    ├── cross_branch::generate_cross_branch_joins_from_metadata()
+    │   (Phase 2: shared nodes in comma-separated patterns → JOINs)
+    │
+    └── cross_branch::generate_relationship_uniqueness_constraints()
+        (Phase 4: r1.id != r2.id for bidirectional patterns)
+```
+
+### Key Types
+
+- **`GraphJoinInference`** — Main pass implementing `AnalyzerPass`. Entry point.
+- **`JoinContext`** — Tracks which aliases are already joined (prevents duplicates).
+  Also tracks VLP endpoints (`VlpEndpointInfo`, `VlpPosition`).
+- **`PatternGraphMetadata`** — Pre-computed index over pattern structure:
+  - `nodes: HashMap<alias, PatternNodeInfo>` — alias, label, is_referenced, appearance_count
+  - `edges: Vec<PatternEdgeInfo>` — alias, rel_types, from/to, is_vlp, direction, is_optional
+- **`NodeAppearance`** — Tracks where a node variable appears (for cross-branch detection)
+
+### Phased Execution in `inference.rs`
+
+1. **Phase 0: Metadata Construction** — `build_pattern_metadata()` builds `PatternGraphMetadata`
+2. **Phase 1: CTE Reference Registration** — `register_with_cte_references()` discovers WITH exports
+3. **Phase 2: Join Collection** — `collect_graph_joins()` recursively traverses plan, calls `infer_graph_join()` for each `GraphRel`
+4. **Phase 3: Cross-Branch JOINs** — `generate_cross_branch_joins_from_metadata()` handles shared nodes
+5. **Phase 4: Uniqueness Constraints** — `generate_relationship_uniqueness_constraints()` prevents duplicate edge traversal
+
+## The `AnalyzerPass` Trait
+
+```rust
+pub trait AnalyzerPass {
+    // Simple pass (no schema needed)
+    fn analyze(
+        &self,
+        logical_plan: Arc<LogicalPlan>,
+        plan_ctx: &mut PlanCtx,
+    ) -> AnalyzerResult<Transformed<Arc<LogicalPlan>>>;
+
+    // Schema-aware pass
+    fn analyze_with_graph_schema(
+        &self,
+        logical_plan: Arc<LogicalPlan>,
+        plan_ctx: &mut PlanCtx,
+        graph_schema: &GraphSchema,
+    ) -> AnalyzerResult<Transformed<Arc<LogicalPlan>>>;
+}
+```
+
+Both methods have default no-op implementations. Each pass overrides whichever variant
+it needs. Most passes override `analyze_with_graph_schema` since they need schema access.
+
+**Return type**: `AnalyzerResult<Transformed<Arc<LogicalPlan>>>`
+- `Transformed::Yes(plan)` — pass modified the plan
+- `Transformed::No(plan)` — pass returned unmodified plan
+
+## Critical Invariants
+
+### 1. Pass Ordering Is Sacred
+
+Many passes have hard dependencies on previous passes:
+
+| Pass | Requires | Reason |
+|------|----------|--------|
+| TypeInference | SchemaInference | Needs table contexts to exist |
+| PatternResolver | TypeInference | Handles remaining untyped nodes |
+| BidirectionalUnion | — | MUST run BEFORE GraphJoinInference |
+| GraphJoinInference | BidirectionalUnion | GraphRel must already be direction-resolved |
+| FilterTagging | GraphJoinInference | Needs PatternSchemaContext for property mapping |
+| CartesianJoinExtraction | FilterTagging | Needs property-mapped predicates |
+| VariableResolver | FilterTagging | Needs property-mapped expressions |
+| CteReferencePopulator | VariableResolver | Needs resolved variable sources |
+| CteColumnResolver | CteReferencePopulator | Needs CTE reference info |
+| PropertyRequirementsAnalyzer | ALL above | Must run last (all refs stable) |
+| UnwindPropertyRewriter | ALL above | Absolute last pass (tuple index rewrite) |
+
+**If you reorder passes, you WILL break things silently.**
+
+### 2. Parser Direction Normalization
+
+The Cypher parser ALREADY normalizes relationship direction:
+- `left_connection` ALWAYS = FROM node (source)
+- `right_connection` ALWAYS = TO node (target)
+- `direction` field only records original syntax
+
+```cypher
+// (a)<-[:REL]-(b) → parser creates: left="b", right="a", direction=Incoming
+// DO NOT check direction field for from/to logic — use left/right directly
+```
+
+**TypeInference and GraphJoinInference both rely on this invariant.**
+
+### 3. PlanCtx Is the Shared State Bus
+
+`PlanCtx` is the mutable context threaded through ALL passes. It stores:
+- `alias_table_ctx_map` — alias → TableCtx (table name, label, properties)
+- CTE columns, CTE entity types, CTE references
+- Optional aliases, projection aliases
+- VLP endpoint info
+- Property requirements
+- PatternSchemaContext
+
+**Each pass reads from previous passes' PlanCtx writes and writes its own data.**
+
+### 4. Schema Access via Task-Local QueryContext
+
+Query-processing code MUST access schema via `get_current_schema()` / `get_current_schema_with_fallback()`, never directly from `GLOBAL_SCHEMAS`. See copilot-instructions.md for details.
+
+### 5. CTE Naming Convention
+
+WITH CTE columns are named `{alias}_{property}`:
+- Node alias `a` with property `name` → CTE column `a_name`
+- Scalar alias `cnt` → CTE column `cnt` (no prefix)
+
+CTE names are generated by `utils::cte_naming::generate_cte_name()` using exported aliases.
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| Filter lost after TrivialWithElimination | WHERE clause silently dropped | WithClause elimination didn't preserve Filter child |
+| Property not found in CTE | `column X cannot be resolved` | CteSchemaResolver didn't register column, or CteColumnResolver didn't resolve it |
+| Wrong property mapping | Gets column from wrong table | Denormalized vs standard property source confusion in FilterTagging |
+| Cross-branch JOIN missing | Cartesian product instead of JOIN | PatternGraphMetadata didn't detect shared node (appearance_count wrong) |
+| Duplicate results with undirected | 2x rows for `(a)--(b)` | BidirectionalUnion not deduplicating, or VLP multi-type mistakenly split |
+| VLP non-transitive still recursing | Infinite/wrong recursion | VlpTransitivityCheck didn't convert to fixed-length |
+| Variable not resolved | `TableAlias("cnt")` reaches renderer | VariableResolver didn't find CTE source for variable |
+| GROUP BY includes aggregate | Invalid SQL | GroupByBuilding `contains_aggregate()` missed nested case |
+| Direction-dependent bug | Works outgoing, fails incoming | Code checking `direction` field instead of left/right connections |
+| Stale PatternSchemaContext | Wrong join strategy | GraphJoinInference ran but PlanCtx not updated for branch |
+
+## Dangerous Files — Handle With Extreme Care
+
+### 🔴 graph_join/inference.rs (4,049 lines)
+The single most dangerous file. Contains `collect_graph_joins()`, `infer_graph_join()`,
+and `build_graph_joins()` — the core join generation logic. Changes here can silently
+break any combination of standard/FK-edge/denormalized/VLP/cross-branch patterns.
+**Always run full test suite after ANY change.**
+
+### 🔴 filter_tagging.rs (3,122 lines)
+Property mapping, filter extraction, and id() decoding. Handles ALL filter placement
+decisions. CartesianProduct filter preservation was a regression hotspot. Changes here
+affect every query with a WHERE clause.
+
+### 🟡 variable_resolver.rs (1,335 lines)
+Resolves all variable references to CTE sources. Scope semantics are complex.
+Bugs here cause variables to silently reference wrong CTE or fail to resolve.
+
+### 🟡 type_inference.rs (1,528 lines)
+Infers missing types using schema. Must respect parser direction normalization
+(invariant #2 above). Incorrect inference causes downstream cascading failures.
+
+### 🟡 bidirectional_union.rs (1,236 lines)
+Generates 2^n UNION branches for n undirected edges. Must correctly handle VLP
+multi-type patterns (skip splitting — CTE handles both directions internally).
+
+### 🟢 Most other files are relatively safe
+Single-purpose passes with clear inputs/outputs and limited blast radius.
+
+## Schema Variation Awareness
+
+Every pass may behave differently based on schema type:
+
+| Concept | Standard | FK-edge | Denormalized | Polymorphic |
+|---------|:--------:|:-------:|:------------:|:-----------:|
+| Node has own table | ✅ | ✅ | ❌ (in edge) | ✅ |
+| Edge has own table | ✅ | ❌ (FK on node) | ✅ | ✅ |
+| JOIN count per hop | 2 | 1 | 0-1 | 2 |
+| Property source | node table | node table | edge table | node table |
+| type_column discrimination | — | — | — | ✅ |
+
+**When fixing a bug, always check: does this fix work for ALL schema variations?**
+
+Key files affected by schema variation:
+- `graph_join/inference.rs` — different JOIN strategies per schema type
+- `filter_tagging.rs` — property mapping varies by source table
+- `projected_columns_resolver.rs` — EmbeddedInEdge vs OwnTable vs Virtual
+- `view_resolver.rs` — denormalized from/to role-sensitive property resolution
+
+## Public API
+
+### Entry Points (in `mod.rs`)
+
+```rust
+pub fn initial_analyzing(
+    plan: Arc<LogicalPlan>,
+    plan_ctx: &mut PlanCtx,
+    current_graph_schema: &GraphSchema,
+) -> AnalyzerResult<Arc<LogicalPlan>>;
+
+pub fn intermediate_analyzing(
+    plan: Arc<LogicalPlan>,
+    plan_ctx: &mut PlanCtx,
+    current_graph_schema: &GraphSchema,
+) -> AnalyzerResult<Arc<LogicalPlan>>;
+
+pub fn final_analyzing(
+    plan: Arc<LogicalPlan>,
+    plan_ctx: &mut PlanCtx,
+    _: &GraphSchema,
+) -> AnalyzerResult<Arc<LogicalPlan>>;
+```
+
+### Re-exported from `graph_join/`
+
+```rust
+pub use graph_join::GraphJoinInference;
+pub use graph_join::{
+    PatternGraphMetadata, PatternNodeInfo, PatternEdgeInfo,
+    PatternMetadataBuilder, expr_references_alias, is_node_referenced,
+    plan_references_alias, JoinContext, VlpEndpointInfo, VlpPosition,
+};
+```
+
+### Other Public Modules
+
+```rust
+pub mod view_resolver;              // ViewResolver for schema lookups
+pub mod multi_type_vlp_expansion;   // Path enumeration for multi-type VLPs
+pub mod property_requirements;      // PropertyRequirements data structure
+pub mod property_requirements_analyzer;
+pub mod where_property_extractor;   // WHERE property extraction (AST-level)
+pub mod errors;                     // AnalyzerError enum
+pub mod graph_join;                 // Full graph_join sub-module
+pub mod match_type_inference;       // Type inference helpers
+```
+
+## Testing Guidance
+
+### Running Tests
+
+```bash
+# All unit tests (fast, no ClickHouse needed)
+cargo test --lib
+
+# Tests specifically in analyzer module
+cargo test query_planner::analyzer
+
+# Graph join tests
+cargo test graph_join
+
+# Multi-type VLP tests
+cargo test test_multi_type_vlp
+
+# Full suite (unit + integration, needs ClickHouse)
+cargo test
+```
+
+### What to Test After Changes
+
+| Changed File | Must Run |
+|-------------|----------|
+| graph_join/inference.rs | `cargo test graph_join` + full integration suite |
+| filter_tagging.rs | `cargo test filter` + any WHERE-related integration tests |
+| type_inference.rs | `cargo test type_inference` + patterns with omitted labels |
+| variable_resolver.rs | `cargo test variable_resolver` + WITH clause queries |
+| bidirectional_union.rs | `cargo test bidirectional` + undirected pattern queries |
+| schema_inference.rs | `cargo test schema_inference` + basic MATCH queries |
+| Any pass | Full `cargo test` — pass ordering means one change can cascade |
+
+### Manual Smoke Tests
+
+After any analyzer change, test these patterns with the benchmark schema:
+
+```cypher
+-- Basic pattern
+MATCH (u:User) RETURN u.name
+
+-- Single hop
+MATCH (u1:User)-[:FOLLOWS]->(u2:User) RETURN u1.name, u2.name
+
+-- Undirected
+MATCH (u1:User)-[:FOLLOWS]-(u2:User) RETURN u1.name, u2.name
+
+-- WITH clause
+MATCH (u:User)-[:FOLLOWS]->(f:User) WITH u, count(f) as cnt RETURN u.name, cnt
+
+-- VLP
+MATCH (u1:User)-[:FOLLOWS*1..3]->(u2:User) RETURN u1.name, u2.name
+
+-- OPTIONAL MATCH
+MATCH (u:User) OPTIONAL MATCH (u)-[:FOLLOWS]->(f:User) RETURN u.name, f.name
+```
+
+## Key Relationships to Other Modules
+
+```
+open_cypher_parser  ──→  query_planner/logical_plan  ──→  ANALYZER  ──→  render_plan
+                              ▲                              │
+                              │                              ▼
+                         plan_builder                    optimizer/
+                              │                        (CartesianJoinExtraction,
+                              ▼                         TrivialWithElimination,
+                          PlanCtx ◄─────────────────  CollectUnwindElimination)
+                              │
+                              ▼
+                        graph_catalog/ (schema access)
+```
+
+The analyzer is the bridge between the parsed AST and the SQL-generating renderer.
+It owns the transformation from "Cypher semantics" to "SQL-ready IR".
+
+## Optimizer Passes Called Within Analyzer
+
+Three optimizer passes are called within the analyzer pipeline (not in a separate optimizer phase):
+
+1. **CartesianJoinExtraction** (in initial_analyzing) — Extracts cross-pattern filters into `join_condition`
+2. **CollectUnwindElimination** (in intermediate_analyzing) — Removes no-op `collect`+`UNWIND` patterns
+3. **TrivialWithElimination** (in intermediate_analyzing) — Removes pass-through WITH clauses
+
+These live in `query_planner/optimizer/` but are invoked via `OptimizerPass::optimize()`.

--- a/src/query_planner/logical_plan/AGENTS.md
+++ b/src/query_planner/logical_plan/AGENTS.md
@@ -1,0 +1,533 @@
+# logical_plan — AGENTS.md
+
+> Intermediate representation (IR) between Cypher AST and ClickHouse SQL generation.
+
+## 1. Module Purpose
+
+The `logical_plan` module defines the **core data structures** and **building logic** that transform a parsed Cypher AST into a tree of `LogicalPlan` nodes. This tree is the canonical intermediate representation consumed by:
+
+- **Analyzer passes** (`query_planner/analyzer/`) — rewrite and optimize the plan
+- **Render phase** (`render_plan/`) — translate the plan into ClickHouse SQL
+
+The module does NOT execute queries or generate SQL directly.
+
+**Scope**: Read-only analytical queries. No CREATE/SET/DELETE/MERGE support.
+
+```
+Cypher Query → Parser → AST → [logical_plan] → LogicalPlan tree → Analyzers → Render → SQL
+                               ^^^^^^^^^^^^^^^
+                               THIS MODULE
+```
+
+## 2. File Inventory (10,055 lines)
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `mod.rs` | 1,939 | Core `LogicalPlan` enum, all plan node structs, rebuild_or_clone impls, Display, tests |
+| `plan_builder.rs` | 479 | Main entry point `build_logical_plan()`, WITH clause chaining |
+| `match_clause/traversal.rs` | 1,669 | MATCH pattern traversal, GraphNode/GraphRel construction |
+| `match_clause/view_scan.rs` | 974 | ViewScan generation for nodes and relationships from schema |
+| `match_clause/helpers.rs` | 663 | Utility functions (property conversion, scan generation, context registration) |
+| `match_clause/tests.rs` | 1,581 | Unit tests for match clause processing |
+| `match_clause/schema_filter.rs` | 138 | Property-based schema filtering (Track C optimization) |
+| `match_clause/mod.rs` | 46 | Re-exports from match_clause submodules |
+| `match_clause/errors.rs` | 8 | Match clause error types |
+| `return_clause.rs` | 745 | RETURN → Projection/GroupBy, pattern comprehension rewriting |
+| `with_clause.rs` | 579 | WITH → WithClause, scope boundary, pattern comprehension metadata |
+| `view_scan.rs` | 306 | `ViewScan` struct definition with all fields |
+| `where_clause.rs` | 260 | WHERE → Filter, UNION branch alias rewriting |
+| `optional_match_clause.rs` | 245 | OPTIONAL MATCH → LEFT JOIN semantics via `is_optional` flag |
+| `unwind_clause.rs` | 171 | UNWIND → Unwind (ARRAY JOIN) |
+| `projection_view.rs` | 84 | `Projection` helpers for ViewScan integration |
+| `filter_view.rs` | 48 | `Filter` helpers for ViewScan integration |
+| `errors.rs` | 46 | `LogicalPlanError` enum |
+| `order_by_clause.rs` | 36 | ORDER BY → OrderBy |
+| `skip_n_limit_clause.rs` | 38 | SKIP/LIMIT → Skip/Limit |
+
+## 3. Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        plan_builder.rs                              │
+│  build_logical_plan(ast, schema) → (Arc<LogicalPlan>, PlanCtx)     │
+│                                                                     │
+│  Processing Order:                                                  │
+│  ┌──────────┐   ┌───────────────┐   ┌────────┐   ┌───────┐        │
+│  │  MATCH   │──▶│OPTIONAL MATCH │──▶│ UNWIND │──▶│ WITH  │        │
+│  │ clauses  │   │   clauses     │   │clauses │   │clause │        │
+│  └──────────┘   └───────────────┘   └────────┘   └───┬───┘        │
+│                                                       │ recursive  │
+│  ┌──────────┐   ┌───────────────┐   ┌────────┐       ▼            │
+│  │  WHERE   │◀──│   ORDER BY    │◀──│ RETURN │  (subsequent       │
+│  │  clause  │   │   SKIP/LIMIT  │   │ clause │   MATCH/WITH)      │
+│  └──────────┘   └───────────────┘   └────────┘                    │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Resulting LogicalPlan Tree                        │
+│                                                                     │
+│  Projection(friend.name)            ← return_clause.rs              │
+│    └─ Filter(u.active = true)       ← where_clause.rs              │
+│        └─ GraphRel(f:FOLLOWS)       ← match_clause/traversal.rs    │
+│            ├─ left: GraphNode(u)                                    │
+│            │   └─ ViewScan(users)   ← match_clause/view_scan.rs    │
+│            ├─ center: ViewScan(follows)                             │
+│            └─ right: GraphNode(friend)                              │
+│                └─ ViewScan(users)                                   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## 4. LogicalPlan Enum — All Variants
+
+```rust
+pub enum LogicalPlan {
+    Empty,              // Sentinel / leaf node (no data)
+    ViewScan(Arc<ViewScan>),  // Table scan with property mapping
+    GraphNode(GraphNode),     // Named graph node pattern
+    GraphRel(GraphRel),       // Relationship pattern (3-way: left/center/right)
+    Filter(Filter),           // WHERE predicate
+    Projection(Projection),   // RETURN / SELECT items
+    GroupBy(GroupBy),          // GROUP BY (from aggregation in RETURN/WITH)
+    OrderBy(OrderBy),         // ORDER BY
+    Skip(Skip),               // OFFSET
+    Limit(Limit),             // LIMIT
+    Cte(Cte),                 // Named CTE wrapper
+    GraphJoins(GraphJoins),   // Computed JOIN plan (from GraphJoinInference analyzer)
+    Union(Union),             // UNION / UNION ALL
+    PageRank(PageRank),       // PageRank algorithm node
+    Unwind(Unwind),           // ARRAY JOIN (UNWIND)
+    CartesianProduct(CartesianProduct), // CROSS JOIN / LEFT JOIN for disconnected patterns
+    WithClause(WithClause),   // WITH scope boundary + projection
+}
+```
+
+### Node Hierarchy (inner → outer)
+
+```
+Leaf nodes: Empty, ViewScan(Arc<ViewScan>), PageRank
+Single-input wrappers: GraphNode, Filter, Projection, GroupBy, OrderBy, Skip, Limit, Cte, Unwind, GraphJoins, WithClause
+Multi-input: GraphRel (left/center/right), CartesianProduct (left/right), Union (vec<inputs>)
+```
+
+## 5. Key Structs
+
+### ViewScan — Table scan with schema mapping
+
+The foundational leaf node. Maps a ClickHouse table to graph properties.
+
+```rust
+pub struct ViewScan {
+    pub source_table: String,           // e.g., "brahmand.users_bench"
+    pub view_filter: Option<LogicalExpr>, // Pre-applied filter
+    pub property_mapping: HashMap<String, PropertyValue>,  // graph_prop → CH column
+    pub id_column: String,              // Node/edge ID column
+    pub output_schema: Vec<String>,     // Available property names
+    pub from_id: Option<String>,        // Relationship source ID column
+    pub to_id: Option<String>,          // Relationship target ID column
+    pub use_final: bool,                // ClickHouse FINAL keyword
+    pub is_denormalized: bool,          // Node embedded in edge table
+    pub from_node_properties: Option<HashMap<String, PropertyValue>>,  // Denormalized FROM
+    pub to_node_properties: Option<HashMap<String, PropertyValue>>,    // Denormalized TO
+    pub type_column: Option<String>,    // Polymorphic edge discriminator
+    pub schema_filter: Option<SchemaFilter>, // YAML-defined always-on filter
+    pub node_label: Option<String>,     // Label (essential for denormalized nodes)
+    // + view_parameter_names/values, type_values, from/to_label_column
+}
+```
+
+### GraphNode — Named node pattern
+
+```rust
+pub struct GraphNode {
+    pub input: Arc<LogicalPlan>,    // ViewScan or Empty (denormalized)
+    pub alias: String,              // "u", "friend", "t1" (generated)
+    pub label: Option<String>,      // "User", "Airport"
+    pub is_denormalized: bool,      // Skip CTE/JOIN for this node
+    pub projected_columns: Option<Vec<(String, String)>>,  // From GraphJoinInference
+    pub node_types: Option<Vec<String>>,  // Multi-type inference candidates
+}
+```
+
+### GraphRel — Relationship pattern (⚠️ CRITICAL: left/right convention)
+
+```rust
+pub struct GraphRel {
+    pub left: Arc<LogicalPlan>,     // ALWAYS source node (from_id)
+    pub center: Arc<LogicalPlan>,   // Relationship ViewScan
+    pub right: Arc<LogicalPlan>,    // ALWAYS target node (to_id)
+    pub alias: String,              // "f", "r", "t2"
+    pub direction: Direction,       // Original syntactic direction (display only!)
+    pub left_connection: String,    // Alias connecting to from_id
+    pub right_connection: String,   // Alias connecting to to_id
+    pub is_rel_anchor: bool,        // Whether this rel is the FROM table
+    pub variable_length: Option<VariableLengthSpec>,  // VLP: *1..3, *2, *
+    pub shortest_path_mode: Option<ShortestPathMode>, // shortestPath mode
+    pub path_variable: Option<String>,  // "p" from MATCH p = (a)-[]->(b)
+    pub where_predicate: Option<LogicalExpr>, // Pushed-down filter
+    pub labels: Option<Vec<String>>,    // [:TYPE1|TYPE2] labels
+    pub is_optional: Option<bool>,      // OPTIONAL MATCH → LEFT JOIN
+    pub anchor_connection: Option<String>, // Base MATCH node for OPTIONAL
+    pub cte_references: HashMap<String, String>,  // alias → CTE name
+    pub pattern_combinations: Option<Vec<TypeCombination>>, // Multi-type inference
+    pub was_undirected: Option<bool>,   // Split from Direction::Either
+}
+```
+
+### WithClause — Scope boundary + projection
+
+```rust
+pub struct WithClause {
+    pub input: Arc<LogicalPlan>,
+    pub items: Vec<ProjectionItem>,
+    pub distinct: bool,
+    pub order_by: Option<Vec<OrderByItem>>,
+    pub skip: Option<u64>,
+    pub limit: Option<u64>,
+    pub where_clause: Option<LogicalExpr>,
+    pub exported_aliases: Vec<String>,  // Visible downstream
+    pub cte_name: Option<String>,       // Populated by CteSchemaResolver
+    pub cte_references: HashMap<String, String>,
+    pub pattern_comprehensions: Vec<PatternComprehensionMeta>,
+}
+```
+
+### Other Important Structs
+
+| Struct | Key Fields | Purpose |
+|--------|-----------|---------|
+| `Filter` | `input`, `predicate: LogicalExpr` | WHERE clause conditions |
+| `Projection` | `input`, `items: Vec<ProjectionItem>`, `distinct`, `pattern_comprehensions` | RETURN clause (SELECT) |
+| `GroupBy` | `input`, `expressions`, `having_clause`, `is_materialization_boundary` | Aggregation grouping |
+| `GraphJoins` | `input`, `joins: Vec<Join>`, `optional_aliases`, `anchor_table`, `cte_references`, `correlation_predicates` | Computed JOIN plan |
+| `CartesianProduct` | `left`, `right`, `is_optional`, `join_condition` | CROSS JOIN / LEFT JOIN |
+| `Union` | `inputs: Vec<Arc<LogicalPlan>>`, `union_type` | UNION ALL / UNION DISTINCT |
+| `Unwind` | `input`, `expression`, `alias`, `label`, `tuple_properties` | ARRAY JOIN |
+| `Cte` | `input`, `name` | Named CTE wrapper |
+| `Join` | `table_name`, `table_alias`, `joining_on`, `join_type`, `pre_filter`, `graph_rel` | Single JOIN operation |
+| `ProjectionItem` | `expression: LogicalExpr`, `col_alias: Option<ColumnAlias>` | One SELECT item |
+| `VariableLengthSpec` | `min_hops`, `max_hops` | VLP range (*1..3, *2, *) |
+| `PatternComprehensionMeta` | `correlation_var`, `direction`, `rel_types`, `agg_type`, `result_alias` | Pattern comprehension metadata for CTE generation |
+
+## 6. Plan Building Flow
+
+### Entry Point
+
+```rust
+// In mod.rs:
+pub fn evaluate_query(ast, schema, ...) → (Arc<LogicalPlan>, PlanCtx)
+pub fn evaluate_cypher_statement(stmt, schema, ...) → (Arc<LogicalPlan>, PlanCtx)
+
+// Delegates to plan_builder.rs:
+pub fn build_logical_plan(ast, schema, ...) → (Arc<LogicalPlan>, PlanCtx)
+```
+
+### Clause Processing Order (plan_builder.rs)
+
+1. **MATCH / OPTIONAL MATCH** (interleaved via `reading_clauses`)
+   - `match_clause::evaluate_match_clause()` → ViewScans + GraphNodes + GraphRels
+   - `optional_match_clause::evaluate_optional_match_clause()` → same but with `is_optional=true`
+2. **UNWIND** → `unwind_clause::evaluate_unwind_clause()` → Unwind node
+3. **WITH** → `with_clause::evaluate_with_clause()` → WithClause node
+   - Recursive: `process_with_clause_chain()` handles chained `WITH...MATCH...WITH`
+   - Creates child `PlanCtx` scope with only exported aliases
+4. **WHERE** → `where_clause::evaluate_where_clause()` → Filter node
+5. **RETURN** → `return_clause::evaluate_return_clause()` → Projection (+ GroupBy if aggregation)
+6. **ORDER BY** → `order_by_clause::evaluate_order_by_clause()` → OrderBy node
+7. **SKIP** → `skip_n_limit_clause::evaluate_skip_clause()` → Skip node
+8. **LIMIT** → `skip_n_limit_clause::evaluate_limit_clause()` → Limit node
+
+### MATCH Clause Processing (match_clause/)
+
+```
+evaluate_match_clause(match_clause, plan, plan_ctx)
+  │
+  ├─ For each path_pattern:
+  │   ├─ PathPattern::Node → generate_scan() → GraphNode
+  │   ├─ PathPattern::ConnectedPattern → traverse_connected_pattern_with_mode()
+  │   │   ├─ Pre-assign aliases for shared Rc nodes
+  │   │   ├─ For each connected_pattern:
+  │   │   │   ├─ Resolve start/end node labels (AST → PlanCtx fallback)
+  │   │   │   ├─ Infer relationship types (explicit, property-filtered, or schema-inferred)
+  │   │   │   ├─ Handle multi-type patterns (pattern_combinations for PatternResolver 2.0)
+  │   │   │   ├─ generate_scan() / generate_denormalization_aware_scan()
+  │   │   │   ├─ generate_relationship_center() → ViewScan for edge table
+  │   │   │   ├─ Build GraphRel(left, center, right)
+  │   │   │   └─ Register aliases in PlanCtx
+  │   │   └─ Handle multi-hop: existing plan becomes left/right child
+  │   └─ PathPattern::ShortestPath / AllShortestPaths → same flow + shortest_path_mode
+  │
+  └─ Multiple disconnected patterns → CartesianProduct
+```
+
+### ViewScan Generation (match_clause/view_scan.rs)
+
+```
+try_generate_view_scan(alias, label, plan_ctx)
+  ├─ Denormalized node → UNION of FROM/TO branches from edge tables
+  ├─ Multi-table node → UNION ALL of ViewScans
+  └─ Standard node → single ViewScan from node table
+
+try_generate_relationship_view_scan(alias, rel_labels, ...)
+  ├─ Multiple types → UNION ALL of relationship ViewScans
+  └─ Single type → single ViewScan with from_id/to_id
+
+generate_relationship_center(alias, labels, ...)
+  └─ Creates ViewScan for the edge/relationship table
+```
+
+### UNION Handling (mod.rs: evaluate_cypher_statement)
+
+```
+QUERY1 UNION [ALL] QUERY2 UNION [ALL] QUERY3
+  ├─ Build plan for each query independently
+  ├─ Filter empty branches (Track C optimization)
+  ├─ 0 branches → Empty plan
+  ├─ 1 branch → unwrap (no UNION needed)
+  └─ N branches → Union { inputs, union_type }
+```
+
+## 7. Critical Invariants
+
+### ⚠️ GraphRel Left/Right Convention (MUST READ)
+
+```
+left = ALWAYS source node (connects to from_id)
+right = ALWAYS target node (connects to to_id)
+
+For (a)-[:R]->(b) (Outgoing): left=a, right=b
+For (a)<-[:R]-(b) (Incoming): left=b, right=a  ← NODES ARE SWAPPED!
+For (a)-[:R]-(b)  (Either):   left=a, right=b  ← Same as Outgoing for storage
+
+The `direction` field is for DISPLAY ONLY. Never use direction-based branching
+for from_id/to_id selection in JOIN logic!
+
+Use:
+  left_connection → from_id
+  right_connection → to_id
+```
+
+### WithClause Scope Isolation
+
+- `WithClause.exported_aliases` defines what's visible downstream
+- `process_with_clause_chain()` creates a **child PlanCtx** with `is_with_scope=true`
+- This child acts as a **barrier** — parent variables not in exported_aliases are hidden
+- Child scope is merged back after subsequent MATCH/WITH processing
+
+### ID Generation
+
+- `generate_id()` → "t1", "t2", "t3"... (global `AtomicU32` counter)
+- `generate_cte_id()` → "cte1", "cte2"... (separate global counter)
+- `reset_alias_counter()` available for tests (non-deterministic in production)
+
+### Empty Branch Filtering
+
+`is_empty_or_filtered_branch()` detects:
+- Explicit: `LogicalPlan::Empty`
+- Implicit: `GraphRel { labels: None }` or `GraphRel { labels: Some([]) }` (Track C filtered all types)
+- Recursive: checks through wrapper nodes (Projection, Filter, etc.)
+
+### Pattern Comprehension Handling
+
+Pattern comprehensions like `size([(a)--() | 1])` are **rewritten during logical planning**:
+- In WITH: `rewrite_with_pattern_comprehensions()` → `PatternComprehensionMeta` attached to WithClause
+- In RETURN: `rewrite_pattern_comprehensions()` → `PatternComprehensionMeta` attached to Projection
+- Render phase consumes metadata to generate CTE + LEFT JOIN SQL
+- This avoids creating GroupBy nodes that break in the VLP path
+
+### rebuild_or_clone Pattern
+
+Every plan node implements `rebuild_or_clone()` using the `Transformed<Arc<LogicalPlan>>` type:
+- If child transformation occurred → rebuild with new children
+- If no transformation → return original `Arc` (zero-cost)
+- `handle_rebuild_or_clone()` helper consolidates the pattern
+- `any_transformed()` checks multiple children (used by GraphRel)
+
+## 8. Common Bug Patterns
+
+### 1. Direction-based JOIN logic
+**Wrong**: Using `GraphRel.direction` to decide which node connects to `from_id`/`to_id`.
+**Right**: Always use `left_connection → from_id`, `right_connection → to_id`.
+
+### 2. Labels not found in subsequent patterns
+**Problem**: `MATCH (a:X)-[r]->(b:Y), (b)-[r2]->(c)` — second usage of `b` has no label in AST.
+**Fix**: Label resolution falls back to PlanCtx: `if let Some(table_ctx) = plan_ctx.get_table_ctx(alias)`.
+
+### 3. Schema not found → silent Empty
+**Problem**: Node label not in schema returns `Empty` instead of error.
+**Fix**: `generate_scan()` returns `Err(NodeNotFound)` when label lookup fails.
+
+### 4. Stale alias counter in tests
+**Problem**: `generate_id()` uses global counter — tests get non-deterministic aliases.
+**Fix**: Call `reset_alias_counter()` at test start.
+
+### 5. WITH scope leaking variables
+**Problem**: Accessing parent-scope variable after WITH barrier.
+**Fix**: `PlanCtx::with_parent_scope(parent, true)` creates proper isolation.
+
+### 6. UNION branch alias conflicts
+**Problem**: UNION branches for untyped patterns suffix aliases (e.g., `o_0`, `o_1`).
+**Fix**: `where_clause.rs` has `rewrite_predicate_aliases()` that maps base → branch aliases.
+
+### 7. Pattern comprehension breaking VLP
+**Problem**: Creating GroupBy nodes for pattern comprehensions interferes with Variable-Length Path processing.
+**Fix**: Extract metadata only (`PatternComprehensionMeta`), defer CTE+JOIN to render phase.
+
+### 8. Multi-type patterns generating excessive UNIONs
+**Problem**: Fully untyped `(a)-[r]->(b)` generates N×M combinations.
+**Mitigation**: Combination pruning via WHERE constraints; `TooManyInferredTypes` error at configurable limit.
+
+## 9. Public API
+
+### Module-Level Functions
+
+```rust
+// Main entry points (mod.rs)
+pub fn evaluate_query(ast, schema, ...) → LogicalPlanResult<(Arc<LogicalPlan>, PlanCtx)>
+pub fn evaluate_cypher_statement(stmt, schema, ...) → LogicalPlanResult<(Arc<LogicalPlan>, PlanCtx)>
+
+// ID generation (mod.rs)
+pub fn generate_id() → String        // "t1", "t2", ...
+pub fn generate_cte_id() → String    // "cte1", "cte2", ...
+pub fn reset_alias_counter()         // For tests only
+```
+
+### Re-exported from match_clause
+
+```rust
+// Pattern evaluation
+pub fn evaluate_match_clause(clause, plan, ctx) → LogicalPlanResult<Arc<LogicalPlan>>
+pub fn evaluate_match_clause_with_optional(clause, plan, ctx, is_optional) → LogicalPlanResult<Arc<LogicalPlan>>
+
+// ViewScan generation
+pub fn try_generate_view_scan(alias, label, ctx) → Result<Option<Arc<LogicalPlan>>>
+pub fn try_generate_relationship_view_scan(alias, labels, ...) → Result<Option<Arc<LogicalPlan>>>
+pub fn generate_relationship_center(alias, labels, ...) → LogicalPlanResult<Arc<LogicalPlan>>
+
+// Helpers
+pub fn generate_scan(alias, label, ctx) → LogicalPlanResult<Arc<LogicalPlan>>
+pub fn generate_denormalization_aware_scan(alias, label, ctx) → LogicalPlanResult<(Arc<LogicalPlan>, bool)>
+pub fn compute_connection_aliases(direction, start, end) → (String, String)
+pub fn compute_rel_node_labels(direction, start_label, end_label) → (Option<String>, Option<String>)
+pub fn compute_variable_length(rel, labels) → Option<VariableLengthSpec>
+pub fn convert_properties(props, alias) → LogicalPlanResult<Vec<LogicalExpr>>
+pub fn register_node_in_context(ctx, alias, label, props, is_named)
+pub fn register_relationship_in_context(ctx, alias, labels, props, ...)
+pub fn register_path_variable(ctx, path_var, graph_rel, rel_alias, shortest_path_mode)
+pub fn is_denormalized_scan(plan) → bool
+pub fn is_label_denormalized(label, ctx) → bool
+pub fn determine_optional_anchor(ctx, is_optional, left, right) → Option<String>
+```
+
+### Public Structs & Enums
+
+All structs documented in Section 5 are public. Key types re-exported:
+- `LogicalPlan` (enum)
+- `ViewScan` (via `pub use view_scan::ViewScan`)
+- `LogicalPlanError` (via `pub use errors::LogicalPlanError`)
+- All plan node structs: `GraphNode`, `GraphRel`, `Filter`, `Projection`, `GroupBy`, `OrderBy`, `Skip`, `Limit`, `Cte`, `Union`, `Unwind`, `CartesianProduct`, `WithClause`, `GraphJoins`, `Join`, `PageRank`
+- Supporting types: `ProjectionItem`, `OrderByItem`, `VariableLengthSpec`, `ShortestPathMode`, `JoinType`, `UnionType`, `PatternComprehensionMeta`, `AggregationType`
+
+## 10. Testing Guidance
+
+### Unit Tests Location
+
+- `mod.rs` tests: `rebuild_or_clone` correctness, AST→LogicalPlan conversions, complex plan structure
+- `match_clause/tests.rs` (1,581 lines): MATCH clause patterns, node/relationship creation, VLP
+- `optional_match_clause.rs` tests: OPTIONAL MATCH with/without WHERE
+- `unwind_clause.rs` tests: UNWIND with literal lists and property access
+- `match_clause/helpers.rs` tests: Property conversion, error cases
+
+### Writing New Tests
+
+```rust
+// 1. Create test schema
+fn setup_test_graph_schema() -> GraphSchema {
+    GraphSchema::build(1, "test_db".to_string(), nodes, relationships)
+}
+
+// 2. Create PlanCtx
+let mut plan_ctx = PlanCtx::new(Arc::new(schema));
+
+// 3. Reset alias counter for deterministic aliases
+reset_alias_counter();
+
+// 4. Build plan from AST constructs
+let plan = evaluate_match_clause(&match_clause, Arc::new(LogicalPlan::Empty), &mut plan_ctx)?;
+
+// 5. Assert plan structure via pattern matching
+match plan.as_ref() {
+    LogicalPlan::GraphRel(rel) => {
+        assert_eq!(rel.alias, "r");
+        assert_eq!(rel.left_connection, "a");
+        assert_eq!(rel.right_connection, "b");
+    }
+    _ => panic!("Expected GraphRel"),
+}
+```
+
+### Key Patterns to Test
+
+- Single node: `MATCH (n:Label)` → GraphNode wrapping ViewScan
+- Single hop: `MATCH (a)-[r:TYPE]->(b)` → GraphRel with left/center/right
+- Multi-hop: `MATCH (a)-[r1]->(b)-[r2]->(c)` → Nested GraphRel
+- VLP: `MATCH (a)-[*1..3]->(b)` → GraphRel with `variable_length` set
+- Shortest path: `shortestPath((a)-[*]->(b))` → GraphRel with `shortest_path_mode`
+- UNION types: `MATCH (a)-[:T1|T2]->(b)` → labels = Some(["T1", "T2"])
+- No type: `MATCH (a)-[]->(b)` → inferred or multi-type with `pattern_combinations`
+- OPTIONAL MATCH: `is_optional = Some(true)`, `anchor_connection` set
+- WITH clause: WithClause with `exported_aliases`, scope isolation
+- Denormalized: `is_denormalized = true`, Empty input scan
+
+### Integration Test Considerations
+
+- Schema must be loaded (use benchmark schema for consistency)
+- Tests that call `build_logical_plan()` need real `GraphSchema`
+- Multi-type tests may produce large UNIONs — use `max_inferred_types` parameter
+- WithClause tests must verify scope isolation (child scope variables)
+
+## 11. Relationship to Other Modules
+
+```
+┌─────────────────────┐     ┌──────────────────────┐
+│ open_cypher_parser/ │────▶│  logical_plan/       │
+│  (AST types)        │     │  (this module)       │
+└─────────────────────┘     └──────────┬───────────┘
+                                       │ produces
+                                       ▼
+                            ┌──────────────────────┐
+                            │ analyzer/ passes     │
+                            │  TypeInference       │
+                            │  GraphJoinInference  │
+                            │  BidirectionalUnion  │
+                            │  GroupByBuilding     │
+                            │  CteSchemaResolver   │
+                            │  FilterPushdown      │
+                            └──────────┬───────────┘
+                                       │ transforms
+                                       ▼
+                            ┌──────────────────────┐
+                            │ render_plan/         │
+                            │  (SQL generation)    │
+                            └──────────────────────┘
+
+Dependencies:
+  ← graph_catalog/graph_schema.rs (schema lookups during ViewScan creation)
+  ← logical_expr/ (LogicalExpr, PropertyAccess, operators)
+  ← plan_ctx/ (PlanCtx, TableCtx — planning context)
+  ← analyzer/match_type_inference (label/type inference functions)
+```
+
+## 12. Key Design Decisions
+
+1. **Arc<LogicalPlan> everywhere**: Plans are immutable trees shared via reference counting. `rebuild_or_clone` creates new nodes only when transformation occurs.
+
+2. **GraphRel normalized convention**: Left=source, right=target regardless of syntactic direction. This simplifies all downstream JOIN logic.
+
+3. **Deferred UNION for multi-type patterns**: Instead of expanding untyped patterns into LogicalPlan Union branches immediately, `pattern_combinations` stores all valid (from, rel, to) tuples. CTE generation creates SQL-level UNIONs, avoiding PlanCtx isolation complexity.
+
+4. **WithClause as separate node**: Unlike Projection (RETURN), WithClause carries ORDER BY/SKIP/LIMIT/WHERE and creates scope isolation. This was designed to prevent analyzers from crossing scope boundaries.
+
+5. **Pattern comprehension metadata**: Extracted as `PatternComprehensionMeta` during planning, NOT as plan nodes. This avoids creating GroupBy nodes that interfere with VLP CTE generation.
+
+6. **ViewScan carries full schema context**: Each ViewScan has property mappings, denormalization info, polymorphic edge metadata, and schema filters — everything the render phase needs to generate correct SQL without additional schema lookups.

--- a/src/query_planner/optimizer/AGENTS.md
+++ b/src/query_planner/optimizer/AGENTS.md
@@ -1,0 +1,484 @@
+# optimizer Module — Agent Guide
+
+> **Purpose**: Transforms `LogicalPlan` trees to improve query execution efficiency
+> before SQL generation. Provides a composable pipeline of optimization passes that
+> embed filters, extract join conditions, eliminate redundant operations, and apply
+> schema-aware optimizations. Passes run in two phases (initial + final) with some
+> passes invoked separately by the analyzer.
+
+## Module Architecture
+
+```
+                        ┌──────────────────────────────────────────────┐
+                        │          query_planner/analyzer/mod.rs       │
+                        │  (orchestrates the full optimization flow)   │
+                        └──────────┬──────────────────┬────────────────┘
+                                   │                  │
+                    ┌──────────────▼──────┐   ┌───────▼──────────────────┐
+                    │ initial_optimization │   │  Analyzer-invoked passes │
+                    │   (mod.rs)           │   │  (called from analyzer)  │
+                    └──────────┬──────────┘   └───────┬──────────────────┘
+                               │                      │
+              ┌────────────────┼──────────┐    ┌──────┼───────────────┐
+              │                │          │    │      │               │
+              ▼                ▼          │    ▼      ▼               │
+  CartesianJoin    FilterIntoGraphRel     │  CollectUnwind   TrivialWith    │
+  Extraction                              │  Elimination     Elimination    │
+                                          │                                │
+                    ┌─────────────────────▼────────────────────────────────┘
+                    │  final_optimization  │
+                    │    (mod.rs)           │
+                    └──────────┬──────────┘
+                               │
+          ┌────────────────────┼────────────────────┐
+          │                    │                    │
+          ▼                    ▼                    ▼
+  ProjectionPushDown  CleanupViewScan      FilterPushDown
+                      Filters                      │
+                                                   ▼
+                                            ViewOptimizer
+```
+
+### Non-Pipeline Components
+
+```
+union_pruning.rs  ← Standalone utility (not an OptimizerPass)
+                     Called from query_planner/logical_plan/match_clause/traversal.rs
+                     Extracts label hints from id() WHERE patterns for UNION branch pruning
+```
+
+## Key Files & Line Counts
+
+| File | Lines | Role |
+|------|------:|------|
+| filter_into_graph_rel.rs | 1,149 | Embed filters into GraphRel/ViewScan nodes |
+| cartesian_join_extraction.rs | 766 | Extract cross-pattern filters into JOIN conditions |
+| collect_unwind_elimination.rs | 572 | Remove redundant collect()+UNWIND sequences |
+| view_optimizer.rs | 349 | Schema-aware ViewScan optimizations (filter simplification) |
+| cleanup_viewscan_filters.rs | 340 | Remove duplicate ViewScan filters inside GraphRel |
+| trivial_with_elimination.rs | 296 | Remove pass-through WITH clauses |
+| union_pruning.rs | 225 | Extract label info from id() patterns for UNION pruning |
+| mod.rs | 200 | Pipeline orchestration: initial_optimization + final_optimization |
+| filter_push_down.rs | 169 | Push filters toward data sources |
+| projection_push_down.rs | 152 | Eliminate unused columns early |
+| optimizer_pass.rs | 34 | OptimizerPass trait definition |
+| errors.rs | 43 | Error types (OptimizerError enum) |
+
+## Optimization Pipeline — Execution Order
+
+### Phase 1: initial_optimization (mod.rs)
+
+Called by the query planner before analyzer passes. Two passes in strict order:
+
+| Order | Pass | Why This Order |
+|:-----:|------|----------------|
+| 1 | **CartesianJoinExtraction** | Must run BEFORE FilterIntoGraphRel to prevent cross-pattern filters from being pushed into a single GraphRel |
+| 2 | **FilterIntoGraphRel** | Embeds remaining filters into GraphRel.where_predicate and ViewScan.view_filter |
+
+### Phase 2: Analyzer-invoked passes (analyzer/mod.rs)
+
+Called between initial and final optimization, inside the analyzer pipeline:
+
+| Order | Pass | Why Here |
+|:-----:|------|----------|
+| 3 | **CollectUnwindElimination** | Runs after CTE resolution but before final optimization |
+| 4 | **TrivialWithElimination** | Runs after CollectUnwindElimination to clean up remaining trivial WITH clauses |
+
+### Phase 3: final_optimization (mod.rs)
+
+Called after analyzer passes. Four passes in strict order:
+
+| Order | Pass | Why This Order |
+|:-----:|------|----------------|
+| 5 | **ProjectionPushDown** | Eliminates unused columns before filter processing |
+| 6 | **CleanupViewScanFilters** | Must run AFTER FilterIntoGraphRel (from Phase 1) — removes redundant ViewScan.view_filter that was already consolidated into GraphRel.where_predicate |
+| 7 | **FilterPushDown** | Pushes remaining filters toward scans |
+| 8 | **ViewOptimizer** | Final schema-aware optimizations (filter simplification, property access optimization) |
+
+### Standalone: union_pruning (not a pipeline pass)
+
+Called directly from `query_planner/logical_plan/match_clause/traversal.rs` during MATCH
+clause planning. Not an `OptimizerPass` implementation — it's a utility function that
+operates on the AST `WhereClause`, not the `LogicalPlan`.
+
+## Each Optimization Pass in Detail
+
+### 1. CartesianJoinExtraction
+
+**File**: `cartesian_join_extraction.rs` (766 lines)
+**Phase**: initial_optimization (runs first)
+**Depends on**: Nothing (first pass in pipeline)
+
+**What it does**: Finds `Filter → CartesianProduct` patterns where the filter predicate
+references aliases from both sides of the CartesianProduct. Extracts those predicates as
+`CartesianProduct.join_condition`, enabling `JOIN ... ON` instead of `CROSS JOIN + WHERE`.
+
+**Patterns handled**:
+- `Filter → CartesianProduct` (direct)
+- `Filter → WithClause(CartesianProduct)` (through WITH)
+
+**Critical behavior**:
+- Splits AND expressions: cross-pattern conditions → `join_condition`, single-sided → remain as Filter
+- **Correlated subqueries** (NOT PathPattern, EXISTS, size()) MUST stay in WHERE clause — ClickHouse
+  doesn't support correlated subqueries in JOIN ON clauses
+- Uses `partition_filter_conditions()` for the split logic
+- Uses `collect_aliases_from_plan()` to determine which aliases belong to left/right sides
+- Also collects `col_alias` from Projection/WithClause items (critical for WITH-defined aliases)
+
+**Helper functions**:
+- `collect_aliases_from_expr()` — extract table aliases referenced in an expression
+- `collect_aliases_from_plan()` — collect all node aliases defined in a plan subtree
+- `partition_filter_conditions()` — split predicates into join conditions vs WHERE filters
+
+### 2. FilterIntoGraphRel
+
+**File**: `filter_into_graph_rel.rs` (1,149 lines)
+**Phase**: initial_optimization (runs second)
+**Depends on**: CartesianJoinExtraction (cross-pattern filters should be extracted first)
+
+**What it does**: Embeds filter predicates directly into `GraphRel.where_predicate` and
+`ViewScan.view_filter` fields, enabling more efficient CTE generation and predicate pushdown.
+
+**Patterns handled** (in match order):
+1. `Filter → Projection → GraphRel` — merge filter into GraphRel.where_predicate, remove Filter wrapper
+2. `Filter → GraphRel` (direct) — same as above without Projection layer
+3. `Filter → Projection → ViewScan` — push filter into ViewScan.view_filter
+4. `Filter → ViewScan` (direct) — push filter into ViewScan.view_filter
+5. `GraphNode(ViewScan)` — inject filters from PlanCtx for this alias into the ViewScan
+6. `Projection(ViewScan)` — match alias labels to ViewScan source tables via schema lookup
+7. `Projection(GraphNode(ViewScan))` — inject filters via GraphNode alias, respects optional aliases
+8. `GraphRel` (direct visit) — collect filters from PlanCtx for left/right/edge aliases
+
+**Filter sources**:
+- Explicit `Filter` nodes in the plan tree
+- `PlanCtx` table contexts — filters stored per-alias by the FilterTagging analyzer
+
+**Critical behaviors**:
+- Merges with existing `where_predicate` using AND when GraphRel already has one
+- Qualifies `Column` expressions with table alias via `qualify_columns_with_alias()`
+- Skips left_connection filters when left child is also a GraphRel (multi-hop — inner GraphRel handles it)
+- Skips filter injection for optional aliases (filters should be JOIN conditions, not WHERE)
+- Tracks `collected_aliases` to avoid duplicate filter injection
+
+**⚠️ MUST NOT run twice** — running FilterIntoGraphRel in both initial and final optimization
+causes duplicate filters. The comment in `final_optimization` explicitly warns about this.
+
+### 3. CollectUnwindElimination
+
+**File**: `collect_unwind_elimination.rs` (572 lines)
+**Phase**: Analyzer-invoked (analyzer/mod.rs, after CTE resolution)
+**Depends on**: CTE resolution must have completed
+
+**What it does**: Detects and removes redundant `collect() + UNWIND` patterns that cancel
+each other out. Provides 2-5x performance improvement for affected queries.
+
+**Pattern detected**:
+```cypher
+-- Before (redundant collect+unwind):
+MATCH (a)-[r]->(b) WITH a, collect(b) as bs UNWIND bs as b RETURN b.name
+-- After (eliminated):
+MATCH (a)-[r]->(b) RETURN b.name
+```
+
+**Two elimination modes**:
+1. **Simple**: WITH only contains `collect(x) as xs` → eliminate both WITH and UNWIND entirely
+2. **Complex**: WITH has other items alongside collect → keep WITH minus the collect item, remove UNWIND
+
+**Alias rewriting**: When eliminating, builds an alias map (`unwound_alias → source_alias`)
+and recursively rewrites all references in downstream Projection, Filter, OrderBy, GroupBy nodes
+via `rewrite_aliases_in_expr()`.
+
+**Does NOT implement OptimizerPass.optimize() conventionally** — uses `optimize_node()` which
+returns `(Arc<LogicalPlan>, HashMap<String, String>)` to propagate alias mappings upward.
+
+### 4. TrivialWithElimination
+
+**File**: `trivial_with_elimination.rs` (296 lines)
+**Phase**: Analyzer-invoked (analyzer/mod.rs, after CollectUnwindElimination)
+**Depends on**: CollectUnwindElimination (may create trivial WITHs after removing collect)
+
+**What it does**: Removes WITH clauses that are pure pass-throughs adding no value.
+
+**A WITH is trivial if ALL of**:
+- No ORDER BY, SKIP, LIMIT, WHERE clause
+- Not DISTINCT
+- All items are simple `TableAlias` expressions (no aggregations, functions, or operators)
+
+**Patterns handled**:
+- `Projection → WithClause(trivial)` → skip WITH, connect Projection to WITH's input
+- `WithClause → WithClause(trivial)` → skip inner WITH, keep outer WITH with inner's input
+
+### 5. ProjectionPushDown
+
+**File**: `projection_push_down.rs` (152 lines)
+**Phase**: final_optimization (runs first in final phase)
+**Depends on**: FilterIntoGraphRel (filters should be embedded before projecting)
+
+**What it does**: Currently a recursive tree walker that propagates through all plan node
+types. The actual column elimination logic (reducing ViewScan output schemas to only
+referenced columns) is a TODO — the infrastructure is in place but the optimization itself
+is primarily structural pass-through.
+
+### 6. CleanupViewScanFilters
+
+**File**: `cleanup_viewscan_filters.rs` (340 lines)
+**Phase**: final_optimization (runs after ProjectionPushDown)
+**Depends on**: FilterIntoGraphRel (from initial_optimization)
+
+**What it does**: Removes `ViewScan.view_filter` fields that became redundant after
+FilterIntoGraphRel consolidated filters into `GraphRel.where_predicate`.
+
+**Context-aware clearing**:
+- ViewScans **inside** a GraphRel subtree → clear `view_filter` (redundant with GraphRel.where_predicate)
+- ViewScans **outside** a GraphRel (node-only queries) → **keep** `view_filter` (no GraphRel to hold it)
+
+**Implementation**: Uses `optimize_with_context(plan, ctx, inside_graph_rel: bool)` to track
+whether current traversal is inside a GraphRel subtree. Sets `inside_graph_rel = true` when
+entering a GraphRel node, propagates to all its children (left, center, right).
+
+### 7. FilterPushDown
+
+**File**: `filter_push_down.rs` (169 lines)
+**Phase**: final_optimization (runs after CleanupViewScanFilters)
+**Depends on**: CleanupViewScanFilters
+
+**What it does**: Currently a recursive tree walker that propagates through all plan node
+types using `rebuild_or_clone`. Like ProjectionPushDown, the advanced filter movement logic
+(pushing filters through joins, aggregations, etc.) is infrastructure-ready but the deep
+pushdown strategy is a TODO.
+
+**Note on ViewScan**: Has a commented TODO for merging additional filters into
+`ViewScan.view_filter` respecting view mappings and property transformations.
+
+### 8. ViewOptimizer
+
+**File**: `view_optimizer.rs` (349 lines)
+**Phase**: final_optimization (runs last)
+**Depends on**: All prior passes
+
+**What it does**: Schema-aware optimizations on ViewScan nodes:
+1. **Property access optimization** — calls `ViewScan.optimize_property_access()`
+2. **Filter simplification** — flattens nested AND expressions: `(A AND B) AND C → A AND B AND C`
+3. **Join order optimization** — placeholder for future selectivity-based reordering
+
+**Configuration flags**:
+- `enable_filter_pushdown: bool` (default: true)
+- `enable_property_optimization: bool` (default: true)
+- `enable_join_optimization: bool` (default: true, but logic is TODO)
+
+### union_pruning (Standalone Utility)
+
+**File**: `union_pruning.rs` (225 lines)
+**Phase**: Not a pipeline pass — called from `logical_plan/match_clause/traversal.rs`
+**Depends on**: `utils::id_encoding::IdEncoding` for ID decoding
+
+**What it does**: Extracts node label information from WHERE clause `id(var) IN [...]`
+patterns to prune unnecessary UNION branches.
+
+**Problem solved**: `MATCH (a)-[r]->(b) WHERE id(a) IN [281474976710657]` would generate
+UNION of ALL relationship types. By decoding the ID to extract the label (e.g., User),
+only User-related relationship branches are generated.
+
+**Patterns recognized**:
+- `id(var) IN [id1, id2, ...]` — extract labels from each ID via `IdEncoding::decode_with_label()`
+- `id(var) = id_value` — single ID equality
+- Recurses through AND/OR operators
+- Respects NOT negation (skips extraction inside NOT)
+
+**Returns**: `HashMap<String, HashSet<String>>` — variable name → set of possible labels
+
+## Critical Invariants
+
+### 1. FilterIntoGraphRel Must Run Exactly Once
+Running it in both `initial_optimization` and `final_optimization` causes duplicate
+filters in the generated SQL. The comment in `final_optimization` explicitly warns:
+```rust
+// FilterIntoGraphRel already ran in initial_optimization - don't run it again!
+// Running it twice causes duplicate filters.
+```
+
+### 2. CartesianJoinExtraction Must Run Before FilterIntoGraphRel
+Cross-pattern filters (referencing aliases from both sides of a CartesianProduct) must
+be extracted as join conditions BEFORE FilterIntoGraphRel embeds them into a single
+GraphRel. Otherwise, the join semantics are lost.
+
+### 3. CleanupViewScanFilters Must Run After FilterIntoGraphRel
+This pass clears ViewScan.view_filter only inside GraphRel contexts. If it runs before
+FilterIntoGraphRel, it clears filters that haven't been consolidated yet, losing them.
+
+### 4. Correlated Subqueries Cannot Be JOIN Conditions
+ClickHouse limitation: correlated subqueries (NOT PathPattern, EXISTS, size()) must stay
+in WHERE clause. `partition_filter_conditions()` in CartesianJoinExtraction checks
+`contains_not_path_pattern()` and forces such predicates into remaining filters.
+
+### 5. Optional Aliases Must Not Get WHERE Filters
+Filters on optional (`OPTIONAL MATCH`) aliases must become JOIN conditions, not WHERE
+predicates. FilterIntoGraphRel skips filter injection for aliases in
+`plan_ctx.get_optional_aliases()`.
+
+### 6. Multi-Hop GraphRel Left Connection Filters Belong to Inner GraphRel
+When a GraphRel's left child is also a GraphRel (multi-hop pattern), the left_connection's
+filters should be handled by the inner GraphRel, not the outer one. FilterIntoGraphRel
+checks `matches!(graph_rel.left.as_ref(), LogicalPlan::GraphRel(_))` and skips.
+
+### 7. Transformed Enum Correctness
+All passes must return `Transformed::Yes(plan)` when the plan was modified and
+`Transformed::No(plan)` when unchanged. This is used by `rebuild_or_clone()` helpers
+to avoid unnecessary allocations. Getting this wrong causes subtle bugs where changes
+are silently dropped.
+
+### 8. CollectUnwindElimination Alias Maps Must Propagate
+When eliminating collect+UNWIND, the alias map must propagate upward through all
+intervening plan nodes. Missing propagation causes "column not found" errors when
+downstream expressions reference the UNWIND alias that no longer exists.
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| Duplicate filters in SQL | Same WHERE condition appears twice | FilterIntoGraphRel ran twice (initial + final) |
+| CROSS JOIN instead of JOIN ON | Cartesian product where JOIN expected | CartesianJoinExtraction didn't run or didn't detect cross-pattern filter |
+| Filter lost for node-only queries | `MATCH (n:Label) WHERE n.x = 1` returns all rows | FilterIntoGraphRel missing ViewScan handler; CleanupViewScanFilters clearing outside GraphRel |
+| Correlated subquery in JOIN ON | ClickHouse error / wrong results | `partition_filter_conditions` not checking `contains_not_path_pattern()` |
+| Optional alias filtered in WHERE | LEFT JOIN returns wrong results (like INNER JOIN) | FilterIntoGraphRel not checking `plan_ctx.get_optional_aliases()` |
+| Column not found after elimination | "Unknown column" in SQL | CollectUnwindElimination alias map not propagated through all node types |
+| Filter on wrong GraphRel | Multi-hop: filter applied at wrong hop level | Left connection filter not skipped when left child is GraphRel |
+| ViewScan filter cleared incorrectly | Node-only query filter lost | CleanupViewScanFilters set `inside_graph_rel = true` for non-GraphRel parent |
+| Trivial WITH incorrectly eliminated | WITH with aggregation removed | `is_trivial_with()` not checking all expression types |
+
+## Public API
+
+### Pipeline Functions (mod.rs)
+
+```rust
+/// Phase 1: CartesianJoinExtraction → FilterIntoGraphRel
+pub fn initial_optimization(
+    plan: Arc<LogicalPlan>,
+    plan_ctx: &mut PlanCtx,
+) -> OptimizerResult<Arc<LogicalPlan>>;
+
+/// Phase 3: ProjectionPushDown → CleanupViewScanFilters → FilterPushDown → ViewOptimizer
+pub fn final_optimization(
+    plan: Arc<LogicalPlan>,
+    plan_ctx: &mut PlanCtx,
+) -> OptimizerResult<Arc<LogicalPlan>>;
+```
+
+### OptimizerPass Trait (optimizer_pass.rs)
+
+```rust
+pub type OptimizerResult<T> = Result<T, OptimizerError>;
+
+pub trait OptimizerPass {
+    fn optimize(
+        &self,
+        logical_plan: Arc<LogicalPlan>,
+        plan_ctx: &mut PlanCtx,
+    ) -> OptimizerResult<Transformed<Arc<LogicalPlan>>>;
+}
+```
+
+### Pass Constructors
+
+| Pass | Constructor | Visibility |
+|------|-------------|------------|
+| `CartesianJoinExtraction` | `::new()` | `pub` (used in mod.rs) |
+| `FilterIntoGraphRel` | `::new()` | `pub` (used in mod.rs) |
+| `ProjectionPushDown` | `::new()` | `pub(crate)` (used in mod.rs) |
+| `FilterPushDown` | `::new()` | `pub(crate)` (used in mod.rs) |
+| `ViewOptimizer` | `::new()` / `::default()` | `pub(crate)` (used in mod.rs) |
+| `CleanupViewScanFilters` | unit struct | `pub(crate)` (used in mod.rs) |
+| `CollectUnwindElimination` | unit struct | `pub` (used in analyzer/mod.rs) |
+| `TrivialWithElimination` | unit struct | `pub` (used in analyzer/mod.rs) |
+
+### Standalone Functions
+
+```rust
+/// Extract node labels from WHERE clause id() patterns (union_pruning.rs)
+pub fn extract_labels_from_id_where(
+    where_clause: &ast::WhereClause<'_>,
+) -> HashMap<String, HashSet<String>>;
+```
+
+### Error Types (errors.rs)
+
+```rust
+pub enum OptimizerError {
+    CombineFilterPredicate,        // Failed to combine filter predicates
+    PlanCtx { pass: Pass, source: PlanCtxError },  // PlanCtx error in a specific pass
+}
+
+pub enum Pass {
+    ProjectionPushDown,
+    FilterPushDown,
+}
+```
+
+## Dependencies
+
+### Upstream (optimizer imports from)
+- `query_planner::logical_plan` — `LogicalPlan`, `GraphRel`, `Filter`, `Projection`, `ViewScan`, etc.
+- `query_planner::logical_expr` — `LogicalExpr`, `Operator`, `PropertyAccess`, `TableAlias`, etc.
+- `query_planner::plan_ctx::PlanCtx` — filter storage per alias, optional alias tracking, schema access
+- `query_planner::transformed::Transformed` — `Yes`/`No` enum for tracking plan modifications
+- `graph_catalog::expression_parser::PropertyValue` — for `qualify_columns_with_alias()`
+- `open_cypher_parser::ast` — AST types in `union_pruning.rs`
+- `utils::id_encoding::IdEncoding` — ID decoding in `union_pruning.rs`
+
+### Downstream (who imports optimizer)
+- `query_planner::analyzer::mod.rs` — calls `CollectUnwindElimination`, `TrivialWithElimination`
+- `query_planner::logical_plan::match_clause::traversal.rs` — calls `extract_labels_from_id_where()`
+- `query_planner/mod.rs` (or equivalent orchestrator) — calls `initial_optimization()`, `final_optimization()`
+
+## Testing Guidance
+
+### Running Tests
+
+```bash
+# All optimizer unit tests
+cargo test --lib optimizer
+
+# Specific pass tests
+cargo test --lib cartesian_join_extraction
+cargo test --lib collect_unwind_elimination
+cargo test --lib trivial_with_elimination
+cargo test --lib view_optimizer
+cargo test --lib union_pruning
+cargo test --lib filter_into_graph_rel
+
+# Full test suite (includes integration tests that exercise optimization)
+cargo test
+```
+
+### Test Coverage Notes
+
+| Pass | Unit Tests | Notes |
+|------|:----------:|-------|
+| CartesianJoinExtraction | 1 test | Tests `collect_aliases_from_expr()` helper. Full coverage via integration tests. |
+| FilterIntoGraphRel | 2 tests | Minimal — tests parse + documents PlanCtx pattern. Complex struct setup needed for full unit tests. Relies on integration tests (test_where_simple.py). |
+| CollectUnwindElimination | 2 tests | Good coverage: simple + complex elimination patterns with plan construction. |
+| TrivialWithElimination | 3 tests | Good coverage: trivial detection, DISTINCT rejection, aggregation rejection. |
+| ViewOptimizer | 4 tests | Constructor, filter simplification, AND flattening, ViewScan optimization. |
+| CleanupViewScanFilters | 0 tests | No unit tests. Behavior validated by integration tests. |
+| FilterPushDown | 0 tests | No unit tests. Structural pass-through validated by integration tests. |
+| ProjectionPushDown | 0 tests | No unit tests. Structural pass-through. |
+| union_pruning | 3 tests | Smoke tests for `extract_labels_from_id_where()` and negation handling. |
+
+### Key Integration Tests
+
+The optimizer passes are heavily tested via end-to-end integration tests that verify
+the generated SQL. Key test files:
+
+- `tests/integration/` — Query-to-SQL pipeline tests
+- `test_where_simple.py` — Validates FilterIntoGraphRel for node-only queries
+- Benchmark queries in `benchmarks/social_network/queries/` — exercise multi-hop, optional, variable-length paths
+
+### Adding a New Optimization Pass
+
+1. Create `new_pass.rs` implementing `OptimizerPass`
+2. Add `mod new_pass;` (or `pub mod`) to `mod.rs`
+3. Determine placement: initial_optimization, final_optimization, or analyzer-invoked
+4. Add to the appropriate function in `mod.rs` or `analyzer/mod.rs`
+5. **Order matters**: document why it must run before/after specific passes
+6. Add unit tests that construct plan nodes and verify transformations
+7. Run full test suite: `cargo test` to verify no regressions

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1,0 +1,341 @@
+# server Module — Agent Guide
+
+> **Purpose**: HTTP + Bolt protocol server layer. Receives Cypher queries, orchestrates the
+> full pipeline (parse → plan → render → SQL gen → ClickHouse execution), manages schema
+> lifecycle, query caching, connection pooling, and parameter substitution.
+> This is the entry point for ALL query processing. Understand the data flow before changing anything.
+
+## Module Architecture
+
+```
+                        ┌──────────────────────────────────────────┐
+                        │              mod.rs                      │
+                        │  Server startup, routing, global statics │
+                        │  GLOBAL_SCHEMAS, GLOBAL_SCHEMA_CONFIGS   │
+                        │  GLOBAL_QUERY_CACHE                      │
+                        └────────┬────────────────────┬────────────┘
+                                 │                    │
+              ┌──────────────────┤                    │
+              ▼                  ▼                    ▼
+    ┌─────────────────┐  ┌──────────────────┐  ┌───────────────────────┐
+    │  handlers.rs    │  │ sql_generation_  │  │  bolt_protocol/       │
+    │  (1243 lines)   │  │ handler.rs (425) │  │  (7986 lines total)   │
+    │                 │  │                  │  │                       │
+    │  POST /query    │  │  POST /query/sql │  │  bolt://localhost:7687│
+    │  GET  /health   │  │  SQL-only, no    │  │  Neo4j Bolt v4.1–5.8 │
+    │  GET  /schemas  │  │  execution       │  │  TCP + WebSocket      │
+    │  POST /schemas  │  │                  │  │                       │
+    └──────┬──────────┘  └──────┬───────────┘  └───────────────────────┘
+           │                    │
+           ▼                    ▼
+    ┌──────────────────────────────────────────────────────────────┐
+    │               Shared Infrastructure                         │
+    │                                                              │
+    │  query_context.rs (403)  — task-local per-query state       │
+    │  query_cache.rs   (581)  — LRU cache for SQL templates      │
+    │  parameter_substitution.rs (368) — $param → SQL escaping    │
+    │  graph_catalog.rs (858)  — schema init/load/validate        │
+    │  connection_pool.rs (158) — role-based ClickHouse pools     │
+    │  clickhouse_client.rs (75) — client factory                 │
+    │  models.rs        (257)  — request/response types           │
+    └──────────────────────────────────────────────────────────────┘
+```
+
+## Data Flow: Query Request Lifecycle
+
+```
+Client POST /query  { "query": "MATCH (n:User) RETURN n", "schema_name": "default" }
+    │
+    ▼
+handlers.rs::query_handler()
+    │
+    ├── 1. Extract payload fields (format, sql_only, schema_name, parameters)
+    ├── 2. Strip CYPHER prefix, extract ReplanOption, strip comments
+    ├── 3. Check for procedure calls (early return if standalone CALL/UNION)
+    ├── 4. Parse query to extract USE clause → determine schema_name
+    │
+    ├── 5. Create QueryContext, wrap in with_query_context()  ← CRITICAL
+    │      └── query_handler_inner() runs inside task-local scope
+    │
+    ├── 6. Check query cache (unless replan=force)
+    │      Cache HIT → substitute params → execute/return
+    │
+    ├── 7. Resolve schema: graph_catalog::get_graph_schema_by_name()
+    │      └── set_current_schema(Arc<GraphSchema>) in task-local context
+    │
+    ├── 8. Parse:  open_cypher_parser::parse_cypher_statement()
+    ├── 9. Plan:   query_planner::evaluate_read_statement()
+    ├── 10. Render: logical_plan.to_render_plan_with_ctx()
+    ├── 11. SQL:    clickhouse_query_generator::generate_sql()
+    │
+    ├── 12. Cache SQL template (GLOBAL_QUERY_CACHE)
+    │
+    ├── 13. Parameter substitution (merge view_parameters + query parameters)
+    ├── 14. Check for unsubstituted $param placeholders
+    │
+    └── 15. Execute via connection_pool.get_client(role) → ClickHouse
+            Return JSON/Pretty/CSV response with performance headers
+```
+
+## Key Files
+
+| File | Lines | Responsibility |
+|------|------:|---------------|
+| `mod.rs` | 441 | Server startup, axum routing, global `OnceCell` statics, Bolt server spawn, signal handling |
+| `handlers.rs` | 1243 | HTTP handlers: `query_handler` (main entry), `health_check`, schema CRUD, `execute_cte_queries`, performance metrics |
+| `sql_generation_handler.rs` | 425 | `POST /query/sql` — translate-only endpoint, no ClickHouse execution, structured error responses |
+| `graph_catalog.rs` | 858 | Schema lifecycle: `initialize_global_schema`, `load_schema_from_content`, `get_graph_schema_by_name`, DB fallback, schema validation, `monitor_schema_updates` |
+| `query_cache.rs` | 581 | LRU cache: `QueryCache`, `QueryCacheKey`, `ReplanOption` (CYPHER replan=force/skip), `CacheMetrics`, schema-scoped invalidation |
+| `query_context.rs` | 403 | **Task-local context** via `tokio::task_local!`: schema, denormalized aliases, relationship columns, CTE property mappings, multi-type VLP aliases |
+| `parameter_substitution.rs` | 368 | `substitute_parameters()`, `find_unsubstituted_parameter()`, SQL injection prevention via string escaping |
+| `models.rs` | 257 | `QueryRequest`, `OutputFormat`, `SqlDialect`, `SqlGenerationRequest/Response`, `SqlOnlyResponse` |
+| `connection_pool.rs` | 158 | `RoleConnectionPool`: lazy-initialized per-role ClickHouse client pools with read/write lock |
+| `clickhouse_client.rs` | 75 | `try_get_client()`: creates ClickHouse client from env vars with safety limits (60s timeout, 1M rows, 1GB result) |
+| `bolt_protocol/` | 7986 | Neo4j Bolt v4.1–5.8 wire protocol (see separate section below) |
+
+**Total**: ~12,795 lines (server core: 4,809 + bolt: 7,986)
+
+## Critical Invariants
+
+### 1. Schema Access Pattern — MOST IMPORTANT
+
+**Rule**: All query-processing code MUST access schema via task-local `QueryContext`, NEVER directly from `GLOBAL_SCHEMAS`.
+
+```rust
+// ✅ CORRECT — in query-processing code
+use crate::server::query_context::get_current_schema;
+let schema = get_current_schema().expect("schema must be set");
+
+// ✅ CORRECT — in code also called from unit tests (fallback to GLOBAL_SCHEMAS)
+use crate::server::query_context::get_current_schema_with_fallback;
+let schema = get_current_schema_with_fallback();
+
+// ❌ WRONG — direct GLOBAL_SCHEMAS access in query processing
+let schemas = GLOBAL_SCHEMAS.get().unwrap().read().await;
+let schema = schemas.get("default");  // Non-deterministic in multi-schema!
+```
+
+**Where GLOBAL_SCHEMAS is appropriate**: `mod.rs` (init), `graph_catalog.rs` (admin), `bolt_protocol/handler.rs` (connection setup), test setup.
+
+### 2. with_query_context() Wrapping
+
+`handlers.rs::query_handler()` creates a `QueryContext` and wraps **all** downstream processing in `with_query_context()`. Without this wrapper, `task_local!` variables return `None` and schema lookups silently fail.
+
+```rust
+// handlers.rs line ~395
+let context = QueryContext::new(Some(schema_name.clone()));
+with_query_context(context, async move {
+    query_handler_inner(/* ... */).await
+}).await
+```
+
+### 3. Schema Name Resolution Order
+
+Schema name is determined in this priority:
+1. `USE <schema>` clause in the Cypher query (parsed from AST)
+2. `schema_name` field in the JSON request body
+3. `"default"` fallback
+
+### 4. Parse Before Schema Lookup
+
+Syntax validation happens BEFORE schema resolution. This prevents misleading "Schema not found" errors when the real issue is a parse error. See `handlers.rs` ~line 340.
+
+### 5. Parameter Substitution After Cache
+
+Cache stores SQL **templates** with `$paramName` placeholders. Parameter substitution happens AFTER cache retrieval, keeping cache entries reusable across different parameter values.
+
+### 6. Global Statics Initialization Order
+
+```
+1. GLOBAL_SCHEMA_CONFIG  (legacy, deprecated)
+2. GLOBAL_SCHEMAS        (HashMap<String, GraphSchema>)
+3. GLOBAL_SCHEMA_CONFIGS (HashMap<String, GraphSchemaConfig>)
+4. GLOBAL_QUERY_CACHE    (QueryCache)
+```
+
+All use `OnceCell<RwLock<...>>` — set exactly once at startup. `GLOBAL_QUERY_CACHE` uses `OnceCell` without `RwLock` (internal `Mutex`).
+
+## Common Bug Patterns
+
+| Pattern | Symptom | Root Cause |
+|---------|---------|------------|
+| Schema not in task-local | `get_current_schema()` returns `None` | Missing `with_query_context()` wrapper or `set_current_schema()` not called |
+| Misleading "Schema not found" | User sees schema error for typo in query | Parse error check missing before schema lookup |
+| Cached SQL with wrong params | Query returns wrong results | Cache key doesn't differentiate parameter values (by design — params substituted after) |
+| Stale cache after schema reload | Old SQL references wrong columns | `invalidate_schema()` not called after schema reload |
+| `$param` in executed SQL | ClickHouse syntax error | Missing `view_parameters` in request; `find_unsubstituted_parameter` check catches this |
+| Mutex poisoning in cache | Cache silently disabled | Panic in another thread holding cache lock; `lock_cache!` macro degrades gracefully |
+| Role pool accumulation | Memory growth over time | Role pools are never evicted (lazy-init only); acceptable for bounded role sets |
+| Connection timeout | Bolt connection drops | Default 300s timeout in `BoltConfig`; configurable |
+
+## HTTP API Routes
+
+| Method | Path | Handler | Purpose |
+|--------|------|---------|---------|
+| GET | `/health` | `health_check` | Service health + version |
+| POST | `/query` | `query_handler` | Full Cypher→SQL→execute pipeline |
+| POST | `/query/sql` | `sql_generation_handler` | Cypher→SQL translation only (no execution) |
+| GET | `/schemas` | `list_schemas_handler` | List loaded schemas |
+| POST | `/schemas/load` | `load_schema_handler` | Load YAML schema at runtime |
+| GET | `/schemas/{name}` | `get_schema_handler` | Get schema details |
+
+## Key Types
+
+### AppState (shared across all requests)
+```rust
+pub struct AppState {
+    pub clickhouse_client: Client,          // Default ClickHouse client
+    pub connection_pool: Arc<RoleConnectionPool>,  // Role-based pools
+    pub config: ServerConfig,               // CLI/env configuration
+}
+```
+
+### QueryContext (per-request, task-local)
+```rust
+pub struct QueryContext {
+    pub schema_name: Option<String>,
+    pub schema: Option<Arc<GraphSchema>>,
+    pub denormalized_aliases: HashMap<String, String>,
+    pub relationship_columns: HashMap<String, (String, String)>,
+    pub cte_property_mappings: HashMap<String, HashMap<String, String>>,
+    pub multi_type_vlp_aliases: HashMap<String, String>,
+}
+```
+
+### QueryRequest (HTTP input)
+```rust
+pub struct QueryRequest {
+    pub query: String,
+    pub format: Option<OutputFormat>,       // JSONEachRow, Pretty, CSV, etc.
+    pub sql_only: Option<bool>,             // Return SQL without executing
+    pub schema_name: Option<String>,        // Schema selection
+    pub parameters: Option<HashMap<String, Value>>,  // Query params ($userId)
+    pub view_parameters: Option<HashMap<String, Value>>,  // View params (tenant_id)
+    pub role: Option<String>,               // ClickHouse RBAC role
+    pub max_inferred_types: Option<usize>,  // For generic patterns [*1]
+    pub tenant_id: Option<String>,          // Multi-tenant deployments
+}
+```
+
+## Dependencies
+
+### Upstream (this module calls)
+- `open_cypher_parser` — parse Cypher queries
+- `query_planner` — logical planning (`evaluate_read_statement`, `evaluate_call_query`)
+- `render_plan` — logical plan → render plan conversion
+- `clickhouse_query_generator` — render plan → SQL string
+- `graph_catalog` — schema types and config parsing
+- `procedures` — procedure execution (schema_info, etc.)
+- `config` — `ServerConfig` from CLI/env
+
+### Downstream (external crates)
+- `axum` — HTTP framework (routing, extraction, response)
+- `clickhouse` — ClickHouse client (query execution)
+- `tokio` — async runtime, `task_local!`, `OnceCell`, `RwLock`
+- `serde_json` — JSON serialization
+- `dotenvy` — environment variable loading
+
+## Testing
+
+### Unit Tests (in-file `#[cfg(test)]`)
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `connection_pool.rs` | 1 (#[ignore]) | Pool creation, role isolation |
+| `parameter_substitution.rs` | 8 | Escaping, substitution, SQL injection prevention |
+| `query_cache.rs` | 5 | LRU eviction, schema invalidation, metrics, replan parsing |
+| `query_context.rs` | 2 | Task-local isolation, denormalized aliases |
+
+### Integration Tests
+- `tests/integration/` — E2E tests via HTTP API
+- `tests/integration/bolt/` — Bolt protocol tests
+- Require running ClickHouse + server instance
+
+### Manual Testing
+```bash
+# Start server
+export GRAPH_CONFIG_PATH="./benchmarks/social_network/schemas/social_benchmark.yaml"
+cargo run --bin clickgraph
+
+# Health check
+curl http://localhost:8080/health
+
+# Query
+curl -X POST http://localhost:8080/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User) RETURN u.name LIMIT 5"}'
+
+# SQL-only (no execution)
+curl -X POST http://localhost:8080/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User) RETURN u.name", "sql_only": true}'
+
+# SQL generation endpoint (structured response)
+curl -X POST http://localhost:8080/query/sql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User) RETURN u.name"}'
+```
+
+## Bolt Protocol Sub-Module
+
+The `bolt_protocol/` directory (7,986 lines, 11 files) implements the Neo4j Bolt wire protocol for compatibility with Neo4j Browser, drivers, and tools. **It warrants its own AGENTS.md.**
+
+### Quick Summary
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `mod.rs` | 383 | `BoltServer`, `BoltContext`, `BoltConfig`, `ConnectionState` enum, version constants (5.8→4.1) |
+| `handler.rs` | 1825 | **Core** — processes HELLO/LOGON/RUN/PULL/BEGIN/COMMIT/ROUTE, integrates with query pipeline |
+| `result_transformer.rs` | 2145 | **Largest** — transforms ClickHouse rows → Neo4j Node/Relationship/Path graph objects |
+| `graph_objects.rs` | 716 | `Node`, `Relationship`, `Path` structs with packstream binary encoding |
+| `connection.rs` | 604 | Handshake, version negotiation, message read/write loop, chunked encoding |
+| `id_mapper.rs` | 570 | Deterministic int↔elementId mapping (53-bit JS-safe, label-encoded, session-scoped) |
+| `messages.rs` | 562 | `BoltMessage`, `BoltValue`, message signatures (HELLO=0x01, RUN=0x10, SUCCESS=0x70, etc.) |
+| `id_rewriter.rs` | 411 | Rewrites `id(alias) = N` queries → property filters for Neo4j Browser expand |
+| `auth.rs` | 401 | `AuthScheme` (None/Basic/Kerberos), `AuthToken`, `Authenticator` with SHA-256 |
+| `errors.rs` | 213 | `BoltError` enum with Neo4j-compatible error codes |
+| `websocket.rs` | 156 | `WebSocketBoltAdapter` — wraps WebSocket as AsyncRead/AsyncWrite for Bolt-over-WS |
+
+### Bolt Data Flow
+```
+Neo4j Browser/Driver → TCP or WebSocket
+    │
+    ├── connection.rs: handshake + version negotiation (4.1–5.8)
+    ├── handler.rs: HELLO → LOGON → RUN(cypher) → PULL
+    │   ├── Query pipeline same as HTTP (parse→plan→render→SQL→execute)
+    │   ├── result_transformer.rs: flat rows → Node/Relationship/Path objects
+    │   └── id_mapper.rs: generate integer IDs for id() compat
+    └── connection.rs: serialize BoltMessage → packstream → chunked TCP
+```
+
+### Bolt-Specific Concerns
+- **State machine**: Connected → Negotiated → Authentication → Ready → Streaming → Failed
+- **Version negotiation**: Server picks highest mutually supported version from client's 4 proposals
+- **ID mapping**: `id_mapper.rs` encodes label (6 bits) + id hash (47 bits) within JS MAX_SAFE_INTEGER
+- **`id_rewriter.rs`**: Neo4j Browser expand/double-click sends `id(n) = 12345`; rewriter decodes to property filter
+- **Thread safety**: `BoltContext` wrapped in `Arc<Mutex<>>` per connection (NOT task-local like HTTP)
+- **All bolt_protocol files have unit tests** (13 test modules total)
+
+## Files You Should NOT Touch Casually
+
+- **handlers.rs** — 1243 lines, orchestrates the entire HTTP query pipeline. Any change to the
+  flow (cache lookup, schema resolution, parameter substitution order) can break query semantics.
+- **graph_catalog.rs** — Schema initialization has multiple fallback paths (YAML → DB → empty).
+  Changing initialization order can leave `GLOBAL_SCHEMAS` unset.
+- **query_context.rs** — The `task_local!` pattern is subtle. Adding new fields requires updating
+  `set_all_render_contexts()` and `clear_all_render_contexts()`.
+- **bolt_protocol/result_transformer.rs** — 2145 lines, the most complex Bolt file. Transforms
+  flat rows to graph objects with label inference, element_id generation, and VLP path reconstruction.
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLICKHOUSE_URL` | (required) | ClickHouse HTTP endpoint |
+| `CLICKHOUSE_USER` | (required) | ClickHouse username |
+| `CLICKHOUSE_PASSWORD` | (required) | ClickHouse password |
+| `CLICKHOUSE_DATABASE` | `"default"` | Default database |
+| `GRAPH_CONFIG_PATH` | (optional) | YAML schema file path |
+| `CLICKGRAPH_QUERY_CACHE_ENABLED` | `true` | Enable/disable query cache |
+| `CLICKGRAPH_QUERY_CACHE_MAX_ENTRIES` | `1000` | Max cached queries |
+| `CLICKGRAPH_QUERY_CACHE_MAX_SIZE_MB` | `100` | Max cache memory |

--- a/src/server/bolt_protocol/AGENTS.md
+++ b/src/server/bolt_protocol/AGENTS.md
@@ -1,0 +1,460 @@
+# AGENTS.md — server/bolt_protocol
+
+> Neo4j Bolt Protocol v4.1–5.8 implementation for ClickGraph.
+> Enables Neo4j Browser, Neo4j Desktop, and any Bolt-compatible driver to query ClickGraph.
+
+## 1. Module Purpose and Role
+
+This sub-module implements the **Neo4j Bolt binary wire protocol**, allowing ClickGraph to masquerade as a Neo4j server. Clients connect over TCP (default port 7687) or WebSocket, negotiate a protocol version, authenticate, and then send Cypher queries. The module:
+
+1. **Accepts connections** — handshake, version negotiation (Bolt 4.1–5.8)
+2. **Authenticates** — Basic, None, or Kerberos (stub) schemes
+3. **Executes queries** — delegates to ClickGraph's parser → planner → SQL generator → ClickHouse pipeline
+4. **Transforms results** — converts flat ClickHouse JSON rows into packstream-encoded Node, Relationship, and Path graph objects
+5. **Manages IDs** — maps ClickGraph's string-based `element_id` (e.g., `"User:42"`) to 53-bit integers that Neo4j Browser expects from `id()`
+6. **Rewrites queries** — intercepts Neo4j Browser's `id(n) = N` expand queries and rewrites them to property filters
+
+This module is the **only alternative transport** to the HTTP API. It is critical for Neo4j Browser visualization.
+
+## 2. Architecture Overview
+
+### Connection Lifecycle
+
+```
+Client TCP connect
+       │
+       ▼
+┌─────────────────┐
+│   Connected     │  (waiting for magic preamble + version proposals)
+└────────┬────────┘
+         │ perform_handshake()
+         ▼
+┌─────────────────┐
+│   Negotiated    │  (version agreed, waiting for HELLO)
+└────────┬────────┘
+         │ handle_hello()
+         ▼
+┌─────────────────┐   Bolt 5.1+: HELLO → Authentication → LOGON → Ready
+│ Authentication  │   Bolt 4.x:  HELLO (with auth) → Ready
+└────────┬────────┘
+         │ handle_logon() or handle_hello() with auth
+         ▼
+┌─────────────────┐
+│     Ready       │ ◄──── RESET resets to here
+└────────┬────────┘
+         │ handle_run()
+         ▼
+┌─────────────────┐
+│   Streaming     │  (results cached, waiting for PULL/DISCARD)
+└────────┬────────┘
+         │ handle_pull() / handle_discard()
+         ▼
+┌─────────────────┐
+│     Ready       │  (back to ready for next query)
+└─────────────────┘
+
+GOODBYE → Failed (connection closes)
+Error   → Failed (connection closes)
+LOGOFF  → Authentication (Bolt 5.1+ re-auth)
+```
+
+### Message Flow for a Query
+
+```
+Client                          BoltHandler                    ClickHouse
+  │                                │                              │
+  │── RUN "MATCH (n:User)..." ────▶│                              │
+  │                                │── parse Cypher               │
+  │                                │── rewrite id() predicates    │
+  │                                │── plan query                 │
+  │                                │── generate SQL               │
+  │                                │── execute SQL ──────────────▶│
+  │                                │◀──── JSON rows ──────────────│
+  │                                │── transform_row() (→ Node/Rel/Path)
+  │                                │── cache results              │
+  │◀──── SUCCESS {fields} ────────│                              │
+  │                                │                              │
+  │── PULL {n: -1} ──────────────▶│                              │
+  │◀──── RECORD [Node{...}] ─────│                              │
+  │◀──── RECORD [Node{...}] ─────│                              │
+  │◀──── SUCCESS {has_more:false} │                              │
+```
+
+### Key Data Structures
+
+- **`BoltContext`** — per-connection mutable state (current state, user, schema, `IdMapper`)
+- **`BoltConfig`** — server-wide immutable config (max message size, timeouts, auth settings)
+- **`BoltServer`** — top-level server that spawns `BoltConnection` per TCP accept
+- **`BoltHandler`** — stateful message handler holding `BoltContext`, `Authenticator`, cached results
+- **`IdMapper`** — session-scoped bidirectional map: `element_id ↔ i64`
+
+## 3. Files
+
+| File | Lines | Responsibility |
+|---|---|---|
+| `mod.rs` | 384 | Module root. Constants (`BOLT_VERSION_*`, `SUPPORTED_VERSIONS`), `ConnectionState` enum, `BoltContext`, `BoltConfig`, `BoltServer`, version negotiation utils. |
+| `handler.rs` | 1826 | **Core orchestrator.** Handles every Bolt message type (HELLO, LOGON, RUN, PULL, BEGIN, COMMIT, ROUTE, etc.). Contains `execute_cypher_query()` which runs the full parse→plan→SQL→execute→transform pipeline. Parameter substitution for `id()` predicates. |
+| `result_transformer.rs` | 2146 | **Largest file.** `extract_return_metadata()` analyzes logical plan to classify return items as Node/Relationship/Path/Scalar/IdFunction. `transform_row()` converts flat ClickHouse rows into packstream-encoded graph objects. Handles fixed-hop paths, VLP paths, multi-label scans, UNION path JSON format, polymorphic edges. |
+| `graph_objects.rs` | 717 | `Node`, `Relationship`, `Path` structs with `to_packstream()` methods. Custom packstream encoding helpers (`encode_integer`, `encode_string`, `encode_properties_map`, `encode_json_value`). |
+| `connection.rs` | 605 | `BoltConnection<S>` — wire-level I/O. Handshake (magic preamble + version negotiation), chunked message reading/writing, packstream message parsing/serialization. Generic over `AsyncRead + AsyncWrite`. |
+| `id_mapper.rs` | 571 | Deterministic 53-bit ID mapping. Label-encoded IDs (6 bits label code + 47 bits id value). Session cache with cross-session chaining via `ACTIVE_SESSION_CACHES` global registry. |
+| `messages.rs` | 563 | `BoltMessage` and `BoltValue` types. Message constructors (hello, run, pull, success, failure, record). Field extractors for auth tokens, database, query, parameters, tenant_id, role, view_parameters. |
+| `id_rewriter.rs` | 412 | Regex-based Cypher query rewriter for `id(alias) = N`, `id(alias) IN [...]`, `NOT id(alias) IN [...]`, `ORDER BY id(alias)`. Translates encoded integer IDs back to `__node_id__` property filters. |
+| `auth.rs` | 402 | `AuthScheme`, `AuthToken`, `AuthenticatedUser`, `Authenticator`. SHA-256 password hashing, static user database. Auth disabled by default for development. |
+| `errors.rs` | 214 | `BoltError` enum with Neo4j-compatible error codes (`Neo.ClientError.*`, `Neo.TransientError.*`). `is_recoverable()` method. |
+| `websocket.rs` | 157 | `WebSocketBoltAdapter` — wraps `WebSocketStream<TcpStream>` to implement `AsyncRead + AsyncWrite`, enabling Bolt-over-WebSocket (for browser-based clients). |
+
+**Total: ~7,997 lines**
+
+## 4. Bolt Protocol State Machine
+
+```rust
+pub enum ConnectionState {
+    Connected,           // TCP accepted, awaiting handshake
+    Negotiated(u32),     // Version agreed (version stored), awaiting HELLO
+    Authentication(u32), // HELLO received (Bolt 5.1+), awaiting LOGON
+    Ready,               // Authenticated, can accept RUN/BEGIN
+    Streaming,           // RUN succeeded, results cached, awaiting PULL/DISCARD
+    Failed,              // Terminal state, connection will close
+    Interrupted,         // Reserved (not currently used)
+}
+```
+
+### State Transitions
+
+| Current State | Message | Next State | Notes |
+|---|---|---|---|
+| `Connected` | handshake OK | `Negotiated(ver)` | Magic preamble + version negotiation |
+| `Negotiated` | HELLO (Bolt 5.1+) | `Authentication(ver)` | No auth in HELLO for 5.1+ |
+| `Negotiated` | HELLO (Bolt 4.x) | `Ready` | Auth included in HELLO |
+| `Authentication` | LOGON | `Ready` | Bolt 5.1+ auth completion |
+| `Ready` | RUN (success) | `Streaming` | Results cached |
+| `Ready` | RUN (failure) | `Ready` | FAILURE sent, state unchanged |
+| `Streaming` | PULL | `Ready` | Records + SUCCESS sent |
+| `Streaming` | DISCARD | `Ready` | Results discarded |
+| `Ready` | BEGIN | `Ready` | tx_id set in context |
+| `Ready` | COMMIT/ROLLBACK | `Ready` | tx_id cleared |
+| `Ready` | LOGOFF | `Authentication(ver)` | Bolt 5.1+ re-auth |
+| Any | RESET | `Ready` | Clears transaction, keeps auth |
+| Any | GOODBYE | `Failed` | No response sent |
+| Any | Error | `Failed` | Connection closes |
+
+### Bolt 4.x vs 5.1+ Authentication Flow
+
+**Bolt 4.x**: `HELLO(user_agent, {scheme, principal, credentials})` → `SUCCESS` → `Ready`
+
+**Bolt 5.1+**: `HELLO(user_agent, {})` → `SUCCESS` → `Authentication` → `LOGON({scheme, principal, credentials})` → `SUCCESS` → `Ready`
+
+### Version Negotiation Details
+
+The handshake sends 4 client version proposals (4 bytes each, big-endian). Bolt 5.x swaps major/minor byte order vs 4.x:
+- **Bolt 4.x**: `[reserved][range][major][minor]`
+- **Bolt 5.x**: `[reserved][range][minor][major]` (SWAPPED)
+
+The `negotiate_version()` function uses a heuristic: if the decoded major byte is 5–8, interpret as Bolt 5.x format; otherwise use 4.x format. Range allows a client to express "I support 5.8 down to 5.0" in a single proposal.
+
+## 5. Result Transformation Pipeline
+
+```
+ClickHouse JSON row
+    │
+    ▼
+extract_return_metadata()     ← Analyzes LogicalPlan + PlanCtx
+    │                            Classifies each RETURN item:
+    │                            - Node { labels }
+    │                            - Relationship { rel_types, from/to_label }
+    │                            - Path { start/end/rel aliases, labels, types, is_vlp }
+    │                            - IdFunction { alias, labels }
+    │                            - Scalar
+    ▼
+transform_row()               ← Per-row transformation
+    │
+    ├── Node ──────────► transform_to_node()
+    │                    1. Extract properties by alias prefix ("n.name" → "name")
+    │                    2. Resolve label (per-row __label__, metadata, schema inference)
+    │                    3. Look up ID columns from NodeSchema
+    │                    4. Generate element_id via generate_node_element_id()
+    │                    5. Assign integer id via id_mapper.get_or_assign()
+    │                    6. Encode to packstream bytes via node.to_packstream()
+    │
+    ├── Relationship ──► transform_to_relationship()
+    │                    1. Extract properties by alias prefix
+    │                    2. Handle multi-type CTE arrays (unwrap single-element arrays)
+    │                    3. Resolve from/to labels (including $any polymorphic)
+    │                    4. Extract from_id/to_id from schema-defined columns
+    │                    5. Generate element_ids for rel, start node, end node
+    │                    6. Assign integer ids via id_mapper
+    │                    7. Encode to packstream bytes
+    │
+    ├── Path ──────────► transform_to_path() or transform_vlp_path()
+    │                    Fixed-hop: find start/end nodes + relationship in row
+    │                    VLP: parse 9-field tuple [start_props, end_props, rel_props, ...]
+    │                    JSON UNION: parse _start_properties, _end_properties JSON columns
+    │                    → Path::single_hop(start, rel, end).to_packstream()
+    │
+    ├── IdFunction ────► compute element_id from row data, then
+    │                    IdMapper::compute_deterministic_id() → i64
+    │
+    └── Scalar ────────► return row[field_name] as-is (BoltValue::Json)
+```
+
+### Multi-Label Scan Detection
+
+`try_transform_multi_label_row()` checks for `{alias}_label`, `{alias}_id`, `{alias}_properties` columns — a special format used by multi-label node scans where each row carries its own label and JSON property blob.
+
+### Label Resolution Priority
+
+For nodes, label is resolved in this order:
+1. Per-row `{alias}.__label__` column (VLP/UNION queries)
+2. Metadata labels from query planning
+3. Global `__label__` column
+4. Schema inference from properties (`infer_node_label_from_properties`)
+
+## 6. ID Mapping Scheme (53-bit, Label-Encoded)
+
+### Problem
+
+Neo4j Browser calls `id(node)` which returns an integer. ClickGraph has string-based `element_id` values like `"User:42"`, `"Post:100"`, `"Airport:LAX"`. The IDs must:
+- Fit in JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1)
+- Be **unique across labels** (`"User:1"` ≠ `"Post:1"`)
+- Be **deterministic** (same element_id always → same integer)
+- Support **reverse lookup** (integer → element_id for expand queries)
+
+### Encoding Layout
+
+```
+┌──────────────────────────────────────────────────────┐
+│  53-bit ID layout (within JS MAX_SAFE_INTEGER)       │
+├──────────┬───────────────────────────────────────────┤
+│  6 bits  │           47 bits                         │
+│  label   │    id_value (raw or hash)                 │
+│  code    │    max: 140 trillion                      │
+│  (0-63)  │                                           │
+└──────────┴───────────────────────────────────────────┘
+```
+
+- **Label code** (6 bits): Assigned by `LABEL_CODE_REGISTRY` (shared with `utils::id_encoding`). Up to 64 distinct labels.
+- **ID value** (47 bits):
+  - Numeric IDs (e.g., `"42"`) → used directly if ≤ 47 bits
+  - String IDs (e.g., `"LAX"`) → `DefaultHasher` hash masked to 47 bits
+  - Composite IDs (e.g., `"tenant1|user42"`) → hash of full string
+
+### Session Cache Architecture
+
+```
+ACTIVE_SESSION_CACHES: RwLock<HashMap<u64, Arc<RwLock<SessionCache>>>>
+        │
+        ├── Connection 1: { "User:42" ↔ 12345, "Post:1" ↔ 67890 }
+        ├── Connection 2: { "User:42" ↔ 12345, "Airport:LAX" ↔ 99999 }
+        └── Connection 3: { ... }
+```
+
+- Each `IdMapper` instance registers itself on creation, unregisters on drop (when `Arc::strong_count ≤ 2`)
+- **Forward lookup** (`element_id → i64`): local cache only
+- **Reverse lookup** (`i64 → element_id`): local cache first, then cross-session chaining
+- `static_lookup_element_id()`: searches all sessions without needing an instance
+- `decode_for_query()`: tries cache lookup first, falls back to bit-pattern extraction for small numeric IDs
+
+## 7. ID Rewriting for Neo4j Browser Expand
+
+When a user double-clicks a node in Neo4j Browser, it sends queries like:
+
+```cypher
+MATCH (a) WHERE id(a) = 140737488355370 RETURN a
+MATCH (a)--(o) WHERE id(a) = 140737488355370 AND NOT id(o) IN [140737488355371, 140737488355372] RETURN o
+```
+
+### Rewrite Pipeline (`id_rewriter.rs`)
+
+1. **`rewrite_id_predicates()`** — entry point, applies all rewrite patterns:
+   - `id(alias) = N` → `(alias:Label AND alias.__node_id__ = value)`
+   - `id(alias) IN [N1, N2]` → `((alias:Label AND alias.__node_id__ = v1) OR (alias:Label AND alias.__node_id__ = v2))`
+   - `NOT id(alias) IN [...]` → `NOT ((alias:Label AND ...) OR ...)`
+   - `ORDER BY id(alias)` → `ORDER BY alias.id`
+2. ID lookup via `IdMapper::get_element_id()` (session cache + cross-session)
+3. Element ID parsed via `parse_node_element_id()` → `(label, id_values)`
+4. `__node_id__` is a **marker property** that `FilterTagging` (in query planner) recognizes and transforms to the actual schema ID column
+
+### Missing ID Handling
+
+If an encoded integer ID is not found in any session cache, the predicate is replaced with `1 = 0` (impossible condition), producing an empty result set.
+
+## 8. Critical Invariants
+
+1. **State machine ordering**: Messages MUST be processed in correct state. RUN requires `Ready`, PULL requires `Streaming`, LOGON requires `Authentication`.
+
+2. **Packstream encoding**: Graph objects (Node 0x4E, Relationship 0x52, Path 0x50, UnboundRelationship 0x72) MUST use exact byte signatures and field counts or Neo4j drivers will reject them.
+
+3. **RECORD message structure**: `RECORD` always has exactly 1 field (a LIST). The serializer in `connection.rs` wraps `BoltMessage::record(fields)` into `0xB1 [RECORD_SIG] [LIST_HEADER field1 field2 ...]`.
+
+4. **element_id is source of truth**: Integer `id` is always derived FROM `element_id` via `IdMapper::compute_deterministic_id()` — never the reverse. This ensures consistency.
+
+5. **53-bit safety**: All integer IDs MUST be ≤ `2^53 - 1` (JavaScript's `MAX_SAFE_INTEGER`). The encoding uses 6 + 47 = 53 bits.
+
+6. **Version byte order**: Bolt 5.x swaps major/minor bytes in handshake response. If you send 4.x format to a 5.x client, negotiation silently fails.
+
+7. **Rc<RefCell<>> boundary**: The Cypher AST contains `Rc<RefCell<>>` which is `!Send`. The handler parses twice: once before the async boundary (for metadata extraction), once after (for planning). This is intentional, not a bug.
+
+8. **Mutex locking**: `BoltContext` uses `std::sync::Mutex` (not `tokio::Mutex`) because locks are held briefly. The `lock_context!` macro adds proper error handling for mutex poisoning.
+
+9. **Schema access**: The handler sets the task-local `QueryContext` schema before calling the query pipeline. GLOBAL_SCHEMAS is accessed directly only for schema lookup at connection/RUN scope.
+
+10. **No write operations**: RUN rejects non-Read query types. Transactions (BEGIN/COMMIT/ROLLBACK) are accepted but function as no-ops for compatibility with drivers that auto-wrap queries in transactions.
+
+## 9. Common Bug Patterns
+
+### Pattern 1: Packstream Field Count Mismatch
+**Symptom**: Neo4j Browser shows "Cannot read property of undefined" or connection drops.
+**Cause**: Node struct must have exactly 4 fields (0xB4), Relationship exactly 8 (0xB8), UnboundRelationship 4 (0xB4). If `to_packstream()` adds/removes fields, the driver's deserializer crashes.
+**Fix**: Always verify struct marker matches actual field count.
+
+### Pattern 2: element_id → id Inconsistency
+**Symptom**: Neo4j Browser expand (double-click) fails to find nodes.
+**Cause**: The `id` in a RECORD response doesn't match what `id(n)` returns because different code paths compute the integer ID differently.
+**Fix**: ALL id computation must go through `IdMapper::compute_deterministic_id()`. Both `transform_row()` and `id()` function evaluation must use this single source of truth.
+
+### Pattern 3: Label Code Collision
+**Symptom**: Two different node types get the same integer ID.
+**Cause**: `LABEL_CODE_REGISTRY` is process-global. If labels are registered in different order across test runs, codes can shift. But within a single process, codes are stable.
+**Risk**: Low (only 64 labels supported). Monitor with > 64 node types.
+
+### Pattern 4: Cross-Session ID Lookup Failure
+**Symptom**: Browser expand query returns empty when it should find nodes.
+**Cause**: The IdMapper session that created the mapping was dropped (connection closed). Cross-session lookup only works while the originating session is alive OR the ID can be reconstructed from bit pattern.
+**Mitigation**: `decode_for_query()` falls back to bit-pattern extraction for numeric IDs < 2^31.
+
+### Pattern 5: Bolt 5.x Version Byte Swap
+**Symptom**: "No compatible version found" despite client supporting 5.x.
+**Cause**: Handshake response sent in wrong byte order for 5.x.
+**Fix**: `perform_handshake()` swaps bytes for versions ≥ 0x00000500.
+
+### Pattern 6: Multi-Type CTE Array Unwrapping
+**Symptom**: Relationship properties show `["FOLLOWS"]` instead of `"FOLLOWS"`.
+**Cause**: Multi-type CTE queries return single-element arrays. `transform_to_relationship()` must detect this pattern and call `extract_first_from_array()`.
+
+### Pattern 7: VLP Path Truncation
+**Symptom**: Multi-hop VLP paths only show first hop in Neo4j Browser.
+**Cause**: `transform_vlp_path()` currently only produces `Path::single_hop()` — multi-hop path serialization is not yet implemented.
+**Status**: Known limitation, logged with warning.
+
+### Pattern 8: Directed Relationship in Expand
+**Symptom**: Neo4j Browser crashes with "t.source is undefined" after expand.
+**Cause**: Making the expand query undirected causes Relationship objects with start/end IDs referencing nodes not in the browser's graph.
+**Fix**: Do NOT rewrite browser expand queries to undirected. There is a comment in `handle_run()` explaining this.
+
+## 10. Public API
+
+### Entry Point
+
+```rust
+// Create and start Bolt server
+let config = BoltConfig::default();
+let server = BoltServer::new(config, clickhouse_client);
+server.handle_connection(tcp_stream, peer_addr).await?;
+```
+
+### Key Public Types
+
+| Type | Location | Usage |
+|---|---|---|
+| `BoltServer` | `mod.rs` | Top-level server, cloneable, spawns connections |
+| `BoltConfig` | `mod.rs` | Server configuration (ports, auth, timeouts) |
+| `BoltContext` | `mod.rs` | Per-connection state (state machine, user, schema, id_mapper) |
+| `ConnectionState` | `mod.rs` | State machine enum |
+| `BoltMessage` | `messages.rs` | Message type with constructors and extractors |
+| `BoltValue` | `messages.rs` | Either `Json(Value)` or `PackstreamBytes(Vec<u8>)` |
+| `Node` | `graph_objects.rs` | Packstream-encodable node struct |
+| `Relationship` | `graph_objects.rs` | Packstream-encodable relationship struct |
+| `Path` | `graph_objects.rs` | Packstream-encodable path struct |
+| `IdMapper` | `id_mapper.rs` | Session-scoped ID mapper (53-bit encoding) |
+| `Authenticator` | `auth.rs` | Authentication manager |
+| `WebSocketBoltAdapter` | `websocket.rs` | WebSocket-to-AsyncRead/Write adapter |
+| `BoltError` | `errors.rs` | Error type with Neo4j error codes |
+
+### Key Public Functions
+
+| Function | Location | Purpose |
+|---|---|---|
+| `extract_return_metadata()` | `result_transformer.rs` | Classify RETURN items as Node/Rel/Path/Scalar |
+| `transform_row()` | `result_transformer.rs` | Convert ClickHouse row → packstream graph objects |
+| `rewrite_id_predicates()` | `id_rewriter.rs` | Rewrite `id(n) = N` to property filters |
+| `IdMapper::compute_deterministic_id()` | `id_mapper.rs` | Static: element_id → 53-bit integer |
+| `IdMapper::decode_for_query()` | `id_mapper.rs` | Static: encoded integer → (label, raw_value) |
+| `utils::negotiate_version()` | `mod.rs` | Select best protocol version from client proposals |
+
+## 11. Testing Guidance
+
+### Unit Tests (in-file `#[cfg(test)]` modules)
+
+All files have unit tests. Run with:
+```bash
+cargo test --lib server::bolt_protocol
+```
+
+Key test areas:
+- **`mod.rs`**: Context creation, state transitions, version negotiation, version string formatting
+- **`messages.rs`**: Message construction, field extraction, type identification
+- **`auth.rs`**: Scheme parsing, token creation, authenticator (enabled/disabled), password hashing
+- **`id_mapper.rs`**: Numeric/string/composite IDs, label collision prevention, session cache chaining, cross-session lookup
+- **`id_rewriter.rs`**: id() equals/IN/NOT IN rewriting, ORDER BY rewriting, complex query with multiple patterns
+- **`graph_objects.rs`**: Packstream encoding for integers, strings, lists, maps, Node/Relationship structures, composite element IDs
+- **`handler.rs`**: HELLO/RESET/GOODBYE/transaction lifecycle (async tests)
+- **`result_transformer.rs`**: value_to_string, field name extraction
+- **`connection.rs`**: MockStream, chunk creation, magic preamble constant
+- **`errors.rs`**: Error creation, error codes, recoverability
+
+### Integration Testing
+
+Requires a running ClickGraph server with Bolt enabled:
+```bash
+# Start server with Bolt
+cargo run --bin clickgraph -- --bolt-port 7687
+
+# Connect with cypher-shell or Neo4j Browser
+cypher-shell -a bolt://localhost:7687 -u neo4j -p password
+```
+
+Tests in `tests/integration/bolt/` cover end-to-end scenarios.
+
+### What to Test After Changes
+
+| Changed File | Test Focus |
+|---|---|
+| `connection.rs` | Handshake, chunked message I/O, version byte order |
+| `handler.rs` | State transitions, query execution, parameter handling |
+| `result_transformer.rs` | Graph object creation with various schemas, edge cases |
+| `graph_objects.rs` | Packstream byte-level verification |
+| `id_mapper.rs` | ID uniqueness, cross-label collision, session chaining |
+| `id_rewriter.rs` | Regex patterns, edge cases in complex queries |
+| `messages.rs` | Field extraction for all message types |
+
+## 12. Dangerous Files / High-Risk Areas
+
+### `result_transformer.rs` (2146 lines) — **HIGHEST RISK**
+- Most complex file. Handles 6+ result formats (standard, VLP, multi-type CTE, UNION JSON, multi-label scan, polymorphic edges)
+- Label resolution has 4-level fallback chain — easy to break
+- Property key cleaning (`clean_property_keys`) removes prefixes that may be needed
+- Relationship ID extraction tries multiple column name patterns (from_id, start_id, schema columns) — order matters
+- Any change here can break Neo4j Browser visualization silently
+
+### `handler.rs` (1826 lines) — **HIGH RISK**
+- Contains `execute_cypher_query()` (~500 lines) which orchestrates the entire pipeline
+- **Two-pass parsing**: parses query twice (before/after async boundary) due to `Rc<RefCell<>>` in AST
+- Parameter substitution (`substitute_cypher_parameters`) has security implications — injection prevention via regex + literal checks
+- State transitions on error paths — incorrect state can wedge the connection
+- Schema resolution has complex fallback: RUN metadata → HELLO metadata → BEGIN metadata → first loaded schema
+
+### `connection.rs` (605 lines) — **MEDIUM RISK**
+- Packstream serialization for RECORD messages has special-case handling (LIST wrapping)
+- Message size validation can cause DoS if too permissive
+- Version byte swap for Bolt 5.x — subtle encoding bug will silently break negotiation
+
+### `id_mapper.rs` (571 lines) — **MEDIUM RISK**
+- Global statics (`ACTIVE_SESSION_CACHES`, `NEXT_CONNECTION_ID`) — thread safety critical
+- `Drop` implementation conditionally unregisters based on `Arc::strong_count` — race condition possible under high concurrency
+- Hash collisions in 47-bit space are theoretically possible for large string IDs
+
+### `graph_objects.rs` (717 lines) — **MEDIUM RISK**
+- Custom packstream implementation — must match Neo4j driver expectations exactly
+- UnboundRelationship (0x72) vs Relationship (0x52) confusion can crash Path deserialization
+- `encode_json_value` for Array/Object types currently returns empty containers (TODO)

--- a/src/testing/AGENTS.md
+++ b/src/testing/AGENTS.md
@@ -1,0 +1,70 @@
+# testing Module — Agent Guide
+
+> **Purpose**: Mock implementations for unit testing other modules.
+> **Status**: Partially implemented — `schema` and `query` submodules are declared but missing.
+> **Not registered in `lib.rs`** — only used via `crate::testing::` in test code.
+
+## Module Architecture
+
+```
+testing/
+├── mod.rs        (11 lines) ← Module declarations (clickhouse, schema, query)
+└── clickhouse.rs (63 lines) ← MockClickHouse using mockall
+```
+
+**Note**: `mod.rs` declares `pub mod schema;` and `pub mod query;` but those files
+do **not** exist. This module is not included in `lib.rs`, so it only compiles
+when referenced from test code (currently only `query_planner/tests/integration_tests.rs`).
+
+**Total**: ~74 lines (of existing code)
+
+## Key Files
+
+### mod.rs — Module Declarations
+```rust
+pub mod clickhouse;
+pub mod schema;   // ⚠️ FILE DOES NOT EXIST
+pub mod query;    // ⚠️ FILE DOES NOT EXIST
+```
+
+### clickhouse.rs — Mock ClickHouse Client
+Uses `mockall` crate to create a `MockClickHouse` with:
+- `query(&str) → Result<Vec<HashMap<String,String>>>` — mock query execution
+- `get_table_schema(&str) → Result<Vec<ColumnInfo>>` — mock schema introspection
+
+`create_mock_client()` returns a pre-configured mock with:
+- Table schema for "users" table (user_id, full_name, age)
+- Query response for queries containing "users" (returns 2 rows)
+
+## Critical Invariants
+
+### 1. Not in lib.rs
+This module is **not** declared in `src/lib.rs`. It's only reachable from test code
+that uses `crate::testing::clickhouse::create_mock_client()`.
+
+### 2. Missing Submodules
+`schema` and `query` submodules are declared but don't exist as files. This will
+cause compilation errors if the module is ever included unconditionally. Currently
+safe because it's only used in `#[cfg(test)]` contexts.
+
+## Dependencies
+
+**What this module uses**:
+- `mockall` crate — mock generation
+- `async_trait` — async mock support
+- `graph_catalog::schema_validator::ColumnInfo` — schema column type
+
+**What uses this module**:
+- `query_planner/tests/integration_tests.rs` — uses `create_mock_client()`
+
+## Testing Guidance
+
+- This module IS test infrastructure — it provides mocks for other tests
+- Run dependent tests with: `cargo test --lib query_planner`
+- If adding new mocks, consider whether `graph_catalog/testing/` (separate module) is more appropriate
+
+## When to Modify
+
+- **Adding mock capabilities**: Extend `MockClickHouse` expectations
+- **New test fixtures**: Add pre-configured mock factories
+- **Fix compilation**: Either create `schema.rs`/`query.rs` or remove the `pub mod` declarations

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -1,0 +1,143 @@
+# utils Module — Agent Guide
+
+> **Purpose**: Shared utility functions used across the codebase.
+> Small, focused helpers — CTE naming, ID encoding, serde helpers.
+> These are foundational utilities that many modules depend on.
+
+## Module Architecture
+
+```
+utils/
+├── mod.rs          (5 lines)   ← Re-exports submodules
+├── cte_naming.rs   (230 lines) ← CTE name generation/parsing (single source of truth)
+├── id_encoding.rs  (277 lines) ← Neo4j-compatible 53-bit ID encoding for Bolt protocol
+├── serde_arc.rs    (20 lines)  ← Serialize/Deserialize for Arc<T>
+└── serde_arc_vec.rs (27 lines) ← Serialize/Deserialize for Vec<Arc<T>>
+```
+
+**Total**: ~560 lines
+
+## Key Files
+
+### cte_naming.rs — CTE Name Generation (CRITICAL)
+
+**Problem solved**: Previously 7+ locations generated CTE names with subtle differences
+(sorting, sequence numbers, empty alias handling), causing bugs where CTEs were created
+with one name but referenced with another.
+
+**Naming convention**: `with_{sorted_aliases}_cte_{counter}`
+- Aliases are ALWAYS sorted alphabetically
+- Examples: `with_friends_p_cte_1`, `with_a_cte_1`, `with_cte_1` (no aliases)
+
+**Functions**:
+- `generate_cte_name(&[aliases], counter) → String` — full name with counter
+- `generate_cte_base_name(&[aliases]) → String` — name without counter (for lookups)
+- `is_generated_cte_name(name) → bool` — checks if name matches `with_*_cte*` pattern
+- `extract_cte_base_name(name) → Option<String>` — strips counter from full name
+- `extract_aliases_from_cte_name(name) → Option<Vec<String>>` — reverse lookup
+
+### id_encoding.rs — Neo4j ID Encoding
+
+Encodes label+ID into a single 53-bit integer (fits JavaScript's `MAX_SAFE_INTEGER`).
+
+**53-bit layout**:
+```
+[6-bit label_code (1-63)][47-bit id_value]
+```
+
+**Key design**: Label codes start at 1 (not 0) so ALL encoded IDs are distinguishable
+from raw values. Raw `42` stays `42`; encoded User:42 becomes `(1 << 47) | 42`.
+
+**Types**:
+- `IdEncoding` — static methods for encode/decode/is_encoded
+- `LabelCodeRegistry` — assigns unique 6-bit codes to label names (max 63)
+- `LABEL_CODE_REGISTRY` — global `lazy_static` RwLock registry
+
+**Functions**:
+- `IdEncoding::encode(label_code, id_value) → i64`
+- `IdEncoding::decode(encoded_id) → (u8, i64)`
+- `IdEncoding::is_encoded(value) → bool` — checks for non-zero high bits
+- `IdEncoding::decode_with_label(encoded_id) → Option<(String, i64)>` — uses global registry
+- `IdEncoding::register_label(label) → u8` — thread-safe registration
+
+### serde_arc.rs — Arc Serde Helper
+Custom serialize/deserialize for `Arc<T>` — serializes the inner value, deserializes
+and wraps in `Arc::new()`. Used as `#[serde(with = "crate::utils::serde_arc")]`.
+
+### serde_arc_vec.rs — Vec<Arc<T>> Serde Helper
+Custom serialize/deserialize for `Vec<Arc<T>>` — serializes each element's inner value,
+deserializes and wraps each in `Arc::new()`. Used as `#[serde(with = "crate::utils::serde_arc_vec")]`.
+
+## Critical Invariants
+
+### 1. CTE Naming is the Single Source of Truth
+**ALL** CTE name generation MUST use `cte_naming.rs` functions. Generating CTE names
+inline in other modules will cause name mismatch bugs. This was a historical pain point.
+
+### 2. ID Encoding Must Be JS-Safe
+All encoded IDs must fit within 2^53 - 1 (JavaScript's MAX_SAFE_INTEGER).
+Neo4j Browser processes these IDs in JavaScript, so precision loss = broken IDs.
+
+### 3. Label Code 0 is Reserved
+Label code 0 means "not encoded" (raw value). This is why `LabelCodeRegistry` starts
+at code 1. Never assign code 0 to a label.
+
+### 4. Global Registry is Thread-Safe but Not Reset
+`LABEL_CODE_REGISTRY` uses `lazy_static` + `RwLock`. Once a label is assigned a code,
+it persists for the process lifetime. This can cause issues in tests if label ordering
+matters — tests should not depend on specific code assignments.
+
+## Dependencies
+
+**What this module uses**:
+- `lazy_static` — global registry (id_encoding)
+- `serde` — serialization traits (serde_arc, serde_arc_vec)
+
+**What uses this module**:
+
+| Utility | Used by |
+|---------|---------|
+| `cte_naming` | `render_plan/plan_builder.rs` |
+| `id_encoding` | `server/bolt_protocol/id_mapper.rs`, `server/graph_catalog.rs`, `query_planner/optimizer/union_pruning.rs` |
+| `serde_arc` | `query_planner/logical_plan/mod.rs`, `query_planner/logical_expr/mod.rs` |
+| `serde_arc_vec` | `query_planner/logical_plan/mod.rs` |
+
+## Public API
+
+```rust
+// CTE naming
+pub fn generate_cte_name(aliases: &[impl AsRef<str>], counter: usize) -> String;
+pub fn generate_cte_base_name(aliases: &[impl AsRef<str>]) -> String;
+pub fn is_generated_cte_name(name: &str) -> bool;
+pub fn extract_cte_base_name(name: &str) -> Option<String>;
+pub fn extract_aliases_from_cte_name(cte_name: &str) -> Option<Vec<String>>;
+
+// ID encoding
+pub struct IdEncoding;
+impl IdEncoding {
+    pub fn encode(label_code: u8, id_value: i64) -> i64;
+    pub fn decode(encoded_id: i64) -> (u8, i64);
+    pub fn is_encoded(value: i64) -> bool;
+    pub fn decode_with_label(encoded_id: i64) -> Option<(String, i64)>;
+    pub fn register_label(label: &str) -> u8;
+    pub fn get_label_code(label: &str) -> Option<u8>;
+}
+
+// Serde helpers (used as #[serde(with = "...")])
+pub mod serde_arc { pub fn serialize/deserialize ... }
+pub mod serde_arc_vec { pub fn serialize/deserialize ... }
+```
+
+## Testing Guidance
+
+- `cte_naming.rs` has comprehensive tests including roundtrip alias extraction
+- `id_encoding.rs` has encode/decode roundtrip, boundary value, and registry tests
+- `serde_arc*.rs` have no dedicated tests (tested implicitly through LogicalPlan serialization)
+- Run with: `cargo test --lib utils`
+- Doc tests: `generate_cte_name`, `generate_cte_base_name`, etc. have runnable doc examples
+
+## When to Modify
+
+- **CTE naming bugs**: Always fix in `cte_naming.rs`, never add inline name generation elsewhere
+- **More labels than 63**: Would require changing the 6-bit label code scheme in id_encoding
+- **New shared utilities**: Add here if used by 2+ modules; keep module-specific utils local


### PR DESCRIPTION
## Summary

Add comprehensive AGENTS.md documentation files for AI-assisted development across all source modules.

### 15 AGENTS.md files created (4,413 lines total)

**Top-level modules (11 files):**
- `src/AGENTS.md` — lib.rs, main.rs, config.rs entry points
- `src/clickhouse_query_generator/AGENTS.md` — SQL generation, VLP CTEs, function translation
- `src/graph_catalog/AGENTS.md` — Schema types, property mappings, 5 schema variations
- `src/open_cypher_parser/AGENTS.md` — AST structure, nom parsers, 23 clause files
- `src/packstream/AGENTS.md` — PackStream binary codec (vendored from neo4rs)
- `src/procedures/AGENTS.md` — 10 Neo4j-compatible metadata procedures
- `src/query_planner/AGENTS.md` — 3-phase pipeline overview, 80+ files
- `src/render_plan/AGENTS.md` — (existing, updated)
- `src/server/AGENTS.md` — HTTP + Bolt server, query lifecycle
- `src/testing/AGENTS.md` — Mock infrastructure
- `src/utils/AGENTS.md` — CTE naming, ID encoding, serde helpers

**Sub-module AGENTS.md (4 files):**
- `src/query_planner/analyzer/AGENTS.md` — 28K-line sub-module, 20+ analysis passes
- `src/query_planner/logical_plan/AGENTS.md` — 17 LogicalPlan variants, plan building flow
- `src/query_planner/optimizer/AGENTS.md` — 8 optimization passes, phase ordering
- `src/server/bolt_protocol/AGENTS.md` — Bolt state machine, result transformation, ID mapping

### Each file documents:
- Module purpose and architecture (ASCII diagrams)
- Key files with line counts and responsibilities
- Critical invariants (what breaks if violated)
- Common bug patterns (symptom → root cause)
- Dependencies (upstream and downstream)
- Public API (traits, structs, functions)
- Testing guidance (specific cargo test commands)
- Schema variation awareness (Standard, FK-edge, Denormalized, Polymorphic, Composite ID)

### Other changes:
- Updated `.gitignore` with `/home/gz/clickgraph/.venv/bin/activate*/AGENTS.md` negation pattern to track these files
