### PR TITLE
refactor: unwrap redundant test mod blocks (module_inception)

### DIFF
--- a/src/clickhouse_query_generator/edge_uniqueness_tests.rs
+++ b/src/clickhouse_query_generator/edge_uniqueness_tests.rs
@@ -1,359 +1,350 @@
-#[cfg(test)]
-mod edge_uniqueness_tests {
-    use crate::clickhouse_query_generator::variable_length_cte::VariableLengthCteGenerator;
-    use crate::graph_catalog::config::Identifier;
-    use crate::graph_catalog::graph_schema::GraphSchema;
-    use crate::query_planner::logical_plan::VariableLengthSpec;
-    use std::collections::HashMap;
+use crate::clickhouse_query_generator::variable_length_cte::VariableLengthCteGenerator;
+use crate::graph_catalog::config::Identifier;
+use crate::graph_catalog::graph_schema::GraphSchema;
+use crate::query_planner::logical_plan::VariableLengthSpec;
+use std::collections::HashMap;
 
-    /// Helper to create a minimal test schema for VLC tests
-    fn create_test_schema() -> GraphSchema {
-        GraphSchema::build(1, "test_db".to_string(), HashMap::new(), HashMap::new())
-    }
+/// Helper to create a minimal test schema for VLC tests
+fn create_test_schema() -> GraphSchema {
+    GraphSchema::build(1, "test_db".to_string(), HashMap::new(), HashMap::new())
+}
 
-    #[test]
-    fn test_default_edge_id_tuple() {
-        // Test that cycle detection uses path_nodes (node-uniqueness)
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 2);
-        let generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "users",
-            "user_id",
-            "follows",
-            "follower_id",
-            "followed_id",
-            "users",
-            "user_id",
-            "u1",
-            "u2",
-            vec![],
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+#[test]
+fn test_default_edge_id_tuple() {
+    // Test that cycle detection uses path_nodes (node-uniqueness)
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 2);
+    let generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "users",
+        "user_id",
+        "follows",
+        "follower_id",
+        "followed_id",
+        "users",
+        "user_id",
+        "u1",
+        "u2",
+        vec![],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_default_tuple_edge_id, got: {:?}",
-                other
-            ),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_default_tuple_edge_id, got: {:?}",
+            other
+        ),
+    };
 
-        // path_nodes is maintained for cycle detection and UNWIND nodes(p) support
-        assert!(
-            sql.contains("path_nodes"),
-            "SQL should contain path_nodes for cycle detection. SQL:\n{}",
-            sql
-        );
+    // path_nodes is maintained for cycle detection and UNWIND nodes(p) support
+    assert!(
+        sql.contains("path_nodes"),
+        "SQL should contain path_nodes for cycle detection. SQL:\n{}",
+        sql
+    );
 
-        // Cycle detection uses path_nodes (node-uniqueness), not path_edges
-        assert!(
-            sql.contains("NOT has(vp.path_nodes,"),
-            "SQL should check node uniqueness via path_nodes. SQL:\n{}",
-            sql
-        );
+    // Cycle detection uses path_nodes (node-uniqueness), not path_edges
+    assert!(
+        sql.contains("NOT has(vp.path_nodes,"),
+        "SQL should check node uniqueness via path_nodes. SQL:\n{}",
+        sql
+    );
 
-        // path_edges should NOT be present (removed for memory optimization)
-        assert!(
-            !sql.contains("path_edges"),
-            "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
-            sql
-        );
+    // path_edges should NOT be present (removed for memory optimization)
+    assert!(
+        !sql.contains("path_edges"),
+        "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ Default Edge ID Test SQL:\n{}", sql);
-    }
+    println!("\n✅ Default Edge ID Test SQL:\n{}", sql);
+}
 
-    #[test]
-    fn test_composite_edge_id() {
-        // Test composite edge ID — cycle detection still uses path_nodes
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 2);
-        let edge_id = Some(Identifier::Composite(vec![
-            "FlightDate".to_string(),
-            "FlightNum".to_string(),
-            "Origin".to_string(),
-            "Dest".to_string(),
-        ]));
+#[test]
+fn test_composite_edge_id() {
+    // Test composite edge ID — cycle detection still uses path_nodes
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 2);
+    let edge_id = Some(Identifier::Composite(vec![
+        "FlightDate".to_string(),
+        "FlightNum".to_string(),
+        "Origin".to_string(),
+        "Dest".to_string(),
+    ]));
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "airports",
-            "airport_code",
-            "flights",
-            "Origin",
-            "Dest",
-            "airports",
-            "airport_code",
-            "a1",
-            "a2",
-            vec![],
-            None,
-            None,
-            None,
-            None,
-            None,
-            edge_id,
-        );
+    let generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "airports",
+        "airport_code",
+        "flights",
+        "Origin",
+        "Dest",
+        "airports",
+        "airport_code",
+        "a1",
+        "a2",
+        vec![],
+        None,
+        None,
+        None,
+        None,
+        None,
+        edge_id,
+    );
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_custom_edge_id_tuple_construction, got: {:?}",
-                other
-            ),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_custom_edge_id_tuple_construction, got: {:?}",
+            other
+        ),
+    };
 
-        // Cycle detection uses path_nodes (node-uniqueness)
-        assert!(
-            sql.contains("NOT has(vp.path_nodes,"),
-            "SQL should check node uniqueness via path_nodes. SQL:\n{}",
-            sql
-        );
+    // Cycle detection uses path_nodes (node-uniqueness)
+    assert!(
+        sql.contains("NOT has(vp.path_nodes,"),
+        "SQL should check node uniqueness via path_nodes. SQL:\n{}",
+        sql
+    );
 
-        // path_edges should NOT be present
-        assert!(
-            !sql.contains("path_edges"),
-            "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
-            sql
-        );
+    // path_edges should NOT be present
+    assert!(
+        !sql.contains("path_edges"),
+        "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ Composite Edge ID Test SQL:\n{}", sql);
-    }
+    println!("\n✅ Composite Edge ID Test SQL:\n{}", sql);
+}
 
-    #[test]
-    fn test_simple_edge_id() {
-        // Test single column edge ID — cycle detection still uses path_nodes
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 2);
-        let edge_id = Some(Identifier::Single("transaction_id".to_string()));
+#[test]
+fn test_simple_edge_id() {
+    // Test single column edge ID — cycle detection still uses path_nodes
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 2);
+    let edge_id = Some(Identifier::Single("transaction_id".to_string()));
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "accounts",
-            "account_id",
-            "transactions",
-            "from_account",
-            "to_account",
-            "accounts",
-            "account_id",
-            "a1",
-            "a2",
-            vec![],
-            None,
-            None,
-            None,
-            None,
-            None,
-            edge_id,
-        );
+    let generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "accounts",
+        "account_id",
+        "transactions",
+        "from_account",
+        "to_account",
+        "accounts",
+        "account_id",
+        "a1",
+        "a2",
+        vec![],
+        None,
+        None,
+        None,
+        None,
+        None,
+        edge_id,
+    );
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_custom_edge_id_column, got: {:?}",
-                other
-            ),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_custom_edge_id_column, got: {:?}",
+            other
+        ),
+    };
 
-        // Cycle detection uses path_nodes (node-uniqueness)
-        assert!(
-            sql.contains("NOT has(vp.path_nodes,"),
-            "SQL should check node uniqueness via path_nodes. SQL:\n{}",
-            sql
-        );
+    // Cycle detection uses path_nodes (node-uniqueness)
+    assert!(
+        sql.contains("NOT has(vp.path_nodes,"),
+        "SQL should check node uniqueness via path_nodes. SQL:\n{}",
+        sql
+    );
 
