### PR TITLE
docs: Update ontime_flights benchmark credentials to test_user/test_pass

### DIFF
--- a/benchmarks/ontime_flights/queries/run_ontime_benchmark.py
+++ b/benchmarks/ontime_flights/queries/run_ontime_benchmark.py
@@ -17,8 +17,8 @@ from datetime import datetime
 
 # ClickHouse connection
 CLICKHOUSE_URL = "http://localhost:18123"
-CLICKHOUSE_USER = "default"
-CLICKHOUSE_PASSWORD = "mypass"
+CLICKHOUSE_USER = "test_user"
+CLICKHOUSE_PASSWORD = "test_pass"
 
 # ClickGraph connection (for SQL generation verification)
 CLICKGRAPH_URL = "http://localhost:8080"


### PR DESCRIPTION
Align with other benchmark setups (social_benchmark) for consistency.