### PR TITLE
refactor: retire 4 too_many_arguments warnings (dead + test-only)

### DIFF
--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -165,6 +165,7 @@ impl NodeSchema {
 
     /// Helper for tests: Create a NodeSchema with default denormalized fields (traditional node pattern)
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)] // 9 fields are intrinsic to NodeSchema; test-only constructor
     pub fn new_traditional(
         database: String,
         table_name: String,

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -1348,6 +1348,7 @@ mod tests {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)] // builds a GraphRel test fixture; 8 args are the entity's fields
     fn make_test_graph_rel(
         left: Arc<LogicalPlan>,
         right: Arc<LogicalPlan>,

--- a/src/query_planner/analyzer/graph_join/tests.rs
+++ b/src/query_planner/analyzer/graph_join/tests.rs
@@ -273,6 +273,7 @@ fn create_graph_node(
     }))
 }
 
+#[allow(clippy::too_many_arguments)] // builds a GraphRel test fixture; 8 args are the entity's fields
 fn create_graph_rel(
     left: Arc<LogicalPlan>,
     center: Arc<LogicalPlan>,

--- a/src/query_planner/logical_plan/view_scan.rs
+++ b/src/query_planner/logical_plan/view_scan.rs
@@ -192,43 +192,6 @@ impl ViewScan {
         }
     }
 
-    /// Create a new relationship view scan with input plan
-    pub fn relationship_with_input(
-        source_table: String,
-        view_filter: Option<LogicalExpr>,
-        property_mapping: HashMap<String, PropertyValue>,
-        id_column: String,
-        output_schema: Vec<String>,
-        projections: Vec<LogicalExpr>,
-        from_id: impl Into<Identifier>,
-        to_id: impl Into<Identifier>,
-        input: Arc<LogicalPlan>,
-    ) -> Self {
-        ViewScan {
-            source_table,
-            view_filter,
-            property_mapping,
-            id_column,
-            output_schema,
-            projections,
-            from_id: Some(from_id.into()),
-            to_id: Some(to_id.into()),
-            input: Some(input),
-            view_parameter_names: None,
-            view_parameter_values: None,
-            use_final: false,       // Default: no FINAL
-            is_denormalized: false, // Default: not denormalized (for edges)
-            from_node_properties: None,
-            to_node_properties: None,
-            type_column: None,
-            type_values: None,
-            from_label_column: None,
-            to_label_column: None,
-            schema_filter: None, // Default: no schema-level filter
-            node_label: None,    // Not used for relationships
-        }
-    }
-
     /// Get the mapped column name for a property
     pub fn get_mapped_column(&self, property: &str) -> Option<&PropertyValue> {
         self.property_mapping.get(property)


### PR DESCRIPTION
## Summary

Tackles the easy wins in the \`too_many_arguments\` backlog — the cases where the right answer is **not** a builder/struct refactor, just deletion or documented allow.

### 1. Delete dead constructor

\`ViewScan::relationship_with_input\` (\`view_scan.rs\`) — 9-arg constructor with **zero callers** anywhere in the workspace. The companion \`new_relationship\` (8 args) covers the live case; the only divergence was setting \`input: Some(...)\`, which no caller ever needed.

### 2. Allow with rationale on three test-only fixtures

| Site | Why allow |
|---|---|
| \`graph_catalog/graph_schema.rs\` — \`NodeSchema::new_traditional\` | Already \`#[cfg(test)]\`; 9 fields are intrinsic to \`NodeSchema\` |
| \`query_planner/analyzer/bidirectional_union.rs\` — \`make_test_graph_rel\` | Test fixture; 8 args are the \`GraphRel\`'s identifying fields |
| \`query_planner/analyzer/graph_join/tests.rs\` — \`create_graph_rel\` | Test fixture; 8 args are the \`GraphRel\`'s identifying fields |

Each \`allow\` includes a one-line justification so a future reader can judge whether the rationale still applies.

## Clippy delta

26 → 22 warnings (4 \`too_many_arguments\` retired).

19 \`too_many_arguments\` warnings remain — all on production code where the parameter list is genuine and would need an args-struct refactor per site. Those need separate, individually-scoped PRs.

## Test plan
- [x] \`cargo build --all-targets\` clean
- [x] \`cargo fmt --all\` applied
- [x] \`cargo clippy --all-targets\` — 4 \`too_many_arguments\` retired
- [x] \`cargo test\` — 1,653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)