-        // path_edges should NOT be present
-        assert!(
-            !sql.contains("path_edges"),
-            "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
-            sql
-        );
+    // path_edges should NOT be present
+    assert!(
+        !sql.contains("path_edges"),
+        "SQL should NOT contain path_edges (removed for memory optimization). SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ Simple Edge ID Test SQL:\n{}", sql);
-    }
+    println!("\n✅ Simple Edge ID Test SQL:\n{}", sql);
+}
 
-    #[test]
-    fn test_bfs_mode_generates_lightweight_cte() {
-        // When use_bfs_mode=true, the generator should produce a BFS CTE
-        // with (node_id, hop) columns instead of per-path tracking arrays.
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 5);
-        let mut generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "Person",
-            "id",
-            "Person_knows_Person",
-            "Person1Id",
-            "Person2Id",
-            "Person",
-            "id",
-            "person1",
-            "person2",
-            vec![],
-            Some(
-                crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest,
-            ),
-            Some("start_node.id = 123".to_string()),
-            Some("end_node.id = 456".to_string()),
-            Some("p".to_string()),
-            None,
-            None,
-        );
-        generator.use_bfs_mode = true;
-        generator.is_undirected = false;
+#[test]
+fn test_bfs_mode_generates_lightweight_cte() {
+    // When use_bfs_mode=true, the generator should produce a BFS CTE
+    // with (node_id, hop) columns instead of per-path tracking arrays.
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 5);
+    let mut generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "Person",
+        "id",
+        "Person_knows_Person",
+        "Person1Id",
+        "Person2Id",
+        "Person",
+        "id",
+        "person1",
+        "person2",
+        vec![],
+        Some(crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest),
+        Some("start_node.id = 123".to_string()),
+        Some("end_node.id = 456".to_string()),
+        Some("p".to_string()),
+        None,
+        None,
+    );
+    generator.use_bfs_mode = true;
+    generator.is_undirected = false;
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!("Expected RawSql for BFS mode, got: {:?}", other),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!("Expected RawSql for BFS mode, got: {:?}", other),
+    };
 
-        // BFS CTE should have node_id and hop columns
-        assert!(
-            sql.contains("node_id") && sql.contains("hop"),
-            "BFS CTE should contain node_id and hop columns. SQL:\n{}",
-            sql
-        );
-        // BFS CTE should NOT contain path_nodes or path_relationships arrays
-        assert!(
-            !sql.contains("arrayConcat"),
-            "BFS CTE should not grow path arrays. SQL:\n{}",
-            sql
-        );
-        // Should have a _bfs recursive CTE and a result wrapper
-        assert!(
-            sql.contains("_bfs"),
-            "BFS mode should generate a _bfs recursive CTE. SQL:\n{}",
-            sql
-        );
-        // Result wrapper should have hop_count for length(path) rewriting
-        assert!(
-            sql.contains("hop_count"),
-            "BFS result wrapper should have hop_count. SQL:\n{}",
-            sql
-        );
+    // BFS CTE should have node_id and hop columns
+    assert!(
+        sql.contains("node_id") && sql.contains("hop"),
+        "BFS CTE should contain node_id and hop columns. SQL:\n{}",
+        sql
+    );
+    // BFS CTE should NOT contain path_nodes or path_relationships arrays
+    assert!(
+        !sql.contains("arrayConcat"),
+        "BFS CTE should not grow path arrays. SQL:\n{}",
+        sql
+    );
+    // Should have a _bfs recursive CTE and a result wrapper
+    assert!(
+        sql.contains("_bfs"),
+        "BFS mode should generate a _bfs recursive CTE. SQL:\n{}",
+        sql
+    );
+    // Result wrapper should have hop_count for length(path) rewriting
+    assert!(
+        sql.contains("hop_count"),
+        "BFS result wrapper should have hop_count. SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ BFS Mode Test SQL:\n{}", sql);
-    }
+    println!("\n✅ BFS Mode Test SQL:\n{}", sql);
+}
 
-    #[test]
-    fn test_bfs_mode_not_activated_without_flag() {
-        // Without use_bfs_mode=true, even with shortestPath, the standard
-        // per-path recursive CTE should be generated (with path_nodes).
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 5);
-        let generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "Person",
-            "id",
-            "Person_knows_Person",
-            "Person1Id",
-            "Person2Id",
-            "Person",
-            "id",
-            "person1",
-            "person2",
-            vec![],
-            Some(
-                crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest,
-            ),
-            Some("start_node.id = 123".to_string()),
-            Some("end_node.id = 456".to_string()),
-            Some("p".to_string()),
-            None,
-            None,
-        );
-        // use_bfs_mode defaults to false
+#[test]
+fn test_bfs_mode_not_activated_without_flag() {
+    // Without use_bfs_mode=true, even with shortestPath, the standard
+    // per-path recursive CTE should be generated (with path_nodes).
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 5);
+    let generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "Person",
+        "id",
+        "Person_knows_Person",
+        "Person1Id",
+        "Person2Id",
+        "Person",
+        "id",
+        "person1",
+        "person2",
+        vec![],
+        Some(crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest),
+        Some("start_node.id = 123".to_string()),
+        Some("end_node.id = 456".to_string()),
+        Some("p".to_string()),
+        None,
+        None,
+    );
+    // use_bfs_mode defaults to false
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!("Expected RawSql, got: {:?}", other),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!("Expected RawSql, got: {:?}", other),
+    };
 
-        // Standard mode should have path_nodes for per-path tracking
-        assert!(
-            sql.contains("path_nodes"),
-            "Standard mode should contain path_nodes. SQL:\n{}",
-            sql
-        );
-        // Should NOT have a _bfs CTE
-        assert!(
-            !sql.contains("_bfs"),
-            "Standard mode should not generate _bfs CTE. SQL:\n{}",
-            sql
-        );
+    // Standard mode should have path_nodes for per-path tracking
+    assert!(
+        sql.contains("path_nodes"),
+        "Standard mode should contain path_nodes. SQL:\n{}",
+        sql
+    );
+    // Should NOT have a _bfs CTE
+    assert!(
+        !sql.contains("_bfs"),
+        "Standard mode should not generate _bfs CTE. SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ BFS Guard Test SQL:\n{}", sql);
-    }
+    println!("\n✅ BFS Guard Test SQL:\n{}", sql);
+}
 
-    #[test]
-    fn test_bfs_mode_undirected_generates_two_branches() {
-        // Undirected BFS should produce UNION ALL of forward + reverse traversal
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 5);
-        let mut generator = VariableLengthCteGenerator::new(
-            &schema,
-            spec,
-            "Person",
-            "id",
-            "Person_knows_Person",
-            "Person1Id",
-            "Person2Id",
-            "Person",
-            "id",
-            "person1",
-            "person2",
-            vec![],
-            Some(
-                crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest,
-            ),
-            Some("start_node.id = 123".to_string()),
-            Some("end_node.id = 456".to_string()),
-            Some("p".to_string()),
-            None,
-            None,
-        );
-        generator.use_bfs_mode = true;
-        generator.is_undirected = true;
+#[test]
+fn test_bfs_mode_undirected_generates_two_branches() {
+    // Undirected BFS should produce UNION ALL of forward + reverse traversal
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 5);
+    let mut generator = VariableLengthCteGenerator::new(
+        &schema,
+        spec,
+        "Person",
+        "id",
+        "Person_knows_Person",
+        "Person1Id",
+        "Person2Id",
+        "Person",
+        "id",
+        "person1",
+        "person2",
+        vec![],
+        Some(crate::clickhouse_query_generator::variable_length_cte::ShortestPathMode::Shortest),
+        Some("start_node.id = 123".to_string()),
+        Some("end_node.id = 456".to_string()),
+        Some("p".to_string()),
+        None,
+        None,
+    );
+    generator.use_bfs_mode = true;
+    generator.is_undirected = true;
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!("Expected RawSql for undirected BFS, got: {:?}", other),
-        };
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!("Expected RawSql for undirected BFS, got: {:?}", other),
+    };
 
