### PR TITLE
refactor: triage 6 dead-code warnings

### DIFF
--- a/src/clickhouse_query_generator/variable_length_cte.rs
+++ b/src/clickhouse_query_generator/variable_length_cte.rs
@@ -846,6 +846,7 @@ impl<'a> VariableLengthCteGenerator<'a> {
     ///
     /// Only matches simple patterns like `end_node.id = <value>` to avoid false positives
     /// from complex multi-predicate filters.
+    #[allow(dead_code)]
     fn extract_target_id_negation(&self) -> Option<String> {
         let filter = self.end_node_filters.as_ref()?;
 

--- a/src/query_planner/analyzer/query_validation.rs
+++ b/src/query_planner/analyzer/query_validation.rs
@@ -21,11 +21,14 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 /// Non-integer literal kinds that are illegal as array subscript indices.
+///
+/// Note: `String` is intentionally absent — bracket subscripts with string keys
+/// (`map['key']`, `node['prop']`) are valid Cypher map/property access and must
+/// not be rejected. See `infer_non_integer_kind`.
 #[derive(Debug)]
 enum NonIntegerKind {
     Boolean,
     Float,
-    Str,
     List,
     Map,
 }
@@ -35,7 +38,6 @@ impl fmt::Display for NonIntegerKind {
         match self {
             NonIntegerKind::Boolean => write!(f, "Boolean"),
             NonIntegerKind::Float => write!(f, "Float"),
-            NonIntegerKind::Str => write!(f, "String"),
             NonIntegerKind::List => write!(f, "List"),
             NonIntegerKind::Map => write!(f, "Map"),
         }

--- a/src/query_planner/logical_plan/match_clause/schema_filter.rs
+++ b/src/query_planner/logical_plan/match_clause/schema_filter.rs
@@ -34,6 +34,7 @@ impl<'a> SchemaPropertyFilter<'a> {
     ///
     /// # Returns
     /// Vector of node label names (e.g., ["User", "NetworkConnection"])
+    #[allow(dead_code)]
     pub fn filter_node_schemas(&self, required_properties: &HashSet<String>) -> Vec<String> {
         // If no properties required, return all node schemas
         if required_properties.is_empty() {

--- a/src/query_planner/logical_plan/with_clause.rs
+++ b/src/query_planner/logical_plan/with_clause.rs
@@ -35,15 +35,13 @@ use crate::{
 use std::sync::Arc;
 
 /// Extracted info from a pattern comprehension (or list comprehension with pattern predicate).
-/// Used to track the pattern, projection, aggregation type, and optional list constraint
+/// Used to track the pattern, aggregation type, and optional list constraint
 /// during WITH/RETURN clause rewriting.
 struct PatternComprehensionInfo<'a> {
     /// The path pattern from the comprehension (e.g., `(p)-[:HAS_TAG]->()`)
     pattern: crate::open_cypher_parser::ast::PathPattern<'a>,
     /// Optional WHERE clause from the comprehension
     where_clause: Option<Box<Expression<'a>>>,
-    /// The projection expression (what gets collected/counted)
-    projection: Box<Expression<'a>>,
     /// How this comprehension is aggregated (Count, GroupArray, Sum, etc.)
     aggregation_type: crate::query_planner::logical_plan::AggregationType,
     /// For list comprehensions: (iteration_var, list_alias) — e.g., ("p", "posts")
@@ -457,7 +455,6 @@ fn rewrite_expression_pattern_comprehensions<'a>(
                 vec![PatternComprehensionInfo {
                     pattern: (*pc.pattern).clone(),
                     where_clause: pc.where_clause.clone(),
-                    projection: pc.projection.clone(),
                     aggregation_type:
                         crate::query_planner::logical_plan::AggregationType::GroupArray,
                     list_constraint: None,
@@ -549,7 +546,6 @@ fn rewrite_expression_pattern_comprehensions<'a>(
                         vec![PatternComprehensionInfo {
                             pattern: (*pc.pattern).clone(),
                             where_clause: pc.where_clause.clone(),
-                            projection: pc.projection.clone(),
                             aggregation_type: agg_type,
                             list_constraint: None,
                         }],
@@ -605,9 +601,6 @@ fn rewrite_expression_pattern_comprehensions<'a>(
 
                                 let iteration_var = lc.variable.to_string();
 
-                                // The identity projection (just the variable itself)
-                                let projection = Box::new(Expression::Variable(lc.variable));
-
                                 // Replace with count(*)
                                 let replacement_expr = Expression::FunctionCallExp(FunctionCall {
                                     name: "count".to_string(),
@@ -621,7 +614,6 @@ fn rewrite_expression_pattern_comprehensions<'a>(
                                     vec![PatternComprehensionInfo {
                                         pattern: path_pattern,
                                         where_clause: None, // WHERE is already in the pattern
-                                        projection,
                                         aggregation_type: crate::query_planner::logical_plan::AggregationType::Count,
                                         list_constraint: Some((iteration_var, list_alias)),
                                     }],

--- a/src/server/bolt_protocol/graph_objects.rs
+++ b/src/server/bolt_protocol/graph_objects.rs
@@ -528,6 +528,11 @@ fn encode_properties_map(properties: &HashMap<String, Value>) -> Vec<u8> {
 const MAX_JSON_NESTING_DEPTH: usize = 64;
 
 /// Encode a JSON value to packstream format.
+///
+/// Test-only convenience wrapper around `encode_json_value_into`. Production
+/// callers use the buffer-writing variant directly to avoid per-element
+/// allocation.
+#[cfg(test)]
 fn encode_json_value(value: &Value) -> Vec<u8> {
     let mut result = Vec::new();
     encode_json_value_into(value, &mut result, 0);

--- a/src/server/clickhouse_client.rs
+++ b/src/server/clickhouse_client.rs
@@ -74,6 +74,7 @@ pub fn get_client() -> Client {
 /// SELECT * FROM data
 /// WHERE required_role IN (SELECT role_name FROM system.current_roles);
 /// ```
+#[allow(dead_code)]
 pub async fn set_role(client: &Client, role: &str) -> Result<(), clickhouse::error::Error> {
     log::debug!("Setting ClickHouse role: {}", role);
     client.query(&format!("SET ROLE {}", role)).execute().await


### PR DESCRIPTION
## Summary

After investigating each dead-code item to confirm it is not a missing wire-up bug:

**Deleted** (genuinely unreachable / orphan field):
- `NonIntegerKind::Str` — unreachable by design. String-keyed array subscripts are valid Cypher map/property access (`map['key']`, `node['prop']`); `infer_non_integer_kind` intentionally excludes `Literal::String`, so the variant cannot be constructed from any input.
- `PatternComprehensionInfo.projection` — stored at 3 construction sites but never read by any consumer. The projection expression is consumed at rewrite time (`pc.projection` on the AST `PatternComprehension`), not via the stored copy.

**Gated `#[cfg(test)]`**:
- `encode_json_value` — test-only convenience wrapper around the zero-alloc `encode_json_value_into` used in production. Used by 6 unit tests only.

**Annotated `#[allow(dead_code)]`** (intentional API surface / WIP, no replacement, no caller — matching existing `#[allow(dead_code)]` siblings in the same files):
- `set_role` — public RBAC entry point (`SET ROLE` for ClickHouse role-based view filtering). Matches sibling `get_client()`.
- `extract_target_id_negation` — shortestPath early-termination predicate. Matches sibling `build_edge_tuple_base`/`build_edge_tuple_recursive`.
- `filter_node_schemas` — sister of the live `filter_relationship_schemas` (only the rel-filter twin is wired into MATCH planning).

Clippy warnings: **65 → 59**.

## Test plan
- [x] cargo build clean — no remaining dead-code warnings
- [x] cargo clippy --all-targets — all 6 dead-code warnings resolved
- [x] cargo test — 1,653 tests pass
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)