### PR TITLE
refactor: address remaining mechanical clippy warnings

### DIFF
--- a/src/clickhouse_query_generator/function_translator.rs
+++ b/src/clickhouse_query_generator/function_translator.rs
@@ -867,8 +867,6 @@ mod tests {
 
     #[test]
     fn test_translate_datetime_epoch_millis_passthrough() {
-        use crate::query_planner::logical_expr::Literal;
-
         // datetime({epochMillis: friend.birthday}) -> friend.birthday (identity)
         let fn_call = ScalarFnCall {
             name: "datetime".to_string(),

--- a/src/query_planner/logical_plan/with_clause.rs
+++ b/src/query_planner/logical_plan/with_clause.rs
@@ -964,15 +964,12 @@ fn find_collect_source_label(
         LogicalPlan::WithClause(wc) => {
             // Check this WithClause's items for collect(X) AS list_alias
             for item in &wc.items {
-                let alias_name = item.col_alias.as_ref().map(|a| a.0.as_str()).or_else(|| {
-                    if let LogicalExpr::TableAlias(ref v) = item.expression {
-                        Some(v.0.as_str())
-                    } else if let LogicalExpr::ColumnAlias(ref v) = item.expression {
-                        Some(v.0.as_str())
-                    } else {
-                        None
-                    }
-                });
+                let fallback = match &item.expression {
+                    LogicalExpr::TableAlias(v) => Some(v.0.as_str()),
+                    LogicalExpr::ColumnAlias(v) => Some(v.0.as_str()),
+                    _ => None,
+                };
+                let alias_name = item.col_alias.as_ref().map(|a| a.0.as_str()).or(fallback);
                 if alias_name == Some(list_alias) {
                     // Found the item producing list_alias. Check if it's collect(X).
                     if let Some(source_var) = extract_collect_source_var(&item.expression) {

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -3747,12 +3747,11 @@ pub fn extract_ctes_with_context(
                     // Detect weight CTE for weighted shortest path
                     // Check task-local QueryContext (set by build_chained_with_match_cte_plan)
                     let weight_cte_config = if graph_rel.shortest_path_mode.is_some() {
-                        crate::server::query_context::get_weight_cte_config().map(|wc| {
+                        crate::server::query_context::get_weight_cte_config().inspect(|wc| {
                             log::info!(
                                 "🏋️ Detected weight CTE '{}' for weighted shortest path",
                                 wc.cte_name
                             );
-                            wc
                         })
                     } else {
                         None

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -2862,29 +2862,9 @@ impl VariableLengthCteStrategy {
             return strategy.generate_sql(context, properties, filters);
         }
 
-        // Build the generator based on pattern type (Traditional/FK-Edge schemas)
-        let mut generator = if self.is_denormalized {
-            // Dead code - we return above for denormalized
-            unreachable!("Denormalized case handled above");
-            VariableLengthCteGenerator::new_denormalized(
-                schema,
-                context.spec.clone(),
-                &self.rel_table,
-                &self.rel_from_col,
-                &self.rel_to_col,
-                &self.pattern_ctx.left_node_alias,
-                &self.pattern_ctx.right_node_alias,
-                context.relationship_cypher_alias.as_deref().unwrap_or(""),
-                properties.to_vec(),
-                shortest_path_mode,
-                filters.start_sql.clone(),
-                filters.end_sql.clone(),
-                filters.relationship_sql.clone(),
-                context.path_variable.clone(),
-                context.relationship_types.clone(),
-                context.edge_id.clone(),
-            )
-        } else if self.start_is_denormalized != self.end_is_denormalized {
+        // Build the generator based on pattern type (Traditional/FK-Edge schemas).
+        // The fully-denormalized case returned above via DenormalizedCteStrategy.
+        let mut generator = if self.start_is_denormalized != self.end_is_denormalized {
             // Mixed access pattern
             VariableLengthCteGenerator::new_mixed(
                 schema,

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -2862,8 +2862,15 @@ impl VariableLengthCteStrategy {
             return strategy.generate_sql(context, properties, filters);
         }
 
-        // Build the generator based on pattern type (Traditional/FK-Edge schemas).
-        // The fully-denormalized case returned above via DenormalizedCteStrategy.
+        // Build the generator for everything except the fully-denormalized
+        // pattern (which returned above via `DenormalizedCteStrategy`).
+        // Three remaining cases:
+        //   * mixed access (one endpoint denormalized, the other not)
+        //     → `new_mixed`
+        //   * traditional / FK-edge / polymorphic edge schemas
+        //     → `new_with_fk_edge` (the polymorphic-capable constructor —
+        //       `polymorphic_info` is extracted in `Self::new` and threaded
+        //       in via the generator's polymorphic fields below)
         let mut generator = if self.start_is_denormalized != self.end_is_denormalized {
             // Mixed access pattern
             VariableLengthCteGenerator::new_mixed(

--- a/src/render_plan/tests/with_clause_cte_tests.rs
+++ b/src/render_plan/tests/with_clause_cte_tests.rs
@@ -244,7 +244,8 @@ mod regression_infinite_loop {
 
 #[cfg(test)]
 mod regression_cte_column_naming {
-    use super::*;
+    // No `use super::*;` — the tests in this module reach into
+    // `crate::utils::cte_column_naming` directly via fully-qualified paths.
 
     /// Regression test for CTE column name resolution.
     /// Before fix: create_cte_reference used strip_prefix("fids_p_") which

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use axum::{
     extract::DefaultBodyLimit,
+    http::StatusCode,
     routing::{get, post},
     Router,
 };
@@ -281,9 +282,10 @@ async fn run_server(app_state: AppState, config: ServerConfig) {
 
     // Per-request timeout (covers parsing + planning + execution)
     if config.query_timeout_secs > 0 {
-        app = app.layer(TimeoutLayer::new(Duration::from_secs(
-            config.query_timeout_secs,
-        )));
+        app = app.layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(config.query_timeout_secs),
+        ));
         log::info!("HTTP request timeout: {}s", config.query_timeout_secs);
     }
 


### PR DESCRIPTION
## Summary

Continued cleanup follow-up to #289 — picks up the warnings that weren't covered there. **98 → 92 warnings.**

## Changes

| Warning | File | Fix |
|---|---|---|
| Deprecated `TimeoutLayer::new` | `src/server/mod.rs` | tower-http 0.6.7 deprecated the bare-`new` constructor. Migrated to `TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, …)` — behaviour identical (that's what `new` was internally calling). |
| Unreachable expression | `src/render_plan/cte_manager/mod.rs` | The Traditional/FK-edge branch carried a dead `if self.is_denormalized { unreachable!(); … }` arm with a stale `new_denormalized` call. The denormalized case already returns earlier via `DenormalizedCteStrategy`, so the whole arm was dead — dropped (~20 lines). |
| `map(\|x\| { log; x })` → `inspect` | `src/render_plan/cte_extraction.rs` | The weight-CTE detection path was using `.map()` purely for a side-effect log, which is exactly what `Option::inspect` is for. |
| Unnecessary `.or_else` closure | `src/query_planner/logical_plan/with_clause.rs` | The closure body was a nested `if let / else if / else` over `item.expression`; hoisted to a `match` computed once into `fallback`, then `.or(fallback)`. |
| Unused imports | `src/clickhouse_query_generator/function_translator.rs`, `src/render_plan/tests/with_clause_cte_tests.rs` | Dropped a `use Literal` from a test that no longer referenced it; replaced an unused `use super::*;` in `regression_cte_column_naming` with a one-line comment. |

## What's left

92 warnings remain, dominated by:
- **14× \"parameter is only used in recursion\"** — recursive helpers threading params through; intentional in many cases
- **12× \"very complex type used\"** — clippy wants `type Foo = …` aliases; cosmetic
- **16× \"too many arguments\"** (8/9/10/25) — architectural, not mechanical
- **7× match→if-let** — readability debate
- **5× dead code** carried from #288 — deliberate API surface / symmetric helpers
- **4× same-name modules** — tests-file convention, file-internal organisation choice
- **2× contains_key+insert** — branching make `entry()` rewrite clunky

These are either interpretive judgement calls or architectural changes; the mechanical pass is largely done.

## Diff

6 files changed, **+17 / -40**.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets` — 98 → 92 warnings; deprecated-API and unreachable-expression warnings now gone
- [x] `cargo test --lib` — 1337 passed
- [x] `cargo test -p clickgraph-embedded --lib` — 145 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)