-        // Count UNION ALL occurrences — undirected BFS should have at least 2
-        // (one for base UNION ALL recursive, one for forward UNION ALL reverse)
-        let union_count = sql.matches("UNION ALL").count();
-        assert!(
-            union_count >= 2,
-            "Undirected BFS should have >=2 UNION ALL (got {}). SQL:\n{}",
-            union_count,
-            sql
-        );
+    // Count UNION ALL occurrences — undirected BFS should have at least 2
+    // (one for base UNION ALL recursive, one for forward UNION ALL reverse)
+    let union_count = sql.matches("UNION ALL").count();
+    assert!(
+        union_count >= 2,
+        "Undirected BFS should have >=2 UNION ALL (got {}). SQL:\n{}",
+        union_count,
+        sql
+    );
 
-        // Both Person1Id and Person2Id should appear as join columns
-        // (forward: Person1Id→Person2Id, reverse: Person2Id→Person1Id)
-        assert!(
-            sql.contains("Person1Id") && sql.contains("Person2Id"),
-            "Undirected BFS should reference both direction columns. SQL:\n{}",
-            sql
-        );
+    // Both Person1Id and Person2Id should appear as join columns
+    // (forward: Person1Id→Person2Id, reverse: Person2Id→Person1Id)
+    assert!(
+        sql.contains("Person1Id") && sql.contains("Person2Id"),
+        "Undirected BFS should reference both direction columns. SQL:\n{}",
+        sql
+    );
 
-        println!("\n✅ Undirected BFS Test SQL:\n{}", sql);
-    }
+    println!("\n✅ Undirected BFS Test SQL:\n{}", sql);
 }

--- a/src/clickhouse_query_generator/where_clause_tests.rs
+++ b/src/clickhouse_query_generator/where_clause_tests.rs
@@ -8,217 +8,211 @@ use crate::graph_catalog::graph_schema::GraphSchema;
 use crate::query_planner::logical_plan::VariableLengthSpec;
 use std::collections::HashMap;
 
-#[cfg(test)]
-mod where_clause_tests {
-    use super::*;
+/// Helper to create a minimal test schema for VLC tests
+fn create_test_schema() -> GraphSchema {
+    GraphSchema::build(1, "test_db".to_string(), HashMap::new(), HashMap::new())
+}
 
-    /// Helper to create a minimal test schema for VLC tests
-    fn create_test_schema() -> GraphSchema {
-        GraphSchema::build(1, "test_db".to_string(), HashMap::new(), HashMap::new())
-    }
+#[test]
+fn test_start_node_filter_in_base_case() {
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::unbounded();
+    let start_filter = Some("start_node.full_name = 'Alice'".to_string());
 
-    #[test]
-    fn test_start_node_filter_in_base_case() {
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::unbounded();
-        let start_filter = Some("start_node.full_name = 'Alice'".to_string());
+    let generator = VariableLengthCteGenerator::new(
+        &schema, // Add schema parameter
+        spec,
+        "users",
+        "user_id",
+        "follows",
+        "follower_id",
+        "followed_id",
+        "users",
+        "user_id",
+        "a",
+        "b",
+        vec![],
+        Some(ShortestPathMode::Shortest),
+        start_filter,
+        None,
+        None, // no path variable
+        None, // no relationship types
+        None, // no edge_id (use default from_id, to_id)
+    );
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema, // Add schema parameter
-            spec,
-            "users",
-            "user_id",
-            "follows",
-            "follower_id",
-            "followed_id",
-            "users",
-            "user_id",
-            "a",
-            "b",
-            vec![],
-            Some(ShortestPathMode::Shortest),
-            start_filter,
-            None,
-            None, // no path variable
-            None, // no relationship types
-            None, // no edge_id (use default from_id, to_id)
-        );
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_start_node_filter_in_base_case, got: {:?}",
+            other
+        ),
+    };
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_start_node_filter_in_base_case, got: {:?}",
-                other
-            ),
-        };
+    // Verify start filter is in base case
+    assert!(
+        sql.contains("WHERE start_node.full_name = 'Alice'"),
+        "Start filter should be in base case WHERE clause"
+    );
 
-        // Verify start filter is in base case
-        assert!(
-            sql.contains("WHERE start_node.full_name = 'Alice'"),
-            "Start filter should be in base case WHERE clause"
-        );
+    println!("\n✓ Generated SQL with start filter:\n{}\n", sql);
+}
 
-        println!("\n✓ Generated SQL with start filter:\n{}\n", sql);
-    }
+#[test]
+fn test_end_node_filter_in_outer_cte() {
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::unbounded();
+    let end_filter = Some("end_full_name = 'Bob'".to_string());
 
-    #[test]
-    fn test_end_node_filter_in_outer_cte() {
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::unbounded();
-        let end_filter = Some("end_full_name = 'Bob'".to_string());
+    let generator = VariableLengthCteGenerator::new(
+        &schema, // Add schema parameter
+        spec,
+        "users",
+        "user_id",
+        "follows",
+        "follower_id",
+        "followed_id",
+        "users",
+        "user_id",
+        "a",
+        "b",
+        vec![],
+        Some(ShortestPathMode::Shortest),
+        None,
+        end_filter,
+        None, // no path variable
+        None, // no relationship types
+        None, // no edge_id (use default from_id, to_id)
+    );
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema, // Add schema parameter
-            spec,
-            "users",
-            "user_id",
-            "follows",
-            "follower_id",
-            "followed_id",
-            "users",
-            "user_id",
-            "a",
-            "b",
-            vec![],
-            Some(ShortestPathMode::Shortest),
-            None,
-            end_filter,
-            None, // no path variable
-            None, // no relationship types
-            None, // no edge_id (use default from_id, to_id)
-        );
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_end_node_filter_in_tiered_case, got: {:?}",
+            other
+        ),
+    };
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_end_node_filter_in_tiered_case, got: {:?}",
-                other
-            ),
-        };
+    // Verify 3-tier structure
+    assert!(sql.contains("_inner AS"), "Should have _inner CTE");
+    assert!(sql.contains("_to_target AS"), "Should have _to_target CTE");
+    assert!(
+        sql.contains("WHERE end_full_name = 'Bob'"),
+        "End filter should be in _to_target CTE"
+    );
 
-        // Verify 3-tier structure
-        assert!(sql.contains("_inner AS"), "Should have _inner CTE");
-        assert!(sql.contains("_to_target AS"), "Should have _to_target CTE");
-        assert!(
-            sql.contains("WHERE end_full_name = 'Bob'"),
-            "End filter should be in _to_target CTE"
-        );
+    println!(
+        "\n✓ Generated SQL with end filter (3-tier structure):\n{}\n",
+        sql
+    );
+}
 
-        println!(
-            "\n✓ Generated SQL with end filter (3-tier structure):\n{}\n",
-            sql
-        );
-    }
+#[test]
+fn test_both_start_and_end_filters() {
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 5);
+    let start_filter = Some("start_node.full_name = 'Alice'".to_string());
+    let end_filter = Some("end_full_name = 'Bob'".to_string());
 
