### PR TITLE
feat(embedded): Phase 3 — executor wiring + ID generation + block-tracking DDL

### DIFF
--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -1191,7 +1191,14 @@ impl<'db> Connection<'db> {
     }
 
     async fn query_async(&self, cypher: &str) -> Result<QueryResult, EmbeddedError> {
-        if let Ok((_, stmt)) = clickgraph::open_cypher_parser::parse_cypher_statement(cypher) {
+        // Strip comments before dispatch parsing so write detection matches
+        // what `handle_write_async` sees during its own parse below — comments
+        // (e.g., `// ...` or `/* ... */`) inside the query would otherwise
+        // break parsing here and silently bypass write routing.
+        let dispatch_input = clickgraph::open_cypher_parser::strip_comments(cypher);
+        if let Ok((_, stmt)) =
+            clickgraph::open_cypher_parser::parse_cypher_statement(&dispatch_input)
+        {
             if let clickgraph::open_cypher_parser::ast::CypherStatement::CopyTo(ref copy_stmt) =
                 stmt
             {
@@ -1229,26 +1236,23 @@ impl<'db> Connection<'db> {
             // emits lightweight INSERT / UPDATE / DELETE per Phase 2's
             // WriteRenderPlan. Read queries fall through to the regular
             // SELECT path below.
+            //
+            // Any query carrying a write clause — CREATE / SET / DELETE /
+            // REMOVE — must enter the write pipeline so we either execute it
+            // or reject it with a clear error. Falling through to the read
+            // path produces confusing render-time errors. Note that
+            // `get_query_type` only inspects SET / DELETE / REMOVE, so we
+            // also need an explicit `create_clause.is_some()` check to cover
+            // `CREATE`, `MATCH ... CREATE`, and `CREATE ... RETURN` variants.
             if let clickgraph::open_cypher_parser::ast::CypherStatement::Query { query, .. } = &stmt
             {
                 use clickgraph::query_planner::types::QueryType;
-                match clickgraph::query_planner::get_query_type(query) {
-                    QueryType::Update | QueryType::Delete => {
-                        return self.handle_write_async(cypher).await;
-                    }
-                    _ => {
-                        // Standalone CREATE has no `delete_clause` / `set_clause`
-                        // / `remove_clause` so `get_query_type` reports `Read`.
-                        // Detect explicitly and route to the write path.
-                        if query.create_clause.is_some()
-                            && query.return_clause.is_none()
-                            && query.match_clauses.is_empty()
-                            && query.optional_match_clauses.is_empty()
-                            && query.with_clause.is_none()
-                        {
-                            return self.handle_write_async(cypher).await;
-                        }
-                    }
+                let is_write = matches!(
+                    clickgraph::query_planner::get_query_type(query),
+                    QueryType::Update | QueryType::Delete
+                ) || query.create_clause.is_some();
+                if is_write {
+                    return self.handle_write_async(cypher).await;
                 }
             }
         }
@@ -1294,8 +1298,19 @@ impl<'db> Connection<'db> {
             let write_plan = build_write_plan(&logical_plan, &schema)
                 .map_err(|e| EmbeddedError::Query(format!("Write render error: {}", e)))?
                 .ok_or_else(|| {
+                    // The dispatch above sent us here because a write clause
+                    // (CREATE / SET / DELETE / REMOVE) was visible in the
+                    // parsed AST, but `build_write_plan` couldn't extract a
+                    // write variant from the planned tree — typically this
+                    // means the write was wrapped under a clause we don't
+                    // yet support in the write pipeline (e.g. CREATE ...
+                    // RETURN). Surface a clear error rather than the
+                    // generic "non-write plan" wording.
                     EmbeddedError::Query(
-                        "Internal error: write dispatch reached non-write plan".to_string(),
+                        "Cypher write clause is not supported in this combination yet \
+                         (e.g. CREATE … RETURN, or write clauses inside subqueries). \
+                         Use a separate write statement followed by a MATCH for now."
+                            .to_string(),
                     )
                 })?;
             let stmts = write_render_to_sql(&write_plan);
@@ -2264,6 +2279,73 @@ graph_schema:
         assert!(
             msg.contains("embedded chdb mode") || msg.contains("EmbeddedChdb"),
             "expected executor-rejection error, got: {}",
+            msg
+        );
+    }
+
+    /// `CREATE` with leading line comments must still route to the write
+    /// path. Regression for the dispatch parser silently bypassing writes
+    /// when the input contained comments.
+    #[test]
+    fn cypher_create_with_comments_routes_to_write_path() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let cypher = "// leading comment\n/* block comment */\nCREATE (a:Person {person_id: 'p1'})";
+        let result = conn
+            .query(cypher)
+            .expect("CREATE with comments must route to write dispatch");
+        let mut iter = result.into_iter();
+        let row = iter.next().unwrap();
+        assert_eq!(row.get("nodes_created").unwrap().as_i64(), Some(1));
+
+        let sqls = captured.lock().unwrap();
+        assert!(
+            sqls[0].starts_with("INSERT INTO"),
+            "comment-prefixed CREATE must still emit INSERT, got: {}",
+            sqls[0]
+        );
+    }
+
+    /// `MATCH … CREATE` (read query feeding a write) must enter the write
+    /// pipeline rather than silently fall through to the read path. We pin
+    /// only that dispatch reaches the write pipeline and produces a
+    /// counter-shaped `QueryResult` — exact semantics for MATCH-driven
+    /// CREATE may keep evolving.
+    #[test]
+    fn cypher_match_create_routes_to_write_path() {
+        let (db, _captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let result = conn
+            .query("MATCH (a:Person) CREATE (b:Person {person_id: 'p2'})")
+            .expect("MATCH … CREATE must reach write pipeline");
+        // Counter-shape ensures we routed to handle_write_async; if it
+        // had fallen through to the read path, the QueryResult columns
+        // would not be the four counter columns.
+        let cols = result.get_column_names();
+        assert_eq!(
+            cols.len(),
+            4,
+            "expected counter result from write path, got cols={:?}",
+            cols
+        );
+        assert!(cols.contains(&"nodes_created".to_string()));
+    }
+
+    /// `CREATE … RETURN` likewise must enter the write pipeline. We don't
+    /// yet support returning rows from a CREATE — the write pipeline
+    /// rejects this combination with a clear error rather than letting it
+    /// silently fall through to the read path.
+    #[test]
+    fn cypher_create_with_return_rejected_with_clear_error() {
+        let (db, _captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let err = conn
+            .query("CREATE (a:Person {person_id: 'p3'}) RETURN a")
+            .expect_err("CREATE … RETURN must surface a write-pipeline error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not supported") && msg.to_lowercase().contains("create"),
+            "expected write-pipeline rejection naming CREATE, got: {}",
             msg
         );
     }

--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -1225,8 +1225,179 @@ impl<'db> Connection<'db> {
                     return self.handle_fulltext_search_call(cypher).await;
                 }
             }
+            // Cypher write clauses route to a separate executor path that
+            // emits lightweight INSERT / UPDATE / DELETE per Phase 2's
+            // WriteRenderPlan. Read queries fall through to the regular
+            // SELECT path below.
+            if let clickgraph::open_cypher_parser::ast::CypherStatement::Query { query, .. } = &stmt
+            {
+                use clickgraph::query_planner::types::QueryType;
+                match clickgraph::query_planner::get_query_type(query) {
+                    QueryType::Update | QueryType::Delete => {
+                        return self.handle_write_async(cypher).await;
+                    }
+                    _ => {
+                        // Standalone CREATE has no `delete_clause` / `set_clause`
+                        // / `remove_clause` so `get_query_type` reports `Read`.
+                        // Detect explicitly and route to the write path.
+                        if query.create_clause.is_some()
+                            && query.return_clause.is_none()
+                            && query.match_clauses.is_empty()
+                            && query.optional_match_clauses.is_empty()
+                            && query.with_clause.is_none()
+                        {
+                            return self.handle_write_async(cypher).await;
+                        }
+                    }
+                }
+            }
         }
         self.query_with_executor_async(cypher, &self.executor).await
+    }
+
+    /// Plan, render, and execute a Cypher write query (CREATE / SET /
+    /// DELETE / REMOVE). Returns Neo4j-compatible counters as a single-row
+    /// `QueryResult` per Decision 0.8 of the embedded-writes design.
+    async fn handle_write_async(&self, cypher: &str) -> Result<QueryResult, EmbeddedError> {
+        use clickgraph::clickhouse_query_generator::write_to_sql::write_render_to_sql;
+        use clickgraph::query_planner::write_guard::ensure_write_target_writable;
+        use clickgraph::render_plan::write_plan_builder::build_write_plan;
+        use clickgraph::server::query_context::{
+            set_current_schema, with_query_context, QueryContext,
+        };
+
+        let schema = Arc::clone(&self.schema);
+        let executor = Arc::clone(&self.executor);
+        let executor_kind = self.db.executor_kind;
+        let cypher = cypher.to_string();
+
+        with_query_context(QueryContext::new(None), async move {
+            set_current_schema(Arc::clone(&schema));
+
+            let compile_start = Instant::now();
+
+            // Parse, plan, run the regular analyzer/optimizer pipeline so
+            // any read pipeline below the write variant is fully resolved
+            // before we render.
+            let cleaned = clickgraph::open_cypher_parser::strip_comments(&cypher);
+            let (_remaining, stmt) =
+                clickgraph::open_cypher_parser::parse_cypher_statement(&cleaned)
+                    .map_err(|e| EmbeddedError::Query(format!("Parse error: {:?}", e)))?;
+            let (logical_plan, _plan_ctx) =
+                clickgraph::query_planner::evaluate_read_statement(stmt, &schema, None, None, None)
+                    .map_err(|e| EmbeddedError::Query(format!("Plan error: {}", e)))?;
+
+            // Decision 0.1 / 0.3 / 0.6 admission check.
+            ensure_write_target_writable(&logical_plan, &schema, executor_kind)
+                .map_err(|e| EmbeddedError::Query(format!("Write rejected: {}", e)))?;
+
+            let write_plan = build_write_plan(&logical_plan, &schema)
+                .map_err(|e| EmbeddedError::Query(format!("Write render error: {}", e)))?
+                .ok_or_else(|| {
+                    EmbeddedError::Query(
+                        "Internal error: write dispatch reached non-write plan".to_string(),
+                    )
+                })?;
+            let stmts = write_render_to_sql(&write_plan);
+            let compile_time_ms = compile_start.elapsed().as_secs_f64() * 1000.0;
+
+            // Execute each rendered statement in order. Counters are
+            // best-effort: chdb's lightweight INSERT/UPDATE/DELETE don't
+            // surface affected-row counts, so we report the statement
+            // count as a coarse signal for now.
+            let exec_start = Instant::now();
+            let mut nodes_created: u64 = 0;
+            let mut properties_set: u64 = 0;
+            let mut nodes_deleted: u64 = 0;
+            let mut relationships_deleted: u64 = 0;
+            let counters = classify_write_counters(&write_plan);
+            nodes_created += counters.nodes_created;
+            properties_set += counters.properties_set;
+            nodes_deleted += counters.nodes_deleted;
+            relationships_deleted += counters.relationships_deleted;
+
+            for sql in &stmts {
+                executor
+                    .execute_json(sql, None)
+                    .await
+                    .map_err(EmbeddedError::from)?;
+            }
+            let execution_time_ms = exec_start.elapsed().as_secs_f64() * 1000.0;
+
+            let column_names = vec![
+                "nodes_created".to_string(),
+                "properties_set".to_string(),
+                "nodes_deleted".to_string(),
+                "relationships_deleted".to_string(),
+            ];
+            let row = vec![
+                Value::Int64(nodes_created as i64),
+                Value::Int64(properties_set as i64),
+                Value::Int64(nodes_deleted as i64),
+                Value::Int64(relationships_deleted as i64),
+            ];
+            Ok(QueryResult::with_timing(
+                column_names,
+                vec![row],
+                compile_time_ms,
+                execution_time_ms,
+            ))
+        })
+        .await
+    }
+}
+
+/// Best-effort counter extraction from a `WriteRenderPlan`. chdb's
+/// lightweight write path doesn't return affected-row counts, so we report
+/// per-operation counts (one Insert = one node created, etc.) rather than
+/// actual row counts. Callers that need accurate row counts should fetch
+/// before/after `count()` themselves.
+#[derive(Default)]
+struct WriteCounters {
+    nodes_created: u64,
+    properties_set: u64,
+    nodes_deleted: u64,
+    relationships_deleted: u64,
+}
+
+fn classify_write_counters(plan: &clickgraph::render_plan::WriteRenderPlan) -> WriteCounters {
+    let mut c = WriteCounters::default();
+    walk(plan, &mut c);
+    c
+}
+
+fn walk(plan: &clickgraph::render_plan::WriteRenderPlan, c: &mut WriteCounters) {
+    use clickgraph::render_plan::WriteRenderPlan;
+    match plan {
+        WriteRenderPlan::Insert(op) => {
+            // Coarse heuristic: each row is one entity. Whether it's a
+            // node or relationship is encoded in the table — we attribute
+            // to nodes_created here. A future refinement can split by
+            // schema lookup once rel CREATE lands (currently rejected).
+            c.nodes_created += op.rows.len() as u64;
+        }
+        WriteRenderPlan::Update(op) => {
+            c.properties_set += op.assignments.len() as u64;
+        }
+        WriteRenderPlan::Delete(_op) => {
+            // Sequence walk decides node-vs-rel by whether the DELETE is
+            // the last in a Sequence (node) or precedes one (rel cleanup).
+            // For a bare top-level Delete, attribute to nodes.
+            c.nodes_deleted += 1;
+        }
+        WriteRenderPlan::Sequence(seq) => {
+            // Rel-cleanup DELETEs precede a final node DELETE in DETACH
+            // DELETE. Attribute earlier DELETEs to relationships.
+            let len = seq.len();
+            for (i, inner) in seq.iter().enumerate() {
+                match inner {
+                    WriteRenderPlan::Delete(_) if i + 1 < len => {
+                        c.relationships_deleted += 1;
+                    }
+                    _ => walk(inner, c),
+                }
+            }
+        }
     }
 }
 
@@ -1363,6 +1534,7 @@ graph_schema:
                 .enable_all()
                 .build()
                 .unwrap(),
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
         }
     }
 
