### PR TITLE
refactor: retire 5 too_many_arguments warnings in render_plan + view_scan

### DIFF
--- a/src/query_planner/logical_plan/view_scan.rs
+++ b/src/query_planner/logical_plan/view_scan.rs
@@ -157,6 +157,7 @@ impl ViewScan {
     }
 
     /// Create a new relationship view scan with source and target columns
+    #[allow(clippy::too_many_arguments)] // relationship view scan needs source table, filter, mapping, id columns, output schema, projections, and from/to id columns; all are intrinsic to the entity
     pub fn new_relationship(
         source_table: String,
         view_filter: Option<LogicalExpr>,

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -289,6 +289,7 @@ fn infer_node_labels_from_rel(
 ///
 /// # Returns
 /// A Cte ready to be added to the CTE list, or an error
+#[allow(clippy::too_many_arguments)] // VLP CTE generation requires the full pattern context (schema, spec, properties, all-three filter slots, mode, types, labels, options); each is a distinct planner input
 pub fn generate_vlp_cte_via_manager(
     pattern_ctx: &PatternSchemaContext,
     schema: &GraphSchema,
@@ -6440,128 +6441,6 @@ pub fn get_node_schema_by_table<'a>(
         }
     }
     None
-}
-
-/// Expand fixed-length path patterns into inline JOINs
-///
-/// This function generates JOIN clauses for exact hop-count patterns (*2, *3, etc.)
-/// without using CTEs. It directly chains relationship and node JOINs.
-///
-/// # Arguments
-/// * `exact_hops` - Number of hops (e.g., 2 for *2)
-/// * `start_table` - Table name for start node
-/// * `start_id_col` - ID column for start node
-/// * `rel_table` - Table name for relationship
-/// * `from_col` - From-node ID column in relationship table
-/// * `to_col` - To-node ID column in relationship table
-/// * `end_table` - Table name for end node
-/// * `end_id_col` - ID column for end node
-/// * `start_alias` - Cypher alias for start node
-/// * `end_alias` - Cypher alias for end node
-///
-/// # Returns
-/// Vector of JOIN items to be added to the FROM clause
-pub fn expand_fixed_length_joins(
-    exact_hops: u32,
-    _start_table: &str,
-    start_id_col: &str,
-    rel_table: &str,
-    from_col: &str,
-    to_col: &str,
-    end_table: &str,
-    end_id_col: &str,
-    start_alias: &str,
-    end_alias: &str,
-) -> Vec<Join> {
-    use super::render_expr::{
-        Operator, OperatorApplication, PropertyAccess, RenderExpr, TableAlias,
-    };
-
-    let mut joins = Vec::new();
-
-    log::debug!(
-        "expand_fixed_length_joins: Generating {} hops from {} to {}",
-        exact_hops,
-        start_alias,
-        end_alias
-    );
-
-    for hop in 1..=exact_hops {
-        let rel_alias = format!("r{}", hop);
-
-        // Determine previous node/relationship alias
-        let prev_alias = if hop == 1 {
-            start_alias.to_string()
-        } else {
-            // Bridge directly through previous relationship's to_id
-            format!("r{}", hop - 1)
-        };
-
-        let prev_id_col = if hop == 1 {
-            start_id_col.to_string()
-        } else {
-            to_col.to_string() // Bridge through previous relationship's to_id
-        };
-
-        // Add relationship JOIN
-        joins.push(Join {
-            table_name: rel_table.to_string(),
-            table_alias: rel_alias.clone(),
-            joining_on: vec![OperatorApplication {
-                operator: Operator::Equal,
-                operands: vec![
-                    RenderExpr::PropertyAccessExp(PropertyAccess {
-                        table_alias: TableAlias(prev_alias),
-                        column: PropertyValue::Column(prev_id_col),
-                    }),
-                    RenderExpr::PropertyAccessExp(PropertyAccess {
-                        table_alias: TableAlias(rel_alias.clone()),
-                        column: PropertyValue::Column(from_col.to_string()),
-                    }),
-                ],
-            }],
-            join_type: JoinType::Inner,
-            pre_filter: None,
-            from_id_column: None,
-            to_id_column: None,
-            graph_rel: None,
-        });
-
-        // TODO: Add intermediate node JOIN only if properties referenced
-        // For now, always bridge directly through relationship IDs (optimization!)
-    }
-
-    // Always add final node JOIN (the endpoint)
-    let last_rel = format!("r{}", exact_hops);
-    joins.push(Join {
-        table_name: end_table.to_string(),
-        table_alias: end_alias.to_string(),
-        joining_on: vec![OperatorApplication {
-            operator: Operator::Equal,
-            operands: vec![
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(last_rel),
-                    column: PropertyValue::Column(to_col.to_string()),
-                }),
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(end_alias.to_string()),
-                    column: PropertyValue::Column(end_id_col.to_string()),
-                }),
-            ],
-        }],
-        join_type: JoinType::Inner,
-        pre_filter: None,
-        from_id_column: None,
-        to_id_column: None,
-        graph_rel: None,
-    });
-
-    log::debug!(
-        "expand_fixed_length_joins: Generated {} JOINs (no intermediate nodes)",
-        joins.len()
-    );
-
-    joins
 }
 
 /// Schema-aware fixed-length VLP JOIN generation using VlpContext

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -377,6 +377,7 @@ impl Cte {
     }
 
     /// Create a new VLP CTE with endpoint information
