### PR TITLE
feat(embedded): Phase 5d — write+RETURN side-channel + accurate counters

### DIFF
--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -1345,9 +1345,8 @@ impl<'db> Connection<'db> {
             // fail with "undefined variable" *after* the INSERT has
             // already executed. Rejecting up-front keeps the database
             // unchanged on failure and surfaces a clear, deterministic
-            // error rather than a partially-applied write. This matches
-            // the Phase 5b/5c contract pinned by
-            // `cypher_create_with_return_rejected_with_clear_error`.
+            // error rather than a partially-applied write. Pinned by
+            // `cypher_create_with_return_rejected_before_insert` below.
             if has_return && matches!(write_subplan, LogicalPlan::Create(_)) {
                 return Err(EmbeddedError::Query(
                     "CREATE … RETURN is not supported in this build of ClickGraph yet. \
@@ -1583,18 +1582,38 @@ async fn run_count_probe(
         .execute_json(sql, None)
         .await
         .map_err(EmbeddedError::from)?;
+    // The probe SQL is fully under our control (`SELECT count() AS n …`),
+    // so a missing row, missing `n` column, or non-numeric value is a
+    // contract violation — most likely a regression in the probe SQL
+    // builder or in the executor's JSON shape. Surface as an error
+    // rather than silently bottoming out at 0, which would let an
+    // inaccurate-counter regression pass tests instead of failing them.
     let Some(serde_json::Value::Object(obj)) = rows.first() else {
-        return Ok(0);
+        return Err(EmbeddedError::Query(format!(
+            "count probe `{sql}` returned no rows; expected one `{{\"n\": <N>}}` row"
+        )));
     };
     let Some(val) = obj.get("n") else {
-        return Ok(0);
+        return Err(EmbeddedError::Query(format!(
+            "count probe `{sql}` row is missing the `n` column; got: {obj:?}"
+        )));
     };
     match val {
-        serde_json::Value::Number(n) => Ok(n.as_u64().unwrap_or(0)),
-        // ClickHouse returns count() as a string in some json formats;
-        // fall back to parsing.
-        serde_json::Value::String(s) => Ok(s.parse::<u64>().unwrap_or(0)),
-        _ => Ok(0),
+        serde_json::Value::Number(n) => n.as_u64().ok_or_else(|| {
+            EmbeddedError::Query(format!(
+                "count probe `{sql}` returned non-u64 number: {n:?}"
+            ))
+        }),
+        // ClickHouse JSONEachRow surfaces `count()` as a string for
+        // values that don't fit i64; accept the string form and parse it.
+        serde_json::Value::String(s) => s.parse::<u64>().map_err(|e| {
+            EmbeddedError::Query(format!(
+                "count probe `{sql}` returned unparseable string `{s}`: {e}"
+            ))
+        }),
+        other => Err(EmbeddedError::Query(format!(
+            "count probe `{sql}` returned unexpected `n` type: {other:?}"
+        ))),
     }
 }
 

--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -1261,9 +1261,15 @@ impl<'db> Connection<'db> {
 
     /// Plan, render, and execute a Cypher write query (CREATE / SET /
     /// DELETE / REMOVE). Returns Neo4j-compatible counters as a single-row
-    /// `QueryResult` per Decision 0.8 of the embedded-writes design.
+    /// `QueryResult` per Decision 0.8 of the embedded-writes design — or,
+    /// when the statement also carries a RETURN clause (Phase 5d), the
+    /// row payload from re-running the read pipeline against the modified
+    /// state with the write counters attached via `QueryResult::get_write_counters()`.
     async fn handle_write_async(&self, cypher: &str) -> Result<QueryResult, EmbeddedError> {
+        use clickgraph::clickhouse_query_generator::cypher_to_sql_read_only;
         use clickgraph::clickhouse_query_generator::write_to_sql::write_render_to_sql;
+        use clickgraph::open_cypher_parser::ast::CypherStatement;
+        use clickgraph::query_planner::logical_plan::LogicalPlan;
         use clickgraph::query_planner::write_guard::ensure_write_target_writable;
         use clickgraph::render_plan::write_plan_builder::build_write_plan;
         use clickgraph::server::query_context::{
@@ -1287,6 +1293,16 @@ impl<'db> Connection<'db> {
             let (_remaining, stmt) =
                 clickgraph::open_cypher_parser::parse_cypher_statement(&cleaned)
                     .map_err(|e| EmbeddedError::Query(format!("Parse error: {:?}", e)))?;
+
+            // Capture whether the statement carries a RETURN clause before
+            // ownership of `stmt` moves into the planner. write+RETURN
+            // routes through the Phase 5d branch below; pure writes keep
+            // the synthetic counter-row response.
+            let has_return = matches!(
+                &stmt,
+                CypherStatement::Query { query, .. } if query.return_clause.is_some()
+            );
+
             let (logical_plan, _plan_ctx) =
                 clickgraph::query_planner::evaluate_read_statement(stmt, &schema, None, None, None)
                     .map_err(|e| EmbeddedError::Query(format!("Plan error: {}", e)))?;
@@ -1295,42 +1311,65 @@ impl<'db> Connection<'db> {
             ensure_write_target_writable(&logical_plan, &schema, executor_kind)
                 .map_err(|e| EmbeddedError::Query(format!("Write rejected: {}", e)))?;
 
-            let write_plan = build_write_plan(&logical_plan, &schema)
+            // Walk past read-only wrappers (Projection / OrderBy / Skip /
+            // Limit) to find the write subplan. write+RETURN puts a
+            // Projection above the write; pure-write statements have the
+            // write at the root. The subplan retains its full read input
+            // (the MATCH/WHERE/etc. that bound the variables we mutate).
+            let write_subplan = find_write_subplan(&logical_plan).ok_or_else(|| {
+                EmbeddedError::Query(
+                    "Cypher write clause is not supported in this combination yet \
+                     (e.g. write clauses inside subqueries). Use a separate \
+                     write statement followed by a MATCH for now."
+                        .to_string(),
+                )
+            })?;
+
+            let write_plan = build_write_plan(write_subplan, &schema)
                 .map_err(|e| EmbeddedError::Query(format!("Write render error: {}", e)))?
                 .ok_or_else(|| {
-                    // The dispatch above sent us here because a write clause
-                    // (CREATE / SET / DELETE / REMOVE) was visible in the
-                    // parsed AST, but `build_write_plan` couldn't extract a
-                    // write variant from the planned tree — typically this
-                    // means the write was wrapped under a clause we don't
-                    // yet support in the write pipeline (e.g. CREATE ...
-                    // RETURN). Surface a clear error rather than the
-                    // generic "non-write plan" wording.
                     EmbeddedError::Query(
-                        "Cypher write clause is not supported in this combination yet \
-                         (e.g. CREATE … RETURN, or write clauses inside subqueries). \
-                         Use a separate write statement followed by a MATCH for now."
+                        "Internal error: write subplan resolved but `build_write_plan` \
+                         returned None. This is a planner/rendering bug; please report."
                             .to_string(),
                     )
                 })?;
+
+            // Phase 5d v1 supports DELETE / SET / REMOVE + RETURN by
+            // executing the write, then re-running the read pipeline with
+            // the write clauses stripped. CREATE + RETURN is *not*
+            // supported by that path: the read pipeline can't see freshly
+            // inserted rows by alias (the alias was never bound by a
+            // MATCH and the inserted row has no MATCH-able identity yet),
+            // so referencing the create-bound alias from RETURN would
+            // fail with "undefined variable" *after* the INSERT has
+            // already executed. Rejecting up-front keeps the database
+            // unchanged on failure and surfaces a clear, deterministic
+            // error rather than a partially-applied write. This matches
+            // the Phase 5b/5c contract pinned by
+            // `cypher_create_with_return_rejected_with_clear_error`.
+            if has_return && matches!(write_subplan, LogicalPlan::Create(_)) {
+                return Err(EmbeddedError::Query(
+                    "CREATE … RETURN is not supported in this build of ClickGraph yet. \
+                     The write would execute but the RETURN cannot reference the \
+                     newly created node by alias from the read pipeline. \
+                     Run CREATE as a separate statement, then MATCH … RETURN."
+                        .to_string(),
+                ));
+            }
+
             let stmts = write_render_to_sql(&write_plan);
             let compile_time_ms = compile_start.elapsed().as_secs_f64() * 1000.0;
 
-            // Execute each rendered statement in order. Counters are
-            // best-effort: chdb's lightweight INSERT/UPDATE/DELETE don't
-            // surface affected-row counts, so we report the statement
-            // count as a coarse signal for now.
+            // Resolve counters via `count()` probes against the same
+            // WHERE that each lightweight DELETE / UPDATE will use, then
+            // execute the mutations themselves. The probes run *before*
+            // the writes so the count reflects the matched-but-not-yet-
+            // mutated row set — DELETE / UPDATE are naturally idempotent
+            // against the probe's snapshot for the chdb workload here.
+            // INSERT counts are exact and don't need a probe.
             let exec_start = Instant::now();
-            let mut nodes_created: u64 = 0;
-            let mut properties_set: u64 = 0;
-            let mut nodes_deleted: u64 = 0;
-            let mut relationships_deleted: u64 = 0;
-            let counters = classify_write_counters(&write_plan);
-            nodes_created += counters.nodes_created;
-            properties_set += counters.properties_set;
-            nodes_deleted += counters.nodes_deleted;
-            relationships_deleted += counters.relationships_deleted;
-
+            let counters = resolve_write_counters(&write_plan, &executor).await?;
             for sql in &stmts {
                 executor
                     .execute_json(sql, None)
@@ -1339,34 +1378,130 @@ impl<'db> Connection<'db> {
             }
             let execution_time_ms = exec_start.elapsed().as_secs_f64() * 1000.0;
 
-            let column_names = vec![
-                "nodes_created".to_string(),
-                "properties_set".to_string(),
-                "nodes_deleted".to_string(),
+            if !has_return {
+                // Pure-write path: surface counters as a synthetic 4-column
+                // single-row result for back-compat with Phase 5a/5b.
+                let column_names = vec![
+                    "nodes_created".to_string(),
+                    "properties_set".to_string(),
+                    "nodes_deleted".to_string(),
+                    "relationships_deleted".to_string(),
+                ];
+                let row = vec![
+                    Value::Int64(counters.nodes_created as i64),
+                    Value::Int64(counters.properties_set as i64),
+                    Value::Int64(counters.nodes_deleted as i64),
+                    Value::Int64(counters.relationships_deleted as i64),
+                ];
+                return Ok(QueryResult::with_timing(
+                    column_names,
+                    vec![row],
+                    compile_time_ms,
+                    execution_time_ms,
+                ));
+            }
+
+            // Phase 5d: write+RETURN. Render the Cypher through the
+            // read-only pipeline (which clears CREATE / SET / DELETE /
+            // REMOVE on the AST internally so the planner re-derives just
+            // the read shape), execute it against the now-modified state,
+            // and attach the write counters via the side-channel.
+            let read_compile_start = Instant::now();
+            let read_sql = cypher_to_sql_read_only(&cypher, &schema, DEFAULT_MAX_CTE_DEPTH)
+                .map_err(EmbeddedError::Query)?;
+            let read_compile_ms = read_compile_start.elapsed().as_secs_f64() * 1000.0;
+
+            let read_exec_start = Instant::now();
+            let json_rows = executor
+                .execute_json(&read_sql, None)
+                .await
+                .map_err(EmbeddedError::from)?;
+            let read_exec_ms = read_exec_start.elapsed().as_secs_f64() * 1000.0;
+
+            let mut column_names: Vec<String> = Vec::new();
+            let mut rows: Vec<Vec<Value>> = Vec::new();
+            for json_row in json_rows {
+                if let serde_json::Value::Object(obj) = json_row {
+                    if column_names.is_empty() {
+                        column_names = obj.keys().cloned().collect();
+                    }
+                    let row_vals: Vec<Value> = column_names
+                        .iter()
+                        .map(|col| {
+                            obj.get(col)
+                                .cloned()
+                                .map(Value::from)
+                                .unwrap_or(Value::Null)
+                        })
+                        .collect();
+                    rows.push(row_vals);
+                }
+            }
+
+            let mut counter_map: HashMap<String, i64> = HashMap::new();
+            counter_map.insert("nodes_created".to_string(), counters.nodes_created as i64);
+            counter_map.insert("properties_set".to_string(), counters.properties_set as i64);
+            counter_map.insert("nodes_deleted".to_string(), counters.nodes_deleted as i64);
+            counter_map.insert(
                 "relationships_deleted".to_string(),
-            ];
-            let row = vec![
-                Value::Int64(nodes_created as i64),
-                Value::Int64(properties_set as i64),
-                Value::Int64(nodes_deleted as i64),
-                Value::Int64(relationships_deleted as i64),
-            ];
-            Ok(QueryResult::with_timing(
+                counters.relationships_deleted as i64,
+            );
+
+            Ok(QueryResult::with_timing_and_counters(
                 column_names,
-                vec![row],
-                compile_time_ms,
-                execution_time_ms,
+                rows,
+                compile_time_ms + read_compile_ms,
+                execution_time_ms + read_exec_ms,
+                counter_map,
             ))
         })
         .await
     }
 }
 
-/// Best-effort counter extraction from a `WriteRenderPlan`. chdb's
-/// lightweight write path doesn't return affected-row counts, so we report
-/// per-operation counts (one Insert = one node created, etc.) rather than
-/// actual row counts. Callers that need accurate row counts should fetch
-/// before/after `count()` themselves.
+/// Walk past read-only wrappers (Projection / OrderBy / Skip / Limit) to
+/// find the topmost write subplan inside `plan`. Returns `None` if the
+/// plan tree contains no write node, or if a write is buried under a
+/// shape we don't yet descend through (UNION, CartesianProduct, etc.).
+///
+/// This lets `handle_write_async` peel off the RETURN/ORDER BY/SKIP/LIMIT
+/// chain that sits above a write in `MATCH … DELETE … RETURN …` shapes
+/// without coupling that knowledge to the write_plan_builder, which only
+/// matches root-level write nodes.
+fn find_write_subplan(
+    plan: &clickgraph::query_planner::logical_plan::LogicalPlan,
+) -> Option<&clickgraph::query_planner::logical_plan::LogicalPlan> {
+    use clickgraph::query_planner::logical_plan::LogicalPlan;
+    match plan {
+        LogicalPlan::Create(_)
+        | LogicalPlan::SetProperties(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Remove(_) => Some(plan),
+        LogicalPlan::Projection(p) => find_write_subplan(&p.input),
+        LogicalPlan::OrderBy(o) => find_write_subplan(&o.input),
+        LogicalPlan::Skip(s) => find_write_subplan(&s.input),
+        LogicalPlan::Limit(l) => find_write_subplan(&l.input),
+        LogicalPlan::Filter(f) => find_write_subplan(&f.input),
+        LogicalPlan::WithClause(w) => find_write_subplan(&w.input),
+        LogicalPlan::GroupBy(g) => find_write_subplan(&g.input),
+        // The graph-join inference pass wraps the entire planned tree in a
+        // `GraphJoins` node even when the join list is empty (it carries
+        // anchor/correlation metadata). Walk through it to reach a write.
+        LogicalPlan::GraphJoins(gj) => find_write_subplan(&gj.input),
+        _ => None,
+    }
+}
+
+/// Counters surfaced as `nodes_created` / `properties_set` /
+/// `nodes_deleted` / `relationships_deleted` on the write `QueryResult`.
+/// `INSERT` counts come straight from the rendered op (rows are exact);
+/// `DELETE` and `UPDATE` counts come from `probe_*_count_sql` probes
+/// run against chdb just before the mutation, since the lightweight
+/// write path doesn't return affected-row counts and a static "+= 1
+/// per op" approximation drifts from the openCypher side-effect contract
+/// when the WHERE matches zero rows (e.g. `OPTIONAL MATCH … DELETE` on
+/// an empty graph) or many rows (e.g. `MATCH (n:X) SET n.k = …` with
+/// multiple `:X`).
 #[derive(Default)]
 struct WriteCounters {
     nodes_created: u64,
@@ -1375,45 +1510,115 @@ struct WriteCounters {
     relationships_deleted: u64,
 }
 
-fn classify_write_counters(plan: &clickgraph::render_plan::WriteRenderPlan) -> WriteCounters {
-    let mut c = WriteCounters::default();
-    walk(plan, &mut c);
-    c
+/// Flat list of count probes derived from a `WriteRenderPlan`. The async
+/// pass over the executor accumulates each probe's affected-row count
+/// into the right `WriteCounters` field; static (INSERT) counts go
+/// straight in without a probe.
+enum ProbeAction {
+    NodesCreatedStatic(u64),
+    NodesDeletedProbe(String),
+    RelationshipsDeletedProbe(String),
+    /// `properties_set` is per-property-per-row: `assignments * affected_rows`.
+    PropertiesSetProbe {
+        assignments: u64,
+        sql: String,
+    },
 }
 
-fn walk(plan: &clickgraph::render_plan::WriteRenderPlan, c: &mut WriteCounters) {
+fn collect_counter_probes(plan: &clickgraph::render_plan::WriteRenderPlan) -> Vec<ProbeAction> {
+    let mut out = Vec::new();
+    push_probes(plan, &mut out);
+    out
+}
+
+fn push_probes(plan: &clickgraph::render_plan::WriteRenderPlan, out: &mut Vec<ProbeAction>) {
+    use clickgraph::clickhouse_query_generator::write_to_sql::{
+        probe_delete_count_sql, probe_update_count_sql,
+    };
     use clickgraph::render_plan::WriteRenderPlan;
     match plan {
         WriteRenderPlan::Insert(op) => {
-            // Coarse heuristic: each row is one entity. Whether it's a
-            // node or relationship is encoded in the table — we attribute
-            // to nodes_created here. A future refinement can split by
-            // schema lookup once rel CREATE lands (currently rejected).
-            c.nodes_created += op.rows.len() as u64;
+            // INSERT counts are exact: one row per VALUES tuple.
+            // Whether it's a node or relationship is encoded in the table,
+            // but rel CREATE is currently rejected by build_write_plan, so
+            // every Insert here is a node create.
+            out.push(ProbeAction::NodesCreatedStatic(op.rows.len() as u64));
         }
         WriteRenderPlan::Update(op) => {
-            c.properties_set += op.assignments.len() as u64;
+            out.push(ProbeAction::PropertiesSetProbe {
+                assignments: op.assignments.len() as u64,
+                sql: probe_update_count_sql(op),
+            });
         }
-        WriteRenderPlan::Delete(_op) => {
-            // Sequence walk decides node-vs-rel by whether the DELETE is
-            // the last in a Sequence (node) or precedes one (rel cleanup).
-            // For a bare top-level Delete, attribute to nodes.
-            c.nodes_deleted += 1;
+        WriteRenderPlan::Delete(op) => {
+            out.push(ProbeAction::NodesDeletedProbe(probe_delete_count_sql(op)));
         }
         WriteRenderPlan::Sequence(seq) => {
-            // Rel-cleanup DELETEs precede a final node DELETE in DETACH
-            // DELETE. Attribute earlier DELETEs to relationships.
+            // DETACH DELETE renders as a Sequence of rel-cleanup DELETEs
+            // followed by the final node DELETE; `Sequence(Delete, …,
+            // Delete)` thus splits N-1 → relationships_deleted and last
+            // → nodes_deleted. Other Sequence shapes (multi-Insert from
+            // CREATE patterns; multi-Update from multi-target SET) walk
+            // recursively under the same rules.
             let len = seq.len();
             for (i, inner) in seq.iter().enumerate() {
                 match inner {
-                    WriteRenderPlan::Delete(_) if i + 1 < len => {
-                        c.relationships_deleted += 1;
+                    WriteRenderPlan::Delete(op) if i + 1 < len => {
+                        out.push(ProbeAction::RelationshipsDeletedProbe(
+                            probe_delete_count_sql(op),
+                        ));
                     }
-                    _ => walk(inner, c),
+                    _ => push_probes(inner, out),
                 }
             }
         }
     }
+}
+
+async fn run_count_probe(
+    executor: &Arc<dyn QueryExecutor>,
+    sql: &str,
+) -> Result<u64, EmbeddedError> {
+    let rows = executor
+        .execute_json(sql, None)
+        .await
+        .map_err(EmbeddedError::from)?;
+    let Some(serde_json::Value::Object(obj)) = rows.first() else {
+        return Ok(0);
+    };
+    let Some(val) = obj.get("n") else {
+        return Ok(0);
+    };
+    match val {
+        serde_json::Value::Number(n) => Ok(n.as_u64().unwrap_or(0)),
+        // ClickHouse returns count() as a string in some json formats;
+        // fall back to parsing.
+        serde_json::Value::String(s) => Ok(s.parse::<u64>().unwrap_or(0)),
+        _ => Ok(0),
+    }
+}
+
+async fn resolve_write_counters(
+    plan: &clickgraph::render_plan::WriteRenderPlan,
+    executor: &Arc<dyn QueryExecutor>,
+) -> Result<WriteCounters, EmbeddedError> {
+    let mut c = WriteCounters::default();
+    for probe in collect_counter_probes(plan) {
+        match probe {
+            ProbeAction::NodesCreatedStatic(n) => c.nodes_created += n,
+            ProbeAction::NodesDeletedProbe(sql) => {
+                c.nodes_deleted += run_count_probe(executor, &sql).await?;
+            }
+            ProbeAction::RelationshipsDeletedProbe(sql) => {
+                c.relationships_deleted += run_count_probe(executor, &sql).await?;
+            }
+            ProbeAction::PropertiesSetProbe { assignments, sql } => {
+                let affected = run_count_probe(executor, &sql).await?;
+                c.properties_set += assignments * affected;
+            }
+        }
+    }
+    Ok(c)
 }
 
 #[cfg(test)]
@@ -1569,6 +1774,18 @@ graph_schema:
                 _role: Option<&str>,
             ) -> Result<Vec<serde_json::Value>, ExecutorError> {
                 self.captured.lock().unwrap().push(sql.to_string());
+                // Phase 5d: write-counter probes (`SELECT count() AS n`)
+                // are now part of the write path. The fake executor has
+                // no underlying data, so we hand back a single-row `n=1`
+                // response — that's the count the *legacy static-count*
+                // approximation implied (one match per Delete / Update),
+                // and it keeps the dispatch-focused unit tests below
+                // pinning the same counter values they pinned pre-Phase-5d
+                // without making them depend on a real chdb session.
+                let trimmed = sql.trim_start();
+                if trimmed.starts_with("SELECT count() AS n") {
+                    return Ok(vec![serde_json::json!({"n": 1})]);
+                }
                 Ok(vec![])
             }
             async fn execute_text(
@@ -2158,6 +2375,13 @@ graph_schema:
         );
     }
 
+    /// `find_first_with_prefix` lets dispatch tests probe the captured
+    /// SQL stream without depending on the exact ordering between
+    /// count-probes (Phase 5d) and the lightweight DELETE/UPDATE itself.
+    fn find_first_with_prefix<'a>(sqls: &'a [String], prefix: &str) -> Option<&'a String> {
+        sqls.iter().find(|s| s.starts_with(prefix))
+    }
+
     #[test]
     fn cypher_set_routes_to_write_path_and_emits_update() {
         let (db, captured) = make_capturing_db(build_writable_test_schema());
@@ -2167,19 +2391,18 @@ graph_schema:
             .expect("SET should succeed via write dispatch");
         let mut iter = result.into_iter();
         let row = iter.next().unwrap();
+        // CapturingExecutor returns `n=1` for count probes (one match
+        // per write op), so properties_set = 1 assignment * 1 row.
         assert_eq!(row.get("properties_set").unwrap().as_i64(), Some(1));
 
         let sqls = captured.lock().unwrap();
-        assert!(
-            sqls[0].starts_with("UPDATE"),
-            "expected UPDATE, got: {}",
-            sqls[0]
-        );
+        let update = find_first_with_prefix(&sqls, "UPDATE")
+            .unwrap_or_else(|| panic!("expected UPDATE in captured SQL, got: {:?}", *sqls));
         // Lightweight UPDATE — no mutations_sync.
         assert!(
-            !sqls[0].to_lowercase().contains("mutations_sync"),
+            !update.to_lowercase().contains("mutations_sync"),
             "must not emit mutations_sync, got: {}",
-            sqls[0]
+            update
         );
     }
 
@@ -2192,14 +2415,12 @@ graph_schema:
             .expect("DELETE should succeed via write dispatch");
         let mut iter = result.into_iter();
         let row = iter.next().unwrap();
+        // CapturingExecutor's count probe returns `n=1` → nodes_deleted=1.
         assert_eq!(row.get("nodes_deleted").unwrap().as_i64(), Some(1));
 
         let sqls = captured.lock().unwrap();
-        assert!(
-            sqls[0].starts_with("DELETE FROM"),
-            "expected DELETE FROM, got: {}",
-            sqls[0]
-        );
+        find_first_with_prefix(&sqls, "DELETE FROM")
+            .unwrap_or_else(|| panic!("expected DELETE FROM in captured SQL, got: {:?}", *sqls));
     }
 
     #[test]
@@ -2212,16 +2433,22 @@ graph_schema:
         let mut iter = result.into_iter();
         let row = iter.next().unwrap();
         // KNOWS touches Person on both sides → 2 rel-cleanup deletes,
-        // then 1 node delete.
+        // then 1 node delete. With the per-op `n=1` mock, that's
+        // relationships_deleted >= 1 and nodes_deleted = 1.
         assert!(row.get("relationships_deleted").unwrap().as_i64().unwrap() >= 1);
         assert_eq!(row.get("nodes_deleted").unwrap().as_i64(), Some(1));
 
         let sqls = captured.lock().unwrap();
-        // Last SQL is the node delete.
+        // Last DELETE statement is the node delete (rel cleanups precede).
+        let last_delete = sqls
+            .iter()
+            .rev()
+            .find(|s| s.starts_with("DELETE FROM"))
+            .unwrap_or_else(|| panic!("expected DELETE in captured SQL, got: {:?}", *sqls));
         assert!(
-            sqls.last().unwrap().contains("`persons`") || sqls.last().unwrap().contains("`person`"),
-            "node DELETE must come last, got: {:?}",
-            sqls
+            last_delete.contains("`persons`") || last_delete.contains("`person`"),
+            "node DELETE must come last, got: {}",
+            last_delete
         );
     }
 
@@ -2232,10 +2459,16 @@ graph_schema:
         conn.query("MATCH (a:Person) WHERE a.person_id = 'p1' REMOVE a.name")
             .expect("REMOVE should succeed");
         let sqls = captured.lock().unwrap();
+        let update = find_first_with_prefix(&sqls, "UPDATE").unwrap_or_else(|| {
+            panic!(
+                "REMOVE should emit an UPDATE setting NULL, got: {:?}",
+                *sqls
+            )
+        });
         assert!(
-            sqls[0].contains("SET `full_name` = NULL"),
+            update.contains("SET `full_name` = NULL"),
             "REMOVE should emit SET … = NULL, got: {}",
-            sqls[0]
+            update
         );
     }
 
@@ -2331,13 +2564,87 @@ graph_schema:
         assert!(cols.contains(&"nodes_created".to_string()));
     }
 
-    /// `CREATE … RETURN` likewise must enter the write pipeline. We don't
-    /// yet support returning rows from a CREATE — the write pipeline
-    /// rejects this combination with a clear error rather than letting it
-    /// silently fall through to the read path.
+    /// Phase 5d: `OPTIONAL MATCH … DELETE … RETURN` must run the write
+    /// pipeline, then re-run the read pipeline and surface the user-visible
+    /// row payload plus the side-effect counters via the new
+    /// `QueryResult::get_write_counters()` side-channel. The pure-write
+    /// 4-column synthetic counter row is *not* used in this path — the
+    /// row payload comes from the read pipeline.
+    ///
+    /// We pin dispatch-shape (side-channel populated, read columns
+    /// surfaced, both write and read SQL reach the executor) here. End-
+    /// to-end counter accuracy on an empty graph (the actual TCK
+    /// `Delete1` [5] expectation of zero side effects) is exercised
+    /// against a real chdb session in `clickgraph-tck`.
     #[test]
-    fn cypher_create_with_return_rejected_with_clear_error() {
-        let (db, _captured) = make_capturing_db(build_writable_test_schema());
+    fn cypher_delete_with_return_executes_writes_and_runs_read_pipeline() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
+        let conn = Connection::new(&db).unwrap();
+        let result = conn
+            .query("OPTIONAL MATCH (a:Person) DELETE a RETURN a")
+            .expect("DELETE … RETURN must succeed via Phase 5d write+RETURN path");
+
+        // Side-channel must be populated; the pure-write synthetic row
+        // must NOT be the surfaced row payload.
+        let counters = result
+            .get_write_counters()
+            .cloned()
+            .expect("write+RETURN must populate get_write_counters()");
+        let cols = result.get_column_names().to_vec();
+        assert!(
+            !cols.iter().any(|c| c == "nodes_created"),
+            "write+RETURN columns must come from the read pipeline, \
+             not the synthetic counter row; got {:?}",
+            cols
+        );
+        // The four canonical counters must all be present in the side-
+        // channel map even when zero, so downstream consumers (e.g. the
+        // TCK harness) can read every key without `Option` juggling.
+        for key in [
+            "nodes_created",
+            "properties_set",
+            "nodes_deleted",
+            "relationships_deleted",
+        ] {
+            assert!(
+                counters.contains_key(key),
+                "side-channel must include `{key}`, got: {counters:?}"
+            );
+        }
+
+        // Both the write (DELETE) and the re-run read pipeline (SELECT)
+        // must reach the executor; the count-probe (`SELECT count() AS n`)
+        // also runs alongside the DELETE per Phase 5d's accurate-counters
+        // pass.
+        let sqls = captured.lock().unwrap();
+        assert!(
+            sqls.iter().any(|s| s.starts_with("DELETE FROM")),
+            "write+RETURN must emit a DELETE statement, got: {:?}",
+            *sqls
+        );
+        assert!(
+            sqls.iter().any(|s| s.starts_with("SELECT count() AS n")),
+            "write+RETURN must probe the count for accurate counters, got: {:?}",
+            *sqls
+        );
+        assert!(
+            sqls.iter()
+                .any(|s| s.to_uppercase().contains("SELECT")
+                    && !s.starts_with("SELECT count() AS n")),
+            "write+RETURN must run the read pipeline (non-probe SELECT), got: {:?}",
+            *sqls
+        );
+    }
+
+    /// `CREATE … RETURN` likewise must enter the write pipeline. Phase 5d
+    /// supports DELETE/SET/REMOVE + RETURN via re-running the read pipeline,
+    /// but CREATE + RETURN remains rejected up-front because the alias
+    /// bound by CREATE has no MATCH-able identity for the read pipeline to
+    /// reference; rejecting before any execution keeps the database
+    /// unchanged on failure rather than leaving a partial INSERT.
+    #[test]
+    fn cypher_create_with_return_rejected_before_insert() {
+        let (db, captured) = make_capturing_db(build_writable_test_schema());
         let conn = Connection::new(&db).unwrap();
         let err = conn
             .query("CREATE (a:Person {person_id: 'p3'}) RETURN a")
@@ -2347,6 +2654,13 @@ graph_schema:
             msg.contains("not supported") && msg.to_lowercase().contains("create"),
             "expected write-pipeline rejection naming CREATE, got: {}",
             msg
+        );
+        // No INSERT must have been emitted: rejection happens before exec.
+        let sqls = captured.lock().unwrap();
+        assert!(
+            !sqls.iter().any(|s| s.to_uppercase().contains("INSERT")),
+            "CREATE … RETURN rejection must not emit any INSERT, got: {:?}",
+            *sqls
         );
     }
 }

--- a/clickgraph-embedded/src/query_result.rs
+++ b/clickgraph-embedded/src/query_result.rs
@@ -1,5 +1,6 @@
 //! `QueryResult` and `Row` types — the output of `Connection::query()`.
 
+use std::collections::HashMap;
 use std::ops::Index;
 
 use super::value::Value;
@@ -18,6 +19,14 @@ pub struct QueryResult {
     compile_time_ms: f64,
     /// Time spent executing the SQL query (milliseconds).
     execution_time_ms: f64,
+    /// Side-effect counters for write+RETURN queries (Phase 5d).
+    /// `Some` when the originating Cypher contained a write clause
+    /// (CREATE / SET / DELETE / REMOVE) *and* a RETURN clause; the row
+    /// payload then carries the user-visible result of the read pipeline,
+    /// while these counters reflect the write portion.
+    /// `None` for pure read queries and (for back-compat) for pure-write
+    /// queries that surface counters as a synthetic single-row payload.
+    write_counters: Option<HashMap<String, i64>>,
 }
 
 impl QueryResult {
@@ -28,6 +37,7 @@ impl QueryResult {
             position: 0,
             compile_time_ms: 0.0,
             execution_time_ms: 0.0,
+            write_counters: None,
         }
     }
 
@@ -43,6 +53,29 @@ impl QueryResult {
             position: 0,
             compile_time_ms,
             execution_time_ms,
+            write_counters: None,
+        }
+    }
+
+    /// Construct a write+RETURN result: user-visible rows plus the
+    /// side-effect counter map produced by the write portion of the
+    /// statement. Used by `handle_write_async` to attach write counters
+    /// to a result whose row payload comes from re-running the read
+    /// pipeline after the writes have executed.
+    pub(crate) fn with_timing_and_counters(
+        column_names: Vec<String>,
+        rows: Vec<Vec<Value>>,
+        compile_time_ms: f64,
+        execution_time_ms: f64,
+        write_counters: HashMap<String, i64>,
+    ) -> Self {
+        Self {
+            column_names,
+            rows,
+            position: 0,
+            compile_time_ms,
+            execution_time_ms,
+            write_counters: Some(write_counters),
         }
     }
 
@@ -73,6 +106,18 @@ impl QueryResult {
     /// Mirrors `kuzu::QueryResult::get_execution_time()`.
     pub fn get_execution_time(&self) -> f64 {
         self.execution_time_ms
+    }
+
+    /// Side-effect counters for a write+RETURN query (Phase 5d).
+    ///
+    /// Returns `Some` only when the originating Cypher contained both a
+    /// write clause (CREATE / SET / DELETE / REMOVE) and a RETURN clause —
+    /// the row payload then carries the read-pipeline output and these
+    /// counters reflect the write portion. Pure read queries and
+    /// pure-write queries (which surface counters as a synthetic row)
+    /// return `None`.
+    pub fn get_write_counters(&self) -> Option<&HashMap<String, i64>> {
+        self.write_counters.as_ref()
     }
 
     /// Infer column data types from the first row of results.

--- a/clickgraph-tck/README.md
+++ b/clickgraph-tck/README.md
@@ -6,13 +6,13 @@ openCypher [Technology Compatibility Kit (TCK)](https://github.com/opencypher/op
 
 **402 / 402 read scenarios passing (100%)** — 0 failing.
 
-Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. Phase 5a (#281) added the side-effect step. Phase 5b (#282) added anonymous-node support (`CREATE ()`, `CREATE (n {...})` route to the `__Unlabeled` table catalogued by `schema_gen.rs`), lifting the file-level `@wip` from `Create1.feature`. Phase 5c (this commit) lifts the file-level `@wip` on `Delete1.feature` and ungates scenario [3]. Status by scenario:
+Write feature files (`Create*`, `Set*`, `Delete*`, `Remove*` — 21 files / 205 scenarios) were imported from upstream openCypher TCK on 2026-05-02 as part of Phase 4 of the embedded-writes work. Phase 5a (#281) added the side-effect step. Phase 5b (#282) added anonymous-node support (`CREATE ()`, `CREATE (n {...})` route to the `__Unlabeled` table catalogued by `schema_gen.rs`), lifting the file-level `@wip` from `Create1.feature`. Phase 5c (#283) lifted the file-level `@wip` on `Delete1.feature` and ungated scenario [3]. Phase 5d (this commit) wires write+RETURN through the embedded executor: when a Cypher statement carries both a write clause and a RETURN clause, `handle_write_async` executes the write, then re-runs the read pipeline against the modified state with the write clauses stripped from the AST, and attaches the side-effect counters via a new `QueryResult::get_write_counters()` side-channel. The TCK harness reads the side-channel first and falls back to the synthetic counter-row shape used by pure writes. Status by scenario:
 
-- **Running end-to-end with full counter assertions:** `Create1` [1] [2] [7] [9] (4).
+- **Running end-to-end with full counter assertions:** `Create1` [1] [2] [7] [9] and `Delete1` [5] (5).
 - **Ungated, pipeline runs, but harness records as skip on an unmapped side-effect key:** `Create1` [3] [4] (`+labels`) and `Delete1` [3] (`-nodes`/`-relationships` are asserted, then the trailing `-labels` row triggers the unmapped-key skip). The DETACH DELETE pipeline still executes — coverage for it lives in `cypher_detach_delete_emits_rel_then_node_delete_sequence` (`clickgraph-embedded`) — but the cucumber report tallies these as skips by design (label mutations are out of scope, so there's no counter to assert against).
 - **Still gated `@wip`:** every other write scenario, with per-scenario reasons in each feature file's header.
 
-The two largest blockers gating the remaining ~190 scenarios are write+RETURN (Phase 5d) and untyped-MATCH+DELETE/SET (Phase 5e). See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix.
+The largest blocker gating the remaining ~190 scenarios is now untyped-MATCH+DELETE/SET (Phase 5e); write+RETURN itself is implemented in Phase 5d but additional `Set*`/`Remove*`/`Delete*` scenarios that combine it with other unsupported pieces (multi-pattern MATCH writes, label mutations, RETURN on relationship-bound aliases) stay `@wip` until those are addressed individually. See [`docs/design/embedded-writes.md`](../docs/design/embedded-writes.md) Appendix.
 
 ## What it tests
 

--- a/clickgraph-tck/tests/features/clauses/delete/Delete1.feature
+++ b/clickgraph-tck/tests/features/clauses/delete/Delete1.feature
@@ -41,17 +41,22 @@
 #     value is exercising the lift path and confirming the ungated dispatch
 #     stays clean. Re-tag candidate for `@unsupported-label-mutation` once
 #     we want it filtered out of the active list.
+#   * [5] is ungated in Phase 5d. `OPTIONAL MATCH (:DoesNotExist) DELETE a
+#     RETURN a` runs the write pipeline (no-op against an empty graph), then
+#     re-runs the read pipeline with the write clauses stripped to produce
+#     the user-visible `| a | null |` row. Side-effect counters are attached
+#     via the new `QueryResult::get_write_counters()` side-channel; the
+#     harness asserts `no side effects` against an all-zero counter map.
 # Scenarios still gated with per-scenario @wip:
 #   * [1] [2] — `MATCH (n) DELETE n` / `MATCH (n) DETACH DELETE n` over an
 #     untyped node match. ClickGraph's untyped MATCH expands to a UNION
 #     across every node table; the DELETE pipeline currently picks one
 #     label via `find_alias_label` and emits a single-table DELETE. Phase
-#     5d/e will extend the pipeline to fan out the DELETE across every
+#     5e will extend the pipeline to fan out the DELETE across every
 #     resolved label (or refuse with a clear "ambiguous DELETE" error).
 #   * [4] [6] — OPTIONAL MATCH (untyped) then DELETE / DETACH DELETE on an
 #     empty graph. Same untyped-DELETE gap as [1] [2], plus OPTIONAL-MATCH-
 #     yielding-no-rows handling on the write path.
-#   * [5] — OPTIONAL MATCH … DELETE … RETURN. Needs write+RETURN (Phase 5d).
 #   * [7] — expects a runtime ConstraintVerificationFailed; ClickGraph's
 #     non-DETACH DELETE silently leaves dangling rows rather than raising
 #     (engine semantics differ). Stay @wip until we add a referential-
@@ -126,7 +131,6 @@ Feature: Delete1 - Deleting nodes
     Then the result should be empty
     And no side effects
 
-  @wip
   Scenario: [5] Ignore null when deleting node
     Given an empty graph
     When executing query:

--- a/clickgraph-tck/tests/features/clauses/delete/Delete1.feature
+++ b/clickgraph-tck/tests/features/clauses/delete/Delete1.feature
@@ -41,7 +41,7 @@
 #     value is exercising the lift path and confirming the ungated dispatch
 #     stays clean. Re-tag candidate for `@unsupported-label-mutation` once
 #     we want it filtered out of the active list.
-#   * [5] is ungated in Phase 5d. `OPTIONAL MATCH (:DoesNotExist) DELETE a
+#   * [5] is ungated in Phase 5d. `OPTIONAL MATCH (a:DoesNotExist) DELETE a
 #     RETURN a` runs the write pipeline (no-op against an empty graph), then
 #     re-runs the read pipeline with the write clauses stripped to produce
 #     the user-visible `| a | null |` row. Side-effect counters are attached

--- a/clickgraph-tck/tests/tck.rs
+++ b/clickgraph-tck/tests/tck.rs
@@ -228,21 +228,31 @@ async fn when_executing_query(world: &mut TckWorld, step: &Step) {
             world.result_columns = result.get_column_names().to_vec();
             let col_names = world.result_columns.clone();
 
-            // Write queries route through `handle_write_async` and return a
-            // single-row counter QueryResult. Detect by exact column shape
-            // and stash the counters separately so the side-effect step can
-            // assert against them. The result_rows stay empty (the TCK
-            // shapes for writes are `the result should be empty`).
-            //
-            // Always reset write_counters first so a regression that drops
-            // the counter row can't leak stale counters from the previous
-            // query in the same scenario. Non-Int64 cells are also a
-            // regression signal (we built that QueryResult ourselves), so
-            // surface them as a captured error rather than silently
-            // skipping the value — otherwise the side-effect step could
-            // pass against an empty counter map.
+            // Reset stale state up-front so a regression that drops counters
+            // can't leak values from the previous query in the same scenario.
             world.write_counters = None;
-            if is_write_counter_shape(&col_names) {
+
+            // Phase 5d: write+RETURN attaches counters via the side-channel
+            // (`get_write_counters`), and the row payload carries the
+            // user-visible result of the read pipeline. Pure-write
+            // statements still surface the synthetic 4-column counter row
+            // for back-compat (Phase 5a/5b).
+            if let Some(side_counters) = result.get_write_counters() {
+                let counters: HashMap<String, i64> =
+                    side_counters.iter().map(|(k, v)| (k.clone(), *v)).collect();
+                world.write_counters = Some(counters);
+                world.result_rows = result
+                    .map(|row| {
+                        let values: Vec<Value> = row.values().to_vec();
+                        format_row(&col_names, &values, &var_labels, &var_rel_types)
+                    })
+                    .collect();
+                world.error = None;
+            } else if is_write_counter_shape(&col_names) {
+                // Pure-write synthetic counter-row. Stash the four counters
+                // and leave result_rows empty (the TCK write shapes are
+                // `the result should be empty`). Non-Int64 cells are a
+                // regression signal; surface as a captured error.
                 match result.next() {
                     Some(row) => {
                         let mut counters = HashMap::new();
@@ -271,8 +281,8 @@ async fn when_executing_query(world: &mut TckWorld, step: &Step) {
                         }
                     }
                     None => {
-                        // Counter shape but no row — that's a contract
-                        // violation in handle_write_async, surface it.
+                        // Counter shape but no row — contract violation
+                        // in handle_write_async, surface it.
                         world.error = Some(
                             "write QueryResult had counter columns but no row \
                              (handle_write_async regression?)"

--- a/src/clickhouse_query_generator/mod.rs
+++ b/src/clickhouse_query_generator/mod.rs
@@ -89,6 +89,55 @@ pub fn cypher_to_sql(
     Ok(generate_sql(render_plan, max_cte_depth))
 }
 
+/// Convert a Cypher query to ClickHouse SQL after clearing all write
+/// clauses (CREATE / SET / DELETE / REMOVE) from the parsed AST.
+///
+/// This is the read-pipeline half of write+RETURN execution: after the
+/// embedded executor has run the write portion, the same statement is
+/// rendered as if it were a pure read query so the user-visible
+/// row payload reflects the post-write state. Stripping the clauses on
+/// the AST avoids re-parsing fragile Cypher strings — the planner
+/// re-derives the read pipeline naturally once those AST nodes are gone.
+pub fn cypher_to_sql_read_only(
+    cypher: &str,
+    schema: &crate::graph_catalog::graph_schema::GraphSchema,
+    max_cte_depth: u32,
+) -> Result<String, String> {
+    use crate::open_cypher_parser::ast::CypherStatement;
+    use crate::render_plan::plan_builder::RenderPlanBuilder;
+
+    let cleaned = crate::open_cypher_parser::strip_comments(cypher);
+    let (_remaining, mut statement) = crate::open_cypher_parser::parse_cypher_statement(&cleaned)
+        .map_err(|e| format!("Parse error: {:?}", e))?;
+
+    if let CypherStatement::Query {
+        ref mut query,
+        ref mut union_clauses,
+    } = statement
+    {
+        query.create_clause = None;
+        query.set_clause = None;
+        query.remove_clause = None;
+        query.delete_clause = None;
+        for u in union_clauses.iter_mut() {
+            u.query.create_clause = None;
+            u.query.set_clause = None;
+            u.query.remove_clause = None;
+            u.query.delete_clause = None;
+        }
+    }
+
+    let (logical_plan, plan_ctx) =
+        crate::query_planner::evaluate_read_statement(statement, schema, None, None, None)
+            .map_err(|e| format!("Plan error: {}", e))?;
+
+    let render_plan = logical_plan
+        .to_render_plan_with_ctx(schema, Some(&plan_ctx), None)
+        .map_err(|e| format!("Render error: {}", e))?;
+
+    Ok(generate_sql(render_plan, max_cte_depth))
+}
+
 /// Convert a Cypher query string to ClickHouse SQL, also returning the
 /// LogicalPlan and PlanCtx for downstream metadata extraction (e.g., graph output).
 ///

--- a/src/clickhouse_query_generator/write_to_sql.rs
+++ b/src/clickhouse_query_generator/write_to_sql.rs
@@ -99,6 +99,33 @@ fn delete_sql(op: &DeleteOp) -> String {
     )
 }
 
+/// Render a probe SQL that counts the rows a `DeleteOp` would affect,
+/// without mutating anything. Used by `clickgraph-embedded` to attach
+/// accurate `nodes_deleted` / `relationships_deleted` counters when the
+/// statement also carries a RETURN clause (Phase 5d): the lightweight
+/// DELETE itself returns no affected-row count, so we run the same
+/// `IN (subquery)` against `count(*)` first.
+pub fn probe_delete_count_sql(op: &DeleteOp) -> String {
+    format!(
+        "SELECT count() AS n FROM `{}`.`{}` WHERE `{}` IN {}",
+        op.database,
+        op.table,
+        op.id_column,
+        render_id_source(&op.source),
+    )
+}
+
+/// Probe SQL for an `UpdateOp` — same pattern as `probe_delete_count_sql`.
+pub fn probe_update_count_sql(op: &UpdateOp) -> String {
+    format!(
+        "SELECT count() AS n FROM `{}`.`{}` WHERE `{}` IN {}",
+        op.database,
+        op.table,
+        op.id_column,
+        render_id_source(&op.source),
+    )
+}
+
 fn render_id_source(source: &RowSource) -> String {
     match source {
         RowSource::Subquery(plan) => format!("({})", render_subquery(plan.as_ref())),


### PR DESCRIPTION
## Summary

- Adds first-class write+RETURN support: `handle_write_async` now executes the write, then re-runs the read pipeline against the modified state with write clauses stripped from the AST, and attaches the four side-effect counters via a new `QueryResult::get_write_counters()` side-channel.
- CREATE+RETURN remains explicitly rejected up-front — the create-bound alias has no MATCH-able identity for the read pipeline, so rejection-before-execution keeps the database unchanged on failure instead of leaving a partial INSERT.
- Replaces the static "+= 1 per op" counter approximation with `count()` probes against the same WHERE each lightweight DELETE / UPDATE uses, so empty-graph and multi-match cases report accurate side effects (this is what TCK `Delete1` [5] requires).

## TCK impact

- Lifts `@wip` on `Delete1` [5] (`OPTIONAL MATCH (a:DoesNotExist) DELETE a RETURN a`).
- Five scenarios now run end-to-end with full counter assertions: `Create1` [1] [2] [7] [9] and `Delete1` [5].
- TCK harness reads the side-channel first; falls back to the synthetic 4-column counter-row shape for pure writes (Phase 5a/5b back-compat).

## New regression tests

- `cypher_delete_with_return_executes_writes_and_runs_read_pipeline` pins the dispatch shape (side-channel populated, read columns surfaced, both write and read SQL reach the executor; count-probe runs alongside the DELETE).
- `cypher_create_with_return_rejected_before_insert` extends the prior rejection test to assert no INSERT is emitted on rejection.

## Test plan

- [x] `cargo test --lib -p clickgraph` (1348 passed)
- [x] `cargo test --lib -p clickgraph-embedded` (143 passed)
- [x] `cargo fmt --all`
- [x] `cargo clippy -p clickgraph-embedded --lib` (no new warnings introduced)
- [ ] CI runs the full TCK against chdb to validate end-to-end Delete1 [5] passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)