@@ -1378,9 +1550,10 @@ graph_schema:
         impl QueryExecutor for CapturingExecutor {
             async fn execute_json(
                 &self,
-                _sql: &str,
+                sql: &str,
                 _role: Option<&str>,
             ) -> Result<Vec<serde_json::Value>, ExecutorError> {
+                self.captured.lock().unwrap().push(sql.to_string());
                 Ok(vec![])
             }
             async fn execute_text(
@@ -1404,6 +1577,7 @@ graph_schema:
                 .enable_all()
                 .build()
                 .unwrap(),
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
         };
         (db, captured)
     }
@@ -1438,6 +1612,7 @@ graph_schema:
                 .enable_all()
                 .build()
                 .unwrap(),
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
         }
     }
 
@@ -1932,6 +2107,164 @@ graph_schema:
             sqls[0].contains("''';"),
             "escaped quote should precede semicolon: {}",
             sqls[0]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Cypher write dispatch (Phase 3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cypher_create_routes_to_write_path_and_emits_insert() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let mut result = conn
+            .query("CREATE (a:Person {person_id: 'p1', name: 'Alice'})")
+            .expect("CREATE should succeed via write dispatch");
+
+        // Counters surface as a single-row QueryResult per Decision 0.8.
+        assert_eq!(result.get_column_names().len(), 4);
+        assert_eq!(result.num_rows(), 1);
+        let row = result.next().unwrap();
+        assert_eq!(row.get("nodes_created").unwrap().as_i64(), Some(1));
+
+        let sqls = captured.lock().unwrap();
+        assert_eq!(sqls.len(), 1, "expected one INSERT, got {:?}", sqls);
+        assert!(
+            sqls[0].starts_with("INSERT INTO"),
+            "expected INSERT, got: {}",
+            sqls[0]
+        );
+        // No SETTINGS at query time per Decision 0.7.
+        assert!(
+            !sqls[0].to_lowercase().contains("settings"),
+            "must not emit SETTINGS at query time, got: {}",
+            sqls[0]
+        );
+    }
+
+    #[test]
+    fn cypher_set_routes_to_write_path_and_emits_update() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let result = conn
+            .query("MATCH (a:Person) WHERE a.person_id = 'p1' SET a.name = 'Bob'")
+            .expect("SET should succeed via write dispatch");
+        let mut iter = result.into_iter();
+        let row = iter.next().unwrap();
+        assert_eq!(row.get("properties_set").unwrap().as_i64(), Some(1));
+
+        let sqls = captured.lock().unwrap();
+        assert!(
+            sqls[0].starts_with("UPDATE"),
+            "expected UPDATE, got: {}",
+            sqls[0]
+        );
+        // Lightweight UPDATE — no mutations_sync.
+        assert!(
+            !sqls[0].to_lowercase().contains("mutations_sync"),
+            "must not emit mutations_sync, got: {}",
+            sqls[0]
+        );
+    }
+
+    #[test]
+    fn cypher_delete_routes_to_write_path_and_emits_delete() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let result = conn
+            .query("MATCH (a:Person) WHERE a.person_id = 'p1' DELETE a")
+            .expect("DELETE should succeed via write dispatch");
+        let mut iter = result.into_iter();
+        let row = iter.next().unwrap();
+        assert_eq!(row.get("nodes_deleted").unwrap().as_i64(), Some(1));
+
+        let sqls = captured.lock().unwrap();
+        assert!(
+            sqls[0].starts_with("DELETE FROM"),
+            "expected DELETE FROM, got: {}",
+            sqls[0]
+        );
+    }
+
+    #[test]
+    fn cypher_detach_delete_emits_rel_then_node_delete_sequence() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let result = conn
+            .query("MATCH (a:Person) WHERE a.person_id = 'p1' DETACH DELETE a")
+            .expect("DETACH DELETE should succeed");
+        let mut iter = result.into_iter();
+        let row = iter.next().unwrap();
+        // KNOWS touches Person on both sides → 2 rel-cleanup deletes,
+        // then 1 node delete.
+        assert!(row.get("relationships_deleted").unwrap().as_i64().unwrap() >= 1);
+        assert_eq!(row.get("nodes_deleted").unwrap().as_i64(), Some(1));
+
+        let sqls = captured.lock().unwrap();
+        // Last SQL is the node delete.
+        assert!(
+            sqls.last().unwrap().contains("`persons`") || sqls.last().unwrap().contains("`person`"),
+            "node DELETE must come last, got: {:?}",
+            sqls
+        );
+    }
+
+    #[test]
+    fn cypher_remove_routes_to_write_path() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        conn.query("MATCH (a:Person) WHERE a.person_id = 'p1' REMOVE a.name")
+            .expect("REMOVE should succeed");
+        let sqls = captured.lock().unwrap();
+        assert!(
+            sqls[0].contains("SET `full_name` = NULL"),
+            "REMOVE should emit SET … = NULL, got: {}",
+            sqls[0]
+        );
+    }
+
+    #[test]
+    fn cypher_write_rejected_in_sql_only_mode() {
+        // `from_executor` tags the Database as SqlOnly. Writes must reject.
+        let schema = build_writable_test_schema();
+        let db = Database::from_executor(
+            schema,
+            Arc::new({
+                use async_trait::async_trait;
+                use clickgraph::executor::{ExecutorError, QueryExecutor};
+                struct Stub;
+                #[async_trait]
+                impl QueryExecutor for Stub {
+                    async fn execute_json(
+                        &self,
+                        _sql: &str,
+                        _role: Option<&str>,
+                    ) -> Result<Vec<serde_json::Value>, ExecutorError> {
+                        Ok(vec![])
+                    }
+                    async fn execute_text(
+                        &self,
+                        _sql: &str,
+                        _format: &str,
+                        _role: Option<&str>,
+                    ) -> Result<String, ExecutorError> {
+                        Ok(String::new())
+                    }
+                }
+                Stub
+            }),
+        )
+        .unwrap();
+        let conn = Connection::new(&db).unwrap();
+        let err = conn
+            .query("CREATE (a:Person {person_id: 'p1'})")
+            .expect_err("must reject write in sql_only mode");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("embedded chdb mode") || msg.contains("EmbeddedChdb"),
+            "expected executor-rejection error, got: {}",
+            msg
         );
     }
 }

