### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0098/0099/0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Fixes the failing weekly Security Audit run on `main` by bumping the transitive `rustls-webpki` dependency from 0.103.10 to 0.103.13. Single-line change to `Cargo.lock`.

## Advisories resolved

| ID | Title | Fix |
|---|---|---|
| RUSTSEC-2026-0104 | Reachable panic in CRL parsing | ≥0.103.13 |
| RUSTSEC-2026-0098 | URI name-constraints incorrectly accepted | ≥0.103.12 |
| RUSTSEC-2026-0099 | Wildcard cert name-constraints accepted | ≥0.103.12 |

`rustls-webpki` is pulled in transitively via `reqwest 0.12 → rustls 0.23 → rustls-webpki`, used only by HTTP client TLS. Patch-version bump within 0.103.x — no API changes.

The two `rand` warnings (RUSTSEC-2026-0097) are non-blocking and unchanged.

## Test plan

- [x] `cargo update -p rustls-webpki` produces only the intended single-package change
- [x] `cargo check -p clickgraph` compiles cleanly
- [ ] Security Audit workflow turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)