### PR TITLE
feat(planner): Phase 5b — anonymous-node CREATE routes to __Unlabeled

### DIFF
--- a/clickgraph-tck/README.md
+++ b/clickgraph-tck/README.md
@@ -6,7 +6,7 @@ openCypher [Technology Compatibility Kit (TCK)](https://github.com/opencypher/op
 
 **402 / 402 read scenarios passing (100%)** — 0 failing.
 
-Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. Phase 5a (#281) added the side-effect step. Phase 5b (this commit) added anonymous-node support (`CREATE ()`, `CREATE (n {...})` route to the `__Unlabeled` table catalogued by `schema_gen.rs`), lifting the file-level `@wip` from `Create1.feature` so its un-gated scenarios run. Remaining write scenarios stay `@wip` per-scenario until the corresponding capability lands. See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix (Phase 5).
+Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. Phase 5a (#281) added the side-effect step. Phase 5b (this commit) added anonymous-node support (`CREATE ()`, `CREATE (n {...})` route to the `__Unlabeled` table catalogued by `schema_gen.rs`), lifting the file-level `@wip` from `Create1.feature`. Of the un-gated scenarios, `Create1` [1] [2] [7] [9] now run end-to-end; [3] and [4] are ungated but the harness still reports them as skips because their side-effect tables include `+labels`, which `effect_to_counter()` deliberately leaves unmapped (label mutations are out of scope). Remaining scenarios stay `@wip` per-scenario until the corresponding capability lands. See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix (Phase 5).
 
 ## What it tests
 

--- a/clickgraph-tck/README.md
+++ b/clickgraph-tck/README.md
@@ -6,7 +6,7 @@ openCypher [Technology Compatibility Kit (TCK)](https://github.com/opencypher/op
 
 **402 / 402 read scenarios passing (100%)** — 0 failing.
 
-Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. They are tagged `@wip` at the Feature level and currently filtered out of the run; per-scenario triage will lift the tag incrementally as harness extensions land. See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix (Phase 4).
+Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. Phase 5a (#281) added the side-effect step. Phase 5b (this commit) added anonymous-node support (`CREATE ()`, `CREATE (n {...})` route to the `__Unlabeled` table catalogued by `schema_gen.rs`), lifting the file-level `@wip` from `Create1.feature` so its un-gated scenarios run. Remaining write scenarios stay `@wip` per-scenario until the corresponding capability lands. See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix (Phase 5).
 
 ## What it tests
 
@@ -47,8 +47,8 @@ Phase 5a (this commit) ships the harness extensions to start running them:
 
 Still pending before more imports unlock:
 
-1. **Schema generation** in `schema_gen.rs` needs to handle anonymous nodes (`CREATE ()`) — bare nodes today don't get a label and aren't catalogued. Several `Create1` / `Delete1` scenarios depend on this.
-2. **Per-scenario disposition** for combinations the write pipeline rejects deliberately (`CREATE … RETURN`, relationship `CREATE`, `DELETE r` for an edge alias, `SET a += {…}` / `SET a = {…}` map-merge / full-map, `MERGE`). Each is rejected with an explicit error today; Phase 5 will lift the implementation gaps and document the rest as out-of-scope.
+1. **Anonymous nodes** are catalogued under the `__Unlabeled` synthetic label in `schema_gen.rs` (since the initial Phase 4 import) and now route through the write pipeline (Phase 5b). `Create1` scenarios [1] [2] [3] [4] [7] [9] are running; the rest stay `@wip` per-scenario behind the issues below.
+2. **Per-scenario disposition** for combinations the write pipeline rejects deliberately (`CREATE … RETURN`, multi-label CREATE (`CREATE (:A:B:C:D)`), relationship `CREATE`, `DELETE r` for an edge alias, `SET a += {…}` / `SET a = {…}` map-merge / full-map, `MERGE`, expected SyntaxError diagnostics). Each is rejected with an explicit error today; Phase 5c+ will lift the implementation gaps and document the rest as out-of-scope.
 
 `MERGE` (Merge1..6 upstream) is not imported yet — tracked for v0.7.x Phase 5.
 

--- a/clickgraph-tck/tests/features/clauses/create/Create1.feature
+++ b/clickgraph-tck/tests/features/clauses/create/Create1.feature
@@ -28,20 +28,21 @@
 
 #encoding: utf-8
 
-# @wip — Phase 4 import from upstream openCypher TCK (master, fetched 2026-05-02).
-# Cypher write clauses (CREATE / SET / DELETE / REMOVE) are implemented in
-# embedded mode as of v0.6.7, but this scenario file requires harness
-# extensions before it runs cleanly:
-#   * `the side effects should be:` step currently no-ops; needs counter
-#     assertion against the QueryResult counters returned by handle_write_async.
-#   * Some scenarios use anonymous nodes (`CREATE ()`) that schema_gen.rs
-#     doesn't yet collect into the universal catalog.
-#   * Several scenarios chain CREATE/MATCH/SET in patterns that exercise
-#     unimplemented combinations (CREATE … RETURN, relationship CREATE,
-#     map-merge SET) — see KNOWN_ISSUES.md.
-# Lifted incrementally as triage lands. See docs/design/embedded-writes.md
-# Appendix (Phase 4) for the plan.
-@wip
+# Phase 4 import from upstream openCypher TCK (master, fetched 2026-05-02).
+# File-level @wip lifted in Phase 5b — anonymous-node CREATE (`CREATE ()`,
+# `CREATE (n {...})`) now routes to the `__Unlabeled` node catalogued by
+# schema_gen.rs, so scenarios [1] [2] [3] [4] [7] [9] run.
+# Scenarios still gated with per-scenario @wip:
+#   * [5] [6] — multi-label CREATE (`CREATE (:A:B:C:D)`); planner rejects.
+#   * [8] [10] [11] [12] — CREATE … RETURN (read-after-write inside the
+#     same statement); rejected upstream by the write/read split.
+#   * [13]-[20] — expect specific compile-time SyntaxError (VariableAlreadyBound,
+#     UndefinedVariable). ClickGraph executes these without raising the
+#     expected diagnostic, which would surface as a triage skip rather than
+#     a meaningful pass — keep @wip until the planner enforces these.
+# Side-effect rows containing `+labels` (scenarios [3] [4] [12]) are mapped
+# to `world.skip_reason` by the harness (effect_to_counter returns None),
+# so those scenarios skip cleanly rather than running half-asserted.
 Feature: Create1 - Creating nodes
 
   Scenario: [1] Create a single node
@@ -86,6 +87,7 @@ Feature: Create1 - Creating nodes
       | +nodes  | 2 |
       | +labels | 1 |
 
+  @wip
   Scenario: [5] Create a single node with multiple labels
     Given an empty graph
     When executing query:
@@ -97,6 +99,7 @@ Feature: Create1 - Creating nodes
       | +nodes  | 1 |
       | +labels | 4 |
 
+  @wip
   Scenario: [6] Create three nodes with multiple labels
     Given an empty graph
     When executing query:
@@ -119,6 +122,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 1 |
 
+  @wip
   Scenario: [8] Create a single node with a property and return it
     Given any graph
     When executing query:
@@ -144,6 +148,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 2 |
 
+  @wip
   Scenario: [10] Create a single node with two properties and return them
     Given any graph
     When executing query:
@@ -158,6 +163,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 2 |
 
+  @wip
   Scenario: [11] Create a single node with null properties should not return those properties
     Given any graph
     When executing query:
@@ -172,6 +178,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 1 |
 
+  @wip
   Scenario: [12] CREATE does not lose precision on large integers
     Given an empty graph
     When executing query:
@@ -187,6 +194,7 @@ Feature: Create1 - Creating nodes
       | +properties | 1 |
       | +labels     | 1 |
 
+  @wip
   Scenario: [13] Fail when creating a node that is already bound
     Given any graph
     When executing query:
@@ -196,6 +204,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [14] Fail when creating a node with properties that is already bound
     Given any graph
     When executing query:
@@ -206,6 +215,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [15] Fail when adding a new label predicate on a node that is already bound 1
     Given an empty graph
     When executing query:
@@ -216,6 +226,7 @@ Feature: Create1 - Creating nodes
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   # Consider improve naming of this and the next three scenarios, they seem to test invariant nature of node patterns
+  @wip
   Scenario: [16] Fail when adding new label predicate on a node that is already bound 2
     Given an empty graph
     When executing query:
@@ -225,6 +236,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [17] Fail when adding new label predicate on a node that is already bound 3
     Given an empty graph
     When executing query:
@@ -234,6 +246,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [18] Fail when adding new label predicate on a node that is already bound 4
     Given an empty graph
     When executing query:
@@ -243,6 +256,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [19] Fail when adding new label predicate on a node that is already bound 5
     Given an empty graph
     When executing query:
@@ -252,6 +266,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
+  @wip
   Scenario: [20] Fail when creating a node using undefined variable in pattern
     Given any graph
     When executing query:

--- a/clickgraph-tck/tests/features/clauses/create/Create1.feature
+++ b/clickgraph-tck/tests/features/clauses/create/Create1.feature
@@ -31,7 +31,13 @@
 # Phase 4 import from upstream openCypher TCK (master, fetched 2026-05-02).
 # File-level @wip lifted in Phase 5b — anonymous-node CREATE (`CREATE ()`,
 # `CREATE (n {...})`) now routes to the `__Unlabeled` node catalogued by
-# schema_gen.rs, so scenarios [1] [2] [3] [4] [7] [9] run.
+# schema_gen.rs. Of the ungated scenarios:
+#   * [1] [2] [7] [9] run to completion and assert their side-effect counters.
+#   * [3] [4] are ungated but the harness still records them as skips because
+#     their side-effect tables include `+labels`, which effect_to_counter()
+#     leaves unmapped on purpose (ClickGraph doesn't support label mutations,
+#     so there is no counter to assert against). They surface in the run as
+#     triage candidates rather than passes.
 # Scenarios still gated with per-scenario @wip:
 #   * [5] [6] — multi-label CREATE (`CREATE (:A:B:C:D)`); planner rejects.
 #   * [8] [10] [11] [12] — CREATE … RETURN (read-after-write inside the
@@ -40,9 +46,6 @@
 #     UndefinedVariable). ClickGraph executes these without raising the
 #     expected diagnostic, which would surface as a triage skip rather than
 #     a meaningful pass — keep @wip until the planner enforces these.
-# Side-effect rows containing `+labels` (scenarios [3] [4] [12]) are mapped
-# to `world.skip_reason` by the harness (effect_to_counter returns None),
-# so those scenarios skip cleanly rather than running half-asserted.
 Feature: Create1 - Creating nodes
 
   Scenario: [1] Create a single node

--- a/src/query_planner/logical_plan/write_clause_builder.rs
+++ b/src/query_planner/logical_plan/write_clause_builder.rs
@@ -325,40 +325,44 @@ fn endpoint_alias_or_create(
     pat: &NodePattern<'_>,
     schema: &GraphSchema,
     out: &mut Vec<CreatePattern>,
-    side: &str,
+    _side: &str,
 ) -> Result<String> {
-    if pat.labels.is_some() {
-        let mut node = create_node_from_pattern(pat, schema)?;
-        let alias = node.alias.clone().unwrap_or_else(generate_id);
-        if node.alias.is_none() {
-            node.alias = Some(alias.clone());
+    // A bare reference like `(a)` (no label, no properties) to a previously
+    // bound alias must keep referencing that alias rather than synthesising
+    // a fresh `__Unlabeled` node.
+    if pat.labels.is_none() && pat.properties.is_none() {
+        if let Some(name) = pat.name {
+            return Ok(name.to_string());
         }
-        out.push(CreatePattern::Node(node));
-        Ok(alias)
-    } else {
-        let name = pat.name.ok_or_else(|| {
-            LogicalPlanError::QueryPlanningError(format!(
-                "CREATE {} endpoint must be either a labelled node or a reference to a bound alias",
-                side
-            ))
-        })?;
-        Ok(name.to_string())
     }
+    let mut node = create_node_from_pattern(pat, schema)?;
+    let alias = node.alias.clone().unwrap_or_else(generate_id);
+    if node.alias.is_none() {
+        node.alias = Some(alias.clone());
+    }
+    out.push(CreatePattern::Node(node));
+    Ok(alias)
 }
 
+/// Sentinel label used when a CREATE pattern declares no label
+/// (e.g. `CREATE ()` or `CREATE (n {prop: 1})`). The active schema must
+/// register a writable node under this label for the CREATE to succeed —
+/// production schemas typically don't, so the missing-schema error fires
+/// just as it would for any other unknown label. Test harnesses (notably
+/// `clickgraph-tck`) catalogue `__Unlabeled` automatically.
+pub(crate) const UNLABELED_DEFAULT: &str = "__Unlabeled";
+
 fn create_node_from_pattern(pat: &NodePattern<'_>, schema: &GraphSchema) -> Result<CreateNode> {
-    let labels = pat.labels.as_ref().ok_or_else(|| {
-        LogicalPlanError::QueryPlanningError(
-            "CREATE requires every node to specify a label (e.g., (a:Person {...}))".to_string(),
-        )
-    })?;
-    if labels.len() != 1 {
-        return Err(LogicalPlanError::QueryPlanningError(format!(
-            "CREATE node patterns must declare exactly one label; got {:?}",
-            labels
-        )));
-    }
-    let label = labels[0].to_string();
+    let label = match pat.labels.as_ref() {
+        None => UNLABELED_DEFAULT.to_string(),
+        Some(labels) if labels.len() == 1 => labels[0].to_string(),
+        Some(labels) => {
+            return Err(LogicalPlanError::QueryPlanningError(format!(
+                "CREATE node patterns must declare at most one label; got {:?}",
+                labels
+            )));
+        }
+    };
 
     let node_schema = schema.node_schema(&label).map_err(|_| {
         LogicalPlanError::NodeNotFound(format!(
@@ -748,10 +752,40 @@ mod tests {
     }
 
     #[test]
-    fn create_node_without_label_rejected() {
-        let err = plan_err("CREATE (a)");
-        let msg = err.to_string();
-        assert!(msg.contains("label"), "got `{}`", msg);
+    fn create_unlabeled_node_without_unlabeled_schema_is_rejected() {
+        // No `__Unlabeled` entry in `build_test_schema()`, so `CREATE ()`
+        // hits the same NodeNotFound path as any other unknown label.
+        let err = plan_err("CREATE ()");
+        assert!(
+            matches!(&err, LogicalPlanError::NodeNotFound(msg) if msg.contains("__Unlabeled")),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn create_unlabeled_node_dispatches_to_unlabeled_when_schema_has_it() {
+        // When the active schema registers an `__Unlabeled` node, anonymous
+        // CREATE patterns route there. This is what TCK harnesses opt into
+        // via schema_gen — production schemas typically don't define it.
+        let mut nodes = HashMap::new();
+        nodes.insert("__Unlabeled".to_string(), person_node("Unlabeled"));
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, HashMap::new());
+
+        let ast = parse_query("CREATE (), (a), (b {name: 'foo'})").expect("parse");
+        let (plan, _ctx) =
+            build_logical_plan(&ast, &schema, None, None, None).expect("planning succeeds");
+        let create = match &*plan {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        assert_eq!(create.patterns.len(), 3);
+        for pat in &create.patterns {
+            match pat {
+                CreatePattern::Node(n) => assert_eq!(n.label, "__Unlabeled"),
+                other => panic!("expected only Node patterns, got {:?}", other),
+            }
+        }
     }
 
     #[test]

--- a/src/query_planner/logical_plan/write_clause_builder.rs
+++ b/src/query_planner/logical_plan/write_clause_builder.rs
@@ -43,8 +43,16 @@ pub fn build_create(
     schema: &GraphSchema,
 ) -> Result<Arc<LogicalPlan>> {
     let mut patterns = Vec::new();
+    // Aliases already bound by the read pipeline (`MATCH (x) CREATE (x)-[:R]->(y)`).
+    // Endpoints whose name is in this set resolve to references rather than
+    // synthesised CreateNodes; everything else (including a bare `(y)` that
+    // isn't bound upstream) gets a fresh `__Unlabeled` CreateNode so the
+    // emitted relationship's start/end aliases always have a corresponding
+    // node pattern in the same CREATE.
+    let mut bound_aliases: std::collections::HashSet<String> = std::collections::HashSet::new();
+    collect_bound_aliases(&input, &mut bound_aliases);
     for path in &create.path_patterns {
-        collect_patterns_from_path(path, schema, &mut patterns)?;
+        collect_patterns_from_path(path, schema, &mut patterns, &mut bound_aliases)?;
     }
     if patterns.is_empty() {
         return Err(LogicalPlanError::QueryPlanningError(
@@ -52,6 +60,44 @@ pub fn build_create(
         ));
     }
     Ok(Arc::new(LogicalPlan::Create(Create { input, patterns })))
+}
+
+/// Collect every alias bound by `plan` (GraphNode / GraphRel aliases at any
+/// depth). Used by CREATE-pattern endpoint resolution to distinguish a bare
+/// `(name)` reference to an upstream binding from a fresh anonymous node.
+fn collect_bound_aliases(plan: &LogicalPlan, out: &mut std::collections::HashSet<String>) {
+    match plan {
+        LogicalPlan::GraphNode(n) => {
+            out.insert(n.alias.clone());
+            collect_bound_aliases(&n.input, out);
+        }
+        LogicalPlan::GraphRel(r) => {
+            out.insert(r.alias.clone());
+            collect_bound_aliases(&r.left, out);
+            collect_bound_aliases(&r.center, out);
+            collect_bound_aliases(&r.right, out);
+        }
+        LogicalPlan::Filter(f) => collect_bound_aliases(&f.input, out),
+        LogicalPlan::Projection(p) => collect_bound_aliases(&p.input, out),
+        LogicalPlan::GroupBy(gb) => collect_bound_aliases(&gb.input, out),
+        LogicalPlan::OrderBy(ob) => collect_bound_aliases(&ob.input, out),
+        LogicalPlan::Skip(s) => collect_bound_aliases(&s.input, out),
+        LogicalPlan::Limit(l) => collect_bound_aliases(&l.input, out),
+        LogicalPlan::Cte(c) => collect_bound_aliases(&c.input, out),
+        LogicalPlan::GraphJoins(gj) => collect_bound_aliases(&gj.input, out),
+        LogicalPlan::Unwind(u) => collect_bound_aliases(&u.input, out),
+        LogicalPlan::Union(u) => u.inputs.iter().for_each(|p| collect_bound_aliases(p, out)),
+        LogicalPlan::CartesianProduct(cp) => {
+            collect_bound_aliases(&cp.left, out);
+            collect_bound_aliases(&cp.right, out);
+        }
+        LogicalPlan::WithClause(wc) => collect_bound_aliases(&wc.input, out),
+        LogicalPlan::Create(c) => collect_bound_aliases(&c.input, out),
+        LogicalPlan::SetProperties(sp) => collect_bound_aliases(&sp.input, out),
+        LogicalPlan::Delete(d) => collect_bound_aliases(&d.input, out),
+        LogicalPlan::Remove(r) => collect_bound_aliases(&r.input, out),
+        LogicalPlan::Empty | LogicalPlan::ViewScan(_) | LogicalPlan::PageRank(_) => {}
+    }
 }
 
 /// Build a `LogicalPlan::SetProperties` from a parsed `SetClause`.
@@ -273,16 +319,19 @@ fn collect_patterns_from_path(
     path: &PathPattern<'_>,
     schema: &GraphSchema,
     out: &mut Vec<CreatePattern>,
+    bound_aliases: &mut std::collections::HashSet<String>,
 ) -> Result<()> {
     match path {
         PathPattern::Node(node_pat) => {
-            out.push(CreatePattern::Node(create_node_from_pattern(
-                node_pat, schema,
-            )?));
+            let node = create_node_from_pattern(node_pat, schema)?;
+            if let Some(alias) = &node.alias {
+                bound_aliases.insert(alias.clone());
+            }
+            out.push(CreatePattern::Node(node));
         }
         PathPattern::ConnectedPattern(connections) => {
             for conn in connections {
-                collect_patterns_from_connection(conn, schema, out)?;
+                collect_patterns_from_connection(conn, schema, out, bound_aliases)?;
             }
         }
         PathPattern::ShortestPath(_) | PathPattern::AllShortestPaths(_) => {
@@ -298,15 +347,19 @@ fn collect_patterns_from_connection(
     conn: &ConnectedPattern<'_>,
     schema: &GraphSchema,
     out: &mut Vec<CreatePattern>,
+    bound_aliases: &mut std::collections::HashSet<String>,
 ) -> Result<()> {
     let start_borrow = conn.start_node.borrow();
     let end_borrow = conn.end_node.borrow();
 
-    // For each endpoint: if labeled, emit a CreateNode (we're creating it);
-    // if it's a bare reference (`(a)` with no label), it must already be bound
-    // by a prior MATCH/CREATE — record only its alias for the relationship.
-    let start_alias = endpoint_alias_or_create(&start_borrow, schema, out, "start")?;
-    let end_alias = endpoint_alias_or_create(&end_borrow, schema, out, "end")?;
+    // For each endpoint: if labeled or property-bearing, emit a CreateNode
+    // (we're creating it). Bare `(name)` resolves to a reference if `name`
+    // is already bound (by `input` or by an earlier pattern in the same
+    // CREATE); otherwise we synthesise an `__Unlabeled` CreateNode so the
+    // emitted relationship's start/end aliases always correspond to a node
+    // pattern. Anonymous endpoints (no name, no label) get a fresh alias.
+    let start_alias = endpoint_alias_or_create(&start_borrow, schema, out, bound_aliases)?;
+    let end_alias = endpoint_alias_or_create(&end_borrow, schema, out, bound_aliases)?;
 
     let rel = create_rel_from_pattern(&conn.relationship, start_alias, end_alias, schema)?;
     // Note: standalone CREATE pattern is `start, rel, end` — the Rel pattern
@@ -316,30 +369,33 @@ fn collect_patterns_from_connection(
     Ok(())
 }
 
-/// Resolve a CREATE relationship endpoint to an alias. If the endpoint is
-/// labeled, emit a `CreatePattern::Node` for it (we're creating a new node);
-/// otherwise it must already be bound by a prior clause, so we only return its
-/// alias. Anonymous labelled endpoints are valid Cypher — synthesise an
-/// internal alias rather than rejecting them.
 fn endpoint_alias_or_create(
     pat: &NodePattern<'_>,
     schema: &GraphSchema,
     out: &mut Vec<CreatePattern>,
-    _side: &str,
+    bound_aliases: &mut std::collections::HashSet<String>,
 ) -> Result<String> {
-    // A bare reference like `(a)` (no label, no properties) to a previously
-    // bound alias must keep referencing that alias rather than synthesising
-    // a fresh `__Unlabeled` node.
+    // Bare reference (`(name)`, no labels, no props) to an alias that is
+    // already bound — by the read pipeline or by an earlier CREATE pattern
+    // in the same clause — resolves to a reference. No new node.
     if pat.labels.is_none() && pat.properties.is_none() {
         if let Some(name) = pat.name {
-            return Ok(name.to_string());
+            if bound_aliases.contains(name) {
+                return Ok(name.to_string());
+            }
         }
     }
+    // Otherwise we're creating a node. `create_node_from_pattern` defaults a
+    // missing label to `__Unlabeled`. Reuse the user-supplied name as alias
+    // when present (so `CREATE (root)-[:LINK]->(root)` binds `root` once and
+    // the second occurrence falls into the bound-reference branch above);
+    // otherwise synthesise an opaque id.
     let mut node = create_node_from_pattern(pat, schema)?;
     let alias = node.alias.clone().unwrap_or_else(generate_id);
     if node.alias.is_none() {
         node.alias = Some(alias.clone());
     }
+    bound_aliases.insert(alias.clone());
     out.push(CreatePattern::Node(node));
     Ok(alias)
 }
@@ -825,6 +881,93 @@ mod tests {
             "got {:?}",
             err
         );
+    }
+
+    // Phase 5b regression coverage: bare-name endpoints in a CREATE'd
+    // relationship must synthesise an `__Unlabeled` CreateNode unless the
+    // alias is already bound by `input` or by an earlier pattern in the
+    // same CREATE — otherwise the emitted Rel points at aliases with no
+    // node pattern.
+    #[test]
+    fn create_self_loop_synthesises_unlabeled_node_once() {
+        let mut nodes = HashMap::new();
+        nodes.insert("__Unlabeled".to_string(), person_node("Unlabeled"));
+        let mut rels = HashMap::new();
+        let mut self_rel = knows_rel();
+        self_rel.from_node = "__Unlabeled".to_string();
+        self_rel.to_node = "__Unlabeled".to_string();
+        self_rel.from_node_table = "unlabeled".to_string();
+        self_rel.to_node_table = "unlabeled".to_string();
+        rels.insert("LINK::__Unlabeled::__Unlabeled".to_string(), self_rel);
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, rels);
+
+        let ast = parse_query("CREATE (root)-[:LINK]->(root)").expect("parse");
+        let (plan, _ctx) =
+            build_logical_plan(&ast, &schema, None, None, None).expect("planning succeeds");
+        let create = match &*plan {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        // Exactly one CreateNode for `root`, plus the relationship.
+        let node_count = create
+            .patterns
+            .iter()
+            .filter(|p| matches!(p, CreatePattern::Node(_)))
+            .count();
+        let rel_count = create
+            .patterns
+            .iter()
+            .filter(|p| matches!(p, CreatePattern::Rel(_)))
+            .count();
+        assert_eq!(node_count, 1, "self-loop must bind `root` exactly once");
+        assert_eq!(rel_count, 1);
+        for p in &create.patterns {
+            if let CreatePattern::Rel(r) = p {
+                assert_eq!(r.start_alias, "root");
+                assert_eq!(r.end_alias, "root");
+            }
+            if let CreatePattern::Node(n) = p {
+                assert_eq!(n.alias.as_deref(), Some("root"));
+                assert_eq!(n.label, "__Unlabeled");
+            }
+        }
+    }
+
+    #[test]
+    fn create_with_matched_alias_does_not_resynthesise() {
+        // `MATCH (a:Person) CREATE (a)-[:KNOWS]->(b)` — `a` is bound upstream,
+        // so it must not produce a fresh CreateNode; `b` is unbound, so it
+        // does (as `__Unlabeled` if no label). Built against a schema that
+        // declares both Person and __Unlabeled as KNOWS endpoints.
+        let mut nodes = HashMap::new();
+        nodes.insert("Person".to_string(), person_node("Person"));
+        nodes.insert("__Unlabeled".to_string(), person_node("Unlabeled"));
+        let mut rels = HashMap::new();
+        let mut p_to_u = knows_rel();
+        p_to_u.to_node = "__Unlabeled".to_string();
+        p_to_u.to_node_table = "unlabeled".to_string();
+        rels.insert("KNOWS::Person::__Unlabeled".to_string(), p_to_u);
+        let schema = GraphSchema::build(1, "test".to_string(), nodes, rels);
+
+        let ast = parse_query("MATCH (a:Person) CREATE (a)-[:KNOWS]->(b)").expect("parse");
+        let (plan, _ctx) =
+            build_logical_plan(&ast, &schema, None, None, None).expect("planning succeeds");
+        let create = match &*plan {
+            LogicalPlan::Create(c) => c,
+            other => panic!("expected Create, got {:?}", other),
+        };
+        let create_nodes: Vec<&CreateNode> = create
+            .patterns
+            .iter()
+            .filter_map(|p| match p {
+                CreatePattern::Node(n) => Some(n),
+                _ => None,
+            })
+            .collect();
+        // Only `b` should be synthesised — `a` came from MATCH.
+        assert_eq!(create_nodes.len(), 1);
+        assert_eq!(create_nodes[0].alias.as_deref(), Some("b"));
+        assert_eq!(create_nodes[0].label, "__Unlabeled");
     }
 
     // Anonymous labelled endpoints get auto-generated aliases (PR #277 review).


### PR DESCRIPTION
## Summary

Anonymous-node CREATE (`CREATE ()`, `CREATE (n)`, `CREATE (n {prop: 1})`) now routes to a sentinel `__Unlabeled` node label, unlocking openCypher TCK Create1 scenarios [1] [2] [3] [4] [7] [9].

- **Planner** (`src/query_planner/logical_plan/write_clause_builder.rs`): when a CREATE node pattern declares no label, default to `__Unlabeled` and look it up in the active schema like any other label. If the schema doesn't register `__Unlabeled` (production schemas typically don't) the existing `NodeNotFound` path fires unchanged. `endpoint_alias_or_create` follows the same logic — labelled or property-bearing endpoints (anonymous or named) get a synthesised CREATE node; a bare `(a)` reference still resolves to the bound alias.
- **TCK** (`Create1.feature`): file-level `@wip` lifted; only still-unsupported scenarios stay `@wip` per-scenario (multi-label CREATE [5] [6], CREATE … RETURN [8] [10] [11] [12], expected-SyntaxError diagnostics [13]–[20]). The harness already catalogues `__Unlabeled` in `schema_gen.rs` from any anonymous CREATE seen in docstrings, so the unlocked scenarios get the schema for free.
- **Side-effect rows** containing `+labels` (Create1 [3] [4]) surface as harness skips via `effect_to_counter` (no counter mapping for label mutations) rather than as half-asserted runs.

## Test plan

- [x] `cargo test -p clickgraph --lib` — 1346 passing (added two new write_clause_builder tests covering positive and negative __Unlabeled paths)
- [x] `cargo test -p clickgraph-embedded --lib` — 142 passing
- [x] `cargo fmt --all && cargo clippy --all-targets -p clickgraph` — clean
- [ ] Full TCK run (CI) — 402 read baseline + Create1 [1] [2] [3] [4] [7] [9] now running. Local run was inconclusive (output stream truncated, killed at 25 min while still healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)