--- a/clickgraph-embedded/src/database.rs
+++ b/clickgraph-embedded/src/database.rs
@@ -115,6 +115,10 @@ pub struct Database {
     /// Shared Tokio runtime for blocking `Connection::query()` calls.
     /// Created once, reused by all connections -- avoids per-call overhead.
     pub(crate) runtime: tokio::runtime::Runtime,
+    /// What kind of backend the primary executor is. Used by the write
+    /// guard (Phase 3 of the embedded-writes plan) to gate Cypher write
+    /// clauses to the embedded chdb path only.
+    pub(crate) executor_kind: clickgraph::query_planner::write_guard::ExecutorKind,
 }
 
 impl Database {
@@ -204,6 +208,7 @@ impl Database {
             remote_executor,
             schema,
             runtime,
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
         })
     }
 
@@ -226,6 +231,7 @@ impl Database {
             remote_executor: Some(remote_executor),
             schema: Arc::new(graph_schema),
             runtime,
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::Remote,
         })
     }
 
@@ -271,6 +277,11 @@ impl Database {
             remote_executor: None,
             schema,
             runtime: build_runtime()?,
+            // Test helper: the executor is opaque, so we cannot route
+            // writes through it safely. Tag as SqlOnly so the write
+            // guard rejects writes here — tests that need writes should
+            // construct a chdb-backed Database via `new` instead.
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::SqlOnly,
         })
     }
 

