### PR TITLE
feat(tck): Phase 5a — side-effect step + label-mutation skip tag

### DIFF
--- a/clickgraph-tck/README.md
+++ b/clickgraph-tck/README.md
@@ -26,7 +26,7 @@ The TCK is the openCypher project's official conformance suite. Each scenario is
 | Null handling | Null1 | 5 |
 | String functions | String1 | 1 |
 
-Scenarios tagged `@NegativeTests`, `@skip`, `@fails`, `@crash`, or `@wip` are skipped.
+Scenarios tagged `@NegativeTests`, `@skip`, `@fails`, `@crash`, `@wip`, or `@unsupported-label-mutation` are skipped. The first five are *temporary* — `@wip` flags features still being triaged for support, and the others mark scenarios that need a one-off look. `@unsupported-label-mutation` is *permanent*: ClickGraph does not support runtime label mutations (`SET n:Label` / `REMOVE n:Label`) because labels are part of the table identity in ClickGraph (one writable table per label), not a runtime property.
 
 ### Write feature files (imported, `@wip`-gated)
 
@@ -37,11 +37,18 @@ Scenarios tagged `@NegativeTests`, `@skip`, `@fails`, `@crash`, or `@wip` are sk
 | `DELETE` | Delete1–6 | ~40 |
 | `REMOVE` | Remove1–3 | ~15 |
 
