### PR TITLE
refactor: factor very-complex types into named aliases

### DIFF
--- a/src/clickhouse_query_generator/function_registry.rs
+++ b/src/clickhouse_query_generator/function_registry.rs
@@ -27,6 +27,9 @@ fn wrap_epoch_millis_arg(args: &[String]) -> Vec<String> {
     }
 }
 
+/// Argument transformation: maps SQL-string args to (possibly rewritten) SQL-string args.
+pub type ArgTransform = fn(&[String]) -> Vec<String>;
+
 /// Function mapping entry
 #[derive(Clone)]
 pub struct FunctionMapping {
@@ -37,7 +40,7 @@ pub struct FunctionMapping {
     pub clickhouse_name: &'static str,
     /// Optional argument transformation function
     /// Takes SQL string args, returns transformed SQL string args
-    pub arg_transform: Option<fn(&[String]) -> Vec<String>>,
+    pub arg_transform: Option<ArgTransform>,
 }
 
 /// Get function mapping for a Neo4j function name

--- a/src/query_planner/analyzer/match_type_inference.rs
+++ b/src/query_planner/analyzer/match_type_inference.rs
@@ -340,11 +340,16 @@ pub fn infer_relationship_type_from_nodes(
 /// - `Ok(Some(combinations))` - Optimized list of valid type combinations
 /// - `Ok(None)` - No optimization needed (patterns not connected or already typed)
 /// - `Err(...)` - Too many combinations even after optimization
+/// One concrete (from_label, to_label, rel_type) triple chosen for an edge.
+pub type ResolvedTriple = (String, String, String);
+/// One full assignment of triples — one entry per pattern in input order.
+pub type PatternCombination = Vec<ResolvedTriple>;
+
 pub fn resolve_connected_patterns(
     patterns: Vec<(String, String, Vec<String>)>, // (from_alias, to_alias, rel_types)
     schema: &GraphSchema,
     max_combinations: usize,
-) -> LogicalPlanResult<Option<Vec<Vec<(String, String, String)>>>> {
+) -> LogicalPlanResult<Option<Vec<PatternCombination>>> {
     // patterns: [(r1_from, r1_to, r1_types), (r2_from, r2_to, r2_types), ...]
     // Each entry: (from_node_alias, to_node_alias, possible_rel_types)
 

--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -125,6 +125,9 @@ use crate::{
 // The default value (5) is now set directly in plan_builder.rs
 // via `max_inferred_types.unwrap_or(5)` and documented in plan_ctx.
 
+/// Result of `infer_pattern_types`: (inferred_edge_types, left_label, right_label).
+pub type InferredPatternTypes = (Option<Vec<String>>, Option<String>, Option<String>);
+
 pub struct TypeInference;
 
 impl TypeInference {
@@ -1844,7 +1847,7 @@ impl TypeInference {
         right_connection: &str,
         plan_ctx: &mut PlanCtx,
         graph_schema: &GraphSchema,
-    ) -> AnalyzerResult<(Option<Vec<String>>, Option<String>, Option<String>)> {
+    ) -> AnalyzerResult<InferredPatternTypes> {
         // STEP 1: Gather all KNOWN constraints
         let known_left_label = plan_ctx
             .get_table_ctx(left_connection)

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -5675,17 +5675,17 @@ pub fn get_fixed_path_info(
     }))
 }
 
+/// (node_aliases, rel_aliases, node_id_columns) — node_id_columns maps alias → (table, id_column).
+type PathAliasesWithIds = (
+    Vec<String>,
+    Vec<String>,
+    std::collections::HashMap<String, (String, String)>,
+);
+
 /// Collect node and relationship aliases plus ID column mappings
 fn collect_path_aliases_with_ids(
     plan: &LogicalPlan,
-) -> Result<
-    (
-        Vec<String>,
-        Vec<String>,
-        std::collections::HashMap<String, (String, String)>,
-    ),
-    super::errors::RenderBuildError,
-> {
+) -> Result<PathAliasesWithIds, super::errors::RenderBuildError> {
     let mut node_aliases = Vec::new();
     let mut rel_aliases = Vec::new();
     let mut node_id_columns = std::collections::HashMap::new();

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -6872,13 +6872,17 @@ fn populate_cte_property_mappings_from_render_plan(
 ///
 /// Returns (flattened_items, compound_key_mappings) where compound_key_mappings contains
 /// entries like ("msg.id", "latestLike_msg_id") for downstream property_mapping injection.
+/// (flattened_items, compound_key_mappings) — compound_key_mappings entries like
+/// ("msg.id", "latestLike_msg_id") feed downstream property_mapping injection.
+type FlattenedMapLiteralResult = (Vec<SelectItem>, Vec<(String, String)>);
+
 fn try_flatten_head_collect_map_literal(
     expr: &crate::query_planner::logical_expr::LogicalExpr,
     col_alias: Option<&str>,
     plan: &LogicalPlan,
     plan_ctx: Option<&PlanCtx>,
     scope: Option<&super::variable_scope::VariableScope>,
-) -> Option<(Vec<SelectItem>, Vec<(String, String)>)> {
+) -> Option<FlattenedMapLiteralResult> {
     use crate::query_planner::logical_expr::LogicalExpr;
 
     let alias = col_alias?;


### PR DESCRIPTION
## Summary

Introduces named type aliases at **5 sites** flagged by \`clippy::type_complexity\` to make function signatures and struct fields self-documenting. Each alias is placed adjacent to its first use and named for what the type *means* in domain terms, not what it's structurally made of.

## New aliases

| Alias | Underlying type | Where |
|---|---|---|
| \`ArgTransform\` | \`fn(&[String]) -> Vec<String>\` | \`clickhouse_query_generator/function_registry.rs\` — argument transform on a Neo4j → ClickHouse function mapping |
| \`ResolvedTriple\` | \`(String, String, String)\` | \`query_planner/analyzer/match_type_inference.rs\` — one chosen \`(from_label, to_label, rel_type)\` for an edge |
| \`PatternCombination\` | \`Vec<ResolvedTriple>\` | same — one full per-pattern assignment of triples |
| \`InferredPatternTypes\` | \`(Option<Vec<String>>, Option<String>, Option<String>)\` | \`query_planner/analyzer/type_inference.rs\` — result of \`infer_pattern_types\`: \`(inferred_edge_types, left_label, right_label)\` |
| \`PathAliasesWithIds\` | \`(Vec<String>, Vec<String>, HashMap<String, (String, String)>)\` | \`render_plan/cte_extraction.rs\` — \`(node_aliases, rel_aliases, alias → (table, id_column))\` |
| \`FlattenedMapLiteralResult\` | \`(Vec<SelectItem>, Vec<(String, String)>)\` | \`render_plan/plan_builder_utils.rs\` — \`(flattened_select_items, compound_key_mappings)\` |

## Clippy delta

31 → 27 warnings. (5 \`type_complexity\` warnings retired; total drop of 4 because one warning was lib + lib-test duplicate.)

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo fmt --all\` applied
- [x] \`cargo clippy --all-targets\` — all 5 \`type_complexity\` warnings retired
- [x] \`cargo test\` — 1,653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)