--- a/clickgraph-embedded/tests/writes_e2e.rs
+++ b/clickgraph-embedded/tests/writes_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for embedded-mode Cypher writes (Phase 3).
+//!
+//! Exercises the full pipeline:
+//!
+//!   parse → plan (write variants) → write_guard → write_plan_builder
+//!     → write_to_sql → chdb execution → read-back verification
+//!
+//! Unlike `chdb_e2e.rs`, these tests use a *writable* schema (no `source:`
+//! field) so the data_loader emits `CREATE TABLE` instead of `CREATE VIEW`.
+//!
+//! **Gating**: Skipped by default. Set `CLICKGRAPH_CHDB_TESTS=1` to run.
+//! Requires the `embedded` feature (uses `Database::new` which loads chdb).
+//! chdb supports only one session per process, so these run in their own
+//! integration-test binary (separate from `chdb_e2e.rs`).
+
+#![cfg(feature = "embedded")]
+
+use std::sync::LazyLock;
+
+use clickgraph_embedded::{Connection, Database, SystemConfig};
+
+fn chdb_tests_enabled() -> bool {
+    std::env::var("CLICKGRAPH_CHDB_TESTS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+struct WritesFixture {
+    _dir: tempfile::TempDir,
+    db: Database,
+}
+
+static FIXTURE: LazyLock<&'static WritesFixture> = LazyLock::new(|| {
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    // Writable schema — no `source:` fields, so the data_loader emits
+    // CREATE TABLE with the lightweight-UPDATE block-tracking SETTINGS.
+    let schema_yaml = r#"name: writes_e2e
+graph_schema:
+  nodes:
+    - label: Person
+      database: default
+      table: persons
+      node_id: person_id
+      type: string
+      property_mappings:
+        person_id: person_id
+        name: full_name
+        age: age
+  edges:
+    - type: KNOWS
+      database: default
+      table: knows
+      from_node: Person
+      to_node: Person
+      from_id: from_person_id
+      to_id: to_person_id
+      property_mappings:
+        since: since_year
+"#;
+
+    let schema_path = dir.path().join("schema.yaml");
+    std::fs::write(&schema_path, schema_yaml).expect("write schema.yaml");
+
+    let db = Database::new(&schema_path, SystemConfig::default()).expect("open chdb database");
+    Box::leak(Box::new(WritesFixture { _dir: dir, db }))
+});
+
+fn conn() -> Option<Connection<'static>> {
+    if !chdb_tests_enabled() {
+        eprintln!("  [skipped] set CLICKGRAPH_CHDB_TESTS=1 to run write e2e tests");
+        return None;
+    }
+    Some(Connection::new(&FIXTURE.db).unwrap())
+}
+
+#[test]
+fn create_node_then_match_back() {
+    let Some(conn) = conn() else { return };
+
+    let mut counters = conn
+        .query("CREATE (a:Person {person_id: 'u1', name: 'Alice', age: 30})")
+        .expect("CREATE");
+    let row = counters.next().unwrap();
+    assert_eq!(row.get("nodes_created").unwrap().as_i64(), Some(1));
+
+    let mut result = conn
+        .query("MATCH (a:Person) WHERE a.person_id = 'u1' RETURN a.name, a.age")
+        .expect("MATCH back");
+    let row = result.next().unwrap();
+    assert_eq!(row.get("a.name").unwrap().as_str(), Some("Alice"));
+    assert_eq!(row.get("a.age").unwrap().as_i64(), Some(30));
+}
+
+#[test]
+fn set_property_changes_value() {
+    let Some(conn) = conn() else { return };
+
+    conn.query("CREATE (a:Person {person_id: 'u2', name: 'Bob', age: 25})")
+        .expect("CREATE");
+    conn.query("MATCH (a:Person) WHERE a.person_id = 'u2' SET a.age = 26")
+        .expect("SET");
+
+    let mut result = conn
+        .query("MATCH (a:Person) WHERE a.person_id = 'u2' RETURN a.age")
+        .expect("MATCH back");
+    let row = result.next().unwrap();
+    assert_eq!(row.get("a.age").unwrap().as_i64(), Some(26));
+}
+
+#[test]
+fn delete_removes_node() {
+    let Some(conn) = conn() else { return };
+
+    conn.query("CREATE (a:Person {person_id: 'u3', name: 'Charlie'})")
+        .expect("CREATE");
+    conn.query("MATCH (a:Person) WHERE a.person_id = 'u3' DELETE a")
+        .expect("DELETE");
+
+    let result = conn
+        .query("MATCH (a:Person) WHERE a.person_id = 'u3' RETURN count(a) AS cnt")
+        .expect("count back");
+    let row = result.into_iter().next().unwrap();
+    assert_eq!(row.get("cnt").unwrap().as_i64(), Some(0));
+}
+
+#[test]
+fn remove_property_sets_null() {
+    let Some(conn) = conn() else { return };
+
+    conn.query("CREATE (a:Person {person_id: 'u4', name: 'Diana', age: 28})")
+        .expect("CREATE");
+    conn.query("MATCH (a:Person) WHERE a.person_id = 'u4' REMOVE a.age")
+        .expect("REMOVE");
+
+    let mut result = conn
+        .query("MATCH (a:Person) WHERE a.person_id = 'u4' RETURN a.age")
+        .expect("MATCH back");
+    let row = result.next().unwrap();
+    // After REMOVE, `a.age` should be NULL.
+    assert!(row.get("a.age").unwrap().is_null());
+}

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -193,6 +193,7 @@ MATCH (u:User) RETURN count(u)
 | `auto_discover_columns` | bool | `false` | Auto-map all table columns as properties |
 | `exclude_columns` | list | `[]` | Columns to exclude from auto-discovery |
 | `naming_convention` | string | `"snake_case"` | Property naming: "snake_case" or "camelCase" |
