### PR TITLE
refactor: clean up unnecessary_unwrap and map_entry warnings

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -2336,12 +2336,7 @@ pub fn extract_ctes_with_context(
 
                     let cleaned_predicate = strip_label_expr_from_logical(where_predicate);
 
-                    if cleaned_predicate.is_none() {
-                        log::info!("🔧 WHERE predicate contained only label expressions - cleared");
-                        (None, None, None, None)
-                    } else {
-                        let cleaned_predicate = cleaned_predicate.unwrap();
-
+                    if let Some(cleaned_predicate) = cleaned_predicate {
                         // Convert LogicalExpr to RenderExpr
                         let render_expr = RenderExpr::try_from(cleaned_predicate).map_err(|e| {
                             RenderBuildError::UnsupportedFeature(format!(
@@ -2530,7 +2525,10 @@ pub fn extract_ctes_with_context(
                             rel_sql_rendered,
                             Some(mapped_categorized),
                         )
-                    } // End of else block for cleaned_predicate.is_none()
+                    } else {
+                        log::info!("🔧 WHERE predicate contained only label expressions - cleared");
+                        (None, None, None, None)
+                    }
                 } else {
                     (None, None, None, None)
                 };

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -17539,7 +17539,7 @@ fn find_pc_cte_join_column(
     if let FromTableItem(Some(ref from)) = with_cte_render.from {
         if let Some(ref from_alias) = from.alias {
             let key = (var_name.to_string(), "id".to_string());
-            if !col_map.contains_key(&key) {
+            col_map.entry(key).or_insert_with(|| {
                 // Condition 1: CTE SELECT has a bare alias matching var_name
                 let cte_has_bare_alias = with_cte_render
                     .select
@@ -17565,12 +17565,12 @@ fn find_pc_cte_join_column(
                 };
                 if cte_has_bare_alias && has_bare_column {
                     // UNWIND scalar: the column name IS the alias
-                    col_map.insert(key, format!("{}.\"{}\"", from_alias, var_name));
+                    format!("{}.\"{}\"", from_alias, var_name)
                 } else {
                     let cte_col = crate::utils::cte_column_naming::cte_column_name(var_name, "id");
-                    col_map.insert(key, format!("{}.{}", from_alias, cte_col));
+                    format!("{}.{}", from_alias, cte_col)
                 }
-            }
+            });
         }
     }
 
@@ -17689,11 +17689,11 @@ fn generate_and_replace_arraycount_pc_subqueries(
             for pc in pattern_comprehensions.iter() {
                 for cv in &pc.correlation_vars {
                     let key = (cv.var_name.clone(), "id".to_string());
-                    if !branch_col_map.contains_key(&key) {
+                    branch_col_map.entry(key).or_insert_with(|| {
                         let cte_col =
                             crate::utils::cte_column_naming::cte_column_name(&cv.var_name, "id");
-                        branch_col_map.insert(key, format!("{}.{}", from_alias, cte_col));
-                    }
+                        format!("{}.{}", from_alias, cte_col)
+                    });
                 }
                 if let Some(ref lc) = pc.list_constraint {
                     let key1 = (lc.list_alias.clone(), "id".to_string());


### PR DESCRIPTION
## Summary
- `cte_extraction.rs`: invert `is_none()` + `unwrap()` into `if let Some(...)` pattern
- `plan_builder_utils.rs`: replace 2× `contains_key` + `insert` with `entry().or_insert_with()`

Clippy warnings: 68 → 65 (resolves all 1× `unnecessary_unwrap` and 2× `map_entry`).

## Test plan
- [x] cargo build clean
- [x] cargo clippy --all-targets — targeted lints fully gone
- [x] cargo test — 1,653 tests pass
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)