-    #[test]
-    fn test_both_start_and_end_filters() {
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 5);
-        let start_filter = Some("start_node.full_name = 'Alice'".to_string());
-        let end_filter = Some("end_full_name = 'Bob'".to_string());
+    let generator = VariableLengthCteGenerator::new(
+        &schema, // Add schema parameter
+        spec,
+        "users",
+        "user_id",
+        "follows",
+        "follower_id",
+        "followed_id",
+        "users",
+        "user_id",
+        "a",
+        "b",
+        vec![],
+        Some(ShortestPathMode::Shortest),
+        start_filter,
+        end_filter,
+        None, // no path variable
+        None, // no relationship types
+        None, // no edge_id (use default from_id, to_id)
+    );
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema, // Add schema parameter
-            spec,
-            "users",
-            "user_id",
-            "follows",
-            "follower_id",
-            "followed_id",
-            "users",
-            "user_id",
-            "a",
-            "b",
-            vec![],
-            Some(ShortestPathMode::Shortest),
-            start_filter,
-            end_filter,
-            None, // no path variable
-            None, // no relationship types
-            None, // no edge_id (use default from_id, to_id)
-        );
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_multiple_filters, got: {:?}",
+            other
+        ),
+    };
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_multiple_filters, got: {:?}",
-                other
-            ),
-        };
+    println!("\n=== Generated SQL with both filters ===\n{}\n", sql);
 
-        println!("\n=== Generated SQL with both filters ===\n{}\n", sql);
+    // Verify both filters present
+    assert!(
+        sql.contains("WHERE start_node.full_name = 'Alice'") || sql.contains("full_name = 'Alice'"),
+        "Start filter should be in base case. SQL:\n{}",
+        sql
+    );
+    assert!(
+        sql.contains("WHERE end_full_name = 'Bob'") || sql.contains("end_full_name = 'Bob'"),
+        "End filter should be in outer CTE. SQL:\n{}",
+        sql
+    );
+    assert!(sql.contains("_inner AS"), "Should have _inner CTE");
+    assert!(sql.contains("_to_target AS"), "Should have _to_target CTE");
 
-        // Verify both filters present
-        assert!(
-            sql.contains("WHERE start_node.full_name = 'Alice'")
-                || sql.contains("full_name = 'Alice'"),
-            "Start filter should be in base case. SQL:\n{}",
-            sql
-        );
-        assert!(
-            sql.contains("WHERE end_full_name = 'Bob'") || sql.contains("end_full_name = 'Bob'"),
-            "End filter should be in outer CTE. SQL:\n{}",
-            sql
-        );
-        assert!(sql.contains("_inner AS"), "Should have _inner CTE");
-        assert!(sql.contains("_to_target AS"), "Should have _to_target CTE");
+    println!("\n✓ Generated SQL with both filters:\n{}\n", sql);
+}
 
-        println!("\n✓ Generated SQL with both filters:\n{}\n", sql);
-    }
+#[test]
+fn test_no_filters_simple_structure() {
+    // Use a range pattern starting at 1 to avoid min_hops filtering
+    // (Fixed patterns like *2 would use inline JOINs in practice, not CTEs)
+    let schema = create_test_schema();
+    let spec = VariableLengthSpec::range(1, 3); // *1..3
 
-    #[test]
-    fn test_no_filters_simple_structure() {
-        // Use a range pattern starting at 1 to avoid min_hops filtering
-        // (Fixed patterns like *2 would use inline JOINs in practice, not CTEs)
-        let schema = create_test_schema();
-        let spec = VariableLengthSpec::range(1, 3); // *1..3
+    let generator = VariableLengthCteGenerator::new(
+        &schema, // Add schema parameter
+        spec,
+        "users",
+        "user_id",
+        "follows",
+        "follower_id",
+        "followed_id",
+        "users",
+        "user_id",
+        "a",
+        "b",
+        vec![],
+        None, // No shortest path mode
+        None, // No start filter
+        None, // No end filter
+        None, // No path variable
+        None, // no relationship types
+        None, // no edge_id (use default from_id, to_id)
+    );
 
-        let generator = VariableLengthCteGenerator::new(
-            &schema, // Add schema parameter
-            spec,
-            "users",
-            "user_id",
-            "follows",
-            "follower_id",
-            "followed_id",
-            "users",
-            "user_id",
-            "a",
-            "b",
-            vec![],
-            None, // No shortest path mode
-            None, // No start filter
-            None, // No end filter
-            None, // No path variable
-            None, // no relationship types
-            None, // no edge_id (use default from_id, to_id)
-        );
+    let cte = generator.generate_cte();
+    let sql = match &cte.content {
+        crate::render_plan::CteContent::RawSql(s) => s,
+        other => panic!(
+            "Expected RawSql content in test_both_start_and_end_filters, got: {:?}",
+            other
+        ),
+    };
 
-        let cte = generator.generate_cte();
-        let sql = match &cte.content {
-            crate::render_plan::CteContent::RawSql(s) => s,
-            other => panic!(
-                "Expected RawSql content in test_both_start_and_end_filters, got: {:?}",
-                other
-            ),
-        };
+    // Verify simple structure (no _inner, _to_target) when min_hops <= 1
+    assert!(
+        !sql.contains("_inner AS"),
+        "Should NOT have _inner CTE without filters/shortest path when min_hops <= 1"
+    );
+    assert!(
+        !sql.contains("_to_target AS"),
+        "Should NOT have _to_target CTE"
+    );
 
-        // Verify simple structure (no _inner, _to_target) when min_hops <= 1
-        assert!(
-            !sql.contains("_inner AS"),
-            "Should NOT have _inner CTE without filters/shortest path when min_hops <= 1"
-        );
-        assert!(
-            !sql.contains("_to_target AS"),
-            "Should NOT have _to_target CTE"
-        );
-
-        println!(
-            "\n✓ Generated SQL without filters (simple structure):\n{}\n",
-            sql
-        );
-    }
+    println!(
+        "\n✓ Generated SQL without filters (simple structure):\n{}\n",
+        sql
+    );
 }

--- a/src/graph_catalog/schema_validator/tests.rs
+++ b/src/graph_catalog/schema_validator/tests.rs
@@ -1,28 +1,25 @@
-#[cfg(test)]
-mod tests {
-    use crate::graph_catalog::testing::mock_clickhouse::create_test_table_schemas;
-    use crate::graph_catalog::SchemaValidator;
+use crate::graph_catalog::testing::mock_clickhouse::create_test_table_schemas;
+use crate::graph_catalog::SchemaValidator;
 
-    #[test]
-    fn test_create_schema_validator() {
-        // Use clickhouse test utilities for integration tests
-        let client = clickhouse::Client::default();
-        let validator = SchemaValidator::new(client);
+#[test]
+fn test_create_schema_validator() {
+    // Use clickhouse test utilities for integration tests
+    let client = clickhouse::Client::default();
+    let validator = SchemaValidator::new(client);
 
-        // Basic constructor test
-        assert!(validator.column_cache.is_empty()); // Cache starts empty
-    }
+    // Basic constructor test
+    assert!(validator.column_cache.is_empty()); // Cache starts empty
+}
 
-    #[test]
-    fn test_table_schemas() {
-        // Test our mock table schemas
-        let tables = create_test_table_schemas();
+#[test]
+fn test_table_schemas() {
+    // Test our mock table schemas
+    let tables = create_test_table_schemas();
 
-        assert!(tables.contains_key("users"));
-        assert!(tables.contains_key("posts"));
-        assert!(tables.contains_key("follows"));
+    assert!(tables.contains_key("users"));
+    assert!(tables.contains_key("posts"));
+    assert!(tables.contains_key("follows"));
 
-        let users_schema = tables.get("users").unwrap();
-        assert_eq!(users_schema.len(), 5);
-    }
+    let users_schema = tables.get("users").unwrap();
+    assert_eq!(users_schema.len(), 5);
 }

--- a/src/render_plan/tests/multiple_relationship_tests.rs
+++ b/src/render_plan/tests/multiple_relationship_tests.rs
@@ -363,582 +363,579 @@ fn setup_test_schema() {
     }
 }
 