+| `id_generation` | enum | `"uuid"` | **Embedded mode only.** How the ID column is filled when Cypher `CREATE` omits it: `"uuid"` (default — DDL `DEFAULT generateUUIDv4()` fills it), `"provided"` (caller must supply, planner errors otherwise), `"snowflake"` (planner emits a `generateSnowflakeID()` call). |
 
 ### Shared Table Attributes (for label_column pattern)
 

--- a/src/executor/data_loader.rs
+++ b/src/executor/data_loader.rs
@@ -236,8 +236,12 @@ pub fn build_node_ddl(node_schema: &NodeSchema) -> String {
         format!("({})", id_columns.join(", "))
     };
 
+    // Lightweight UPDATE prerequisite (Decision 0.7 of the embedded-writes
+    // design): the table must be created with the two block-tracking
+    // columns enabled. Without these, chdb returns Code 48 NOT_IMPLEMENTED
+    // when a Cypher SET clause runs against the table.
     format!(
-        "CREATE TABLE IF NOT EXISTS `{}`.`{}` ({}) ENGINE = ReplacingMergeTree(_version) ORDER BY {}",
+        "CREATE TABLE IF NOT EXISTS `{}`.`{}` ({}) ENGINE = ReplacingMergeTree(_version) ORDER BY {} SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1",
         node_schema.database,
         node_schema.table_name,
         col_defs.join(", "),
@@ -299,8 +303,9 @@ pub fn build_edge_ddl(rel_schema: &RelationshipSchema) -> String {
     order_cols.extend(from_id_cols.iter().map(|s| s.to_string()));
     order_cols.extend(to_id_cols.iter().map(|s| s.to_string()));
 
+    // Lightweight UPDATE prerequisite (Decision 0.7) — see node DDL above.
     format!(
-        "CREATE TABLE IF NOT EXISTS `{}`.`{}` ({}) ENGINE = ReplacingMergeTree(_version) ORDER BY ({})",
+        "CREATE TABLE IF NOT EXISTS `{}`.`{}` ({}) ENGINE = ReplacingMergeTree(_version) ORDER BY ({}) SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1",
         rel_schema.database,
         rel_schema.table_name,
         col_defs.join(", "),
@@ -347,6 +352,19 @@ graph_schema:
         assert!(ddl.contains("_version UInt64 DEFAULT now64()"));
         assert!(ddl.contains("ReplacingMergeTree(_version)"));
         assert!(ddl.contains("ORDER BY (person_id)"));
+        // Lightweight UPDATE prerequisites (Decision 0.7) — block-tracking
+        // columns must be enabled. Without these, chdb returns Code 48
+        // NOT_IMPLEMENTED on Cypher SET.
+        assert!(
+            ddl.contains("enable_block_number_column = 1"),
+            "missing enable_block_number_column SETTING: {}",
+            ddl
+        );
+        assert!(
+            ddl.contains("enable_block_offset_column = 1"),
+            "missing enable_block_offset_column SETTING: {}",
+            ddl
+        );
         // ID column should not be duplicated
         let id_count = ddl.matches("person_id").count();
         // person_id appears in: column def, ORDER BY = 2 occurrences
@@ -393,6 +411,17 @@ graph_schema:
         assert!(ddl.contains("_version UInt64 DEFAULT now64()"));
         assert!(ddl.contains("ReplacingMergeTree(_version)"));
         assert!(ddl.contains("ORDER BY (from_person_id, to_person_id)"));
+        // Lightweight UPDATE prerequisites (Decision 0.7).
+        assert!(
+            ddl.contains("enable_block_number_column = 1"),
+            "missing enable_block_number_column: {}",
+            ddl
+        );
+        assert!(
+            ddl.contains("enable_block_offset_column = 1"),
+            "missing enable_block_offset_column: {}",
+            ddl
+        );
     }
 
     #[test]

--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -1339,6 +1339,7 @@ fn build_node_schema(
         node_id_types,
         source: node_def.source.clone(),
         property_types,
+        id_generation: None,
     })
 }
 
@@ -3765,6 +3766,7 @@ graph_schema:
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
         nodes
@@ -3909,6 +3911,7 @@ graph_schema:
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
         nodes

--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -570,10 +570,41 @@ pub struct NodeDefinition {
     /// When absent, DDL columns default to String
     #[serde(default)]
     pub property_types: HashMap<String, String>,
+
+    /// Optional: ID generation strategy for embedded-mode CREATE.
+    /// Accepted values (case-insensitive): "uuid" (default), "provided", "snowflake".
+    /// Server / source-backed schemas ignore this field — writes are rejected
+    /// upstream by the executor admission check.
+    #[serde(default)]
+    pub id_generation: Option<String>,
 }
 
 fn default_naming_convention() -> String {
     "snake_case".to_string()
+}
+
+/// Parse the optional `id_generation` YAML attribute into an `IdStrategy`.
+/// Returns `Ok(None)` when unset; otherwise validates against the closed set
+/// of accepted values (case-insensitive).
+fn parse_id_generation(
+    raw: &Option<String>,
+    label: &str,
+) -> Result<Option<crate::clickhouse_query_generator::IdStrategy>, GraphSchemaError> {
+    use crate::clickhouse_query_generator::IdStrategy;
+    let Some(value) = raw.as_deref() else {
+        return Ok(None);
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "uuid" => Ok(Some(IdStrategy::Uuid)),
+        "provided" => Ok(Some(IdStrategy::Provided)),
+        "snowflake" => Ok(Some(IdStrategy::Snowflake)),
+        other => Err(GraphSchemaError::InvalidConfig {
+            message: format!(
+                "Node '{}': invalid id_generation '{}' (expected one of: uuid, provided, snowflake)",
+                label, other
+            ),
+        }),
+    }
 }
 
 /// Relationship definition in schema config
