### PR TITLE
refactor: box CypherStatement::Query payload (large_enum_variant)

### DIFF
--- a/src/open_cypher_parser/ast.rs
+++ b/src/open_cypher_parser/ast.rs
@@ -11,11 +11,15 @@ pub enum UnionType {
 }
 
 /// A complete Cypher statement - either a regular query or a standalone procedure call
+///
+/// `Query.query` is boxed because `OpenCypherQueryAst` is ~720 bytes — far larger than
+/// `ProcedureCall` (~72 bytes) and `CopyTo` (~80 bytes). Without boxing, every value of
+/// this enum (including the small variants) pays the 720-byte cost. See clippy::large_enum_variant.
 #[derive(Debug, PartialEq, Clone)]
 pub enum CypherStatement<'a> {
     /// Regular query with optional UNION clauses
     Query {
-        query: OpenCypherQueryAst<'a>,
+        query: Box<OpenCypherQueryAst<'a>>,
         union_clauses: Vec<UnionClause<'a>>,
     },
     /// Standalone procedure call (e.g., CALL db.labels())

--- a/src/open_cypher_parser/mod.rs
+++ b/src/open_cypher_parser/mod.rs
@@ -81,7 +81,7 @@ pub fn parse_cypher_statement(
     Ok((
         input,
         CypherStatement::Query {
-            query: first_query,
+            query: Box::new(first_query),
             union_clauses,
         },
     ))

--- a/src/query_planner/ast_transform/mod.rs
+++ b/src/query_planner/ast_transform/mod.rs
@@ -41,10 +41,10 @@ pub fn transform_id_functions<'a>(
                 "  Transforming main query with {} MATCH clauses",
                 query.match_clauses.len()
             );
-            let transformed_query = transform_query(query, &mut transformer);
+            let transformed_query = transform_query(*query, &mut transformer);
 
             CypherStatement::Query {
-                query: transformed_query,
+                query: Box::new(transformed_query),
                 union_clauses: union_clauses
                     .into_iter()
                     .map(|uc| crate::open_cypher_parser::ast::UnionClause {
@@ -372,14 +372,14 @@ fn split_query_by_labels<'a>(
                             .cloned();
 
                         // Clone and modify the query to add the label
-                        modified_query = clone_query_with_label(
+                        modified_query = Box::new(clone_query_with_label(
                             arena,
                             &modified_query,
                             var_name,
                             label,
                             id_values,
                             schema,
-                        );
+                        ));
                     }
                 }
 
@@ -451,7 +451,7 @@ fn split_query_by_labels<'a>(
                     .collect();
 
                 for combo in &label_combos {
-                    let mut modified_query = query.clone();
+                    let mut modified_query: OpenCypherQueryAst<'_> = (*query).clone();
                     for (var_name, label) in combo {
                         let id_values = id_values_by_label
                             .get(*var_name)
@@ -507,7 +507,7 @@ fn split_query_by_labels<'a>(
                 );
 
                 return CypherStatement::Query {
-                    query: first,
+                    query: Box::new(first),
                     union_clauses: new_unions,
                 };
             }
@@ -600,7 +600,7 @@ fn split_query_by_labels<'a>(
                 new_union_clauses.len() + 1
             );
             CypherStatement::Query {
-                query: main_query,
+                query: Box::new(main_query),
                 union_clauses: new_union_clauses,
             }
         }

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -199,7 +199,7 @@ pub fn evaluate_cypher_statement(
             // If no union clauses, just evaluate the single query
             if union_clauses.is_empty() {
                 return evaluate_query(
-                    query,
+                    *query,
                     schema,
                     tenant_id,
                     view_parameter_values,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1167,7 +1167,7 @@ async fn query_handler_inner(
                 }
             };
             let logical_plan =
-                match query_planner::evaluate_call_query(query_ast.clone(), &graph_schema) {
+                match query_planner::evaluate_call_query((**query_ast).clone(), &graph_schema) {
                     Ok(plan) => plan,
                     Err(e) => {
                         // Return 400 for call planning errors (both sql_only and normal mode)

--- a/src/server/sql_generation_handler.rs
+++ b/src/server/sql_generation_handler.rs
@@ -231,7 +231,7 @@ pub async fn sql_generation_handler(
         // Note: CALL with UNION doesn't make sense, so we use the first query
         let planning_start = Instant::now();
         let logical_plan =
-            match query_planner::evaluate_call_query(first_query.clone(), &graph_schema) {
+            match query_planner::evaluate_call_query((**first_query).clone(), &graph_schema) {
                 Ok(plan) => plan,
                 Err(e) => {
                     let _planning_time = planning_start.elapsed().as_secs_f64() * 1000.0;


### PR DESCRIPTION
## Summary

Wraps the \`Query\` variant's \`query\` field in \`Box<OpenCypherQueryAst<'a>>\` so the enum's footprint isn't dominated by one variant.

| | Largest variant | Second-largest |
|---|---|---|
| Before | 728 bytes (\`Query\`) | 72 bytes (\`ProcedureCall\`) |
| After | ~80 bytes | 72 bytes |

Every value of \`CypherStatement\` — including the small \`ProcedureCall\` and \`CopyTo\` variants — was previously paying the 728-byte cost. Boxing the \`Query\` payload eliminates that overhead.

## Why the diff is small

Mechanical impact ended up at **6 files / 28 lines** thanks to Rust's auto-deref coercion at function-arg position — read-only call sites that pass \`&query\` or invoke methods through it compile unchanged. Only sites that **construct**, **move**, or **clone-by-value** the inner AST needed touching.

## Sites touched

- \`ast.rs\` — field type changed to \`Box<...>\`, with a doc comment explaining why
- \`open_cypher_parser/mod.rs\` — parser wraps parsed AST in \`Box::new\`
- \`ast_transform/mod.rs\` — \`Box::new\` at three construction sites; \`*query\` to deref out where ownership is taken; \`(*query).clone()\` where the inner AST is cloned
- \`logical_plan/mod.rs\` — \`*query\` to pass owned inner to \`evaluate_query\`
- \`server/handlers.rs\`, \`server/sql_generation_handler.rs\` — \`(**query_ast).clone()\` where caller needs the inner AST by value

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo build -p clickgraph-embedded\` clean (verifies the only other crate that destructures \`CypherStatement::Query\`)
- [x] \`cargo fmt --all\` applied
- [x] \`cargo clippy --all-targets\` — the lone \`large_enum_variant\` warning retired (27 → 26)
- [x] \`cargo test\` — 1,653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)