-These exercise the Cypher write pipeline added in v0.6.7 (`CREATE` / `SET` / `DELETE` / `REMOVE` against ClickGraph-managed embedded tables — see [`docs/wiki/Cypher-Language-Reference.md#write-clauses`](../docs/wiki/Cypher-Language-Reference.md#write-clauses)). Triage requires harness extensions in three layers:
+These exercise the Cypher write pipeline added in v0.6.7 (`CREATE` / `SET` / `DELETE` / `REMOVE` against ClickGraph-managed embedded tables — see [`docs/wiki/Cypher-Language-Reference.md#write-clauses`](../docs/wiki/Cypher-Language-Reference.md#write-clauses)).
 
-1. **Side-effect step** (`the side effects should be:`, currently a no-op at line 360 of `tests/tck.rs`) needs to parse the Gherkin table and assert against `QueryResult` counters. The counters that exist today cover only `+nodes` / `-nodes` / `+properties` / `-properties` / `+relationships` / `-relationships`. They do **not** cover the `+labels` / `-labels` / `+properties` for label-mutation rows, because ClickGraph doesn't support `SET n:Label` / `REMOVE n:Label` at all (labels are encoded into the table identity — see [Cypher Language Reference](../docs/wiki/Cypher-Language-Reference.md#write-clauses)). Scenarios asserting label side-effects therefore stay `@wip` permanently and should be triaged into a separate `@unsupported-label-mutation` tag rather than waiting on the harness.
-2. **Schema generation** in `schema_gen.rs` needs to handle anonymous nodes (`CREATE ()`) — bare nodes today don't get a label and aren't catalogued. Several Create*/Delete* scenarios depend on this.
-3. **Per-scenario disposition** for combinations the write pipeline rejects deliberately (`CREATE … RETURN`, relationship `CREATE`, `DELETE r` for an edge alias, `SET a += {…}` / `SET a = {…}` map-merge / full-map, `SET a:Label` / `REMOVE a:Label` label mutations, `MERGE`). Each is rejected with an explicit error today; Phase 5 will lift the implementation gaps and document the rest as out-of-scope.
+Phase 5a (this commit) ships the harness extensions to start running them:
+
+- **Side-effect step** — `the side effects should be:` now parses the Gherkin table and asserts against the four `QueryResult` counter columns returned by `handle_write_async` (`nodes_created` / `properties_set` / `nodes_deleted` / `relationships_deleted`). `+nodes` / `+properties` / `-nodes` / `-relationships` / `-properties` map directly. Unmappable side effects (label mutations, future `+relationships` for relationship CREATE) mark the scenario as skipped via `world.skip_reason` so they surface as triage candidates rather than hard-failing the run.
+- **Counter capture** — `when_executing_query` detects the four-column counter shape returned by writes and stashes the row in `TckWorld::write_counters` so the side-effect step can read it. Read queries leave `write_counters = None`.
+- **Permanent skip tag `@unsupported-label-mutation`** — added to `Set3.feature` (label-add scenarios) and `Remove2.feature` (label-remove scenarios). The cucumber filter and `schema_gen::feature_is_filtered()` both recognise it. Re-tagging these from `@wip` reflects that label mutations will never be supported (labels are part of the table identity in ClickGraph), so they should be filtered out structurally, not held in triage limbo.
+
+Still pending before more imports unlock:
+
+1. **Schema generation** in `schema_gen.rs` needs to handle anonymous nodes (`CREATE ()`) — bare nodes today don't get a label and aren't catalogued. Several `Create1` / `Delete1` scenarios depend on this.
+2. **Per-scenario disposition** for combinations the write pipeline rejects deliberately (`CREATE … RETURN`, relationship `CREATE`, `DELETE r` for an edge alias, `SET a += {…}` / `SET a = {…}` map-merge / full-map, `MERGE`). Each is rejected with an explicit error today; Phase 5 will lift the implementation gaps and document the rest as out-of-scope.
 
 `MERGE` (Merge1..6 upstream) is not imported yet — tracked for v0.7.x Phase 5.
 

--- a/clickgraph-tck/tests/features/clauses/remove/Remove2.feature
+++ b/clickgraph-tck/tests/features/clauses/remove/Remove2.feature
@@ -28,20 +28,14 @@
 
 #encoding: utf-8
 
-# @wip — Phase 4 import from upstream openCypher TCK (master, fetched 2026-05-02).
-# Cypher write clauses (CREATE / SET / DELETE / REMOVE) are implemented in
-# embedded mode as of v0.6.7, but this scenario file requires harness
-# extensions before it runs cleanly:
-#   * `the side effects should be:` step currently no-ops; needs counter
-#     assertion against the QueryResult counters returned by handle_write_async.
-#   * Some scenarios use anonymous nodes (`CREATE ()`) that schema_gen.rs
-#     doesn't yet collect into the universal catalog.
-#   * Several scenarios chain CREATE/MATCH/SET in patterns that exercise
-#     unimplemented combinations (CREATE … RETURN, relationship CREATE,
-#     map-merge SET) — see KNOWN_ISSUES.md.
-# Lifted incrementally as triage lands. See docs/design/embedded-writes.md
-# Appendix (Phase 4) for the plan.
-@wip
+# @unsupported-label-mutation — ClickGraph does not support runtime label
+# mutations (`SET n:Label` / `REMOVE n:Label`). Labels are part of the
+# table identity in ClickGraph (one writable table per node label), so
+# adding or removing a label is a structural change rather than a
+# runtime property mutation. These scenarios are filtered out
+# permanently by the cucumber harness — track in
+# docs/wiki/Cypher-Language-Reference.md#write-clauses.
+@unsupported-label-mutation
 Feature: Remove2 - Remove a Label
 
   Scenario: [1] Remove a single label from a node with a single label

--- a/clickgraph-tck/tests/features/clauses/set/Set3.feature
+++ b/clickgraph-tck/tests/features/clauses/set/Set3.feature
@@ -28,20 +28,14 @@
 
 #encoding: utf-8
 
-# @wip — Phase 4 import from upstream openCypher TCK (master, fetched 2026-05-02).
-# Cypher write clauses (CREATE / SET / DELETE / REMOVE) are implemented in
-# embedded mode as of v0.6.7, but this scenario file requires harness
-# extensions before it runs cleanly:
-#   * `the side effects should be:` step currently no-ops; needs counter
-#     assertion against the QueryResult counters returned by handle_write_async.
-#   * Some scenarios use anonymous nodes (`CREATE ()`) that schema_gen.rs
-#     doesn't yet collect into the universal catalog.
-#   * Several scenarios chain CREATE/MATCH/SET in patterns that exercise
-#     unimplemented combinations (CREATE … RETURN, relationship CREATE,
-#     map-merge SET) — see KNOWN_ISSUES.md.
-# Lifted incrementally as triage lands. See docs/design/embedded-writes.md
-# Appendix (Phase 4) for the plan.
-@wip
+# @unsupported-label-mutation — ClickGraph does not support runtime label
+# mutations (`SET n:Label` / `REMOVE n:Label`). Labels are part of the
+# table identity in ClickGraph (one writable table per node label), so
+# adding or removing a label is a structural change rather than a
+# runtime property mutation. These scenarios are filtered out
+# permanently by the cucumber harness — track in
+# docs/wiki/Cypher-Language-Reference.md#write-clauses.
+@unsupported-label-mutation
 Feature: Set3 - Set a Label
 
   Scenario: [1] Add a single label to a node with no label

--- a/clickgraph-tck/tests/schema_gen.rs
+++ b/clickgraph-tck/tests/schema_gen.rs
@@ -179,7 +179,15 @@ fn feature_is_filtered(content: &str) -> bool {
             // tags the cucumber filter recognises.
             for tok in rest.split_whitespace() {
                 let tok = tok.trim_start_matches('@');
-                if matches!(tok, "wip" | "skip" | "fails" | "crash" | "NegativeTests") {
+                if matches!(
+                    tok,
+                    "wip"
+                        | "skip"
+                        | "fails"
+                        | "crash"
+                        | "NegativeTests"
+                        | "unsupported-label-mutation"
+                ) {
                     return true;
                 }
             }
@@ -413,7 +421,14 @@ mod tests {
         // catalog gets out of sync with the scenarios actually run.
         // Keep this set in lock-step with `feature_is_filtered()` and
         // the cucumber filter in `tests/tck.rs:filter_run`.
-        for tag in ["@wip", "@skip", "@fails", "@crash", "@NegativeTests"] {
+        for tag in [
+            "@wip",
+            "@skip",
+            "@fails",
+            "@crash",
+            "@NegativeTests",
+            "@unsupported-label-mutation",
+        ] {
             let src = format!("{tag}\nFeature: Foo\n  Scenario: bar\n    Given x\n");
             assert!(
                 feature_is_filtered(&src),

--- a/clickgraph-tck/tests/tck.rs
+++ b/clickgraph-tck/tests/tck.rs
@@ -233,18 +233,54 @@ async fn when_executing_query(world: &mut TckWorld, step: &Step) {
             // and stash the counters separately so the side-effect step can
             // assert against them. The result_rows stay empty (the TCK
             // shapes for writes are `the result should be empty`).
+            //
+            // Always reset write_counters first so a regression that drops
+            // the counter row can't leak stale counters from the previous
+            // query in the same scenario. Non-Int64 cells are also a
+            // regression signal (we built that QueryResult ourselves), so
+            // surface them as a captured error rather than silently
+            // skipping the value — otherwise the side-effect step could
+            // pass against an empty counter map.
+            world.write_counters = None;
             if is_write_counter_shape(&col_names) {
-                if let Some(row) = result.next() {
-                    let mut counters = HashMap::new();
-                    for (name, value) in col_names.iter().zip(row.values().iter()) {
-                        if let Some(n) = value.as_i64() {
-                            counters.insert(name.clone(), n);
+                match result.next() {
+                    Some(row) => {
+                        let mut counters = HashMap::new();
+                        let mut bad_cell: Option<(String, String)> = None;
+                        for (name, value) in col_names.iter().zip(row.values().iter()) {
+                            match value.as_i64() {
+                                Some(n) => {
+                                    counters.insert(name.clone(), n);
+                                }
+                                None => {
+                                    bad_cell = Some((name.clone(), format!("{:?}", value)));
+                                    break;
+                                }
+                            }
+                        }
+                        if let Some((name, repr)) = bad_cell {
+                            world.error = Some(format!(
+                                "write counter `{name}` was not Int64 (got {repr}); \
+                                 handle_write_async result shape regressed?"
+                            ));
+                            world.result_rows.clear();
+                        } else {
+                            world.write_counters = Some(counters);
+                            world.result_rows.clear();
+                            world.error = None;
                         }
                     }
-                    world.write_counters = Some(counters);
+                    None => {
+                        // Counter shape but no row — that's a contract
+                        // violation in handle_write_async, surface it.
+                        world.error = Some(
+                            "write QueryResult had counter columns but no row \
+                             (handle_write_async regression?)"
+                                .to_string(),
+                        );
+                        world.result_rows.clear();
+                    }
                 }
-                world.result_rows.clear();
-                world.error = None;
             } else {
                 world.result_rows = result
                     .map(|row| {
@@ -252,7 +288,6 @@ async fn when_executing_query(world: &mut TckWorld, step: &Step) {
                         format_row(&col_names, &values, &var_labels, &var_rel_types)
                     })
                     .collect();
-                world.write_counters = None;
                 world.error = None;
             }
         }
@@ -473,7 +508,21 @@ async fn then_side_effects(world: &mut TckWorld, step: &Step) {
                 return;
             }
         };
-        let actual = counters.get(counter).copied().unwrap_or(0);
+        // Treat an absent counter key as a hard error rather than 0 —
+        // a silent default would let a regression in counter capture
+        // (e.g., column rename, non-Int64 cell silently dropped) make
+        // assertions pass when they shouldn't.
+        let actual = match counters.get(counter) {
+            Some(n) => *n,
+            None => {
+                panic!(
+                    "side-effect counter `{counter}` is missing from the captured \
+                     counter row; available={counters:?}. This indicates \
+                     handle_write_async returned a different counter shape than \
+                     expected — fix the harness mapping or handle_write_async."
+                );
+            }
+        };
         assert_eq!(
             actual, expected,
             "side-effect mismatch for {key}: expected {expected}, got {actual} \

--- a/clickgraph-tck/tests/tck.rs
+++ b/clickgraph-tck/tests/tck.rs
@@ -107,6 +107,11 @@ pub struct TckWorld {
     last_sql: Option<String>,
     /// Variable name → node label (for edge table routing).
     node_label_map: HashMap<String, String>,
+    /// Side-effect counters captured from the last write query
+    /// (`nodes_created` / `properties_set` / `nodes_deleted` /
+    /// `relationships_deleted`). `None` for read queries — we detect a
+    /// write by checking the result column shape.
+    write_counters: Option<HashMap<String, i64>>,
 }
 
 impl TckWorld {
@@ -121,6 +126,7 @@ impl TckWorld {
             error: None,
             last_sql: None,
             node_label_map: HashMap::new(),
+            write_counters: None,
         }
     }
 
@@ -221,20 +227,55 @@ async fn when_executing_query(world: &mut TckWorld, step: &Step) {
         Ok(mut result) => {
             world.result_columns = result.get_column_names().to_vec();
             let col_names = world.result_columns.clone();
-            world.result_rows = result
-                .map(|row| {
-                    let values: Vec<Value> = row.values().to_vec();
-                    format_row(&col_names, &values, &var_labels, &var_rel_types)
-                })
-                .collect();
-            world.error = None;
+
+            // Write queries route through `handle_write_async` and return a
+            // single-row counter QueryResult. Detect by exact column shape
+            // and stash the counters separately so the side-effect step can
+            // assert against them. The result_rows stay empty (the TCK
+            // shapes for writes are `the result should be empty`).
+            if is_write_counter_shape(&col_names) {
+                if let Some(row) = result.next() {
+                    let mut counters = HashMap::new();
+                    for (name, value) in col_names.iter().zip(row.values().iter()) {
+                        if let Some(n) = value.as_i64() {
+                            counters.insert(name.clone(), n);
+                        }
+                    }
+                    world.write_counters = Some(counters);
+                }
+                world.result_rows.clear();
+                world.error = None;
+            } else {
+                world.result_rows = result
+                    .map(|row| {
+                        let values: Vec<Value> = row.values().to_vec();
+                        format_row(&col_names, &values, &var_labels, &var_rel_types)
+                    })
+                    .collect();
+                world.write_counters = None;
+                world.error = None;
+            }
         }
         Err(e) => {
             world.error = Some(e.to_string());
             world.result_rows.clear();
             world.result_columns.clear();
+            world.write_counters = None;
         }
     }
+}
+
+/// Recognise the four-column counter shape that `handle_write_async`
+/// returns. Used to distinguish read vs. write QueryResult and route the
+/// side-effect step to counter assertions.
+fn is_write_counter_shape(cols: &[String]) -> bool {
+    const EXPECTED: [&str; 4] = [
+        "nodes_created",
+        "properties_set",
+        "nodes_deleted",
+        "relationships_deleted",
+    ];
+    cols.len() == EXPECTED.len() && EXPECTED.iter().all(|n| cols.iter().any(|c| c == n))
 }
 
 // ---------------------------------------------------------------------------
@@ -352,15 +393,116 @@ async fn then_result_empty(world: &mut TckWorld) {
 }
 
 #[then(regex = r"^no side effects$")]
-async fn then_no_side_effects(_world: &mut TckWorld) {
-    // In read-only test scenarios, there should be no side effects.
-    // We accept this step as a no-op.
+async fn then_no_side_effects(world: &mut TckWorld) {
+    if world.is_skip() {
+        return;
+    }
+    // For read-only queries the write_counters field is None and there's
+    // nothing to check. For write queries we assert all four counters are
+    // zero. This matches the TCK semantics — read scenarios assert "no
+    // side effects" too, and we don't want to break the 402/402 baseline.
+    if let Some(counters) = &world.write_counters {
+        for (name, value) in counters {
+            assert_eq!(
+                *value, 0,
+                "expected no side effects but {name} = {value}; counters={counters:?}"
+            );
+        }
+    }
 }
 
 #[then(regex = r"^the side effects should be:$")]
-async fn then_side_effects(_world: &mut TckWorld) {
-    // Side-effect tracking (node/rel counts) is not implemented.
-    // Accept without assertion.
+async fn then_side_effects(world: &mut TckWorld, step: &Step) {
+    if world.is_skip() {
+        return;
+    }
+    let table = match step.table() {
+        Some(t) => t,
+        None => return,
+    };
+
+    let counters = match &world.write_counters {
+        Some(c) => c.clone(),
+        None => {
+            // Read query — no counter row was captured. The scenario
+            // either hit a skip path or the harness still doesn't route
+            // this query through the write pipeline. Mark @wip-style
+            // skip rather than fail so triage can surface it.
+            world.skip_reason = Some(
+                "side effects asserted but no counter row was captured \
+                 (likely a read-shaped query that should have routed to \
+                 the write pipeline)"
+                    .to_string(),
+            );
+            return;
+        }
+    };
+
+    // Each Gherkin row is `| <key> | <value> |`. The keys we know how to
+    // map are listed in `effect_to_counter`. Unknown keys (today: any
+    // `+labels` / `-labels` / `+properties` from a label mutation, plus
+    // any future `+nodes` for relationship CREATE that's still unsupported)
+    // mark the scenario as skipped so it's surfaced as @wip rather than
+    // failing the run.
+    for row in &table.rows {
+        if row.len() < 2 {
+            continue;
+        }
+        let key = row[0].trim();
+        let expected_str = row[1].trim();
+        let expected: i64 = match expected_str.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                world.skip_reason = Some(format!(
+                    "side-effect value '{expected_str}' is not an integer (key={key})"
+                ));
+                return;
+            }
+        };
+
+        let counter = match effect_to_counter(key) {
+            Some(c) => c,
+            None => {
+                // Unsupported side-effect category (label mutations,
+                // edge creation that's not implemented). Skip rather
+                // than fail.
+                world.skip_reason = Some(format!(
+                    "side-effect '{key}' is not yet mapped to a ClickGraph counter \
+                     (typical for label mutations or unimplemented write forms)"
+                ));
+                return;
+            }
+        };
+        let actual = counters.get(counter).copied().unwrap_or(0);
+        assert_eq!(
+            actual, expected,
+            "side-effect mismatch for {key}: expected {expected}, got {actual} \
+             (counter={counter}, all={counters:?})"
+        );
+    }
+}
+
+/// Map a TCK side-effect key to the QueryResult counter column it
+/// corresponds to. `None` means the side effect isn't representable in
+/// the current four-counter shape — typically label mutations, which
+/// ClickGraph doesn't support at all (labels are baked into the table
+/// identity, see Cypher Language Reference).
+fn effect_to_counter(key: &str) -> Option<&'static str> {
+    match key {
+        "+nodes" => Some("nodes_created"),
+        "+properties" => Some("properties_set"),
+        "-nodes" => Some("nodes_deleted"),
+        "-relationships" => Some("relationships_deleted"),
+        // `-properties` (REMOVE / SET = NULL) is also `properties_set`
+        // in our model since the work is a SET … = NULL update — but
+        // TCK scenarios that use it generally assert it alone, so we
+        // mirror that here.
+        "-properties" => Some("properties_set"),
+        // Label mutations: not supported at all (out of scope).
+        // Relationship CREATE side effect (`+relationships`): not yet
+        // supported, so leave unmapped to surface as @wip skip.
+        _ => None,
+    }
 }
 
 #[then(regex = r"^an? (\w+) should be raised at (?:compile|runtime|any)(?:\s+time)?: (.+)$")]
@@ -562,11 +704,20 @@ fn main() {
             // cross-contamination.
             .max_concurrent_scenarios(1)
             .filter_run("tests/features", |_, _, sc| {
-                // Skip scenarios tagged @skip or @NegativeTests
+                // Skip scenarios tagged with any harness-recognised filter
+                // tag. `unsupported-label-mutation` is a permanent skip
+                // (labels are part of the table identity in ClickGraph —
+                // see docs/wiki/Cypher-Language-Reference.md#write-clauses);
+                // the rest are temporary import / triage gates.
                 !sc.tags.iter().any(|t| {
                     matches!(
                         t.as_str(),
-                        "skip" | "fails" | "NegativeTests" | "crash" | "wip"
+                        "skip"
+                            | "fails"
+                            | "NegativeTests"
+                            | "crash"
+                            | "wip"
+                            | "unsupported-label-mutation"
                     )
                 })
             }),


### PR DESCRIPTION
## Summary

Wires the TCK harness to actually run the imported write feature files from PR #280 (currently `@wip`-gated). First step in Phase 5 of the embedded-writes work.

### Side-effect step now asserts counters

`the side effects should be:` was a no-op at `tck.rs:360` after PR #280. It now parses the Gherkin row table and asserts against the four counter columns `handle_write_async` returns:

| TCK key | counter |
|---|---|
| `+nodes` | `nodes_created` |
| `+properties` | `properties_set` |
| `-nodes` | `nodes_deleted` |
| `-relationships` | `relationships_deleted` |
| `-properties` | `properties_set` (REMOVE / SET = NULL) |

`when_executing_query` detects the four-column counter shape and stashes the row in `TckWorld::write_counters`. Read queries leave it `None`; the side-effect step then knows whether the query was a write. Unmappable keys (`+labels` / `-labels` / `+relationships` for unimplemented forms) set `world.skip_reason` so they surface as triage rather than hard-failing the run.

`no side effects` was updated similarly: asserts all four counters are zero for writes, no-ops for reads — so the existing 402/402 read baseline is unchanged.

### Permanent `@unsupported-label-mutation` tag

Label mutations (`SET n:Label` / `REMOVE n:Label`) will never be supported in ClickGraph — labels are part of the table identity (one writable table per label), not a runtime property. Phase 4 review #3 flagged that holding label scenarios in `@wip` would be misleading.

- `Set3.feature` (8 label-add scenarios) and `Remove2.feature` (5 label-remove scenarios) re-tagged from `@wip` to `@unsupported-label-mutation` with an explanatory comment block.
- Cucumber filter (`tests/tck.rs`) and `schema_gen::feature_is_filtered()` both recognise the new tag.
- `test_feature_is_filtered_recognises_filter_tags` updated to cover it alongside the existing tag set.

### Deferred to Phase 5b

`CREATE ()` (anonymous nodes, no label) needs `schema_gen.rs` to catalog `__Unlabeled` and the write pipeline to dispatch to a default writable table — that's genuine implementation work, not harness wiring. Affected scenarios stay `@wip` with a comment. README updated to flag this as the remaining blocker before more imports unlock.

`MERGE` (Merge1..6 upstream) is intentionally not imported yet — tracked for v0.7.x Phase 5.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo check -p clickgraph-tck --tests` — clean (only pre-existing dead-code warnings in helpers)
- [x] `cargo test -p clickgraph` — 1345 lib tests passing
- [x] `cargo test -p clickgraph-embedded --lib` — 142 lib tests passing
- [x] Schema-gen unit test (`test_feature_is_filtered_recognises_filter_tags`) extended to cover `@unsupported-label-mutation`
- [ ] CI runs full TCK suite and confirms 402/402 read baseline preserved (local TCK runs are ~15-20 min due to chdb + universal-schema warm-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)