@@ -1339,7 +1370,7 @@ fn build_node_schema(
         node_id_types,
         source: node_def.source.clone(),
         property_types,
-        id_generation: None,
+        id_generation: parse_id_generation(&node_def.id_generation, &node_def.label)?,
     })
 }
 
@@ -2709,6 +2740,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Standard(StandardEdgeDefinition {
@@ -2778,6 +2810,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Standard(StandardEdgeDefinition {
@@ -2841,6 +2874,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Polymorphic(PolymorphicEdgeDefinition {
@@ -2903,6 +2937,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Polymorphic(PolymorphicEdgeDefinition {
@@ -2967,6 +3002,7 @@ graph_schema:
                         types: None,
                         source: None,
                         property_types: HashMap::new(),
+                        id_generation: None,
                     },
                     NodeDefinition {
                         label: "User".to_string(),
@@ -2988,6 +3024,7 @@ graph_schema:
                         types: None,
                         source: None,
                         property_types: HashMap::new(),
+                        id_generation: None,
                     },
                 ],
                 relationships: vec![],
@@ -3055,6 +3092,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Polymorphic(PolymorphicEdgeDefinition {
@@ -3123,6 +3161,7 @@ graph_schema:
                     types: None,
                     source: None,
                     property_types: HashMap::new(),
+                    id_generation: None,
                 }],
                 relationships: vec![],
                 edges: vec![EdgeDefinition::Polymorphic(PolymorphicEdgeDefinition {
@@ -3518,6 +3557,7 @@ mod node_id_identity_mapping_tests {
             types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let discovery = TableDiscovery {
@@ -3573,6 +3613,7 @@ mod node_id_identity_mapping_tests {
             types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let discovery = TableDiscovery {
@@ -3629,6 +3670,7 @@ mod node_id_identity_mapping_tests {
             types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let discovery = TableDiscovery {
@@ -3646,6 +3688,101 @@ mod node_id_identity_mapping_tests {
             node_schema.property_mappings["ip"].to_sql_column_only(),
             "orig_h",
             "Explicit mapping should take precedence over identity mapping"
+        );
+    }
+
+    #[test]
+    fn test_id_generation_yaml_round_trip() {
+        // YAML deserialization → IdStrategy mapping for all three accepted
+        // values (and case-insensitivity), plus the unset / invalid cases.
+        use crate::clickhouse_query_generator::IdStrategy;
+
+        let cases = [
+            ("uuid", IdStrategy::Uuid),
+            ("UUID", IdStrategy::Uuid),
+            ("provided", IdStrategy::Provided),
+            ("Snowflake", IdStrategy::Snowflake),
+        ];
+        for (raw, expected) in cases {
+            let yaml = format!(
+                r#"
+name: id_gen_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test
+      table: users
+      node_id: user_id
+      type: string
+      id_generation: {raw}
+      property_mappings:
+        user_id: user_id
+"#
+            );
+            let config = GraphSchemaConfig::from_yaml_str(&yaml)
+                .expect("YAML should parse with id_generation");
+            assert_eq!(
+                config.graph_schema.nodes[0].id_generation.as_deref(),
+                Some(raw),
+                "raw YAML field should round-trip"
+            );
+
+            let schema = config
+                .to_graph_schema()
+                .expect("schema should build with id_generation");
+            let node_schema = schema.node_schema("User").expect("User node schema");
+            assert_eq!(
+                node_schema.id_generation,
+                Some(expected),
+                "id_generation '{raw}' should map to {:?}",
+                expected
+            );
+        }
+
+        // Unset → None
+        let yaml_no_id = r#"
+name: id_gen_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test
+      table: users
+      node_id: user_id
+      type: string
+      property_mappings:
+        user_id: user_id
+"#;
+        let schema = GraphSchemaConfig::from_yaml_str(yaml_no_id)
+            .unwrap()
+            .to_graph_schema()
+            .unwrap();
+        assert!(
+            schema.node_schema("User").unwrap().id_generation.is_none(),
+            "missing id_generation should stay None"
+        );
+
+        // Invalid → InvalidConfig error
+        let yaml_bad = r#"
+name: id_gen_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test
+      table: users
+      node_id: user_id
+      type: string
+      id_generation: bogus
+      property_mappings:
+        user_id: user_id
+"#;
+        let err = GraphSchemaConfig::from_yaml_str(yaml_bad)
+            .unwrap()
+            .to_graph_schema()
+            .expect_err("invalid id_generation must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid id_generation") && msg.contains("bogus"),
+            "error should name the bad value: {msg}"
         );
     }
 }

--- a/src/graph_catalog/constraint_compiler.rs
+++ b/src/graph_catalog/constraint_compiler.rs
@@ -188,6 +188,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 

--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -98,6 +98,14 @@ pub struct NodeSchema {
     /// When present, DDL columns use the specified ClickHouse type instead of String
     #[serde(skip)]
     pub property_types: HashMap<String, SchemaType>,
+
+    /// Optional: How the node ID column is filled when Cypher CREATE omits
+    /// it (Decision 0.2 of the embedded-writes design). `None` is treated as
+    /// `Uuid` — the DDL `DEFAULT generateUUIDv4()` fills the column. Other
+    /// strategies (`Provided`, `Snowflake`) are dispatched by
+    /// `clickhouse_query_generator::auto_id_decision`.
+    #[serde(skip)]
+    pub id_generation: Option<crate::clickhouse_query_generator::IdStrategy>,
 }
 
 impl NodeSchema {
@@ -187,6 +195,7 @@ impl NodeSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 }
@@ -1886,6 +1895,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let flight_edge = RelationshipSchema {
@@ -1967,6 +1977,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let flight_edge = RelationshipSchema {
@@ -2041,6 +2052,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let user = NodeSchema {
@@ -2074,6 +2086,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut from_props = HashMap::new();
@@ -2161,6 +2174,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut to_props_post = HashMap::new();
@@ -2187,6 +2201,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut to_props = HashMap::new();
@@ -2278,6 +2293,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut from_props = HashMap::new();
@@ -2352,6 +2368,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let flight_edge = RelationshipSchema {
@@ -2423,6 +2440,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut from_props = HashMap::new();
@@ -2507,6 +2525,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         let mut from_props = HashMap::new();

--- a/src/graph_catalog/pattern_schema.rs
+++ b/src/graph_catalog/pattern_schema.rs
@@ -1381,6 +1381,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 
@@ -1408,6 +1409,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 

--- a/src/procedures/apoc_meta_schema.rs
+++ b/src/procedures/apoc_meta_schema.rs
@@ -270,6 +270,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 

--- a/src/query_planner/analyzer/filter_tagging.rs
+++ b/src/query_planner/analyzer/filter_tagging.rs
@@ -2504,6 +2504,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 
@@ -2544,6 +2545,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 

--- a/src/query_planner/analyzer/graph_join/tests.rs
+++ b/src/query_planner/analyzer/graph_join/tests.rs
@@ -55,6 +55,7 @@ fn create_test_graph_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -81,6 +82,7 @@ fn create_test_graph_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -940,6 +942,7 @@ fn create_self_referencing_fk_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1027,6 +1030,7 @@ fn create_non_self_referencing_fk_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1064,6 +1068,7 @@ fn create_non_self_referencing_fk_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1428,6 +1433,7 @@ fn create_composite_id_graph_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1460,6 +1466,7 @@ fn create_composite_id_graph_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/src/query_planner/analyzer/match_type_inference.rs
+++ b/src/query_planner/analyzer/match_type_inference.rs
@@ -530,6 +530,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
         nodes.insert(
@@ -554,6 +555,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 
@@ -654,6 +656,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 

--- a/src/query_planner/analyzer/multi_type_vlp_expansion.rs
+++ b/src/query_planner/analyzer/multi_type_vlp_expansion.rs
@@ -466,6 +466,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 
@@ -492,6 +493,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 
@@ -746,6 +748,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
         nodes.insert(
@@ -770,6 +773,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
         relationships.insert(

--- a/src/query_planner/analyzer/test_multi_type_vlp_auto_inference.rs
+++ b/src/query_planner/analyzer/test_multi_type_vlp_auto_inference.rs
@@ -51,6 +51,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 
@@ -77,6 +78,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 

--- a/src/query_planner/analyzer/view_resolver_tests.rs
+++ b/src/query_planner/analyzer/view_resolver_tests.rs
@@ -38,6 +38,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
         nodes.insert("User".to_string(), node_schema);
 

--- a/src/query_planner/logical_plan/match_clause/tests.rs
+++ b/src/query_planner/logical_plan/match_clause/tests.rs
@@ -520,6 +520,7 @@ fn test_generate_scan() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -578,6 +579,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -602,6 +604,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -626,6 +629,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -756,6 +760,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -780,6 +785,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -804,6 +810,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -828,6 +835,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
     nodes.insert(
@@ -852,6 +860,7 @@ fn create_test_schema_with_relationships() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -989,6 +998,7 @@ fn create_single_relationship_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1264,6 +1274,7 @@ fn test_infer_relationship_type_too_many_matches_error() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1363,6 +1374,7 @@ fn create_single_node_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1400,6 +1412,7 @@ fn create_multi_node_schema() -> GraphSchema {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
     }
@@ -1483,6 +1496,7 @@ fn test_infer_node_label_many_nodes_no_error() {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
     }
@@ -1534,6 +1548,7 @@ fn test_infer_node_label_denormalized_single_node() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1575,6 +1590,7 @@ fn test_infer_relationship_type_polymorphic_edge() {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
     }

--- a/src/query_planner/logical_plan/optional_match_clause.rs
+++ b/src/query_planner/logical_plan/optional_match_clause.rs
@@ -156,6 +156,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
         nodes.insert("User".to_string(), user_node);
 

--- a/src/query_planner/logical_plan/write_clause_builder.rs
+++ b/src/query_planner/logical_plan/write_clause_builder.rs
@@ -567,6 +567,7 @@ mod tests {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         }
     }
 

--- a/src/query_planner/write_guard.rs
+++ b/src/query_planner/write_guard.rs
@@ -371,6 +371,7 @@ mod tests {
             node_id_types: None,
             source: source.map(|s| s.to_string()),
             property_types: std::collections::HashMap::new(),
+            id_generation: None,
         }
     }
 

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -3267,6 +3267,7 @@ mod tests {
                 node_id_types: None,
                 source: None,
                 property_types: HashMap::new(),
+                id_generation: None,
             },
         );
 

--- a/src/render_plan/tests/denormalized_property_tests.rs
+++ b/src/render_plan/tests/denormalized_property_tests.rs
@@ -62,6 +62,7 @@ fn setup_denormalized_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -473,6 +474,7 @@ fn test_denormalized_edge_table_same_table_for_node_and_edge() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/src/render_plan/tests/multiple_relationship_tests.rs
+++ b/src/render_plan/tests/multiple_relationship_tests.rs
@@ -252,6 +252,7 @@ fn setup_test_schema() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -278,6 +279,7 @@ fn setup_test_schema() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -304,6 +306,7 @@ fn setup_test_schema() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -330,6 +333,7 @@ fn setup_test_schema() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/src/render_plan/tests/polymorphic_edge_tests.rs
+++ b/src/render_plan/tests/polymorphic_edge_tests.rs
@@ -61,6 +61,7 @@ fn setup_polymorphic_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -101,6 +102,7 @@ fn setup_polymorphic_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -403,6 +405,7 @@ fn test_non_polymorphic_relationship() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -502,6 +505,7 @@ fn test_fixed_endpoint_polymorphic_edge() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -528,6 +532,7 @@ fn test_fixed_endpoint_polymorphic_edge() {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/src/render_plan/tests/vlp_property_pruning_tests.rs
+++ b/src/render_plan/tests/vlp_property_pruning_tests.rs
@@ -64,6 +64,7 @@ fn setup_person_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
     nodes.insert("Person".to_string(), person_node);
 

--- a/src/render_plan/tests/where_clause_filter_tests.rs
+++ b/src/render_plan/tests/where_clause_filter_tests.rs
@@ -120,6 +120,7 @@ fn setup_test_graph_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
     nodes.insert("User".to_string(), user_node);
 

--- a/src/render_plan/tests/with_clause_cte_tests.rs
+++ b/src/render_plan/tests/with_clause_cte_tests.rs
@@ -87,6 +87,7 @@ fn setup_test_graph_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
     nodes.insert("User".to_string(), user_node);
 
@@ -116,6 +117,7 @@ fn setup_test_graph_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
     nodes.insert("Post".to_string(), post_node);
 

--- a/src/render_plan/tests/write_sql_tests.rs
+++ b/src/render_plan/tests/write_sql_tests.rs
@@ -53,6 +53,7 @@ fn person_node() -> NodeSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     }
 }
 
@@ -378,6 +379,7 @@ fn detach_delete_uses_resolved_pk_column_for_non_id_schemas() {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
     node.column_names.sort();
 

--- a/tests/rust/integration/browser_test_schemas.rs
+++ b/tests/rust/integration/browser_test_schemas.rs
@@ -58,6 +58,7 @@ pub fn create_standard_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -102,6 +103,7 @@ pub fn create_standard_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -266,6 +268,7 @@ pub fn create_fk_edge_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -302,6 +305,7 @@ pub fn create_fk_edge_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -383,6 +387,7 @@ pub fn create_denormalized_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -484,6 +489,7 @@ pub fn create_composite_id_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -520,6 +526,7 @@ pub fn create_composite_id_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -668,6 +675,7 @@ pub fn create_polymorphic_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -712,6 +720,7 @@ pub fn create_polymorphic_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/tests/rust/integration/complex_feature_tests.rs
+++ b/tests/rust/integration/complex_feature_tests.rs
@@ -73,6 +73,7 @@ fn create_test_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -128,6 +129,7 @@ fn create_test_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -1625,6 +1627,7 @@ async fn test_expression_property_preserved_through_render_phase() {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/tests/rust/integration/cte_column_aliasing_tests.rs
+++ b/tests/rust/integration/cte_column_aliasing_tests.rs
@@ -61,6 +61,7 @@ fn create_test_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
 
     nodes.insert("User".to_string(), user_schema);

--- a/tests/rust/integration/parameter_function_test.rs
+++ b/tests/rust/integration/parameter_function_test.rs
@@ -48,6 +48,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -82,6 +83,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -120,6 +122,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -154,6 +157,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -188,6 +192,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 
@@ -222,6 +227,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/tests/rust/integration/path_variable_tests.rs
+++ b/tests/rust/integration/path_variable_tests.rs
@@ -47,6 +47,7 @@ fn create_test_schema() -> GraphSchema {
             label_value: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/tests/rust/integration/skip_offset_tests.rs
+++ b/tests/rust/integration/skip_offset_tests.rs
@@ -60,6 +60,7 @@ fn create_test_schema() -> GraphSchema {
             node_id_types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         },
     );
 

--- a/tests/rust/integration/with_where_having_tests.rs
+++ b/tests/rust/integration/with_where_having_tests.rs
@@ -45,6 +45,7 @@ fn create_test_schema() -> GraphSchema {
         node_id_types: None,
         source: None,
         property_types: HashMap::new(),
+        id_generation: None,
     };
 
     nodes.insert("Node".to_string(), node_schema);

--- a/tests/rust/unit/test_view_parameters.rs
+++ b/tests/rust/unit/test_view_parameters.rs
@@ -169,6 +169,7 @@ property_mappings:
             types: None,
             source: None,
             property_types: HashMap::new(),
+            id_generation: None,
         };
 
         // Serialize to YAML


### PR DESCRIPTION
## Summary

Phase 3 of [embedded-mode Cypher writes](docs/design/embedded-writes.md): the executor + DDL pieces that turn the Phase 1/2 scaffolding into end-to-end working writes.

```
parse → plan (write variants) → write_guard → write_plan_builder
   → write_to_sql → chdb execution → counter QueryResult
```

## What landed

- **`data_loader.rs`** (Decision 0.7): every writable node and edge table CREATE TABLE now appends `SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1`. Without these, chdb returns Code 48 NOT_IMPLEMENTED on Cypher SET. Asserts added to the existing `build_node_ddl` / `build_edge_ddl` tests.
- **`NodeSchema::id_generation: Option<IdStrategy>`** (Decision 0.2): new optional field; `None` is treated as `Uuid` (existing behaviour). Plumbed through ~95 NodeSchema construction sites.
- **`Database::executor_kind`**: tracks whether the primary executor is `EmbeddedChdb` / `Remote` / `SqlOnly`. Set by every constructor; consumed by the write guard so writes are gated to chdb only.
- **`Connection::query()` dispatch** (Decision 0.1): detects write clauses (`CREATE` / `SET` / `DELETE` / `REMOVE`) in the parsed AST and routes them to `handle_write_async()`, which:
  1. Re-parses, plans, runs the analyzer/optimizer pipeline so the read pipeline below the write variant is fully resolved.
  2. Calls `write_guard::ensure_write_target_writable` for executor + schema admission.
  3. Renders to SQL via `build_write_plan` + `write_render_to_sql`.
  4. Executes each rendered statement via `executor.execute_json`.
  5. Returns Neo4j-compatible counters as a single-row `QueryResult` (Decision 0.8): `nodes_created` / `properties_set` / `nodes_deleted` / `relationships_deleted`.
- **`docs/schema-reference.md`**: documents the new `id_generation` attribute.

Counters are best-effort per Decision 0.4 — chdb's lightweight path doesn't surface affected-row counts, so the planner reports per-operation counts (one INSERT row → 1 node created, one SET assignment → 1 property set, etc.). DETACH DELETE attributes earlier DELETEs in the Sequence as relationship cleanups and the final DELETE as the node delete.

## Test plan

- [x] 6 new lib tests in `clickgraph-embedded::connection` (CapturingExecutor now captures both `execute_json` and `execute_text`):
  - `cypher_create_routes_to_write_path_and_emits_insert`
  - `cypher_set_routes_to_write_path_and_emits_update`
  - `cypher_delete_routes_to_write_path_and_emits_delete`
  - `cypher_detach_delete_emits_rel_then_node_delete_sequence`
  - `cypher_remove_routes_to_write_path`
  - `cypher_write_rejected_in_sql_only_mode`
- [x] New integration file `clickgraph-embedded/tests/writes_e2e.rs` (gated on `CLICKGRAPH_CHDB_TESTS=1` and the `embedded` feature) with 4 chdb round-trip tests: create+match-back, set+verify, delete+count=0, remove+null.
- [x] DDL block-tracking SETTINGS asserted in `build_node_ddl` / `build_edge_ddl` tests.
- [x] All `clickgraph-embedded` lib tests (139) and `clickgraph` lib tests (1344) + 279 integration + 7 unit + 30 stress still green. Clean lib clippy.

> Note: `cargo check --tests` against `clickgraph-embedded` without the `embedded` feature trips on pre-existing `chdb_e2e.rs` / `hybrid_e2e.rs` (never feature-gated). My new `writes_e2e.rs` is properly gated.

## Next

Phase 4 per the design doc — TCK unblock + hardening:
- Drop per-scenario skip tags on the ~19 currently-skipped write scenarios as each becomes implementable.
- `STATUS.md` / `KNOWN_ISSUES.md` / `README.md` updates.
- `docs/wiki/cypher-language-reference.md` write-clause sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)