+    #[allow(clippy::too_many_arguments)] // VLP endpoint metadata: each pair (alias, table, id_col) is needed for both start and end nodes; not factorable without losing clarity
     pub fn new_vlp(
         cte_name: String,
         content: CteContent,
@@ -424,44 +425,6 @@ impl Cte {
                 },
             ],
             from_alias: Some(VLP_CTE_FROM_ALIAS.to_string()), // VLP CTEs use standard FROM alias
-            outer_where_filters: None,
-            with_exported_aliases: Vec::new(),
-            variable_registry: None,
-        }
-    }
-
-    /// Create a new VLP CTE with full column metadata from CteGenerationResult
-    pub fn new_vlp_with_columns(
-        cte_name: String,
-        content: CteContent,
-        is_recursive: bool,
-        start_alias: String,
-        end_alias: String,
-        start_table: String,
-        end_table: String,
-        cypher_start_alias: String,
-        cypher_end_alias: String,
-        start_id_col: String,
-        end_id_col: String,
-        path_variable: Option<String>,
-        columns: Vec<CteColumnMetadata>,
-        from_alias: String,
-    ) -> Self {
-        Self {
-            cte_name,
-            content,
-            is_recursive,
-            vlp_start_alias: Some(start_alias),
-            vlp_end_alias: Some(end_alias),
-            vlp_start_table: Some(start_table),
-            vlp_end_table: Some(end_table),
-            vlp_cypher_start_alias: Some(cypher_start_alias),
-            vlp_cypher_end_alias: Some(cypher_end_alias),
-            vlp_start_id_col: Some(start_id_col),
-            vlp_end_id_col: Some(end_id_col),
-            vlp_path_variable: path_variable,
-            columns,
-            from_alias: Some(from_alias),
             outer_where_filters: None,
             with_exported_aliases: Vec::new(),
             variable_registry: None,


### PR DESCRIPTION
## Summary

Two dead deletions and three documented allows.

### Dead code deleted

| Site | Args | Note |
|---|---|---|
| \`Cte::new_vlp_with_columns\` | 14/7 | No callers anywhere in the workspace; only \`Cte::new_vlp\` is used |
| \`expand_fixed_length_joins\` | 10/7 | No callers; only the schema-aware \`expand_fixed_length_joins_with_context\` is used (from \`render_plan/join_builder.rs\` at two sites) |

### Documented allows with rationale

| Site | Args | Why allow |
|---|---|---|
| \`Cte::new_vlp\` | 12/7 | VLP endpoint metadata: each pair of \`(alias, table, id_col)\` is needed for both start and end nodes; not factorable without losing clarity |
| \`cte_extraction::generate_vlp_cte_via_manager\` | 19/7 | VLP CTE generation requires the full pattern context (schema, spec, properties, all-three filter slots, mode, types, labels, options); each is a distinct planner input |
| \`ViewScan::new_relationship\` | 8/7 | Relationship view scan needs source table, filter, mapping, id columns, output schema, projections, and from/to id columns; all intrinsic to the entity |

## Clippy delta

18 → 13 warnings (5 \`too_many_arguments\` retired).

## Test plan
- [x] \`cargo build --all-targets\` clean
- [x] \`cargo fmt --all\` applied
- [x] \`cargo clippy --all-targets\` — 5 \`too_many_arguments\` retired
- [x] \`cargo test\` — 1,653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)