-#[cfg(test)]
-mod multiple_relationship_tests {
-    use super::*;
+#[test]
+#[serial(global_schema)]
+#[ignore = "Multi-rel now routes through VLP JOIN expansion, not rel_* CTEs - architectural change"]
+fn test_multiple_relationship_types_union() {
+    // Setup test schema
+    setup_test_schema();
 
-    #[test]
-    #[serial(global_schema)]
-    #[ignore = "Multi-rel now routes through VLP JOIN expansion, not rel_* CTEs - architectural change"]
-    fn test_multiple_relationship_types_union() {
-        // Setup test schema
-        setup_test_schema();
+    // Test that [:FOLLOWS|FRIENDS_WITH] generates UNION CTE
+    let cypher = "MATCH (u1:User)-[:FOLLOWS|FRIENDS_WITH]->(u2:User) RETURN u1, u2";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse multiple relationship types: {:?}",
+        parse_result.err()
+    );
 
-        // Test that [:FOLLOWS|FRIENDS_WITH] generates UNION CTE
-        let cypher = "MATCH (u1:User)-[:FOLLOWS|FRIENDS_WITH]->(u2:User) RETURN u1, u2";
-        let parse_result = open_cypher_parser::parse_query(cypher);
-        assert!(
-            parse_result.is_ok(),
-            "Failed to parse multiple relationship types: {:?}",
-            parse_result.err()
-        );
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
 
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
 
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
+    let render_plan = render_plan.unwrap();
 
-        let render_plan = render_plan.unwrap();
+    // Check that we have CTEs
+    assert!(
+        !render_plan.ctes.0.is_empty(),
+        "Expected CTEs for multiple relationship types"
+    );
 
-        // Check that we have CTEs
-        assert!(
-            !render_plan.ctes.0.is_empty(),
-            "Expected CTEs for multiple relationship types"
-        );
+    // Find the relationship CTE
+    let rel_cte = render_plan
+        .ctes
+        .0
+        .iter()
+        .find(|cte| cte.cte_name.starts_with("rel_"));
+    assert!(
+        rel_cte.is_some(),
+        "Expected relationship CTE with name starting with 'rel_'"
+    );
 
-        // Find the relationship CTE
-        let rel_cte = render_plan
-            .ctes
-            .0
-            .iter()
-            .find(|cte| cte.cte_name.starts_with("rel_"));
-        assert!(
-            rel_cte.is_some(),
-            "Expected relationship CTE with name starting with 'rel_'"
-        );
+    let rel_cte = rel_cte.unwrap();
 
-        let rel_cte = rel_cte.unwrap();
-
-        // Check that the CTE content contains UNION
-        match &rel_cte.content {
-            crate::render_plan::CteContent::RawSql(sql) => {
-                assert!(
-                    sql.contains("UNION ALL"),
-                    "Expected UNION ALL in CTE SQL: {}",
-                    sql
-                );
-                assert!(
-                    sql.contains("user_follows"),
-                    "Expected user_follows table in UNION: {}",
-                    sql
-                );
-                assert!(
-                    sql.contains("friendships"),
-                    "Expected friendships table in UNION: {}",
-                    sql
-                );
-            }
-            _ => panic!("Expected RawSql content for relationship CTE"),
+    // Check that the CTE content contains UNION
+    match &rel_cte.content {
+        crate::render_plan::CteContent::RawSql(sql) => {
+            assert!(
+                sql.contains("UNION ALL"),
+                "Expected UNION ALL in CTE SQL: {}",
+                sql
+            );
+            assert!(
+                sql.contains("user_follows"),
+                "Expected user_follows table in UNION: {}",
+                sql
+            );
+            assert!(
+                sql.contains("friendships"),
+                "Expected friendships table in UNION: {}",
+                sql
+            );
         }
+        _ => panic!("Expected RawSql content for relationship CTE"),
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    #[ignore = "Multi-rel now routes through VLP JOIN expansion, not rel_* CTEs - architectural change"]
-    fn test_three_relationship_types_union() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+#[ignore = "Multi-rel now routes through VLP JOIN expansion, not rel_* CTEs - architectural change"]
+fn test_three_relationship_types_union() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test that [:PURCHASED|PLACED_ORDER|ORDER_CONTAINS] generates UNION CTE with 3 tables
-        let cypher = "MATCH (c:Customer)-[:PURCHASED|PLACED_ORDER|ORDER_CONTAINS]->(target) RETURN c, target";
-        let parse_result = open_cypher_parser::parse_query(cypher);
-        assert!(
-            parse_result.is_ok(),
-            "Failed to parse three relationship types: {:?}",
-            parse_result.err()
-        );
+    // Test that [:PURCHASED|PLACED_ORDER|ORDER_CONTAINS] generates UNION CTE with 3 tables
+    let cypher =
+        "MATCH (c:Customer)-[:PURCHASED|PLACED_ORDER|ORDER_CONTAINS]->(target) RETURN c, target";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse three relationship types: {:?}",
+        parse_result.err()
+    );
 
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
 
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
 
-        let render_plan = render_plan.unwrap();
+    let render_plan = render_plan.unwrap();
 
-        // Check that we have CTEs
-        assert!(
-            !render_plan.ctes.0.is_empty(),
-            "Expected CTEs for three relationship types"
-        );
+    // Check that we have CTEs
+    assert!(
+        !render_plan.ctes.0.is_empty(),
+        "Expected CTEs for three relationship types"
+    );
 
-        // Find the relationship CTE
-        let rel_cte = render_plan
-            .ctes
-            .0
-            .iter()
-            .find(|cte| cte.cte_name.starts_with("rel_"));
-        assert!(
-            rel_cte.is_some(),
-            "Expected relationship CTE with name starting with 'rel_'"
-        );
+    // Find the relationship CTE
+    let rel_cte = render_plan
+        .ctes
+        .0
+        .iter()
+        .find(|cte| cte.cte_name.starts_with("rel_"));
+    assert!(
+        rel_cte.is_some(),
+        "Expected relationship CTE with name starting with 'rel_'"
+    );
 
-        let rel_cte = rel_cte.unwrap();
+    let rel_cte = rel_cte.unwrap();
 
-        // Check that the CTE content contains UNION and all three tables
-        match &rel_cte.content {
-            crate::render_plan::CteContent::RawSql(sql) => {
-                println!("Generated SQL for 3 relationship types:\n{}", sql);
-                assert!(
-                    sql.contains("UNION ALL"),
-                    "Expected UNION ALL in CTE SQL: {}",
-                    sql
-                );
+    // Check that the CTE content contains UNION and all three tables
+    match &rel_cte.content {
+        crate::render_plan::CteContent::RawSql(sql) => {
+            println!("Generated SQL for 3 relationship types:\n{}", sql);
+            assert!(
+                sql.contains("UNION ALL"),
+                "Expected UNION ALL in CTE SQL: {}",
+                sql
+            );
 
-                // Count UNION ALL occurrences - should be 2 for 3 tables (table1 UNION ALL table2 UNION ALL table3)
-                let union_count = sql.matches("UNION ALL").count();
-                assert_eq!(
-                    union_count, 2,
-                    "Expected 2 UNION ALL clauses for 3 tables, got {}: {}",
-                    union_count, sql
-                );
+            // Count UNION ALL occurrences - should be 2 for 3 tables (table1 UNION ALL table2 UNION ALL table3)
+            let union_count = sql.matches("UNION ALL").count();
+            assert_eq!(
+                union_count, 2,
+                "Expected 2 UNION ALL clauses for 3 tables, got {}: {}",
+                union_count, sql
+            );
 
-                // Check all three tables are present
-                assert!(
-                    sql.contains("orders"),
-                    "Expected orders table in UNION: {}",
-                    sql
-                );
-                assert!(
-                    sql.contains("orders"),
-                    "Expected orders table for PLACED_ORDER in UNION: {}",
-                    sql
-                );
-                assert!(
-                    sql.contains("order_items"),
-                    "Expected order_items table for ORDER_CONTAINS in UNION: {}",
-                    sql
-                );
-                let select_count = sql.matches("SELECT").count();
-                assert_eq!(
-                    select_count, 3,
-                    "Expected 3 SELECT statements for 3 relationship types, got {}: {}",
-                    select_count, sql
-                );
-            }
-            _ => panic!("Expected RawSql content for relationship CTE"),
+            // Check all three tables are present
+            assert!(
+                sql.contains("orders"),
+                "Expected orders table in UNION: {}",
+                sql
+            );
+            assert!(
+                sql.contains("orders"),
+                "Expected orders table for PLACED_ORDER in UNION: {}",
+                sql
+            );
+            assert!(
+                sql.contains("order_items"),
+                "Expected order_items table for ORDER_CONTAINS in UNION: {}",
+                sql
+            );
+            let select_count = sql.matches("SELECT").count();
+            assert_eq!(
+                select_count, 3,
+                "Expected 3 SELECT statements for 3 relationship types, got {}: {}",
+                select_count, sql
+            );
         }
+        _ => panic!("Expected RawSql content for relationship CTE"),
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    fn test_single_relationship_type_no_union() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+fn test_single_relationship_type_no_union() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test that single relationship type doesn't generate UNION
-        let cypher = "MATCH (u1:User)-[:FOLLOWS]->(u2:User) RETURN u1, u2";
-        let parse_result = open_cypher_parser::parse_query(cypher);
-        assert!(
-            parse_result.is_ok(),
-            "Failed to parse single relationship type: {:?}",
-            parse_result.err()
-        );
+    // Test that single relationship type doesn't generate UNION
+    let cypher = "MATCH (u1:User)-[:FOLLOWS]->(u2:User) RETURN u1, u2";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse single relationship type: {:?}",
+        parse_result.err()
+    );
 
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
 
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
 
-        let render_plan = render_plan.unwrap();
+    let render_plan = render_plan.unwrap();
 
-        // For single relationship types, we shouldn't have UNION CTEs
-        // (though we might have other CTEs for variable-length paths)
-        let union_ctes = render_plan.ctes.0.iter().filter(|cte| {
+    // For single relationship types, we shouldn't have UNION CTEs
+    // (though we might have other CTEs for variable-length paths)
+    let union_ctes = render_plan.ctes.0.iter().filter(|cte| {
             matches!(&cte.content, crate::render_plan::CteContent::RawSql(sql) if sql.contains("UNION ALL"))
         });
-        assert_eq!(
-            union_ctes.count(),
-            0,
-            "Expected no UNION CTEs for single relationship type"
-        );
-    }
+    assert_eq!(
+        union_ctes.count(),
+        0,
+        "Expected no UNION CTEs for single relationship type"
+    );
+}
 
-    // ==================== Multi-Hop Traversal Tests ====================
-    // These tests verify the fix for the multi-hop join bug where the second
-    // relationship's ON clause was being incorrectly filtered out.
-    //
-    // NOTE: These tests require complete schema setup including node tables.
-    // The schema initialization isn't working properly in unit test context.
-    // Multi-hop functionality is verified in integration tests instead.
+// ==================== Multi-Hop Traversal Tests ====================
+// These tests verify the fix for the multi-hop join bug where the second
+// relationship's ON clause was being incorrectly filtered out.
+//
+// NOTE: These tests require complete schema setup including node tables.
+// The schema initialization isn't working properly in unit test context.
+// Multi-hop functionality is verified in integration tests instead.
 
-    #[test]
-    #[serial(global_schema)]
-    #[ignore = "Requires complete schema setup - verified in integration tests"]
-    fn test_two_hop_traversal_has_all_on_clauses() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+#[ignore = "Requires complete schema setup - verified in integration tests"]
+fn test_two_hop_traversal_has_all_on_clauses() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Bug scenario: (a)-[:FOLLOWS]->(b)-[:FOLLOWS]->(c)
-        // The second relationship join was missing its ON clause
-        let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN a.name, b.name, c.name";
-        let parse_result = open_cypher_parser::parse_query(cypher);
-        assert!(
-            parse_result.is_ok(),
-            "Failed to parse two-hop query: {:?}",
-            parse_result.err()
-        );
+    // Bug scenario: (a)-[:FOLLOWS]->(b)-[:FOLLOWS]->(c)
+    // The second relationship join was missing its ON clause
+    let cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN a.name, b.name, c.name";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse two-hop query: {:?}",
+        parse_result.err()
+    );
 
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
 
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
 
-        let render_plan = render_plan.unwrap();
+    let render_plan = render_plan.unwrap();
 
-        // Generate SQL to check JOIN structure
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+    // Generate SQL to check JOIN structure
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
 
-        println!("Two-hop SQL:\n{}", sql);
+    println!("Two-hop SQL:\n{}", sql);
 
-        // Critical check: Verify relationship table appears
-        assert!(
-            sql.contains("user_follows"),
-            "Expected user_follows table for FOLLOWS relationships: {}",
-            sql
-        );
+    // Critical check: Verify relationship table appears
+    assert!(
+        sql.contains("user_follows"),
+        "Expected user_follows table for FOLLOWS relationships: {}",
+        sql
+    );
 
-        // Most important: Each JOIN must have an ON clause (this was the bug)
-        // Count JOIN keywords (don't double-count "INNER JOIN" which contains "JOIN")
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        // Count ON clauses
-        let on_count = sql.matches(" ON ").count();
+    // Most important: Each JOIN must have an ON clause (this was the bug)
+    // Count JOIN keywords (don't double-count "INNER JOIN" which contains "JOIN")
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    // Count ON clauses
+    let on_count = sql.matches(" ON ").count();
 
-        // CRITICAL FIX VERIFICATION: All JOINs must have ON clauses
-        // For multi-hop (a)->(b)->(c): expect 4 JOINs with 4 ON clauses
-        // - JOIN 1: a -> follows (rel1)
-        // - JOIN 2: follows (rel1) -> b
-        // - JOIN 3: b -> follows (rel2)
-        // - JOIN 4: follows (rel2) -> c
-        assert!(
-            on_count > 0 && on_count == join_count,
-            "Missing ON clauses for multi-hop query: {} JOINs but only {} ON clauses.\nSQL: {}",
-            join_count,
-            on_count,
-            sql
-        );
+    // CRITICAL FIX VERIFICATION: All JOINs must have ON clauses
+    // For multi-hop (a)->(b)->(c): expect 4 JOINs with 4 ON clauses
+    // - JOIN 1: a -> follows (rel1)
+    // - JOIN 2: follows (rel1) -> b
+    // - JOIN 3: b -> follows (rel2)
+    // - JOIN 4: follows (rel2) -> c
+    assert!(
+        on_count > 0 && on_count == join_count,
+        "Missing ON clauses for multi-hop query: {} JOINs but only {} ON clauses.\nSQL: {}",
+        join_count,
+        on_count,
+        sql
+    );
 
-        // Verify no JOIN is missing its ON clause (pattern: "JOIN table AS alias\n" without ON)
-        // This is the specific bug we fixed: JOIN without ON clause
-        if sql.contains("INNER JOIN") || sql.contains("LEFT JOIN") {
-            let lines: Vec<&str> = sql.lines().collect();
-            for (i, line) in lines.iter().enumerate() {
-                if line.contains("JOIN ") && !line.contains("--") {
-                    // Skip comments
-                    // Next non-empty line should contain "ON" or be another JOIN or end of query
-                    if let Some(next_line) = lines.get(i + 1) {
-                        let next_trimmed = next_line.trim();
-                        if !next_trimmed.is_empty()
-                            && !next_trimmed.starts_with("ON")
-                            && !next_trimmed.contains("JOIN")
-                            && !next_trimmed.contains("WHERE")
-                            && !next_trimmed.contains("LIMIT")
-                            && !next_trimmed.contains("ORDER BY")
-                        {
-                            panic!(
+    // Verify no JOIN is missing its ON clause (pattern: "JOIN table AS alias\n" without ON)
+    // This is the specific bug we fixed: JOIN without ON clause
+    if sql.contains("INNER JOIN") || sql.contains("LEFT JOIN") {
+        let lines: Vec<&str> = sql.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if line.contains("JOIN ") && !line.contains("--") {
+                // Skip comments
+                // Next non-empty line should contain "ON" or be another JOIN or end of query
+                if let Some(next_line) = lines.get(i + 1) {
+                    let next_trimmed = next_line.trim();
+                    if !next_trimmed.is_empty()
+                        && !next_trimmed.starts_with("ON")
+                        && !next_trimmed.contains("JOIN")
+                        && !next_trimmed.contains("WHERE")
+                        && !next_trimmed.contains("LIMIT")
+                        && !next_trimmed.contains("ORDER BY")
+                    {
+                        panic!(
                                 "JOIN at line {} appears to be missing ON clause. Line: '{}', Next: '{}'",
                                 i, line, next_trimmed
                             );
-                        }
                     }
                 }
             }
         }
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    #[ignore = "Requires complete schema setup - verified in integration tests"]
-    fn test_three_hop_traversal_has_all_on_clauses() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+#[ignore = "Requires complete schema setup - verified in integration tests"]
+fn test_three_hop_traversal_has_all_on_clauses() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Extended test: (a)-[:FOLLOWS]->(b)-[:FOLLOWS]->(c)-[:FOLLOWS]->(d)
-        let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User)-[:FOLLOWS]->(d:User) RETURN a.name, d.name";
-        let parse_result = open_cypher_parser::parse_query(cypher);
+    // Extended test: (a)-[:FOLLOWS]->(b)-[:FOLLOWS]->(c)-[:FOLLOWS]->(d)
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User)-[:FOLLOWS]->(d:User) RETURN a.name, d.name";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse three-hop query: {:?}",
+        parse_result.err()
+    );
+
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
+
+    let render_plan = render_plan.unwrap();
+
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+
+    println!("Three-hop SQL:\n{}", sql);
+
+    // Verify relationship tables appear
+    assert!(
+        sql.contains("user_follows"),
+        "Expected user_follows table: {}",
+        sql
+    );
+
+    // Critical: All JOINs must have ON clauses
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    let on_count = sql.matches(" ON ").count();
+    assert!(
+        on_count > 0 && join_count > 0,
+        "Three-hop query should have JOINs with ON clauses: {} JOINs, {} ON clauses",
+        join_count,
+        on_count
+    );
+
+    // Verify no JOIN is missing ON clause
+    if join_count > 0 {
         assert!(
-            parse_result.is_ok(),
-            "Failed to parse three-hop query: {:?}",
-            parse_result.err()
-        );
-
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
-
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
-
-        let render_plan = render_plan.unwrap();
-
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
-
-        println!("Three-hop SQL:\n{}", sql);
-
-        // Verify relationship tables appear
-        assert!(
-            sql.contains("user_follows"),
-            "Expected user_follows table: {}",
-            sql
-        );
-
-        // Critical: All JOINs must have ON clauses
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        let on_count = sql.matches(" ON ").count();
-        assert!(
-            on_count > 0 && join_count > 0,
-            "Three-hop query should have JOINs with ON clauses: {} JOINs, {} ON clauses",
+            on_count >= join_count / 2, // Allow optimizer to merge some joins
+            "Too many JOINs missing ON clauses in three-hop: {} JOINs but only {} ON clauses",
             join_count,
             on_count
         );
-
-        // Verify no JOIN is missing ON clause
-        if join_count > 0 {
-            assert!(
-                on_count >= join_count / 2, // Allow optimizer to merge some joins
-                "Too many JOINs missing ON clauses in three-hop: {} JOINs but only {} ON clauses",
-                join_count,
-                on_count
-            );
-        }
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    fn test_multi_hop_intermediate_nodes_referenced() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+fn test_multi_hop_intermediate_nodes_referenced() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test where intermediate nodes are referenced in RETURN
-        // This should NOT cause joins to be dropped
-        let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN a, b, c";
-        let parse_result = open_cypher_parser::parse_query(cypher);
+    // Test where intermediate nodes are referenced in RETURN
+    // This should NOT cause joins to be dropped
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN a, b, c";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse query: {:?}",
+        parse_result.err()
+    );
+
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
+
+    let render_plan = render_plan.unwrap();
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+
+    println!("Multi-hop with intermediate nodes SQL:\n{}", sql);
+
+    // Verify SQL is generated
+    assert!(
+        sql.to_lowercase().contains("select"),
+        "Should have SELECT clause: {}",
+        sql
+    );
+
+    // Critical: Verify all JOINs have ON clauses (the actual bug we fixed)
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    let on_count = sql.matches(" ON ").count();
+    if join_count > 0 {
         assert!(
-            parse_result.is_ok(),
-            "Failed to parse query: {:?}",
-            parse_result.err()
-        );
-
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
-
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
-
-        let render_plan = render_plan.unwrap();
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
-
-        println!("Multi-hop with intermediate nodes SQL:\n{}", sql);
-
-        // Verify SQL is generated
-        assert!(
-            sql.to_lowercase().contains("select"),
-            "Should have SELECT clause: {}",
-            sql
-        );
-
-        // Critical: Verify all JOINs have ON clauses (the actual bug we fixed)
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        let on_count = sql.matches(" ON ").count();
-        if join_count > 0 {
-            assert!(
                 on_count > 0,
                 "Multi-hop with all nodes referenced: {} JOINs but {} ON clauses (should have ON clauses)",
                 join_count,
                 on_count
             );
-        }
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    fn test_multi_hop_mixed_directions() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+fn test_multi_hop_mixed_directions() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test multi-hop with mixed directions: (a)-[:FOLLOWS]->(b)<-[:FOLLOWS]-(c)
-        let cypher =
-            "MATCH (a:User)-[:FOLLOWS]->(b:User)<-[:FOLLOWS]-(c:User) RETURN a.name, c.name";
-        let parse_result = open_cypher_parser::parse_query(cypher);
+    // Test multi-hop with mixed directions: (a)-[:FOLLOWS]->(b)<-[:FOLLOWS]-(c)
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)<-[:FOLLOWS]-(c:User) RETURN a.name, c.name";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse mixed-direction query: {:?}",
+        parse_result.err()
+    );
+
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
+
+    let render_plan = render_plan.unwrap();
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+
+    println!("Mixed-direction multi-hop SQL:\n{}", sql);
+
+    // Verify all JOINs have ON clauses (critical fix)
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    let on_count = sql.matches(" ON ").count();
+    if join_count > 0 {
         assert!(
-            parse_result.is_ok(),
-            "Failed to parse mixed-direction query: {:?}",
-            parse_result.err()
+            on_count > 0,
+            "Mixed-direction query: {} JOINs but {} ON clauses (should have ON clauses)",
+            join_count,
+            on_count
         );
-
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
-
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
-
-        let render_plan = render_plan.unwrap();
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
-
-        println!("Mixed-direction multi-hop SQL:\n{}", sql);
-
-        // Verify all JOINs have ON clauses (critical fix)
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        let on_count = sql.matches(" ON ").count();
-        if join_count > 0 {
-            assert!(
-                on_count > 0,
-                "Mixed-direction query: {} JOINs but {} ON clauses (should have ON clauses)",
-                join_count,
-                on_count
-            );
-        }
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    fn test_multi_hop_with_where_clause() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+fn test_multi_hop_with_where_clause() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test multi-hop with WHERE filtering on intermediate nodes
-        let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) WHERE b.name = 'Bob' RETURN a, c";
-        let parse_result = open_cypher_parser::parse_query(cypher);
+    // Test multi-hop with WHERE filtering on intermediate nodes
+    let cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) WHERE b.name = 'Bob' RETURN a, c";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse query with WHERE: {:?}",
+        parse_result.err()
+    );
+
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
+
+    let render_plan = render_plan.unwrap();
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+
+    println!("Multi-hop with WHERE SQL:\n{}", sql);
+
+    // Verify WHERE clause exists
+    assert!(
+        sql.contains("WHERE") || sql.contains("where"),
+        "Expected WHERE clause in SQL: {}",
+        sql
+    );
+
+    // Critical: Verify all JOINs have ON clauses (WHERE shouldn't affect this)
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    let on_count = sql.matches(" ON ").count();
+    if join_count > 0 {
         assert!(
-            parse_result.is_ok(),
-            "Failed to parse query with WHERE: {:?}",
-            parse_result.err()
+            on_count > 0,
+            "WHERE clause shouldn't remove ON clauses: {} JOINs but {} ON clauses",
+            join_count,
+            on_count
         );
-
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
-
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
-
-        let render_plan = render_plan.unwrap();
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
-
-        println!("Multi-hop with WHERE SQL:\n{}", sql);
-
-        // Verify WHERE clause exists
-        assert!(
-            sql.contains("WHERE") || sql.contains("where"),
-            "Expected WHERE clause in SQL: {}",
-            sql
-        );
-
-        // Critical: Verify all JOINs have ON clauses (WHERE shouldn't affect this)
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        let on_count = sql.matches(" ON ").count();
-        if join_count > 0 {
-            assert!(
-                on_count > 0,
-                "WHERE clause shouldn't remove ON clauses: {} JOINs but {} ON clauses",
-                join_count,
-                on_count
-            );
-        }
     }
+}
 
-    #[test]
-    #[serial(global_schema)]
-    #[ignore = "Requires complete schema setup - verified in integration tests"]
-    fn test_multi_hop_different_relationship_types() {
-        // Setup test schema
-        setup_test_schema();
+#[test]
+#[serial(global_schema)]
+#[ignore = "Requires complete schema setup - verified in integration tests"]
+fn test_multi_hop_different_relationship_types() {
+    // Setup test schema
+    setup_test_schema();
 
-        // Test multi-hop with different relationship types at each step
-        // (a)-[:FOLLOWS]->(b)-[:FRIENDS_WITH]->(c)
-        let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FRIENDS_WITH]->(c:User) RETURN a, c";
-        let parse_result = open_cypher_parser::parse_query(cypher);
+    // Test multi-hop with different relationship types at each step
+    // (a)-[:FOLLOWS]->(b)-[:FRIENDS_WITH]->(c)
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FRIENDS_WITH]->(c:User) RETURN a, c";
+    let parse_result = open_cypher_parser::parse_query(cypher);
+    assert!(
+        parse_result.is_ok(),
+        "Failed to parse multi-type query: {:?}",
+        parse_result.err()
+    );
+
+    let query = parse_result.unwrap();
+    let schema = get_test_schema();
+    let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    let render_plan = logical_plan.to_render_plan(&schema);
+    assert!(
+        render_plan.is_ok(),
+        "Failed to create render plan: {:?}",
+        render_plan.err()
+    );
+
+    let render_plan = render_plan.unwrap();
+    let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
+
+    println!("Multi-hop different types SQL:\n{}", sql);
+
+    // Verify at least one relationship table appears (optimizer may skip unreferenced ones)
+    let has_follows = sql.contains("user_follows");
+    let has_friendship = sql.contains("friendships");
+    assert!(
+        has_follows || has_friendship,
+        "Expected at least one relationship table (user_follows or friendships): {}",
+        sql
+    );
+
+    // Critical: Verify all JOINs have ON clauses
+    let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
+    let on_count = sql.matches(" ON ").count();
+    if join_count > 0 {
         assert!(
-            parse_result.is_ok(),
-            "Failed to parse multi-type query: {:?}",
-            parse_result.err()
+            on_count > 0,
+            "Multi-type traversal: {} JOINs but {} ON clauses (should have ON clauses)",
+            join_count,
+            on_count
         );
-
-        let query = parse_result.unwrap();
-        let schema = get_test_schema();
-        let (logical_plan, _plan_ctx) = build_logical_plan(&query, &schema, None, None, None)
-            .expect("Failed to build logical plan");
-
-        let render_plan = logical_plan.to_render_plan(&schema);
-        assert!(
-            render_plan.is_ok(),
-            "Failed to create render plan: {:?}",
-            render_plan.err()
-        );
-
-        let render_plan = render_plan.unwrap();
-        let sql = crate::clickhouse_query_generator::generate_sql(render_plan, 10);
-
-        println!("Multi-hop different types SQL:\n{}", sql);
-
-        // Verify at least one relationship table appears (optimizer may skip unreferenced ones)
-        let has_follows = sql.contains("user_follows");
-        let has_friendship = sql.contains("friendships");
-        assert!(
-            has_follows || has_friendship,
-            "Expected at least one relationship table (user_follows or friendships): {}",
-            sql
-        );
-
-        // Critical: Verify all JOINs have ON clauses
-        let join_count = sql.matches("INNER JOIN").count() + sql.matches("LEFT JOIN").count();
-        let on_count = sql.matches(" ON ").count();
-        if join_count > 0 {
-            assert!(
-                on_count > 0,
-                "Multi-type traversal: {} JOINs but {} ON clauses (should have ON clauses)",
-                join_count,
-                on_count
-            );
-        }
     }
 }


### PR DESCRIPTION
## Summary

Four test files had an inner `#[cfg(test)] mod foo { ... }` wrapper where the file itself was already declared as a module of the same name in its parent (and either already test-gated, or directly the test file). The inner mod was fully redundant — module path was `foo::foo`.

Files:
- \`src/graph_catalog/schema_validator/tests.rs\`
- \`src/clickhouse_query_generator/where_clause_tests.rs\`
- \`src/clickhouse_query_generator/edge_uniqueness_tests.rs\`
- \`src/render_plan/tests/multiple_relationship_tests.rs\`

For each: removed the inner \`mod foo {\` wrapper, the matching closing brace, and the \`use super::*;\` (file-level items are now adjacent to the tests, so no need to re-import). cargo fmt re-indented the bodies.

Clippy warnings: **50 → 46** (all 4 \`module_inception\` lints resolved).

## Test plan
- [x] cargo build clean
- [x] cargo clippy --all-targets — all 4 module_inception warnings cleared
- [x] cargo test — 1,653 tests pass
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)