### PR TITLE
feat(planner): Phase 1 — write LogicalPlan variants + builder + guard

### DIFF
--- a/src/query_planner/AGENTS.md
+++ b/src/query_planner/AGENTS.md
@@ -338,7 +338,31 @@ Every pass returns `Transformed::Yes(plan)` if it modified the plan, `Transforme
 ### 7. PlanCtx Dual Registration
 `PlanCtx::insert_table_ctx()` registers variables in BOTH the legacy `alias_table_ctx_map` AND the new `VariableRegistry`. Both systems must stay in sync during the migration period.
 
-## Recent Changes (Feb 2026)
+## Recent Changes (May 2026)
+
+### Write LogicalPlan Variants (Phase 1 of embedded-mode writes)
+
+**What changed**: Added four write variants to `LogicalPlan`:
+
+- `Create { input, patterns: Vec<CreatePattern> }` — node and/or relationship creation
+- `SetProperties { input, items: Vec<SetItem> }` — property assignment
+- `Delete { input, targets: Vec<String>, detach: bool }` — node/edge deletion
+- `Remove { input, items: Vec<RemoveItem> }` — property removal
+
+`input` is the preceding read pipeline (or `LogicalPlan::Empty` for standalone CREATE). All write variants are routed only through embedded chdb execution.
+
+**Builder**: `logical_plan/write_clause_builder.rs` converts AST → variants. Resolves labels via `GraphSchema`, validates property names, rejects:
+- Source-backed (`source:` set) targets
+- FK-edge relationships (out of scope for v1)
+- Multi-label CREATE patterns
+- Undirected CREATE relationships
+- Variable-length paths inside CREATE
+
+**Guard**: `query_planner/write_guard.rs::ensure_write_target_writable(plan, schema, executor)` is the single admission check called by the executor before rendering. Centralises Decisions 0.1 (executor must be `EmbeddedChdb`), 0.3 (no source-backed targets), and 0.6 (no FK-edges). The HTTP/Bolt server's existing reject at `handlers.rs:1356` is retained as defence-in-depth.
+
+**Wiring**: `logical_plan/plan_builder.rs::build_logical_plan` processes write clauses *after* WHERE and *before* RETURN, in order CREATE → SET → REMOVE → DELETE.
+
+**Read-side passes**: every analyzer/optimizer/render `match` over `LogicalPlan` now has a write-variant arm — most simply pass the plan through unchanged because writes use a separate render/execute path (Phase 2/3). The few exceptions that *do* recurse into `input` are the metadata-collection helpers (`extract_pattern_info`, `find_label_for_alias_in_plan`, `extract_filters`, etc.) — preceding read pipeline must still be analysed for property requirements.
 
 ### Schema Type System Migration
 **What Changed**: `NodeIdSchema.dtype` and `RelationshipSchema.from/to_node_id_dtype` migrated from `String` to `SchemaType` enum.

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -502,6 +502,15 @@ fn transform_bidirectional(
                 }
             }
         }
+
+        // Write variants — preserved unchanged; bidirectional-union analysis is
+        // a read-side concern. Their preceding read pipeline (input) is not
+        // recursed because by the time it ran, BidirectionalUnion already fired
+        // on the read plan.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => Ok(Transformed::No(plan.clone())),
     }
 }
 

--- a/src/query_planner/analyzer/cte_column_resolver.rs
+++ b/src/query_planner/analyzer/cte_column_resolver.rs
@@ -489,6 +489,13 @@ impl AnalyzerPass for CteColumnResolver {
             | LogicalPlan::PageRank(_)
             | LogicalPlan::Unwind(_)
             | LogicalPlan::CartesianProduct(_) => Transformed::No(logical_plan.clone()),
+
+            // Write variants — pass through unchanged. CTE column resolution is
+            // a read-side concern; write evaluation uses a separate pipeline.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         })
     }
 }

--- a/src/query_planner/analyzer/cte_schema_resolver.rs
+++ b/src/query_planner/analyzer/cte_schema_resolver.rs
@@ -217,6 +217,12 @@ impl AnalyzerPass for CteSchemaResolver {
             | LogicalPlan::PageRank(_)
             | LogicalPlan::Unwind(_)
             | LogicalPlan::CartesianProduct(_) => Transformed::No(logical_plan.clone()),
+
+            // Write variants — read-side analysis pass-through.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         })
     }
 }

--- a/src/query_planner/analyzer/duplicate_scans_removing.rs
+++ b/src/query_planner/analyzer/duplicate_scans_removing.rs
@@ -249,6 +249,11 @@ impl DuplicateScansRemoving {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side duplicate-scan removal does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/filter_tagging.rs
+++ b/src/query_planner/analyzer/filter_tagging.rs
@@ -74,6 +74,10 @@ impl AnalyzerPass for FilterTagging {
             LogicalPlan::Unwind(_) => "Unwind",
             LogicalPlan::CartesianProduct(_) => "CartesianProduct",
             LogicalPlan::WithClause(_) => "WithClause",
+            LogicalPlan::Create(_) => "Create",
+            LogicalPlan::SetProperties(_) => "SetProperties",
+            LogicalPlan::Delete(_) => "Delete",
+            LogicalPlan::Remove(_) => "Remove",
         };
         log::trace!("FilterTagging: About to match on variant: {}", variant_name);
         Ok(match logical_plan.as_ref() {
@@ -503,6 +507,11 @@ impl AnalyzerPass for FilterTagging {
                 };
                 Transformed::Yes(Arc::new(LogicalPlan::WithClause(new_with)))
             }
+            // Write variants — read-side filter tagging does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         })
     }
 }

--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -331,6 +331,19 @@ impl GraphJoinInference {
             }
             // Leaf nodes - nothing to extract
             LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => {}
+            // Write variants — recurse into preceding read pipeline.
+            LogicalPlan::Create(c) => {
+                Self::extract_pattern_info(&c.input, plan_ctx, metadata)?;
+            }
+            LogicalPlan::SetProperties(sp) => {
+                Self::extract_pattern_info(&sp.input, plan_ctx, metadata)?;
+            }
+            LogicalPlan::Delete(d) => {
+                Self::extract_pattern_info(&d.input, plan_ctx, metadata)?;
+            }
+            LogicalPlan::Remove(r) => {
+                Self::extract_pattern_info(&r.input, plan_ctx, metadata)?;
+            }
         }
 
         Ok(())
@@ -389,6 +402,11 @@ impl GraphJoinInference {
             | LogicalPlan::PageRank(_)
             | LogicalPlan::Cte(_)
             | LogicalPlan::Union(_) => {}
+            // Write variants — recurse into preceding read pipeline.
+            LogicalPlan::Create(c) => Self::collect_fresh_scan_aliases(&c.input, aliases),
+            LogicalPlan::SetProperties(sp) => Self::collect_fresh_scan_aliases(&sp.input, aliases),
+            LogicalPlan::Delete(d) => Self::collect_fresh_scan_aliases(&d.input, aliases),
+            LogicalPlan::Remove(r) => Self::collect_fresh_scan_aliases(&r.input, aliases),
         }
     }
 
@@ -597,6 +615,19 @@ impl GraphJoinInference {
 
             // Leaf nodes - nothing to recurse
             LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => {}
+            // Write variants — recurse into preceding read pipeline.
+            LogicalPlan::Create(c) => {
+                self.register_with_cte_references(&c.input, plan_ctx, captured_refs)?;
+            }
+            LogicalPlan::SetProperties(sp) => {
+                self.register_with_cte_references(&sp.input, plan_ctx, captured_refs)?;
+            }
+            LogicalPlan::Delete(d) => {
+                self.register_with_cte_references(&d.input, plan_ctx, captured_refs)?;
+            }
+            LogicalPlan::Remove(r) => {
+                self.register_with_cte_references(&r.input, plan_ctx, captured_refs)?;
+            }
         }
 
         Ok(())
@@ -1829,6 +1860,11 @@ impl GraphJoinInference {
                     }
                 }
             }
+            // Write variants — read-side join inference does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }
@@ -2280,6 +2316,11 @@ impl GraphJoinInference {
                 // Don't recurse - treat this as a boundary
                 Ok(())
             }
+            // Write variants — read-side join collection does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Ok(()),
         };
 
         crate::debug_print!("+- collect_graph_joins EXIT");

--- a/src/query_planner/analyzer/graph_join/metadata.rs
+++ b/src/query_planner/analyzer/graph_join/metadata.rs
@@ -191,6 +191,13 @@ impl PatternMetadataBuilder {
                 Self::extract_pattern_info(&wc.input, plan_ctx, metadata)?
             }
             LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => {}
+            // Write variants — recurse into preceding read pipeline.
+            LogicalPlan::Create(c) => Self::extract_pattern_info(&c.input, plan_ctx, metadata)?,
+            LogicalPlan::SetProperties(sp) => {
+                Self::extract_pattern_info(&sp.input, plan_ctx, metadata)?
+            }
+            LogicalPlan::Delete(d) => Self::extract_pattern_info(&d.input, plan_ctx, metadata)?,
+            LogicalPlan::Remove(r) => Self::extract_pattern_info(&r.input, plan_ctx, metadata)?,
         }
         Ok(())
     }

--- a/src/query_planner/analyzer/graph_traversal_planning.rs
+++ b/src/query_planner/analyzer/graph_traversal_planning.rs
@@ -301,6 +301,11 @@ impl AnalyzerPass for GraphTRaversalPlanning {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side traversal planning does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/group_by_building.rs
+++ b/src/query_planner/analyzer/group_by_building.rs
@@ -371,6 +371,11 @@ impl AnalyzerPass for GroupByBuilding {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side group-by building does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/pattern_resolver.rs
+++ b/src/query_planner/analyzer/pattern_resolver.rs
@@ -514,6 +514,12 @@ fn clone_plan_with_labels(plan: &LogicalPlan, combo: &HashMap<String, String>) -
         // Base cases that don't need recursion
         LogicalPlan::Empty => LogicalPlan::Empty,
         LogicalPlan::ViewScan(view_scan) => LogicalPlan::ViewScan(view_scan.clone()),
+
+        // Write variants — clone unchanged; pattern resolution only operates on read patterns.
+        LogicalPlan::Create(c) => LogicalPlan::Create(c.clone()),
+        LogicalPlan::SetProperties(sp) => LogicalPlan::SetProperties(sp.clone()),
+        LogicalPlan::Delete(d) => LogicalPlan::Delete(d.clone()),
+        LogicalPlan::Remove(r) => LogicalPlan::Remove(r.clone()),
     }
 }
 
@@ -764,6 +770,12 @@ fn extract_relationships_recursive(
         | LogicalPlan::PageRank(_) => {
             // Base cases - no relationships
         }
+
+        // Write variants — no relationships to extract from write payload.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => {}
     }
 }
 

--- a/src/query_planner/analyzer/plan_sanitization.rs
+++ b/src/query_planner/analyzer/plan_sanitization.rs
@@ -159,6 +159,11 @@ impl PlanSanitization {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side plan sanitization does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/projected_columns_resolver.rs
+++ b/src/query_planner/analyzer/projected_columns_resolver.rs
@@ -371,6 +371,12 @@ impl AnalyzerPass for ProjectedColumnsResolver {
             | LogicalPlan::PageRank(_)
             | LogicalPlan::Unwind(_)
             | LogicalPlan::CartesianProduct(_) => Transformed::No(logical_plan.clone()),
+
+            // Write variants — read-side projected-columns resolution does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         })
     }
 }

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -357,6 +357,11 @@ impl AnalyzerPass for ProjectionTagging {
                     Transformed::Yes(Arc::new(LogicalPlan::WithClause(new_wc)))
                 }
             }
+            // Write variants — read-side projection tagging does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/property_requirements_analyzer.rs
+++ b/src/query_planner/analyzer/property_requirements_analyzer.rs
@@ -340,6 +340,13 @@ impl PropertyRequirementsAnalyzer {
             LogicalPlan::Empty => {
                 log::info!("🔍 PropertyRequirementsAnalyzer: Reached Empty plan");
             }
+
+            // Write variants — recurse into preceding read pipeline (the write
+            // payload itself doesn't surface read-side property requirements).
+            LogicalPlan::Create(c) => Self::analyze_node(&c.input, requirements),
+            LogicalPlan::SetProperties(sp) => Self::analyze_node(&sp.input, requirements),
+            LogicalPlan::Delete(d) => Self::analyze_node(&d.input, requirements),
+            LogicalPlan::Remove(r) => Self::analyze_node(&r.input, requirements),
         }
     }
 

--- a/src/query_planner/analyzer/query_validation.rs
+++ b/src/query_planner/analyzer/query_validation.rs
@@ -517,6 +517,11 @@ impl AnalyzerPass for QueryValidation {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side query validation does not apply here.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/analyzer/scoping_with_collapse.rs
+++ b/src/query_planner/analyzer/scoping_with_collapse.rs
@@ -91,6 +91,12 @@ fn contains_with_clause(plan: &LogicalPlan) -> bool {
         LogicalPlan::GraphNode(gn) => contains_with_clause(&gn.input),
         // Leaf nodes — no children to recurse into
         LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => false,
+
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => contains_with_clause(&c.input),
+        LogicalPlan::SetProperties(sp) => contains_with_clause(&sp.input),
+        LogicalPlan::Delete(d) => contains_with_clause(&d.input),
+        LogicalPlan::Remove(r) => contains_with_clause(&r.input),
     }
 }
 

--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -1039,6 +1039,11 @@ impl TypeInference {
                     Ok(Transformed::No(plan))
                 }
             }
+            // Write variants — read-side label inference does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Ok(Transformed::No(plan)),
         }
     }
 
@@ -3340,6 +3345,11 @@ impl TypeInference {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side table-name push does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan.get_plan().clone())
     }
@@ -3623,6 +3633,11 @@ impl TypeInference {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side table-name push does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }
@@ -4844,6 +4859,12 @@ fn clone_plan_with_labels(
         // Base cases that don't need recursion
         LogicalPlan::Empty => LogicalPlan::Empty,
         LogicalPlan::ViewScan(view_scan) => LogicalPlan::ViewScan(view_scan.clone()),
+
+        // Write variants — clone unchanged; label inference only applies to read patterns.
+        LogicalPlan::Create(c) => LogicalPlan::Create(c.clone()),
+        LogicalPlan::SetProperties(sp) => LogicalPlan::SetProperties(sp.clone()),
+        LogicalPlan::Delete(d) => LogicalPlan::Delete(d.clone()),
+        LogicalPlan::Remove(r) => LogicalPlan::Remove(r.clone()),
     }
 }
 

--- a/src/query_planner/analyzer/unwind_property_rewriter.rs
+++ b/src/query_planner/analyzer/unwind_property_rewriter.rs
@@ -207,6 +207,12 @@ fn rewrite_plan(plan: Arc<LogicalPlan>) -> Arc<LogicalPlan> {
 
         // Base cases - no children to rewrite
         LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => plan.clone(),
+
+        // Write variants — UNWIND-property rewriting only operates on read plans.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => plan.clone(),
     }
 }
 
@@ -370,5 +376,11 @@ fn find_tuple_property_index(
 
         // Base cases
         LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => None,
+
+        // Write variants — no tuple-property indices to find.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => None,
     }
 }

--- a/src/query_planner/analyzer/unwind_tuple_enricher.rs
+++ b/src/query_planner/analyzer/unwind_tuple_enricher.rs
@@ -143,6 +143,12 @@ pub fn enrich_unwind_with_tuple_info(plan: Arc<LogicalPlan>) -> Arc<LogicalPlan>
         )),
         // Leaf nodes - no children to recurse into
         LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => plan.clone(),
+
+        // Write variants — no UNWIND tuple enrichment needed.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => plan.clone(),
     }
 }
 

--- a/src/query_planner/logical_expr/expression_rewriter.rs
+++ b/src/query_planner/logical_expr/expression_rewriter.rs
@@ -106,6 +106,12 @@ pub(crate) fn find_label_for_alias_in_plan(
             None
         }
         LogicalPlan::Empty | LogicalPlan::PageRank(_) => None,
+
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => find_label_for_alias_in_plan(&c.input, target_alias),
+        LogicalPlan::SetProperties(sp) => find_label_for_alias_in_plan(&sp.input, target_alias),
+        LogicalPlan::Delete(d) => find_label_for_alias_in_plan(&d.input, target_alias),
+        LogicalPlan::Remove(r) => find_label_for_alias_in_plan(&r.input, target_alias),
     }
 }
 

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -106,6 +106,7 @@ mod unwind_clause;
 mod view_scan;
 mod where_clause;
 mod with_clause;
+pub mod write_clause_builder;
 
 pub use view_scan::ViewScan;
 
@@ -505,6 +506,114 @@ pub enum LogicalPlan {
     /// This is NOT just a projection - it has bridging semantics and contains
     /// ORDER BY, SKIP, LIMIT, WHERE as part of its syntax (per OpenCypher grammar).
     WithClause(WithClause),
+
+    /// CREATE clause — embedded-mode write op (chdb only).
+    /// `input` carries the optional preceding read pipeline; `LogicalPlan::Empty`
+    /// for standalone CREATE.
+    Create(Create),
+
+    /// SET clause — embedded-mode write op (chdb only).
+    /// Each item updates a single property on a bound alias.
+    SetProperties(SetProperties),
+
+    /// DELETE / DETACH DELETE clause — embedded-mode write op (chdb only).
+    Delete(Delete),
+
+    /// REMOVE clause — embedded-mode write op (chdb only).
+    /// In ClickHouse-backed storage we represent this as `SET property = NULL`.
+    Remove(Remove),
+}
+
+/// A property literal carried by CREATE / SET write operations.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct WriteProperty {
+    pub key: String,
+    pub value: LogicalExpr,
+}
+
+/// A node to be created by a CREATE clause.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct CreateNode {
+    /// Optional Cypher alias (`a` in `CREATE (a:Person {...})`). Subsequent
+    /// clauses in the same query may reference this alias.
+    pub alias: Option<String>,
+    /// Resolved node label. Single label only — Cypher CREATE forbids multi-label nodes.
+    pub label: String,
+    pub properties: Vec<WriteProperty>,
+}
+
+/// A relationship to be created by a CREATE clause.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct CreateRel {
+    pub alias: Option<String>,
+    pub rel_type: String,
+    /// Direction of the edge as written in Cypher. `Either` is illegal for CREATE
+    /// and rejected by the planner.
+    pub direction: Direction,
+    /// Alias of the start node (must be bound by a prior MATCH or CREATE in this query).
+    pub start_alias: String,
+    pub end_alias: String,
+    pub properties: Vec<WriteProperty>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum CreatePattern {
+    Node(CreateNode),
+    Rel(CreateRel),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Create {
+    /// Preceding query input. `LogicalPlan::Empty` for standalone CREATE.
+    #[serde(with = "serde_arc")]
+    pub input: Arc<LogicalPlan>,
+    pub patterns: Vec<CreatePattern>,
+}
+
+/// A single `n.prop = expr` SET item.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct SetItem {
+    /// Alias bound by a prior MATCH (e.g., `n` in `SET n.age = 30`).
+    pub target_alias: String,
+    /// Property name on that alias.
+    pub property: String,
+    /// New value expression.
+    pub value: LogicalExpr,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct SetProperties {
+    #[serde(with = "serde_arc")]
+    pub input: Arc<LogicalPlan>,
+    pub items: Vec<SetItem>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Delete {
+    #[serde(with = "serde_arc")]
+    pub input: Arc<LogicalPlan>,
+    /// Aliases to delete. Each must be bound by a prior MATCH.
+    pub targets: Vec<String>,
+    /// `DETACH DELETE` flag — when true, planner emits per-relationship DELETEs first.
+    pub detach: bool,
+}
+
+/// A single `REMOVE n.prop` item.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct RemoveItem {
+    pub target_alias: String,
+    pub property: String,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Remove {
+    #[serde(with = "serde_arc")]
+    pub input: Arc<LogicalPlan>,
+    pub items: Vec<RemoveItem>,
 }
 
 /// Cartesian product of two disconnected graph patterns.
@@ -1590,6 +1699,10 @@ impl LogicalPlan {
                 }
                 c
             }
+            LogicalPlan::Create(c) => c.input.count_plan_nodes_impl(cap, current),
+            LogicalPlan::SetProperties(sp) => sp.input.count_plan_nodes_impl(cap, current),
+            LogicalPlan::Delete(d) => d.input.count_plan_nodes_impl(cap, current),
+            LogicalPlan::Remove(r) => r.input.count_plan_nodes_impl(cap, current),
         }
     }
 }
@@ -1667,6 +1780,18 @@ impl LogicalPlan {
             LogicalPlan::WithClause(with_clause) => {
                 children.push(&with_clause.input);
             }
+            LogicalPlan::Create(c) => {
+                children.push(&c.input);
+            }
+            LogicalPlan::SetProperties(sp) => {
+                children.push(&sp.input);
+            }
+            LogicalPlan::Delete(d) => {
+                children.push(&d.input);
+            }
+            LogicalPlan::Remove(r) => {
+                children.push(&r.input);
+            }
             LogicalPlan::ViewScan(_) => {
                 // ViewScan is a leaf node - no children to traverse
             }
@@ -1713,6 +1838,12 @@ impl LogicalPlan {
                 wc.items.len(),
                 wc.distinct
             ),
+            LogicalPlan::Create(c) => format!("Create(patterns: {})", c.patterns.len()),
+            LogicalPlan::SetProperties(sp) => format!("SetProperties(items: {})", sp.items.len()),
+            LogicalPlan::Delete(d) => {
+                format!("Delete(targets: {}, detach: {})", d.targets.len(), d.detach)
+            }
+            LogicalPlan::Remove(r) => format!("Remove(items: {})", r.items.len()),
         }
     }
 
@@ -1749,6 +1880,10 @@ impl LogicalPlan {
             LogicalPlan::WithClause(with_clause) => {
                 with_clause.input.contains_variable_length_path()
             }
+            LogicalPlan::Create(c) => c.input.contains_variable_length_path(),
+            LogicalPlan::SetProperties(sp) => sp.input.contains_variable_length_path(),
+            LogicalPlan::Delete(d) => d.input.contains_variable_length_path(),
+            LogicalPlan::Remove(r) => r.input.contains_variable_length_path(),
             // Leaf nodes
             LogicalPlan::ViewScan(_) | LogicalPlan::Empty | LogicalPlan::PageRank(_) => false,
         }

--- a/src/query_planner/logical_plan/plan_builder.rs
+++ b/src/query_planner/logical_plan/plan_builder.rs
@@ -38,7 +38,7 @@ use crate::{
         logical_plan::{
             errors::LogicalPlanError, match_clause, optional_match_clause, order_by_clause,
             return_clause, skip_n_limit_clause, unwind_clause, where_clause, with_clause,
-            LogicalPlan,
+            write_clause_builder, LogicalPlan,
         },
         plan_ctx::PlanCtx,
     },
@@ -68,11 +68,18 @@ pub fn build_logical_plan(
     );
 
     // 🚨 DIAGNOSTIC: Check if query is completely empty
+    // Standalone write queries (e.g., `CREATE (a:Person {...})` with no RETURN)
+    // are valid — they have no read-side clauses but do have CREATE/SET/DELETE/REMOVE.
+    let has_write_clause = query_ast.create_clause.is_some()
+        || query_ast.set_clause.is_some()
+        || query_ast.delete_clause.is_some()
+        || query_ast.remove_clause.is_some();
     if query_ast.match_clauses.is_empty()
         && query_ast.optional_match_clauses.is_empty()
         && query_ast.unwind_clauses.is_empty()
         && query_ast.return_clause.is_none()
         && query_ast.with_clause.is_none()
+        && !has_write_clause
     {
         log::error!("❌ EMPTY QUERY DETECTED: Parser returned empty AST!");
         log::error!("   This usually means:");
@@ -208,6 +215,23 @@ pub fn build_logical_plan(
     // For "WITH a, COUNT(b) as follows WHERE follows > 1", the WHERE can now reference "follows"
     if let Some(where_clause) = &query_ast.where_clause {
         logical_plan = where_clause::evaluate_where_clause(where_clause, logical_plan)?;
+    }
+
+    // Process write clauses (embedded chdb only; gated by `write_guard` at the
+    // executor entry point). Order matters: CREATE wraps its preceding read
+    // pipeline, then SET / REMOVE / DELETE chain on top. Per OpenCypher,
+    // queries with multiple write clauses apply them in this order.
+    if let Some(create_clause) = &query_ast.create_clause {
+        logical_plan = write_clause_builder::build_create(create_clause, logical_plan, schema)?;
+    }
+    if let Some(set_clause) = &query_ast.set_clause {
+        logical_plan = write_clause_builder::build_set(set_clause, logical_plan, schema)?;
+    }
+    if let Some(remove_clause) = &query_ast.remove_clause {
+        logical_plan = write_clause_builder::build_remove(remove_clause, logical_plan, schema)?;
+    }
+    if let Some(delete_clause) = &query_ast.delete_clause {
+        logical_plan = write_clause_builder::build_delete(delete_clause, logical_plan, schema)?;
     }
 
     if let Some(return_clause) = &query_ast.return_clause {

--- a/src/query_planner/logical_plan/write_clause_builder.rs
+++ b/src/query_planner/logical_plan/write_clause_builder.rs
@@ -25,8 +25,8 @@ use crate::{
     query_planner::{
         logical_expr::{Direction, LogicalExpr},
         logical_plan::{
-            errors::LogicalPlanError, Create, CreateNode, CreatePattern, CreateRel, Delete,
-            LogicalPlan, Remove, RemoveItem, SetItem, SetProperties, WriteProperty,
+            errors::LogicalPlanError, generate_id, Create, CreateNode, CreatePattern, CreateRel,
+            Delete, LogicalPlan, Remove, RemoveItem, SetItem, SetProperties, WriteProperty,
         },
     },
 };
@@ -55,14 +55,21 @@ pub fn build_create(
 }
 
 /// Build a `LogicalPlan::SetProperties` from a parsed `SetClause`.
+///
+/// Property names are validated against the alias's schema when the alias
+/// resolves to a statically-known label in `input`. Aliases whose label can
+/// only be inferred later (e.g., bound across a WITH boundary) are accepted
+/// without validation here; downstream passes catch them.
 pub fn build_set(
     set: &SetClause<'_>,
     input: Arc<LogicalPlan>,
-    _schema: &GraphSchema,
+    schema: &GraphSchema,
 ) -> Result<Arc<LogicalPlan>> {
     let mut items = Vec::with_capacity(set.set_items.len());
     for op in &set.set_items {
-        items.push(set_item_from_op(op)?);
+        let item = set_item_from_op(op)?;
+        validate_alias_property(&item.target_alias, &item.property, &input, schema, "SET")?;
+        items.push(item);
     }
     Ok(Arc::new(LogicalPlan::SetProperties(SetProperties {
         input,
@@ -71,15 +78,21 @@ pub fn build_set(
 }
 
 /// Build a `LogicalPlan::Delete` from a parsed `DeleteClause`.
+///
+/// Validates that each target alias is bound by `input` and (when its label
+/// resolves statically) that the target schema is writable.
 pub fn build_delete(
     del: &DeleteClause<'_>,
     input: Arc<LogicalPlan>,
-    _schema: &GraphSchema,
+    schema: &GraphSchema,
 ) -> Result<Arc<LogicalPlan>> {
     let mut targets = Vec::with_capacity(del.delete_items.len());
     for expr in &del.delete_items {
         match expr {
-            Expression::Variable(name) => targets.push((*name).to_string()),
+            Expression::Variable(name) => {
+                validate_alias_writable(name, &input, schema, "DELETE")?;
+                targets.push((*name).to_string());
+            }
             other => {
                 return Err(LogicalPlanError::QueryPlanningError(format!(
                     "DELETE only accepts bare variable references; got `{:?}`",
@@ -96,20 +109,122 @@ pub fn build_delete(
 }
 
 /// Build a `LogicalPlan::Remove` from a parsed `RemoveClause`.
+///
+/// Property validation works the same way as `build_set`.
 pub fn build_remove(
     rem: &RemoveClause<'_>,
     input: Arc<LogicalPlan>,
-    _schema: &GraphSchema,
+    schema: &GraphSchema,
 ) -> Result<Arc<LogicalPlan>> {
-    let items = rem
-        .remove_items
-        .iter()
-        .map(|prop| RemoveItem {
+    let mut items = Vec::with_capacity(rem.remove_items.len());
+    for prop in &rem.remove_items {
+        validate_alias_property(prop.base, prop.key, &input, schema, "REMOVE")?;
+        items.push(RemoveItem {
             target_alias: prop.base.to_string(),
             property: prop.key.to_string(),
-        })
-        .collect();
+        });
+    }
     Ok(Arc::new(LogicalPlan::Remove(Remove { input, items })))
+}
+
+// ---------------------------------------------------------------------------
+// Alias / property validation for SET / DELETE / REMOVE
+// ---------------------------------------------------------------------------
+
+/// If `alias`'s label can be resolved from `input`, verify the schema is
+/// writable (no `source:`, no FK-edge for relationships).
+fn validate_alias_writable(
+    alias: &str,
+    input: &Arc<LogicalPlan>,
+    schema: &GraphSchema,
+    clause: &str,
+) -> Result<()> {
+    let Some(label) = find_alias_label(alias, input) else {
+        // Alias not bound in this plan tree — caller must MATCH it first.
+        return Err(LogicalPlanError::QueryPlanningError(format!(
+            "{} target `{}` is not bound by a preceding MATCH clause",
+            clause, alias
+        )));
+    };
+    if let Some(node_schema) = schema.node_schema_opt(&label) {
+        if node_schema.source.is_some() {
+            return Err(LogicalPlanError::InvalidSchema {
+                label,
+                reason: format!(
+                    "label resolves to a source-backed (read-only) table; cannot {}",
+                    clause
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Validate that `property` exists on `alias`'s schema (when statically
+/// resolvable) and that the schema is writable.
+fn validate_alias_property(
+    alias: &str,
+    property: &str,
+    input: &Arc<LogicalPlan>,
+    schema: &GraphSchema,
+    clause: &str,
+) -> Result<()> {
+    let Some(label) = find_alias_label(alias, input) else {
+        // Label unresolved at this point — defer to downstream passes.
+        return Ok(());
+    };
+    if let Some(node_schema) = schema.node_schema_opt(&label) {
+        if node_schema.source.is_some() {
+            return Err(LogicalPlanError::InvalidSchema {
+                label,
+                reason: format!(
+                    "label resolves to a source-backed (read-only) table; cannot {}",
+                    clause
+                ),
+            });
+        }
+        let known = node_schema.property_mappings.contains_key(property)
+            || node_schema.column_names.iter().any(|c| c == property);
+        if !known {
+            return Err(LogicalPlanError::QueryPlanningError(format!(
+                "property `{}` is not defined for node label `{}` ({} clause)",
+                property, label, clause
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Walk the plan tree looking for a `GraphNode` or `GraphRel` whose alias
+/// matches and which carries a static label. Returns `None` if the alias is
+/// not found or its label is not statically resolvable here.
+fn find_alias_label(alias: &str, plan: &LogicalPlan) -> Option<String> {
+    match plan {
+        LogicalPlan::GraphNode(node) if node.alias == alias => node.label.clone(),
+        LogicalPlan::GraphNode(node) => find_alias_label(alias, &node.input),
+        LogicalPlan::GraphRel(rel) => find_alias_label(alias, &rel.left)
+            .or_else(|| find_alias_label(alias, &rel.center))
+            .or_else(|| find_alias_label(alias, &rel.right)),
+        LogicalPlan::Filter(f) => find_alias_label(alias, &f.input),
+        LogicalPlan::Projection(p) => find_alias_label(alias, &p.input),
+        LogicalPlan::GroupBy(gb) => find_alias_label(alias, &gb.input),
+        LogicalPlan::OrderBy(ob) => find_alias_label(alias, &ob.input),
+        LogicalPlan::Skip(s) => find_alias_label(alias, &s.input),
+        LogicalPlan::Limit(l) => find_alias_label(alias, &l.input),
+        LogicalPlan::Cte(c) => find_alias_label(alias, &c.input),
+        LogicalPlan::GraphJoins(gj) => find_alias_label(alias, &gj.input),
+        LogicalPlan::Unwind(u) => find_alias_label(alias, &u.input),
+        LogicalPlan::Union(u) => u.inputs.iter().find_map(|p| find_alias_label(alias, p)),
+        LogicalPlan::CartesianProduct(cp) => {
+            find_alias_label(alias, &cp.left).or_else(|| find_alias_label(alias, &cp.right))
+        }
+        LogicalPlan::WithClause(wc) => find_alias_label(alias, &wc.input),
+        LogicalPlan::Create(c) => find_alias_label(alias, &c.input),
+        LogicalPlan::SetProperties(sp) => find_alias_label(alias, &sp.input),
+        LogicalPlan::Delete(d) => find_alias_label(alias, &d.input),
+        LogicalPlan::Remove(r) => find_alias_label(alias, &r.input),
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +281,8 @@ fn collect_patterns_from_connection(
 /// Resolve a CREATE relationship endpoint to an alias. If the endpoint is
 /// labeled, emit a `CreatePattern::Node` for it (we're creating a new node);
 /// otherwise it must already be bound by a prior clause, so we only return its
-/// alias.
+/// alias. Anonymous labelled endpoints are valid Cypher — synthesise an
+/// internal alias rather than rejecting them.
 fn endpoint_alias_or_create(
     pat: &NodePattern<'_>,
     schema: &GraphSchema,
@@ -174,13 +290,11 @@ fn endpoint_alias_or_create(
     side: &str,
 ) -> Result<String> {
     if pat.labels.is_some() {
-        let node = create_node_from_pattern(pat, schema)?;
-        let alias = node.alias.clone().ok_or_else(|| {
-            LogicalPlanError::QueryPlanningError(format!(
-                "CREATE {} endpoint with a label must also have an alias",
-                side
-            ))
-        })?;
+        let mut node = create_node_from_pattern(pat, schema)?;
+        let alias = node.alias.clone().unwrap_or_else(generate_id);
+        if node.alias.is_none() {
+            node.alias = Some(alias.clone());
+        }
         out.push(CreatePattern::Node(node));
         Ok(alias)
     } else {
@@ -638,5 +752,82 @@ mod tests {
             "got {:?}",
             err
         );
+    }
+
+    // Anonymous labelled endpoints get auto-generated aliases (PR #277 review).
+    #[test]
+    fn create_relationship_with_anonymous_endpoints() {
+        let p = plan("CREATE (:Person {name: 'a'})-[:KNOWS]->(:Person {name: 'b'})");
+        let create = match p {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        // Two anonymous Person nodes + the KNOWS rel = 3 patterns.
+        assert_eq!(create.patterns.len(), 3);
+        let aliases: Vec<String> = create
+            .patterns
+            .iter()
+            .filter_map(|p| match p {
+                CreatePattern::Node(n) => n.alias.clone(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(aliases.len(), 2);
+        assert_ne!(aliases[0], aliases[1], "anonymous aliases must be distinct");
+
+        let rel = create.patterns.iter().find_map(|p| match p {
+            CreatePattern::Rel(r) => Some(r),
+            _ => None,
+        });
+        let rel = rel.expect("Rel pattern present");
+        assert_eq!(rel.start_alias, aliases[0]);
+        assert_eq!(rel.end_alias, aliases[1]);
+    }
+
+    // SET / REMOVE now validate properties against the bound alias's schema.
+    #[test]
+    fn set_unknown_property_rejected() {
+        let err = plan_err("MATCH (a:Person) SET a.nickname = 'x'");
+        let msg = err.to_string();
+        assert!(msg.contains("nickname"), "got `{}`", msg);
+    }
+
+    #[test]
+    fn remove_unknown_property_rejected() {
+        let err = plan_err("MATCH (a:Person) REMOVE a.nickname");
+        let msg = err.to_string();
+        assert!(msg.contains("nickname"), "got `{}`", msg);
+    }
+
+    #[test]
+    fn set_against_source_backed_label_rejected() {
+        let mut node = person_node("Source");
+        node.source = Some("table_function:numbers(10)".to_string());
+        node.column_names.push("payload".to_string());
+        node.property_mappings.insert(
+            "payload".to_string(),
+            PropertyValue::Column("payload".to_string()),
+        );
+        let mut nodes = HashMap::new();
+        nodes.insert("Source".to_string(), node);
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, HashMap::new());
+
+        let ast = parse_query("MATCH (a:Source) SET a.payload = 1").expect("parse");
+        let err = build_logical_plan(&ast, &schema, None, None, None).expect_err("must error");
+        assert!(
+            matches!(err, LogicalPlanError::InvalidSchema { .. }),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn delete_unbound_alias_rejected() {
+        // Standalone DELETE with no MATCH — alias is not bound anywhere.
+        // The parser routes this through a query AST with delete_clause set
+        // but no reading clauses; build_delete must reject it.
+        let err = plan_err("MATCH (a:Person) DELETE b");
+        let msg = err.to_string();
+        assert!(msg.contains("not bound"), "got `{}`", msg);
     }
 }

--- a/src/query_planner/logical_plan/write_clause_builder.rs
+++ b/src/query_planner/logical_plan/write_clause_builder.rs
@@ -1,0 +1,642 @@
+//! Write-clause builder: AST → LogicalPlan write variants.
+//!
+//! Converts parsed write-clause AST nodes (`CreateClause`, `SetClause`,
+//! `DeleteClause`, `RemoveClause`) into the corresponding `LogicalPlan`
+//! variants (`Create`, `SetProperties`, `Delete`, `Remove`).
+//!
+//! Per the embedded-writes design (Phase 1), this builder:
+//! - Resolves node/relationship labels against the `GraphSchema`.
+//! - Validates property names belong to the target schema.
+//! - Rejects schemas with `source:` set (read-only source-backed targets).
+//! - Rejects FK-edge relationships (out of scope for v1).
+//!
+//! Executor- and engine-level checks (e.g., "is this an embedded chdb
+//! database?") happen later in `write_guard`.
+
+use std::sync::Arc;
+
+use crate::{
+    graph_catalog::graph_schema::GraphSchema,
+    open_cypher_parser::ast::{
+        ConnectedPattern, CreateClause, DeleteClause, Direction as AstDirection, Expression,
+        NodePattern, Operator as AstOperator, OperatorApplication, PathPattern, Property,
+        PropertyKVPair, RelationshipPattern, RemoveClause, SetClause,
+    },
+    query_planner::{
+        logical_expr::{Direction, LogicalExpr},
+        logical_plan::{
+            errors::LogicalPlanError, Create, CreateNode, CreatePattern, CreateRel, Delete,
+            LogicalPlan, Remove, RemoveItem, SetItem, SetProperties, WriteProperty,
+        },
+    },
+};
+
+type Result<T> = std::result::Result<T, LogicalPlanError>;
+
+/// Build a `LogicalPlan::Create` from a parsed `CreateClause`.
+///
+/// `input` is the preceding read pipeline (e.g., `MATCH (a) CREATE (b)`),
+/// or `LogicalPlan::Empty` for standalone CREATE.
+pub fn build_create(
+    create: &CreateClause<'_>,
+    input: Arc<LogicalPlan>,
+    schema: &GraphSchema,
+) -> Result<Arc<LogicalPlan>> {
+    let mut patterns = Vec::new();
+    for path in &create.path_patterns {
+        collect_patterns_from_path(path, schema, &mut patterns)?;
+    }
+    if patterns.is_empty() {
+        return Err(LogicalPlanError::QueryPlanningError(
+            "CREATE clause must specify at least one node or relationship".to_string(),
+        ));
+    }
+    Ok(Arc::new(LogicalPlan::Create(Create { input, patterns })))
+}
+
+/// Build a `LogicalPlan::SetProperties` from a parsed `SetClause`.
+pub fn build_set(
+    set: &SetClause<'_>,
+    input: Arc<LogicalPlan>,
+    _schema: &GraphSchema,
+) -> Result<Arc<LogicalPlan>> {
+    let mut items = Vec::with_capacity(set.set_items.len());
+    for op in &set.set_items {
+        items.push(set_item_from_op(op)?);
+    }
+    Ok(Arc::new(LogicalPlan::SetProperties(SetProperties {
+        input,
+        items,
+    })))
+}
+
+/// Build a `LogicalPlan::Delete` from a parsed `DeleteClause`.
+pub fn build_delete(
+    del: &DeleteClause<'_>,
+    input: Arc<LogicalPlan>,
+    _schema: &GraphSchema,
+) -> Result<Arc<LogicalPlan>> {
+    let mut targets = Vec::with_capacity(del.delete_items.len());
+    for expr in &del.delete_items {
+        match expr {
+            Expression::Variable(name) => targets.push((*name).to_string()),
+            other => {
+                return Err(LogicalPlanError::QueryPlanningError(format!(
+                    "DELETE only accepts bare variable references; got `{:?}`",
+                    other
+                )));
+            }
+        }
+    }
+    Ok(Arc::new(LogicalPlan::Delete(Delete {
+        input,
+        targets,
+        detach: del.is_detach,
+    })))
+}
+
+/// Build a `LogicalPlan::Remove` from a parsed `RemoveClause`.
+pub fn build_remove(
+    rem: &RemoveClause<'_>,
+    input: Arc<LogicalPlan>,
+    _schema: &GraphSchema,
+) -> Result<Arc<LogicalPlan>> {
+    let items = rem
+        .remove_items
+        .iter()
+        .map(|prop| RemoveItem {
+            target_alias: prop.base.to_string(),
+            property: prop.key.to_string(),
+        })
+        .collect();
+    Ok(Arc::new(LogicalPlan::Remove(Remove { input, items })))
+}
+
+// ---------------------------------------------------------------------------
+// CREATE helpers
+// ---------------------------------------------------------------------------
+
+fn collect_patterns_from_path(
+    path: &PathPattern<'_>,
+    schema: &GraphSchema,
+    out: &mut Vec<CreatePattern>,
+) -> Result<()> {
+    match path {
+        PathPattern::Node(node_pat) => {
+            out.push(CreatePattern::Node(create_node_from_pattern(
+                node_pat, schema,
+            )?));
+        }
+        PathPattern::ConnectedPattern(connections) => {
+            for conn in connections {
+                collect_patterns_from_connection(conn, schema, out)?;
+            }
+        }
+        PathPattern::ShortestPath(_) | PathPattern::AllShortestPaths(_) => {
+            return Err(LogicalPlanError::QueryPlanningError(
+                "shortestPath / allShortestPaths are not allowed in CREATE".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn collect_patterns_from_connection(
+    conn: &ConnectedPattern<'_>,
+    schema: &GraphSchema,
+    out: &mut Vec<CreatePattern>,
+) -> Result<()> {
+    let start_borrow = conn.start_node.borrow();
+    let end_borrow = conn.end_node.borrow();
+
+    // For each endpoint: if labeled, emit a CreateNode (we're creating it);
+    // if it's a bare reference (`(a)` with no label), it must already be bound
+    // by a prior MATCH/CREATE — record only its alias for the relationship.
+    let start_alias = endpoint_alias_or_create(&start_borrow, schema, out, "start")?;
+    let end_alias = endpoint_alias_or_create(&end_borrow, schema, out, "end")?;
+
+    let rel = create_rel_from_pattern(&conn.relationship, start_alias, end_alias, schema)?;
+    // Note: standalone CREATE pattern is `start, rel, end` — the Rel pattern
+    // is emitted *after* both endpoints so the planner can register endpoint
+    // aliases before resolving the relationship.
+    out.push(CreatePattern::Rel(rel));
+    Ok(())
+}
+
+/// Resolve a CREATE relationship endpoint to an alias. If the endpoint is
+/// labeled, emit a `CreatePattern::Node` for it (we're creating a new node);
+/// otherwise it must already be bound by a prior clause, so we only return its
+/// alias.
+fn endpoint_alias_or_create(
+    pat: &NodePattern<'_>,
+    schema: &GraphSchema,
+    out: &mut Vec<CreatePattern>,
+    side: &str,
+) -> Result<String> {
+    if pat.labels.is_some() {
+        let node = create_node_from_pattern(pat, schema)?;
+        let alias = node.alias.clone().ok_or_else(|| {
+            LogicalPlanError::QueryPlanningError(format!(
+                "CREATE {} endpoint with a label must also have an alias",
+                side
+            ))
+        })?;
+        out.push(CreatePattern::Node(node));
+        Ok(alias)
+    } else {
+        let name = pat.name.ok_or_else(|| {
+            LogicalPlanError::QueryPlanningError(format!(
+                "CREATE {} endpoint must be either a labelled node or a reference to a bound alias",
+                side
+            ))
+        })?;
+        Ok(name.to_string())
+    }
+}
+
+fn create_node_from_pattern(pat: &NodePattern<'_>, schema: &GraphSchema) -> Result<CreateNode> {
+    let labels = pat.labels.as_ref().ok_or_else(|| {
+        LogicalPlanError::QueryPlanningError(
+            "CREATE requires every node to specify a label (e.g., (a:Person {...}))".to_string(),
+        )
+    })?;
+    if labels.len() != 1 {
+        return Err(LogicalPlanError::QueryPlanningError(format!(
+            "CREATE node patterns must declare exactly one label; got {:?}",
+            labels
+        )));
+    }
+    let label = labels[0].to_string();
+
+    let node_schema = schema.node_schema(&label).map_err(|_| {
+        LogicalPlanError::NodeNotFound(format!(
+            "label `{}` is not defined in the active graph schema",
+            label
+        ))
+    })?;
+
+    if node_schema.source.is_some() {
+        return Err(LogicalPlanError::InvalidSchema {
+            label: label.clone(),
+            reason: "node label resolves to a source-backed (read-only) table".to_string(),
+        });
+    }
+
+    let properties = build_write_properties(
+        pat.properties.as_deref(),
+        |key| {
+            node_schema.property_mappings.contains_key(key)
+                || node_schema.column_names.iter().any(|c| c == key)
+        },
+        &format!("node label `{}`", label),
+    )?;
+
+    Ok(CreateNode {
+        alias: pat.name.map(|n| n.to_string()),
+        label,
+        properties,
+    })
+}
+
+fn create_rel_from_pattern(
+    rel: &RelationshipPattern<'_>,
+    start_alias: String,
+    end_alias: String,
+    schema: &GraphSchema,
+) -> Result<CreateRel> {
+    let labels = rel.labels.as_ref().ok_or_else(|| {
+        LogicalPlanError::QueryPlanningError(
+            "CREATE relationships must specify a single type (e.g., -[:KNOWS]->)".to_string(),
+        )
+    })?;
+    if labels.len() != 1 {
+        return Err(LogicalPlanError::QueryPlanningError(format!(
+            "CREATE relationship patterns must declare exactly one type; got {:?}",
+            labels
+        )));
+    }
+    let rel_type = labels[0].to_string();
+
+    let rel_schema = schema
+        .get_relationships_schema_opt(&rel_type)
+        .ok_or_else(|| LogicalPlanError::RelationshipNotFound(rel_type.clone()))?;
+
+    if rel_schema.source.is_some() {
+        return Err(LogicalPlanError::InvalidSchema {
+            label: rel_type.clone(),
+            reason: "relationship resolves to a source-backed (read-only) table".to_string(),
+        });
+    }
+    if rel_schema.is_fk_edge {
+        return Err(LogicalPlanError::InvalidSchema {
+            label: rel_type.clone(),
+            reason:
+                "FK-edge relationships are not writable in v1; declare a standard edge schema instead"
+                    .to_string(),
+        });
+    }
+    if rel.variable_length.is_some() {
+        return Err(LogicalPlanError::QueryPlanningError(
+            "variable-length paths are not allowed in CREATE".to_string(),
+        ));
+    }
+
+    let direction = match rel.direction {
+        AstDirection::Outgoing => Direction::Outgoing,
+        AstDirection::Incoming => Direction::Incoming,
+        AstDirection::Either => {
+            return Err(LogicalPlanError::QueryPlanningError(
+                "CREATE relationships must have an explicit direction".to_string(),
+            ));
+        }
+    };
+
+    let properties = build_write_properties(
+        rel.properties.as_deref(),
+        |key| {
+            rel_schema.property_mappings.contains_key(key)
+                || rel_schema.column_names.iter().any(|c| c == key)
+        },
+        &format!("relationship type `{}`", rel_type),
+    )?;
+
+    Ok(CreateRel {
+        alias: rel.name.map(|n| n.to_string()),
+        rel_type,
+        direction,
+        start_alias,
+        end_alias,
+        properties,
+    })
+}
+
+fn build_write_properties<F>(
+    props: Option<&[Property<'_>]>,
+    is_known: F,
+    target_desc: &str,
+) -> Result<Vec<WriteProperty>>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut out = Vec::new();
+    let Some(props) = props else { return Ok(out) };
+    for property in props {
+        match property {
+            Property::PropertyKV(PropertyKVPair { key, value }) => {
+                if !is_known(key) {
+                    return Err(LogicalPlanError::QueryPlanningError(format!(
+                        "property `{}` is not defined for {}",
+                        key, target_desc
+                    )));
+                }
+                let logical = LogicalExpr::try_from(value.clone())?;
+                out.push(WriteProperty {
+                    key: (*key).to_string(),
+                    value: logical,
+                });
+            }
+            Property::Param(_) => {
+                return Err(LogicalPlanError::FoundParamInProperties);
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// SET helpers
+// ---------------------------------------------------------------------------
+
+fn set_item_from_op(op: &OperatorApplication<'_>) -> Result<SetItem> {
+    if op.operator != AstOperator::Equal || op.operands.len() != 2 {
+        return Err(LogicalPlanError::QueryPlanningError(
+            "SET items must be of the form `alias.property = expression`".to_string(),
+        ));
+    }
+    let lhs = &op.operands[0];
+    let rhs = &op.operands[1];
+
+    let (alias, property) = match lhs {
+        Expression::PropertyAccessExp(pa) => (pa.base.to_string(), pa.key.to_string()),
+        other => {
+            return Err(LogicalPlanError::QueryPlanningError(format!(
+                "SET LHS must be a property access (e.g., `a.name`); got `{:?}`",
+                other
+            )));
+        }
+    };
+
+    let value = LogicalExpr::try_from(rhs.clone())?;
+    Ok(SetItem {
+        target_alias: alias,
+        property,
+        value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph_catalog::config::Identifier;
+    use crate::graph_catalog::expression_parser::PropertyValue;
+    use crate::graph_catalog::schema_types::SchemaType;
+    use crate::graph_catalog::{GraphSchema, NodeIdSchema, NodeSchema, RelationshipSchema};
+    use crate::open_cypher_parser::parse_query;
+    use crate::query_planner::logical_plan::plan_builder::build_logical_plan;
+    use std::collections::HashMap;
+
+    fn person_node(name: &str) -> NodeSchema {
+        NodeSchema {
+            database: "test".to_string(),
+            table_name: name.to_lowercase(),
+            column_names: vec!["id".to_string(), "name".to_string(), "age".to_string()],
+            primary_keys: "id".to_string(),
+            node_id: NodeIdSchema::single("id".to_string(), SchemaType::String),
+            property_mappings: [
+                ("id".to_string(), PropertyValue::Column("id".to_string())),
+                (
+                    "name".to_string(),
+                    PropertyValue::Column("name".to_string()),
+                ),
+                ("age".to_string(), PropertyValue::Column("age".to_string())),
+            ]
+            .into_iter()
+            .collect(),
+            view_parameters: None,
+            engine: None,
+            use_final: None,
+            filter: None,
+            is_denormalized: false,
+            from_properties: None,
+            to_properties: None,
+            denormalized_source_table: None,
+            label_column: None,
+            label_value: None,
+            node_id_types: None,
+            source: None,
+            property_types: HashMap::new(),
+        }
+    }
+
+    fn knows_rel() -> RelationshipSchema {
+        RelationshipSchema {
+            database: "test".to_string(),
+            table_name: "knows".to_string(),
+            column_names: vec!["from_id".to_string(), "to_id".to_string()],
+            from_node: "Person".to_string(),
+            to_node: "Person".to_string(),
+            from_node_table: "person".to_string(),
+            to_node_table: "person".to_string(),
+            from_id: Identifier::from("from_id"),
+            to_id: Identifier::from("to_id"),
+            from_node_id_dtype: SchemaType::String,
+            to_node_id_dtype: SchemaType::String,
+            property_mappings: HashMap::new(),
+            view_parameters: None,
+            engine: None,
+            use_final: None,
+            filter: None,
+            edge_id: None,
+            type_column: None,
+            from_label_column: None,
+            to_label_column: None,
+            from_label_values: None,
+            to_label_values: None,
+            from_node_properties: None,
+            to_node_properties: None,
+            is_fk_edge: false,
+            constraints: None,
+            edge_id_types: None,
+            source: None,
+            property_types: HashMap::new(),
+        }
+    }
+
+    fn build_test_schema() -> GraphSchema {
+        let mut nodes = HashMap::new();
+        nodes.insert("Person".to_string(), person_node("Person"));
+
+        let mut rels = HashMap::new();
+        rels.insert("KNOWS::Person::Person".to_string(), knows_rel());
+
+        GraphSchema::build(1, "test".to_string(), nodes, rels)
+    }
+
+    fn plan(cypher: &str) -> LogicalPlan {
+        let ast = parse_query(cypher).expect("parse should succeed");
+        let schema = build_test_schema();
+        let (plan, _ctx) =
+            build_logical_plan(&ast, &schema, None, None, None).expect("planning should succeed");
+        Arc::try_unwrap(plan).unwrap_or_else(|arc| (*arc).clone())
+    }
+
+    fn plan_err(cypher: &str) -> LogicalPlanError {
+        let ast = parse_query(cypher).expect("parse should succeed");
+        let schema = build_test_schema();
+        build_logical_plan(&ast, &schema, None, None, None).expect_err("planning should fail")
+    }
+
+    // ---------- Positive cases ----------
+
+    #[test]
+    fn create_standalone_node() {
+        let p = plan("CREATE (a:Person {name: 'Alice', age: 30})");
+        let create = match p {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        assert_eq!(create.patterns.len(), 1);
+        match &create.patterns[0] {
+            CreatePattern::Node(node) => {
+                assert_eq!(node.label, "Person");
+                assert_eq!(node.alias.as_deref(), Some("a"));
+                assert_eq!(node.properties.len(), 2);
+            }
+            other => panic!("expected Node, got {:?}", other),
+        }
+        assert!(matches!(*create.input, LogicalPlan::Empty));
+    }
+
+    #[test]
+    fn create_relationship_between_matched_nodes() {
+        let p = plan("MATCH (a:Person), (b:Person) CREATE (a)-[:KNOWS]->(b)");
+        let create = match p {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        // ConnectedPattern emits [start_node, rel, end_node]
+        assert!(create
+            .patterns
+            .iter()
+            .any(|p| matches!(p, CreatePattern::Rel(r) if r.rel_type == "KNOWS")));
+        // input is the MATCH pipeline
+        assert!(!matches!(*create.input, LogicalPlan::Empty));
+    }
+
+    #[test]
+    fn set_property_after_match() {
+        let p = plan("MATCH (a:Person) SET a.age = 30");
+        let sp = match p {
+            LogicalPlan::SetProperties(sp) => sp,
+            other => panic!("expected SetProperties, got {:?}", other),
+        };
+        assert_eq!(sp.items.len(), 1);
+        assert_eq!(sp.items[0].target_alias, "a");
+        assert_eq!(sp.items[0].property, "age");
+    }
+
+    #[test]
+    fn delete_simple() {
+        let p = plan("MATCH (a:Person) DELETE a");
+        let del = match p {
+            LogicalPlan::Delete(d) => d,
+            other => panic!("expected Delete, got {:?}", other),
+        };
+        assert_eq!(del.targets, vec!["a".to_string()]);
+        assert!(!del.detach);
+    }
+
+    #[test]
+    fn detach_delete_flag_propagates() {
+        let p = plan("MATCH (a:Person) DETACH DELETE a");
+        let del = match p {
+            LogicalPlan::Delete(d) => d,
+            other => panic!("expected Delete, got {:?}", other),
+        };
+        assert!(del.detach);
+    }
+
+    #[test]
+    fn remove_property() {
+        let p = plan("MATCH (a:Person) REMOVE a.age");
+        let rem = match p {
+            LogicalPlan::Remove(r) => r,
+            other => panic!("expected Remove, got {:?}", other),
+        };
+        assert_eq!(rem.items.len(), 1);
+        assert_eq!(rem.items[0].target_alias, "a");
+        assert_eq!(rem.items[0].property, "age");
+    }
+
+    // ---------- Negative cases ----------
+
+    #[test]
+    fn create_unknown_label_rejected() {
+        let err = plan_err("CREATE (a:Alien {name: 'x'})");
+        assert!(
+            matches!(&err, LogicalPlanError::NodeNotFound(_)),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn create_unknown_property_rejected() {
+        let err = plan_err("CREATE (a:Person {nickname: 'x'})");
+        let msg = err.to_string();
+        assert!(msg.contains("nickname"), "got `{}`", msg);
+    }
+
+    #[test]
+    fn create_unknown_relationship_rejected() {
+        let err = plan_err("MATCH (a:Person), (b:Person) CREATE (a)-[:HATES]->(b)");
+        assert!(
+            matches!(&err, LogicalPlanError::RelationshipNotFound(_)),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn create_undirected_relationship_rejected() {
+        let err = plan_err("MATCH (a:Person), (b:Person) CREATE (a)-[:KNOWS]-(b)");
+        let msg = err.to_string();
+        assert!(msg.contains("explicit direction"), "got `{}`", msg);
+    }
+
+    #[test]
+    fn create_node_without_label_rejected() {
+        let err = plan_err("CREATE (a)");
+        let msg = err.to_string();
+        assert!(msg.contains("label"), "got `{}`", msg);
+    }
+
+    #[test]
+    fn create_against_source_backed_label_rejected() {
+        let mut node = person_node("Source");
+        node.source = Some("table_function:numbers(10)".to_string());
+        let mut nodes = HashMap::new();
+        nodes.insert("Source".to_string(), node);
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, HashMap::new());
+
+        let ast = parse_query("CREATE (a:Source {name: 'x'})").expect("parse");
+        let err = build_logical_plan(&ast, &schema, None, None, None).expect_err("must error");
+        assert!(
+            matches!(err, LogicalPlanError::InvalidSchema { .. }),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn create_against_fk_edge_rejected() {
+        let mut nodes = HashMap::new();
+        nodes.insert("Person".to_string(), person_node("Person"));
+
+        let mut rel = knows_rel();
+        rel.is_fk_edge = true;
+        let mut rels = HashMap::new();
+        rels.insert("KNOWS::Person::Person".to_string(), rel);
+
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, rels);
+
+        let ast =
+            parse_query("MATCH (a:Person), (b:Person) CREATE (a)-[:KNOWS]->(b)").expect("parse");
+        let err = build_logical_plan(&ast, &schema, None, None, None).expect_err("must error");
+        assert!(
+            matches!(err, LogicalPlanError::InvalidSchema { .. }),
+            "got {:?}",
+            err
+        );
+    }
+}

--- a/src/query_planner/mod.rs
+++ b/src/query_planner/mod.rs
@@ -23,6 +23,7 @@ pub mod transformed;
 pub mod translator;
 pub mod typed_variable;
 pub mod types;
+pub mod write_guard;
 
 pub fn get_query_type(query_ast: &OpenCypherQueryAst) -> QueryType {
     // CALL with RETURN (e.g., CALL db.labels() YIELD label RETURN ...) is a read query

--- a/src/query_planner/optimizer/cartesian_join_extraction.rs
+++ b/src/query_planner/optimizer/cartesian_join_extraction.rs
@@ -451,6 +451,11 @@ impl OptimizerPass for CartesianJoinExtraction {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side cartesian-join extraction does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
 
         Ok(transformed_plan)
@@ -614,6 +619,11 @@ fn collect_aliases_from_plan_inner(plan: &LogicalPlan, aliases: &mut HashSet<Str
             }
             collect_aliases_from_plan_inner(&wc.input, aliases);
         }
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => collect_aliases_from_plan_inner(&c.input, aliases),
+        LogicalPlan::SetProperties(sp) => collect_aliases_from_plan_inner(&sp.input, aliases),
+        LogicalPlan::Delete(d) => collect_aliases_from_plan_inner(&d.input, aliases),
+        LogicalPlan::Remove(r) => collect_aliases_from_plan_inner(&r.input, aliases),
     }
 }
 

--- a/src/query_planner/optimizer/cleanup_viewscan_filters.rs
+++ b/src/query_planner/optimizer/cleanup_viewscan_filters.rs
@@ -308,6 +308,11 @@ impl CleanupViewScanFilters {
                     Transformed::No(_) => Transformed::No(logical_plan),
                 }
             }
+            // Write variants — read-side filter cleanup does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan),
         };
 
         Ok(transformed_plan)

--- a/src/query_planner/optimizer/collect_unwind_elimination.rs
+++ b/src/query_planner/optimizer/collect_unwind_elimination.rs
@@ -356,6 +356,12 @@ impl CollectUnwindElimination {
             | LogicalPlan::Cte(_)
             | LogicalPlan::PageRank(_)
             | LogicalPlan::Empty => Ok((plan, HashMap::new())),
+
+            // Write variants — collect/unwind elimination only operates on read plans.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Ok((plan, HashMap::new())),
         }
     }
 

--- a/src/query_planner/optimizer/filter_into_graph_rel.rs
+++ b/src/query_planner/optimizer/filter_into_graph_rel.rs
@@ -1064,6 +1064,11 @@ impl OptimizerPass for FilterIntoGraphRel {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side filter pushdown does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/optimizer/filter_push_down.rs
+++ b/src/query_planner/optimizer/filter_push_down.rs
@@ -143,6 +143,11 @@ impl OptimizerPass for FilterPushDown {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side filter pushdown does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/optimizer/projection_push_down.rs
+++ b/src/query_planner/optimizer/projection_push_down.rs
@@ -126,6 +126,11 @@ impl OptimizerPass for ProjectionPushDown {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — read-side projection pushdown does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
         Ok(transformed_plan)
     }

--- a/src/query_planner/optimizer/view_optimizer.rs
+++ b/src/query_planner/optimizer/view_optimizer.rs
@@ -269,6 +269,11 @@ impl OptimizerPass for ViewOptimizer {
                     Transformed::No(_) => Transformed::No(logical_plan.clone()),
                 }
             }
+            // Write variants — view optimization does not apply.
+            LogicalPlan::Create(_)
+            | LogicalPlan::SetProperties(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Remove(_) => Transformed::No(logical_plan.clone()),
         };
 
         Ok(transformed_plan)

--- a/src/query_planner/write_guard.rs
+++ b/src/query_planner/write_guard.rs
@@ -8,6 +8,15 @@
 //!   for defence-in-depth).
 //! - **Decision 0.6**: FK-edge writes are rejected (also enforced upstream).
 //!
+//! Validation scope per write variant:
+//! - **`CREATE`**: every `CreateNode` / `CreateRel` is validated (label/type
+//!   resolves, schema is writable, edge is not FK-edge).
+//! - **`SET` / `DELETE` / `REMOVE`**: targets are bound aliases from the
+//!   preceding read pipeline. The guard walks `input` to resolve each alias's
+//!   label statically and re-checks 0.3 / 0.6 on the resolved schema. When a
+//!   label cannot be resolved at this stage (e.g., bound across a WITH
+//!   boundary), validation is deferred to the renderer / executor.
+//!
 //! Call sites: the embedded `Connection::query()` should call
 //! `ensure_write_target_writable` after the planner produces a `LogicalPlan`
 //! and before the renderer executes it.
@@ -51,10 +60,16 @@ pub enum WriteGuardError {
     ExecutorNotWritable(ExecutorKind),
 
     #[error(
-        "Cannot write to label `{label}`: it resolves to a source-backed (read-only) table. \
+        "Cannot write to node label `{label}`: it resolves to a source-backed (read-only) table. \
          Source-backed schemas (Parquet/S3/Iceberg/Delta) are read-only by design."
     )]
-    SourceBackedTarget { label: String },
+    SourceBackedNode { label: String },
+
+    #[error(
+        "Cannot write to relationship type `{rel_type}`: it resolves to a source-backed \
+         (read-only) table. Source-backed schemas (Parquet/S3/Iceberg/Delta) are read-only by design."
+    )]
+    SourceBackedRelationship { rel_type: String },
 
     #[error(
         "Cannot write to relationship type `{rel_type}`: it is an FK-edge schema, which is not \
@@ -73,8 +88,10 @@ pub enum WriteGuardError {
 /// Walk the plan tree, and if any write variant is present, enforce decisions
 /// 0.1, 0.3 and 0.6.
 ///
-/// Read-only plans pass through silently (no traversal cost beyond a single
-/// dispatch on the root variant).
+/// The implementation makes two passes: a structural check for any write
+/// variant (whole-tree walk, but cheap — leaves return immediately and there
+/// is no cloning), then full schema-level validation only when writes are
+/// found. Read-only plans pay only the first pass.
 pub fn ensure_write_target_writable(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -89,7 +106,7 @@ pub fn ensure_write_target_writable(
     check_writes_recursive(plan, schema)
 }
 
-/// Cheap structural check: does this plan tree contain any write variant?
+/// Structural check: does this plan tree contain any write variant?
 fn plan_contains_write(plan: &LogicalPlan) -> bool {
     match plan {
         LogicalPlan::Create(_)
@@ -130,9 +147,24 @@ fn check_writes_recursive(plan: &LogicalPlan, schema: &GraphSchema) -> Result<()
             }
             check_writes_recursive(&c.input, schema)
         }
-        LogicalPlan::SetProperties(sp) => check_writes_recursive(&sp.input, schema),
-        LogicalPlan::Delete(d) => check_writes_recursive(&d.input, schema),
-        LogicalPlan::Remove(r) => check_writes_recursive(&r.input, schema),
+        LogicalPlan::SetProperties(sp) => {
+            for item in &sp.items {
+                check_alias_target_writable(&item.target_alias, &sp.input, schema)?;
+            }
+            check_writes_recursive(&sp.input, schema)
+        }
+        LogicalPlan::Delete(d) => {
+            for alias in &d.targets {
+                check_alias_target_writable(alias, &d.input, schema)?;
+            }
+            check_writes_recursive(&d.input, schema)
+        }
+        LogicalPlan::Remove(r) => {
+            for item in &r.items {
+                check_alias_target_writable(&item.target_alias, &r.input, schema)?;
+            }
+            check_writes_recursive(&r.input, schema)
+        }
 
         LogicalPlan::GraphNode(gn) => check_writes_recursive(&gn.input, schema),
         LogicalPlan::GraphRel(gr) => {
@@ -175,7 +207,7 @@ fn check_create_pattern(
                 .node_schema_opt(&node.label)
                 .ok_or_else(|| WriteGuardError::UnknownNodeLabel(node.label.clone()))?;
             if node_schema.source.is_some() {
-                return Err(WriteGuardError::SourceBackedTarget {
+                return Err(WriteGuardError::SourceBackedNode {
                     label: node.label.clone(),
                 });
             }
@@ -185,8 +217,8 @@ fn check_create_pattern(
                 .get_relationships_schema_opt(&rel.rel_type)
                 .ok_or_else(|| WriteGuardError::UnknownRelationshipType(rel.rel_type.clone()))?;
             if rel_schema.source.is_some() {
-                return Err(WriteGuardError::SourceBackedTarget {
-                    label: rel.rel_type.clone(),
+                return Err(WriteGuardError::SourceBackedRelationship {
+                    rel_type: rel.rel_type.clone(),
                 });
             }
             if rel_schema.is_fk_edge {
@@ -199,10 +231,109 @@ fn check_create_pattern(
     Ok(())
 }
 
+/// For SET / DELETE / REMOVE: locate the alias in the input plan, then if its
+/// label / relationship type is statically resolvable, re-check decisions
+/// 0.3 and 0.6. Aliases whose label cannot be resolved at this stage (e.g.,
+/// bound across a WITH boundary) are deferred to downstream validation.
+fn check_alias_target_writable(
+    alias: &str,
+    input: &LogicalPlan,
+    schema: &GraphSchema,
+) -> Result<(), WriteGuardError> {
+    if let Some(label) = find_alias_node_label(alias, input) {
+        if let Some(node_schema) = schema.node_schema_opt(&label) {
+            if node_schema.source.is_some() {
+                return Err(WriteGuardError::SourceBackedNode { label });
+            }
+        }
+        return Ok(());
+    }
+    if let Some(rel_type) = find_alias_rel_type(alias, input) {
+        if let Some(rel_schema) = schema.get_relationships_schema_opt(&rel_type) {
+            if rel_schema.source.is_some() {
+                return Err(WriteGuardError::SourceBackedRelationship { rel_type });
+            }
+            if rel_schema.is_fk_edge {
+                return Err(WriteGuardError::FkEdgeTarget { rel_type });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn find_alias_node_label(alias: &str, plan: &LogicalPlan) -> Option<String> {
+    match plan {
+        LogicalPlan::GraphNode(n) if n.alias == alias => n.label.clone(),
+        LogicalPlan::GraphNode(n) => find_alias_node_label(alias, &n.input),
+        LogicalPlan::GraphRel(r) => find_alias_node_label(alias, &r.left)
+            .or_else(|| find_alias_node_label(alias, &r.center))
+            .or_else(|| find_alias_node_label(alias, &r.right)),
+        LogicalPlan::Filter(f) => find_alias_node_label(alias, &f.input),
+        LogicalPlan::Projection(p) => find_alias_node_label(alias, &p.input),
+        LogicalPlan::GroupBy(gb) => find_alias_node_label(alias, &gb.input),
+        LogicalPlan::OrderBy(ob) => find_alias_node_label(alias, &ob.input),
+        LogicalPlan::Skip(s) => find_alias_node_label(alias, &s.input),
+        LogicalPlan::Limit(l) => find_alias_node_label(alias, &l.input),
+        LogicalPlan::Cte(c) => find_alias_node_label(alias, &c.input),
+        LogicalPlan::GraphJoins(gj) => find_alias_node_label(alias, &gj.input),
+        LogicalPlan::Unwind(u) => find_alias_node_label(alias, &u.input),
+        LogicalPlan::Union(u) => u
+            .inputs
+            .iter()
+            .find_map(|p| find_alias_node_label(alias, p)),
+        LogicalPlan::CartesianProduct(cp) => find_alias_node_label(alias, &cp.left)
+            .or_else(|| find_alias_node_label(alias, &cp.right)),
+        LogicalPlan::WithClause(wc) => find_alias_node_label(alias, &wc.input),
+        LogicalPlan::Create(c) => find_alias_node_label(alias, &c.input),
+        LogicalPlan::SetProperties(sp) => find_alias_node_label(alias, &sp.input),
+        LogicalPlan::Delete(d) => find_alias_node_label(alias, &d.input),
+        LogicalPlan::Remove(r) => find_alias_node_label(alias, &r.input),
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => None,
+    }
+}
+
+fn find_alias_rel_type(alias: &str, plan: &LogicalPlan) -> Option<String> {
+    match plan {
+        LogicalPlan::GraphRel(r) if r.alias == alias => {
+            r.labels.as_ref().and_then(|l| l.first().cloned())
+        }
+        LogicalPlan::GraphRel(r) => find_alias_rel_type(alias, &r.left)
+            .or_else(|| find_alias_rel_type(alias, &r.center))
+            .or_else(|| find_alias_rel_type(alias, &r.right)),
+        LogicalPlan::GraphNode(n) => find_alias_rel_type(alias, &n.input),
+        LogicalPlan::Filter(f) => find_alias_rel_type(alias, &f.input),
+        LogicalPlan::Projection(p) => find_alias_rel_type(alias, &p.input),
+        LogicalPlan::GroupBy(gb) => find_alias_rel_type(alias, &gb.input),
+        LogicalPlan::OrderBy(ob) => find_alias_rel_type(alias, &ob.input),
+        LogicalPlan::Skip(s) => find_alias_rel_type(alias, &s.input),
+        LogicalPlan::Limit(l) => find_alias_rel_type(alias, &l.input),
+        LogicalPlan::Cte(c) => find_alias_rel_type(alias, &c.input),
+        LogicalPlan::GraphJoins(gj) => find_alias_rel_type(alias, &gj.input),
+        LogicalPlan::Unwind(u) => find_alias_rel_type(alias, &u.input),
+        LogicalPlan::Union(u) => u.inputs.iter().find_map(|p| find_alias_rel_type(alias, p)),
+        LogicalPlan::CartesianProduct(cp) => {
+            find_alias_rel_type(alias, &cp.left).or_else(|| find_alias_rel_type(alias, &cp.right))
+        }
+        LogicalPlan::WithClause(wc) => find_alias_rel_type(alias, &wc.input),
+        LogicalPlan::Create(c) => find_alias_rel_type(alias, &c.input),
+        LogicalPlan::SetProperties(sp) => find_alias_rel_type(alias, &sp.input),
+        LogicalPlan::Delete(d) => find_alias_rel_type(alias, &d.input),
+        LogicalPlan::Remove(r) => find_alias_rel_type(alias, &r.input),
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query_planner::logical_plan::{Create, CreateNode, Delete};
+    use crate::graph_catalog::config::Identifier;
+    use crate::graph_catalog::expression_parser::PropertyValue;
+    use crate::graph_catalog::schema_types::SchemaType;
+    use crate::graph_catalog::{NodeIdSchema, NodeSchema, RelationshipSchema};
+    use crate::query_planner::logical_expr::Direction;
+    use crate::query_planner::logical_plan::{
+        Create, CreateNode, CreateRel, Delete, GraphNode, GraphRel, SetItem, SetProperties,
+    };
     use std::sync::Arc;
 
     fn empty_schema() -> GraphSchema {
@@ -212,6 +343,127 @@ mod tests {
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
         )
+    }
+
+    fn person_node_with_source(source: Option<&str>) -> NodeSchema {
+        NodeSchema {
+            database: "test".to_string(),
+            table_name: "person".to_string(),
+            column_names: vec!["id".to_string(), "name".to_string()],
+            primary_keys: "id".to_string(),
+            node_id: NodeIdSchema::single("id".to_string(), SchemaType::String),
+            property_mappings: [(
+                "name".to_string(),
+                PropertyValue::Column("name".to_string()),
+            )]
+            .into_iter()
+            .collect(),
+            view_parameters: None,
+            engine: None,
+            use_final: None,
+            filter: None,
+            is_denormalized: false,
+            from_properties: None,
+            to_properties: None,
+            denormalized_source_table: None,
+            label_column: None,
+            label_value: None,
+            node_id_types: None,
+            source: source.map(|s| s.to_string()),
+            property_types: std::collections::HashMap::new(),
+        }
+    }
+
+    fn knows_rel(is_fk: bool) -> RelationshipSchema {
+        RelationshipSchema {
+            database: "test".to_string(),
+            table_name: "knows".to_string(),
+            column_names: vec!["from_id".to_string(), "to_id".to_string()],
+            from_node: "Person".to_string(),
+            to_node: "Person".to_string(),
+            from_node_table: "person".to_string(),
+            to_node_table: "person".to_string(),
+            from_id: Identifier::from("from_id"),
+            to_id: Identifier::from("to_id"),
+            from_node_id_dtype: SchemaType::String,
+            to_node_id_dtype: SchemaType::String,
+            property_mappings: std::collections::HashMap::new(),
+            view_parameters: None,
+            engine: None,
+            use_final: None,
+            filter: None,
+            edge_id: None,
+            type_column: None,
+            from_label_column: None,
+            to_label_column: None,
+            from_label_values: None,
+            to_label_values: None,
+            from_node_properties: None,
+            to_node_properties: None,
+            is_fk_edge: is_fk,
+            constraints: None,
+            edge_id_types: None,
+            source: None,
+            property_types: std::collections::HashMap::new(),
+        }
+    }
+
+    fn schema_with_person(source: Option<&str>) -> GraphSchema {
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert("Person".to_string(), person_node_with_source(source));
+        GraphSchema::build(
+            1,
+            "test".to_string(),
+            nodes,
+            std::collections::HashMap::new(),
+        )
+    }
+
+    fn schema_with_fk_edge() -> GraphSchema {
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert("Person".to_string(), person_node_with_source(None));
+        let mut rels = std::collections::HashMap::new();
+        rels.insert("KNOWS::Person::Person".to_string(), knows_rel(true));
+        GraphSchema::build(1, "test".to_string(), nodes, rels)
+    }
+
+    fn graph_node_alias(alias: &str, label: Option<&str>) -> Arc<LogicalPlan> {
+        Arc::new(LogicalPlan::GraphNode(GraphNode {
+            input: Arc::new(LogicalPlan::Empty),
+            alias: alias.to_string(),
+            label: label.map(|s| s.to_string()),
+            is_denormalized: false,
+            projected_columns: None,
+            node_types: None,
+        }))
+    }
+
+    fn graph_rel(
+        alias: &str,
+        rel_type: &str,
+        left: Arc<LogicalPlan>,
+        right: Arc<LogicalPlan>,
+    ) -> Arc<LogicalPlan> {
+        Arc::new(LogicalPlan::GraphRel(GraphRel {
+            left,
+            center: Arc::new(LogicalPlan::Empty),
+            right,
+            alias: alias.to_string(),
+            direction: Direction::Outgoing,
+            left_connection: "a".to_string(),
+            right_connection: "b".to_string(),
+            is_rel_anchor: false,
+            variable_length: None,
+            shortest_path_mode: None,
+            path_variable: None,
+            where_predicate: None,
+            labels: Some(vec![rel_type.to_string()]),
+            is_optional: None,
+            anchor_connection: None,
+            cte_references: std::collections::HashMap::new(),
+            pattern_combinations: None,
+            was_undirected: None,
+        }))
     }
 
     #[test]
@@ -260,5 +512,83 @@ mod tests {
         let err =
             ensure_write_target_writable(&plan, &schema, ExecutorKind::EmbeddedChdb).unwrap_err();
         assert!(matches!(err, WriteGuardError::UnknownNodeLabel(_)));
+    }
+
+    #[test]
+    fn create_rel_against_source_backed_emits_relationship_error() {
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert("Person".to_string(), person_node_with_source(None));
+        let mut rel = knows_rel(false);
+        rel.source = Some("table_function:numbers(10)".to_string());
+        let mut rels = std::collections::HashMap::new();
+        rels.insert("KNOWS::Person::Person".to_string(), rel);
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, rels);
+
+        let plan = LogicalPlan::Create(Create {
+            input: Arc::new(LogicalPlan::Empty),
+            patterns: vec![CreatePattern::Rel(CreateRel {
+                alias: None,
+                rel_type: "KNOWS".to_string(),
+                direction: Direction::Outgoing,
+                start_alias: "a".to_string(),
+                end_alias: "b".to_string(),
+                properties: vec![],
+            })],
+        });
+        let err =
+            ensure_write_target_writable(&plan, &schema, ExecutorKind::EmbeddedChdb).unwrap_err();
+        assert!(
+            matches!(err, WriteGuardError::SourceBackedRelationship { .. }),
+            "got {:?}",
+            err
+        );
+    }
+
+    // SET on a bound alias whose schema is source-backed must be rejected by
+    // the guard (Decision 0.3 enforcement on SET, not just CREATE).
+    #[test]
+    fn set_against_source_backed_alias_rejected() {
+        let schema = schema_with_person(Some("table_function:numbers(10)"));
+        let plan = LogicalPlan::SetProperties(SetProperties {
+            input: graph_node_alias("a", Some("Person")),
+            items: vec![SetItem {
+                target_alias: "a".to_string(),
+                property: "name".to_string(),
+                value: crate::query_planner::logical_expr::LogicalExpr::Literal(
+                    crate::query_planner::logical_expr::Literal::String("x".to_string()),
+                ),
+            }],
+        });
+        let err =
+            ensure_write_target_writable(&plan, &schema, ExecutorKind::EmbeddedChdb).unwrap_err();
+        assert!(
+            matches!(err, WriteGuardError::SourceBackedNode { .. }),
+            "got {:?}",
+            err
+        );
+    }
+
+    // DELETE on a relationship alias whose type is FK-edge must be rejected.
+    #[test]
+    fn delete_against_fk_edge_alias_rejected() {
+        let schema = schema_with_fk_edge();
+        let input = graph_rel(
+            "r",
+            "KNOWS",
+            graph_node_alias("a", Some("Person")),
+            graph_node_alias("b", Some("Person")),
+        );
+        let plan = LogicalPlan::Delete(Delete {
+            input,
+            targets: vec!["r".to_string()],
+            detach: false,
+        });
+        let err =
+            ensure_write_target_writable(&plan, &schema, ExecutorKind::EmbeddedChdb).unwrap_err();
+        assert!(
+            matches!(err, WriteGuardError::FkEdgeTarget { .. }),
+            "got {:?}",
+            err
+        );
     }
 }

--- a/src/query_planner/write_guard.rs
+++ b/src/query_planner/write_guard.rs
@@ -1,0 +1,264 @@
+//! Write guard — centralised admission checks for write `LogicalPlan` variants.
+//!
+//! Per the embedded-writes design (Phase 0):
+//! - **Decision 0.1**: Writes are only admitted when the executor is the
+//!   embedded chdb backend. Server mode and SQL-only/remote bindings reject.
+//! - **Decision 0.3**: Source-backed (read-only) targets are rejected at plan
+//!   time (also enforced upstream in `write_clause_builder`; replicated here
+//!   for defence-in-depth).
+//! - **Decision 0.6**: FK-edge writes are rejected (also enforced upstream).
+//!
+//! Call sites: the embedded `Connection::query()` should call
+//! `ensure_write_target_writable` after the planner produces a `LogicalPlan`
+//! and before the renderer executes it.
+//!
+//! The HTTP/Bolt server retains its existing reject at
+//! `src/server/handlers.rs:1356` as a separate defence-in-depth check —
+//! this guard does not replace it.
+
+use crate::{
+    graph_catalog::graph_schema::GraphSchema,
+    query_planner::logical_plan::{CreatePattern, LogicalPlan},
+};
+
+use thiserror::Error;
+
+/// Identifies the execution backend the planner is producing SQL for.
+///
+/// Only `EmbeddedChdb` may execute write `LogicalPlan` variants. The other
+/// kinds will be rejected by `ensure_write_target_writable` if a write
+/// variant appears.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutorKind {
+    /// Embedded chdb (`Database::new(...)` with the `embedded` feature).
+    /// Writes are permitted.
+    EmbeddedChdb,
+    /// Translation-only mode (`Database::sql_only(...)`). No execution.
+    SqlOnly,
+    /// External ClickHouse via HTTP (`Database::new_remote(...)`). Writes rejected.
+    Remote,
+    /// HTTP / Bolt server. Writes rejected.
+    Server,
+}
+
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum WriteGuardError {
+    #[error(
+        "Cypher write clauses (CREATE/SET/DELETE/REMOVE) are only supported in embedded chdb mode; \
+         this connection is `{0:?}`. Use `Database::new(schema, SystemConfig)` (with the `embedded` \
+         feature) to enable writes."
+    )]
+    ExecutorNotWritable(ExecutorKind),
+
+    #[error(
+        "Cannot write to label `{label}`: it resolves to a source-backed (read-only) table. \
+         Source-backed schemas (Parquet/S3/Iceberg/Delta) are read-only by design."
+    )]
+    SourceBackedTarget { label: String },
+
+    #[error(
+        "Cannot write to relationship type `{rel_type}`: it is an FK-edge schema, which is not \
+         writable in v1. Declare a standard edge-table schema (separate edge table with \
+         from_id/to_id columns) to enable writes."
+    )]
+    FkEdgeTarget { rel_type: String },
+
+    #[error("Unknown node label `{0}` referenced in write clause")]
+    UnknownNodeLabel(String),
+
+    #[error("Unknown relationship type `{0}` referenced in write clause")]
+    UnknownRelationshipType(String),
+}
+
+/// Walk the plan tree, and if any write variant is present, enforce decisions
+/// 0.1, 0.3 and 0.6.
+///
+/// Read-only plans pass through silently (no traversal cost beyond a single
+/// dispatch on the root variant).
+pub fn ensure_write_target_writable(
+    plan: &LogicalPlan,
+    schema: &GraphSchema,
+    executor: ExecutorKind,
+) -> Result<(), WriteGuardError> {
+    if !plan_contains_write(plan) {
+        return Ok(());
+    }
+    if executor != ExecutorKind::EmbeddedChdb {
+        return Err(WriteGuardError::ExecutorNotWritable(executor));
+    }
+    check_writes_recursive(plan, schema)
+}
+
+/// Cheap structural check: does this plan tree contain any write variant?
+fn plan_contains_write(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => true,
+
+        LogicalPlan::GraphNode(gn) => plan_contains_write(&gn.input),
+        LogicalPlan::GraphRel(gr) => {
+            plan_contains_write(&gr.left)
+                || plan_contains_write(&gr.center)
+                || plan_contains_write(&gr.right)
+        }
+        LogicalPlan::Filter(f) => plan_contains_write(&f.input),
+        LogicalPlan::Projection(p) => plan_contains_write(&p.input),
+        LogicalPlan::GroupBy(gb) => plan_contains_write(&gb.input),
+        LogicalPlan::OrderBy(ob) => plan_contains_write(&ob.input),
+        LogicalPlan::Skip(s) => plan_contains_write(&s.input),
+        LogicalPlan::Limit(l) => plan_contains_write(&l.input),
+        LogicalPlan::Cte(cte) => plan_contains_write(&cte.input),
+        LogicalPlan::GraphJoins(gj) => plan_contains_write(&gj.input),
+        LogicalPlan::Union(u) => u.inputs.iter().any(|i| plan_contains_write(i)),
+        LogicalPlan::Unwind(uw) => plan_contains_write(&uw.input),
+        LogicalPlan::CartesianProduct(cp) => {
+            plan_contains_write(&cp.left) || plan_contains_write(&cp.right)
+        }
+        LogicalPlan::WithClause(wc) => plan_contains_write(&wc.input),
+
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => false,
+    }
+}
+
+fn check_writes_recursive(plan: &LogicalPlan, schema: &GraphSchema) -> Result<(), WriteGuardError> {
+    match plan {
+        LogicalPlan::Create(c) => {
+            for pattern in &c.patterns {
+                check_create_pattern(pattern, schema)?;
+            }
+            check_writes_recursive(&c.input, schema)
+        }
+        LogicalPlan::SetProperties(sp) => check_writes_recursive(&sp.input, schema),
+        LogicalPlan::Delete(d) => check_writes_recursive(&d.input, schema),
+        LogicalPlan::Remove(r) => check_writes_recursive(&r.input, schema),
+
+        LogicalPlan::GraphNode(gn) => check_writes_recursive(&gn.input, schema),
+        LogicalPlan::GraphRel(gr) => {
+            check_writes_recursive(&gr.left, schema)?;
+            check_writes_recursive(&gr.center, schema)?;
+            check_writes_recursive(&gr.right, schema)
+        }
+        LogicalPlan::Filter(f) => check_writes_recursive(&f.input, schema),
+        LogicalPlan::Projection(p) => check_writes_recursive(&p.input, schema),
+        LogicalPlan::GroupBy(gb) => check_writes_recursive(&gb.input, schema),
+        LogicalPlan::OrderBy(ob) => check_writes_recursive(&ob.input, schema),
+        LogicalPlan::Skip(s) => check_writes_recursive(&s.input, schema),
+        LogicalPlan::Limit(l) => check_writes_recursive(&l.input, schema),
+        LogicalPlan::Cte(cte) => check_writes_recursive(&cte.input, schema),
+        LogicalPlan::GraphJoins(gj) => check_writes_recursive(&gj.input, schema),
+        LogicalPlan::Unwind(uw) => check_writes_recursive(&uw.input, schema),
+        LogicalPlan::Union(u) => {
+            for input in &u.inputs {
+                check_writes_recursive(input, schema)?;
+            }
+            Ok(())
+        }
+        LogicalPlan::CartesianProduct(cp) => {
+            check_writes_recursive(&cp.left, schema)?;
+            check_writes_recursive(&cp.right, schema)
+        }
+        LogicalPlan::WithClause(wc) => check_writes_recursive(&wc.input, schema),
+
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => Ok(()),
+    }
+}
+
+fn check_create_pattern(
+    pattern: &CreatePattern,
+    schema: &GraphSchema,
+) -> Result<(), WriteGuardError> {
+    match pattern {
+        CreatePattern::Node(node) => {
+            let node_schema = schema
+                .node_schema_opt(&node.label)
+                .ok_or_else(|| WriteGuardError::UnknownNodeLabel(node.label.clone()))?;
+            if node_schema.source.is_some() {
+                return Err(WriteGuardError::SourceBackedTarget {
+                    label: node.label.clone(),
+                });
+            }
+        }
+        CreatePattern::Rel(rel) => {
+            let rel_schema = schema
+                .get_relationships_schema_opt(&rel.rel_type)
+                .ok_or_else(|| WriteGuardError::UnknownRelationshipType(rel.rel_type.clone()))?;
+            if rel_schema.source.is_some() {
+                return Err(WriteGuardError::SourceBackedTarget {
+                    label: rel.rel_type.clone(),
+                });
+            }
+            if rel_schema.is_fk_edge {
+                return Err(WriteGuardError::FkEdgeTarget {
+                    rel_type: rel.rel_type.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_planner::logical_plan::{Create, CreateNode, Delete};
+    use std::sync::Arc;
+
+    fn empty_schema() -> GraphSchema {
+        GraphSchema::build(
+            0,
+            "test".to_string(),
+            std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
+        )
+    }
+
+    #[test]
+    fn read_only_plan_passes_in_any_executor() {
+        let plan = LogicalPlan::Empty;
+        let schema = empty_schema();
+        for kind in [
+            ExecutorKind::EmbeddedChdb,
+            ExecutorKind::SqlOnly,
+            ExecutorKind::Remote,
+            ExecutorKind::Server,
+        ] {
+            assert!(ensure_write_target_writable(&plan, &schema, kind).is_ok());
+        }
+    }
+
+    #[test]
+    fn write_plan_rejected_outside_embedded() {
+        let plan = LogicalPlan::Delete(Delete {
+            input: Arc::new(LogicalPlan::Empty),
+            targets: vec!["a".to_string()],
+            detach: false,
+        });
+        let schema = empty_schema();
+        for kind in [
+            ExecutorKind::SqlOnly,
+            ExecutorKind::Remote,
+            ExecutorKind::Server,
+        ] {
+            let err = ensure_write_target_writable(&plan, &schema, kind).unwrap_err();
+            assert!(matches!(err, WriteGuardError::ExecutorNotWritable(_)));
+        }
+    }
+
+    #[test]
+    fn unknown_label_rejected_in_embedded() {
+        let plan = LogicalPlan::Create(Create {
+            input: Arc::new(LogicalPlan::Empty),
+            patterns: vec![CreatePattern::Node(CreateNode {
+                alias: Some("a".to_string()),
+                label: "DoesNotExist".to_string(),
+                properties: vec![],
+            })],
+        });
+        let schema = empty_schema();
+        let err =
+            ensure_write_target_writable(&plan, &schema, ExecutorKind::EmbeddedChdb).unwrap_err();
+        assert!(matches!(err, WriteGuardError::UnknownNodeLabel(_)));
+    }
+}

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4451,6 +4451,10 @@ pub fn extract_ctes_with_context(
                     LogicalPlan::Unwind(_) => "Unwind",
                     LogicalPlan::CartesianProduct(_) => "CartesianProduct",
                     LogicalPlan::WithClause(_) => "WithClause",
+                    LogicalPlan::Create(_) => "Create",
+                    LogicalPlan::SetProperties(_) => "SetProperties",
+                    LogicalPlan::Delete(_) => "Delete",
+                    LogicalPlan::Remove(_) => "Remove",
                 }
             );
             extract_ctes_with_context(
@@ -4949,6 +4953,11 @@ pub fn extract_ctes_with_context(
             );
             Ok(ctes)
         }
+        // Write variants — write payloads do not contribute CTEs to read-side rendering.
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => Ok(vec![]),
     }
 }
 

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4953,11 +4953,21 @@ pub fn extract_ctes_with_context(
             );
             Ok(ctes)
         }
-        // Write variants — write payloads do not contribute CTEs to read-side rendering.
-        LogicalPlan::Create(_)
-        | LogicalPlan::SetProperties(_)
-        | LogicalPlan::Delete(_)
-        | LogicalPlan::Remove(_) => Ok(vec![]),
+        // Write variants — recurse into the preceding read pipeline so any
+        // CTEs it produced (WITH CTEs, VLP CTEs, etc.) still reach the
+        // renderer. The write payload itself does not contribute CTEs.
+        LogicalPlan::Create(c) => {
+            extract_ctes_with_context(&c.input, last_node_alias, context, schema, plan_ctx)
+        }
+        LogicalPlan::SetProperties(sp) => {
+            extract_ctes_with_context(&sp.input, last_node_alias, context, schema, plan_ctx)
+        }
+        LogicalPlan::Delete(d) => {
+            extract_ctes_with_context(&d.input, last_node_alias, context, schema, plan_ctx)
+        }
+        LogicalPlan::Remove(r) => {
+            extract_ctes_with_context(&r.input, last_node_alias, context, schema, plan_ctx)
+        }
     }
 }
 

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -483,6 +483,11 @@ impl FilterBuilder for LogicalPlan {
                 }
             }
             LogicalPlan::WithClause(wc) => wc.input.extract_filters()?,
+            // Write variants — recurse into preceding read pipeline for filter extraction.
+            LogicalPlan::Create(c) => c.input.extract_filters()?,
+            LogicalPlan::SetProperties(sp) => sp.input.extract_filters()?,
+            LogicalPlan::Delete(d) => d.input.extract_filters()?,
+            LogicalPlan::Remove(r) => r.input.extract_filters()?,
         };
         Ok(filters)
     }

--- a/src/render_plan/from_builder.rs
+++ b/src/render_plan/from_builder.rs
@@ -261,6 +261,14 @@ impl FromBuilder for LogicalPlan {
             }
 
             LogicalPlan::WithClause(wc) => from_table_to_view_ref(wc.input.extract_from()?),
+
+            // Write variants — recurse into preceding read pipeline. The write
+            // payload itself does not produce a FROM clause (its SQL is rendered
+            // separately in Phase 2's write_to_sql.rs).
+            LogicalPlan::Create(c) => from_table_to_view_ref(c.input.extract_from()?),
+            LogicalPlan::SetProperties(sp) => from_table_to_view_ref(sp.input.extract_from()?),
+            LogicalPlan::Delete(d) => from_table_to_view_ref(d.input.extract_from()?),
+            LogicalPlan::Remove(r) => from_table_to_view_ref(r.input.extract_from()?),
         };
 
         Ok(view_ref_to_from_table(from_ref))

--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -618,6 +618,12 @@ impl RenderPlanBuilder for LogicalPlan {
                     .or(cp.right.extract_last_node_cte(schema)?)
             }
             LogicalPlan::WithClause(wc) => wc.input.extract_last_node_cte(schema)?,
+
+            // Write variants — recurse into preceding read pipeline.
+            LogicalPlan::Create(c) => c.input.extract_last_node_cte(schema)?,
+            LogicalPlan::SetProperties(sp) => sp.input.extract_last_node_cte(schema)?,
+            LogicalPlan::Delete(d) => d.input.extract_last_node_cte(schema)?,
+            LogicalPlan::Remove(r) => r.input.extract_last_node_cte(schema)?,
         };
         Ok(last_node_cte)
     }

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -678,6 +678,12 @@ pub(super) fn find_table_name_for_alias(plan: &LogicalPlan, target_alias: &str) 
 
         // === WithClause - search input ===
         LogicalPlan::WithClause(wc) => find_table_name_for_alias(&wc.input, target_alias),
+
+        // === Write variants - recurse into preceding read pipeline ===
+        LogicalPlan::Create(c) => find_table_name_for_alias(&c.input, target_alias),
+        LogicalPlan::SetProperties(sp) => find_table_name_for_alias(&sp.input, target_alias),
+        LogicalPlan::Delete(d) => find_table_name_for_alias(&d.input, target_alias),
+        LogicalPlan::Remove(r) => find_table_name_for_alias(&r.input, target_alias),
     }
 }
 
@@ -2318,6 +2324,10 @@ pub(super) fn plan_type_name(plan: &LogicalPlan) -> &'static str {
         LogicalPlan::Unwind(_) => "Unwind",
         LogicalPlan::CartesianProduct(_) => "CartesianProduct",
         LogicalPlan::WithClause(_) => "WithClause",
+        LogicalPlan::Create(_) => "Create",
+        LogicalPlan::SetProperties(_) => "SetProperties",
+        LogicalPlan::Delete(_) => "Delete",
+        LogicalPlan::Remove(_) => "Remove",
     }
 }
 

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -1897,6 +1897,12 @@ pub fn extract_filters(plan: &LogicalPlan) -> RenderPlanBuilderResult<Option<Ren
             }
         }
         LogicalPlan::WithClause(wc) => extract_filters(&wc.input)?,
+
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => extract_filters(&c.input)?,
+        LogicalPlan::SetProperties(sp) => extract_filters(&sp.input)?,
+        LogicalPlan::Delete(d) => extract_filters(&d.input)?,
+        LogicalPlan::Remove(r) => extract_filters(&r.input)?,
     };
     Ok(filters)
 }
@@ -2629,6 +2635,12 @@ pub fn extract_from(plan: &LogicalPlan) -> RenderPlanBuilderResult<Option<FromTa
             }
         }
         LogicalPlan::WithClause(wc) => from_table_to_view_ref(extract_from(&wc.input)?),
+
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => from_table_to_view_ref(extract_from(&c.input)?),
+        LogicalPlan::SetProperties(sp) => from_table_to_view_ref(extract_from(&sp.input)?),
+        LogicalPlan::Delete(d) => from_table_to_view_ref(extract_from(&d.input)?),
+        LogicalPlan::Remove(r) => from_table_to_view_ref(extract_from(&r.input)?),
     };
     Ok(view_ref_to_from_table(from_ref))
 }

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -1267,6 +1267,14 @@ impl SelectBuilder for LogicalPlan {
                 }
                 items
             }
+
+            // Write variants — recurse into preceding read pipeline. The write
+            // clause itself does not contribute SELECT items (Phase 2 renders
+            // counters separately).
+            LogicalPlan::Create(c) => c.input.extract_select_items(plan_ctx)?,
+            LogicalPlan::SetProperties(sp) => sp.input.extract_select_items(plan_ctx)?,
+            LogicalPlan::Delete(d) => d.input.extract_select_items(plan_ctx)?,
+            LogicalPlan::Remove(r) => r.input.extract_select_items(plan_ctx)?,
         };
 
         Ok(select_items)

--- a/src/server/bolt_protocol/result_transformer.rs
+++ b/src/server/bolt_protocol/result_transformer.rs
@@ -230,6 +230,12 @@ fn find_relationship_direction(plan: &LogicalPlan, rel_alias: &str) -> Option<St
         LogicalPlan::GraphNode(gn) => find_relationship_direction(&gn.input, rel_alias),
         LogicalPlan::GraphJoins(gj) => find_relationship_direction(&gj.input, rel_alias),
         LogicalPlan::ViewScan(_) | LogicalPlan::Empty => None,
+
+        // Write variants — recurse into preceding read pipeline.
+        LogicalPlan::Create(c) => find_relationship_direction(&c.input, rel_alias),
+        LogicalPlan::SetProperties(sp) => find_relationship_direction(&sp.input, rel_alias),
+        LogicalPlan::Delete(d) => find_relationship_direction(&d.input, rel_alias),
+        LogicalPlan::Remove(r) => find_relationship_direction(&r.input, rel_alias),
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of [embedded-mode Cypher writes](docs/design/embedded-writes.md): adds the **planner-layer scaffolding** for `CREATE` / `SET` / `DELETE` / `REMOVE`. No read-side behaviour changes; write variants are gated to embedded chdb and not yet executed (Phase 3 wires the executor).

## What's new

- **`LogicalPlan` variants**: `Create`, `SetProperties`, `Delete`, `Remove` — each carries the preceding read pipeline as `input` (or `Empty` for standalone `CREATE`).
- **`logical_plan/write_clause_builder.rs`**: AST → variants. Resolves labels via `GraphSchema`, validates property names, rejects source-backed targets (Decision 0.3), FK-edges (Decision 0.6), multi-label nodes, undirected/variable-length `CREATE` relationships.
- **`query_planner/write_guard.rs`**: `ExecutorKind` enum + `ensure_write_target_writable()` — single admission check per Decision 0.1 (writes only in `EmbeddedChdb`), with defence-in-depth re-checks of 0.3/0.6.
- **`plan_builder`**: wires `CREATE → SET → REMOVE → DELETE` between `WHERE` and `RETURN`; allows otherwise-empty AST when a write clause is present.

## Read-side fan-out

36 exhaustive `match LogicalPlan` sites across analyzer/optimizer/render now have write-variant arms. Most pass through unchanged (writes never reach the read-side pipeline); a few metadata helpers (`extract_pattern_info`, `find_label_for_alias_in_plan`, `extract_filters`, …) recurse into `input` so the preceding read pipeline still gets analysed.

## Test plan

- [x] 13 new unit tests in `write_clause_builder`:
  - Positive: standalone `CREATE`, `CREATE` with bound endpoints, `SET`, `DELETE`, `DETACH DELETE`, `REMOVE`
  - Negative: unknown label/property/relationship, undirected `CREATE`, missing label, source-backed target, FK-edge target
- [x] 3 new tests in `write_guard`: read-only pass-through, executor reject, unknown-label reject
- [x] Full clickgraph suite: **1314 lib + 279 integration + 7 unit + 30 stress** still green
- [x] `cargo fmt --all && cargo clippy -p clickgraph --all-targets` clean (only pre-existing warnings remain)

## Next

- **Phase 2**: render plan + `clickhouse_query_generator/write_to_sql.rs`
- **Phase 3**: embedded executor wiring + `data_loader.rs` block-tracking SETTINGS

🤖 Generated with [Claude Code](https://claude.com/claude-code)