### PR TITLE
docs: fix all 113 rustdoc broken-link warnings

### DIFF
--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -366,7 +366,7 @@ impl<'db> Connection<'db> {
     /// - Directed edges: `(n)-[:KNOWS {since: 2020}]->(m)`
     /// - Multi-statement blocks (multiple CREATE statements in one string)
     ///
-    /// Returns [`LoadStats`] with counts of nodes and edges inserted.
+    /// Returns [`LoadStats`](crate::cypher_loader::LoadStats) with counts of nodes and edges inserted.
     ///
     /// # Notes
     ///

--- a/clickgraph-embedded/src/cypher_loader.rs
+++ b/clickgraph-embedded/src/cypher_loader.rs
@@ -5,7 +5,7 @@
 //! **Low-level (parser only):** Parse a Cypher CREATE block into structured
 //! [`ParsedCreate`] data that you can inspect or transform before loading.
 //!
-//! **High-level (connection helper):** Use [`Connection::load_cypher_create`]
+//! **High-level (connection helper):** Use [`Connection::load_cypher_create`](crate::Connection::load_cypher_create)
 //! to parse and insert data in one call, returning [`LoadStats`].
 //!
 //! # Supported syntax
@@ -127,7 +127,7 @@ pub struct ParsedCreate {
     pub edges: Vec<ParsedEdge>,
 }
 
-/// Statistics returned by [`Connection::load_cypher_create`].
+/// Statistics returned by [`Connection::load_cypher_create`](crate::Connection::load_cypher_create).
 #[derive(Debug, Default, Clone)]
 pub struct LoadStats {
     /// Number of nodes inserted.

--- a/clickgraph-embedded/src/database.rs
+++ b/clickgraph-embedded/src/database.rs
@@ -351,6 +351,7 @@ fn build_runtime() -> Result<tokio::runtime::Runtime, EmbeddedError> {
         .map_err(|e| EmbeddedError::Query(format!("Failed to create runtime: {}", e)))
 }
 
+#[cfg(feature = "embedded")]
 fn pseudo_random_suffix() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()

--- a/src/clickhouse_query_generator/to_sql_query.rs
+++ b/src/clickhouse_query_generator/to_sql_query.rs
@@ -3693,8 +3693,8 @@ impl ToSql for FilterItems {
 /// ARRAY JOIN for ClickHouse - maps from Cypher UNWIND clauses
 /// Supports multiple UNWIND for cartesian product
 ///
-/// Example: UNWIND [1,2] AS x UNWIND [10,20] AS y
-/// Generates: ARRAY JOIN [1,2] AS x ARRAY JOIN [10,20] AS y
+/// Example: `UNWIND [1,2] AS x UNWIND [10,20] AS y`
+/// Generates: `ARRAY JOIN [1,2] AS x ARRAY JOIN [10,20] AS y`
 impl ToSql for ArrayJoinItem {
     fn to_sql(&self) -> String {
         if self.0.is_empty() {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -3,7 +3,7 @@
 //! The `QueryExecutor` trait abstracts over different SQL execution backends:
 //! - [`remote::RemoteClickHouseExecutor`] — wraps the existing `RoleConnectionPool`
 //!   for remote ClickHouse server connections.
-//! - [`chdb_embedded::ChdbExecutor`] — in-process chdb for embedded deployments
+//! - `chdb_embedded::ChdbExecutor` — in-process chdb for embedded deployments
 //!   (requires the `embedded` feature).
 
 use async_trait::async_trait;

--- a/src/graph_catalog/expression_parser.rs
+++ b/src/graph_catalog/expression_parser.rs
@@ -151,7 +151,7 @@ pub enum ClickHouseExpr {
         right: Box<ClickHouseExpr>,
     },
 
-    /// Array indexing: tags[1]
+    /// Array indexing: `tags[1]`
     ArrayIndex {
         array: Box<ClickHouseExpr>,
         index: Box<ClickHouseExpr>,

--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -285,14 +285,14 @@ pub struct RelationshipSchema {
     ///
     /// Two variants:
     /// 1. Self-referencing: edge table = from_node table = to_node table
-    ///    Example: fs_objects.parent_id → fs_objects.object_id
-    ///    Query: (child:Object)-[:PARENT]->(parent:Object)
-    ///    SQL:   child.parent_id = parent.object_id
+    ///    - Example: `fs_objects.parent_id → fs_objects.object_id`
+    ///    - Query: `(child:Object)-[:PARENT]->(parent:Object)`
+    ///    - SQL:   `child.parent_id = parent.object_id`
     ///
     /// 2. Non-self-referencing: edge table = from_node table ≠ to_node table
-    ///    Example: orders.customer_id → customers.customer_id
-    ///    Query: (o:Order)-[:PLACED_BY]->(c:Customer)
-    ///    SQL:   o.customer_id = c.customer_id
+    ///    - Example: `orders.customer_id → customers.customer_id`
+    ///    - Query: `(o:Order)-[:PLACED_BY]->(c:Customer)`
+    ///    - SQL:   `o.customer_id = c.customer_id`
     ///
     /// Detection: edge table matches from_node OR to_node table, with no
     /// denormalized node properties (from_node_properties/to_node_properties).
@@ -1491,8 +1491,8 @@ impl GraphSchema {
     ///
     /// Example (Zeek DNS log):
     ///
-    /// - REQUESTED: (IP)-[:REQUESTED]->(Domain)  from dns_log
-    /// - RESOLVED_TO: (Domain)-[:RESOLVED_TO]->(ResolvedIP)  from dns_log
+    /// - REQUESTED: `(IP)-[:REQUESTED]->(Domain)`  from dns_log
+    /// - RESOLVED_TO: `(Domain)-[:RESOLVED_TO]->(ResolvedIP)`  from dns_log
     ///
     /// These are coupled because:
     ///
@@ -1500,7 +1500,7 @@ impl GraphSchema {
     /// - Coupling node: Domain (REQUESTED.to_node == RESOLVED_TO.from_node)
     ///
     /// IMPORTANT: Same edge type twice is NOT coupled - each hop is a different row!
-    /// For example: (a)-[r1:FLIGHT]->(b)-[r2:FLIGHT]->(c) requires joining two flight rows.
+    /// For example: `(a)-[r1:FLIGHT]->(b)-[r2:FLIGHT]->(c)` requires joining two flight rows.
     pub fn are_edges_coupled(&self, edge1_type: &str, edge2_type: &str) -> bool {
         // CRITICAL FIX: Same edge type is NEVER coupled!
         // Multi-hop on same edge type means different rows, must JOIN.
@@ -1535,7 +1535,7 @@ impl GraphSchema {
     /// Returns Some(CoupledEdgeInfo) if edges are coupled,
     /// where the coupling node connects them (same value in the same row)
     ///
-    /// For pattern: (a)-[e1]->(b)-[e2]->(c)
+    /// For pattern: `(a)-[e1]->(b)-[e2]->(c)`
     /// If e1 and e2 are coupled, returns Some(info) with coupling_node = "b"
     ///
     /// IMPORTANT: Same edge type twice is NOT coupled - each hop is a different row!

--- a/src/open_cypher_parser/ast.rs
+++ b/src/open_cypher_parser/ast.rs
@@ -25,7 +25,7 @@ pub enum CypherStatement<'a> {
     /// Standalone procedure call (e.g., CALL db.labels())
     ProcedureCall(StandaloneProcedureCall<'a>),
     /// COPY TO statement for exporting query results
-    /// Syntax: COPY (<cypher>) TO '<destination>' [FORMAT <fmt>] [(options)]
+    /// Syntax: `COPY (<cypher>) TO '<destination>' [FORMAT <fmt>] [(options)]`
     CopyTo(CopyToStatement<'a>),
 }
 
@@ -592,26 +592,26 @@ pub enum Expression<'a> {
     /// Used in ClickHouse array functions like arrayFilter, arrayMap
     /// Example: x -> x > 5, (x, y) -> x + y
     Lambda(LambdaExpression<'a>),
-    /// Pattern comprehension: [(pattern) WHERE condition | projection]
+    /// Pattern comprehension: `[(pattern) WHERE condition | projection]`
     /// Returns a list of projected values from matched patterns
-    /// Example: [(user)-[:FOLLOWS]->(follower) WHERE follower.active | follower.name]
+    /// Example: `[(user)-[:FOLLOWS]->(follower) WHERE follower.active | follower.name]`
     PatternComprehension(PatternComprehension<'a>),
-    /// List comprehension: [x IN list WHERE cond | expr]
+    /// List comprehension: `[x IN list WHERE cond | expr]`
     /// Filters and/or transforms a list
-    /// Example: [x IN range(1,10) WHERE x > 5 | x * 2]
-    /// Example: [p IN posts WHERE (p)-[:HAS_TAG]->()]
+    /// Example: `[x IN range(1,10) WHERE x > 5 | x * 2]`
+    /// Example: `[p IN posts WHERE (p)-[:HAS_TAG]->()]`
     ListComprehension(ListComprehension<'a>),
-    /// Array subscript: array[index]
+    /// Array subscript: `array[index]`
     /// Access element at specified index (1-based in Cypher)
-    /// Example: labels(n)[1], list[0], [1,2,3][2]
+    /// Example: `labels(n)[1]`, `list[0]`, `[1,2,3][2]`
     ArraySubscript {
         array: Box<Expression<'a>>,
         index: Box<Expression<'a>>,
     },
-    /// Array slicing: array[from..to]
+    /// Array slicing: `array[from..to]`
     /// Extract subarray from index 'from' to 'to' (inclusive, 0-based in Cypher)
-    /// Both bounds are optional: [..3], [2..], [..]
-    /// Example: list[0..5], collect(n)[..10], [1,2,3,4,5][2..4]
+    /// Both bounds are optional: `[..3]`, `[2..]`, `[..]`
+    /// Example: `list[0..5]`, `collect(n)[..10]`, `[1,2,3,4,5][2..4]`
     ArraySlicing {
         array: Box<Expression<'a>>,
         from: Option<Box<Expression<'a>>>,
@@ -633,9 +633,12 @@ pub struct LambdaExpression<'a> {
 }
 
 /// EXISTS subquery: checks if a pattern exists
+///
 /// Examples:
-///   EXISTS { (u)-[:FOLLOWS]->(:User) }
-///   EXISTS { MATCH (u)-[:FOLLOWS]->(f) WHERE f.active = true }
+/// ```text
+/// EXISTS { (u)-[:FOLLOWS]->(:User) }
+/// EXISTS { MATCH (u)-[:FOLLOWS]->(f) WHERE f.active = true }
+/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct ExistsSubquery<'a> {
     /// The pattern to check for existence
@@ -664,14 +667,18 @@ pub struct ReduceExpression<'a> {
 }
 
 /// Pattern comprehension: generates a list from pattern matches
-/// Syntax: [(pattern) WHERE condition | projection]
+///
+/// Syntax: `[(pattern) WHERE condition | projection]`
+///
 /// Examples:
-///   [(user)-[:FOLLOWS]->(f) | f.name] => ['Alice', 'Bob', 'Charlie']
-///   [(a)-[:KNOWS]->(b) WHERE b.age > 25 | b.name] => ['Dave', 'Eve']
-///   [(n)-[r]->(m) | r.weight] => [1.5, 2.0, 3.7]
+/// ```text
+/// [(user)-[:FOLLOWS]->(f) | f.name] => ['Alice', 'Bob', 'Charlie']
+/// [(a)-[:KNOWS]->(b) WHERE b.age > 25 | b.name] => ['Dave', 'Eve']
+/// [(n)-[r]->(m) | r.weight] => [1.5, 2.0, 3.7]
+/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct PatternComprehension<'a> {
-    /// The graph pattern to match (e.g., (user)-[:FOLLOWS]->(follower))
+    /// The graph pattern to match (e.g., `(user)-[:FOLLOWS]->(follower)`)
     pub pattern: Box<PathPattern<'a>>,
     /// Optional WHERE clause for filtering matches
     pub where_clause: Option<Box<Expression<'a>>>,
@@ -680,13 +687,17 @@ pub struct PatternComprehension<'a> {
 }
 
 /// List comprehension: filters and/or transforms a list
-/// Syntax: [variable IN list WHERE condition | projection]
+///
+/// Syntax: `[variable IN list WHERE condition | projection]`
 /// The WHERE clause and projection are both optional.
 /// When projection is None, returns the variable itself (identity filter).
+///
 /// Examples:
-///   [x IN range(1,10) WHERE x > 5] => [6, 7, 8, 9, 10]
-///   [x IN [1,2,3] | x * 2] => [2, 4, 6]
-///   [p IN posts WHERE (p)-[:HAS_TAG]->()]
+/// ```text
+/// [x IN range(1,10) WHERE x > 5] => [6, 7, 8, 9, 10]
+/// [x IN [1,2,3] | x * 2] => [2, 4, 6]
+/// [p IN posts WHERE (p)-[:HAS_TAG]->()]
+/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct ListComprehension<'a> {
     /// The iteration variable name (e.g., "x", "p")

--- a/src/procedures/db_schema_node_type_properties.rs
+++ b/src/procedures/db_schema_node_type_properties.rs
@@ -4,10 +4,10 @@
 //! Used by Neodash for richer schema introspection.
 //!
 //! Output columns:
-//! - nodeType: String (e.g., ":`User`")
-//! - nodeLabels: Vec<String> (e.g., ["User"])
+//! - nodeType: String (e.g., `":`User`"`)
+//! - nodeLabels: `Vec<String>` (e.g., `["User"]`)
 //! - propertyName: String (e.g., "name")
-//! - propertyTypes: Vec<String> (e.g., ["String"])
+//! - propertyTypes: `Vec<String>` (e.g., `["String"]`)
 //! - mandatory: bool (true if property always exists)
 
 use crate::graph_catalog::graph_schema::GraphSchema;

--- a/src/procedures/db_schema_rel_type_properties.rs
+++ b/src/procedures/db_schema_rel_type_properties.rs
@@ -6,7 +6,7 @@
 //! Output columns:
 //! - relType: String (e.g., ":`FOLLOWS`")
 //! - propertyName: String (e.g., "since")
-//! - propertyTypes: Vec<String> (e.g., ["DateTime"])
+//! - propertyTypes: `Vec<String>` (e.g., `["DateTime"]`)
 //! - mandatory: bool (true if property always exists)
 
 use crate::graph_catalog::graph_schema::GraphSchema;

--- a/src/query_planner/analyzer/graph_join/join_generation.rs
+++ b/src/query_planner/analyzer/graph_join/join_generation.rs
@@ -35,7 +35,7 @@ type AnalyzerResult<T> = Result<T, AnalyzerError>;
 // Resolved table info passed by caller
 // =============================================================================
 
-/// All resolved names for one (a)-[r]->(b) pattern.
+/// All resolved names for one `(a)-[r]->(b)` pattern.
 /// Caller resolves CTE vs base-table names before calling generate_pattern_joins.
 pub struct ResolvedTables<'a> {
     pub left_alias: &'a str,
@@ -53,7 +53,7 @@ pub struct ResolvedTables<'a> {
 // Step 1: Generate joins for one pattern — schema decides WHAT joins
 // =============================================================================
 
-/// Generate joins for a single (a)-[r]->(b) pattern based on JoinStrategy.
+/// Generate joins for a single `(a)-[r]->(b)` pattern based on JoinStrategy.
 ///
 /// Anchor-aware: if a node is already available (from a prior pattern), no FROM
 /// marker is generated for it. The edge table anchors on whichever node is available.

--- a/src/query_planner/analyzer/graph_join/metadata.rs
+++ b/src/query_planner/analyzer/graph_join/metadata.rs
@@ -43,24 +43,24 @@ pub struct PatternNodeInfo {
 }
 
 /// Metadata about an edge (relationship) in the MATCH pattern graph.
-/// Represents a single relationship pattern like -[r:TYPE]->
+/// Represents a single relationship pattern like `-[r:TYPE]->`
 #[derive(Debug, Clone)]
 pub struct PatternEdgeInfo {
     /// Edge variable alias (e.g., "r", "follows", "t1")
     pub alias: String,
-    /// Relationship types (e.g., ["FOLLOWS"], or ["FOLLOWS", "FRIENDS"] for [:FOLLOWS|FRIENDS])
+    /// Relationship types (e.g., `["FOLLOWS"]`, or `["FOLLOWS", "FRIENDS"]` for `[:FOLLOWS|FRIENDS]`)
     pub rel_types: Vec<String>,
-    /// Source node variable (e.g., "a" in (a)-[r]->(b))
+    /// Source node variable (e.g., "a" in `(a)-[r]->(b)`)
     pub from_node: String,
-    /// Target node variable (e.g., "b" in (a)-[r]->(b))
+    /// Target node variable (e.g., "b" in `(a)-[r]->(b)`)
     pub to_node: String,
     /// Whether this edge's properties are referenced in the query
     pub is_referenced: bool,
-    /// Whether this is a variable-length path (e.g., *1..3, *)
+    /// Whether this is a variable-length path (e.g., `*1..3`, `*`)
     pub is_vlp: bool,
     /// Whether this is a shortest path pattern
     pub is_shortest_path: bool,
-    /// Direction: Outgoing (-[r]->), Incoming (<-[r]-), Either (-[r]-)
+    /// Direction: Outgoing (`-[r]->`), Incoming (`<-[r]-`), Either (`-[r]-`)
     pub direction: Direction,
     /// Whether this edge is part of an OPTIONAL MATCH
     pub is_optional: bool,

--- a/src/query_planner/analyzer/graph_join/mod.rs
+++ b/src/query_planner/analyzer/graph_join/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Key Types
 //!
-//! - [`GraphJoinInference`] - Main analyzer pass implementing [`AnalyzerPass`]
+//! - [`GraphJoinInference`] - Main analyzer pass implementing `AnalyzerPass`
 //! - [`JoinContext`] - Tracks joined tables during traversal (re-exported from join_context)
 //! - [`VlpEndpointInfo`] - Variable-length path endpoint information
 //! - [`PatternGraphMetadata`] - Complete metadata for a MATCH clause

--- a/src/query_planner/analyzer/multi_type_vlp_expansion.rs
+++ b/src/query_planner/analyzer/multi_type_vlp_expansion.rs
@@ -14,13 +14,13 @@
 //! ```
 //!
 //! Valid 1-hop paths:
-//! - User-[FOLLOWS]->User
-//! - User-[AUTHORED]->Post
+//! - `User-[FOLLOWS]->User`
+//! - `User-[AUTHORED]->Post`
 //!
 //! Valid 2-hop paths:
-//! - User-[FOLLOWS]->User-[FOLLOWS]->User
-//! - User-[FOLLOWS]->User-[AUTHORED]->Post
-//! - User-[AUTHORED]->Post-[?]->??? (check schema for edges from Post)
+//! - `User-[FOLLOWS]->User-[FOLLOWS]->User`
+//! - `User-[FOLLOWS]->User-[AUTHORED]->Post`
+//! - `User-[AUTHORED]->Post-[?]->???` (check schema for edges from Post)
 //!
 //! Invalid paths are filtered out based on schema constraints.
 

--- a/src/query_planner/analyzer/where_property_extractor.rs
+++ b/src/query_planner/analyzer/where_property_extractor.rs
@@ -23,15 +23,15 @@ impl WherePropertyExtractor {
     /// Returns: HashMap mapping alias → set of property names
     ///
     /// # Examples
-    /// ```
-    /// // WHERE n.bytes_sent > 100
-    /// // Returns: {"n": {"bytes_sent"}}
+    /// ```text
+    /// WHERE n.bytes_sent > 100
+    /// Returns: {"n": {"bytes_sent"}}
     ///
-    /// // WHERE n.x = 1 AND n.y = 2
-    /// // Returns: {"n": {"x", "y"}}
+    /// WHERE n.x = 1 AND n.y = 2
+    /// Returns: {"n": {"x", "y"}}
     ///
-    /// // WHERE n.x > 1 OR r.y < 10
-    /// // Returns: {"n": {"x"}, "r": {"y"}}
+    /// WHERE n.x > 1 OR r.y < 10
+    /// Returns: {"n": {"x"}, "r": {"y"}}
     /// ```
     pub fn extract_property_references(
         where_clause: &WhereClause,

--- a/src/query_planner/ast_transform/id_function.rs
+++ b/src/query_planner/ast_transform/id_function.rs
@@ -46,7 +46,7 @@ pub struct IdFunctionTransformer<'a> {
     schema: Option<&'a crate::graph_catalog::GraphSchema>,
     /// Extracted label constraints for UNION pruning (variable → set of labels)
     pub label_constraints: HashMap<String, HashSet<String>>,
-    /// ID values grouped by variable and label: variable → label → [id_values]
+    /// ID values grouped by variable and label: `variable → label → [id_values]`
     pub id_values_by_label: HashMap<String, HashMap<String, Vec<String>>>,
 }
 

--- a/src/query_planner/logical_expr/mod.rs
+++ b/src/query_planner/logical_expr/mod.rs
@@ -47,7 +47,7 @@ pub enum LogicalExpr {
 
     Star,
 
-    /// Table Alias (e.g. (p)-[f:Follow]-(u), p, f and u are table alias expr).
+    /// Table Alias (e.g. `(p)-[f:Follow]-(u)`, p, f and u are table alias expr).
     TableAlias(TableAlias),
 
     ColumnAlias(ColumnAlias),
@@ -103,7 +103,7 @@ pub enum LogicalExpr {
         label: String,
     },
 
-    /// Pattern count: size((n)-[:REL]->())
+    /// Pattern count: `size((n)-[:REL]->())`
     /// Counts the number of matches for a relationship pattern
     /// Generates a correlated COUNT(*) subquery
     PatternCount(PatternCount),
@@ -113,23 +113,23 @@ pub enum LogicalExpr {
     /// Example: x -> x > 5
     Lambda(LambdaExpr),
 
-    /// Pattern comprehension: [(pattern) WHERE condition | projection]
+    /// Pattern comprehension: `[(pattern) WHERE condition | projection]`
     /// Returns a list of projected values from matched patterns
     /// Will be rewritten to OPTIONAL MATCH + collect() during query planning
     PatternComprehension(PatternComprehensionExpr),
 
-    /// Array subscript: array[index]
+    /// Array subscript: `array[index]`
     /// Access element at specified index (1-based in Cypher, converted to 0-based for ClickHouse)
-    /// Example: labels(n)[1], list[0], [1,2,3][2]
+    /// Example: `labels(n)[1]`, `list[0]`, `[1,2,3][2]`
     ArraySubscript {
         array: Box<LogicalExpr>,
         index: Box<LogicalExpr>,
     },
 
-    /// Array slicing: array[from..to]
+    /// Array slicing: `array[from..to]`
     /// Extract subarray from index 'from' to 'to' (0-based, inclusive in Cypher)
-    /// Both bounds are optional: [..3], [2..], [..]
-    /// Example: list[0..5], collect(n)[..10], [1,2,3,4,5][2..4]
+    /// Both bounds are optional: `[..3]`, `[2..]`, `[..]`
+    /// Example: `list[0..5]`, `collect(n)[..10]`, `[1,2,3,4,5][2..4]`
     ArraySlicing {
         array: Box<LogicalExpr>,
         from: Option<Box<LogicalExpr>>,
@@ -149,7 +149,7 @@ pub enum LogicalExpr {
 }
 
 /// Pattern count for size() on patterns
-/// Represents size((n)-[:REL]->()) which counts pattern matches
+/// Represents `size((n)-[:REL]->())` which counts pattern matches
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PatternCount {
     /// The pattern to count
@@ -191,10 +191,14 @@ pub struct LambdaExpr {
 }
 
 /// Pattern comprehension: returns list of values from pattern matches
-/// Example: [(user)-[:FOLLOWS]->(follower) WHERE follower.active | follower.name]
+///
+/// Example: `[(user)-[:FOLLOWS]->(follower) WHERE follower.active | follower.name]`
+///
 /// This will be rewritten during query planning to:
-///   OPTIONAL MATCH (user)-[:FOLLOWS]->(follower) WHERE follower.active
-///   RETURN collect(follower.name)
+/// ```text
+/// OPTIONAL MATCH (user)-[:FOLLOWS]->(follower) WHERE follower.active
+/// RETURN collect(follower.name)
+/// ```
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PatternComprehensionExpr {
     /// The graph pattern to match
@@ -884,7 +888,7 @@ mod tests {
 impl LogicalExpr {
     /// Check if this expression contains correlated subqueries (NOT PathPattern or EXISTS)
     /// Such expressions must go in WHERE clause, not JOIN ON (ClickHouse limitation)
-    /// Returns true for patterns like: NOT (a)-[:REL]-(b) or EXISTS((a)-[:REL]-(b))
+    /// Returns true for patterns like: `NOT (a)-[:REL]-(b)` or `EXISTS((a)-[:REL]-(b))`
     pub fn contains_not_path_pattern(&self) -> bool {
         match self {
             LogicalExpr::OperatorApplicationExp(op_app) => {

--- a/src/query_planner/logical_plan/match_clause/helpers.rs
+++ b/src/query_planner/logical_plan/match_clause/helpers.rs
@@ -255,7 +255,7 @@ pub fn compute_rel_node_labels(
 
 /// Compute left/right connection aliases based on relationship direction.
 ///
-/// Similar to `compute_rel_node_labels` but for string aliases rather than Option<String> labels.
+/// Similar to `compute_rel_node_labels` but for string aliases rather than `Option<String>` labels.
 /// Used to determine which node alias serves as the "from" and "to" connection for JOIN generation.
 ///
 /// # Arguments

--- a/src/query_planner/optimizer/mod.rs
+++ b/src/query_planner/optimizer/mod.rs
@@ -8,24 +8,24 @@
 //! | Pass | Purpose |
 //! |------|---------|
 //! | [`CartesianJoinExtraction`] | Extract CROSS JOINs from disconnected patterns |
-//! | [`FilterIntoGraphRel`] | Embed filters into GraphRel nodes |
-//! | [`ProjectionPushDown`] | Eliminate unused columns early |
-//! | [`CleanupViewScanFilters`] | Remove redundant filters on ViewScans |
-//! | [`FilterPushDown`] | Push filters closer to scans |
-//! | [`ViewOptimizer`] | Schema-aware view optimizations |
-//! | [`TrivialWithElimination`] | Remove unnecessary WITH clauses |
-//! | [`CollectUnwindElimination`] | Optimize collect/unwind sequences |
+//! | `FilterIntoGraphRel` | Embed filters into GraphRel nodes |
+//! | `ProjectionPushDown` | Eliminate unused columns early |
+//! | `CleanupViewScanFilters` | Remove redundant filters on ViewScans |
+//! | `FilterPushDown` | Push filters closer to scans |
+//! | `ViewOptimizer` | Schema-aware view optimizations |
+//! | `TrivialWithElimination` | Remove unnecessary WITH clauses |
+//! | `CollectUnwindElimination` | Optimize collect/unwind sequences |
 //!
 //! # Execution Order
 //!
 //! Passes are applied in a specific order for correctness across
 //! [`initial_optimization`] and [`final_optimization`]:
 //! 1. [`CartesianJoinExtraction`]
-//! 2. [`FilterIntoGraphRel`]
-//! 3. [`ProjectionPushDown`]
-//! 4. [`CleanupViewScanFilters`]
-//! 5. [`FilterPushDown`]
-//! 6. [`ViewOptimizer`]
+//! 2. `FilterIntoGraphRel`
+//! 3. `ProjectionPushDown`
+//! 4. `CleanupViewScanFilters`
+//! 5. `FilterPushDown`
+//! 6. `ViewOptimizer`
 //!
 //! # Usage
 //!

--- a/src/query_planner/optimizer/union_pruning.rs
+++ b/src/query_planner/optimizer/union_pruning.rs
@@ -40,12 +40,12 @@ use std::collections::{HashMap, HashSet};
 ///
 /// # Example
 ///
-/// ```ignore
-/// // WHERE id(a) IN [281474976710657, 281474976710658]
-/// // Returns: {"a": {"User"}}
+/// ```text
+/// WHERE id(a) IN [281474976710657, 281474976710658]
+/// Returns: {"a": {"User"}}
 ///
-/// // WHERE id(a) = 281474976710657 AND id(b) = 844424930131969
-/// // Returns: {"a": {"User"}, "b": {"Post"}}
+/// WHERE id(a) = 281474976710657 AND id(b) = 844424930131969
+/// Returns: {"a": {"User"}, "b": {"Post"}}
 /// ```
 pub fn extract_labels_from_id_where<'a>(
     where_clause: &ast::WhereClause<'a>,

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -153,21 +153,21 @@ pub struct PlanCtx {
     status_messages: Vec<(StatusLevel, String)>,
 
     /// Node type combinations for simple untyped node queries
-    /// Map: node_alias → Vec<label>
-    /// Example: {"n": ["User", "Post", "ZeekLog"]}
+    /// Map: `node_alias → Vec<label>`
+    /// Example: `{"n": ["User", "Post", "ZeekLog"]}`
     /// Used when a simple node query like `MATCH (n) RETURN n` can match multiple node types
     /// CTE generation will create UNION of all node tables
     node_combinations: HashMap<String, Vec<String>>,
 
     /// Pattern type combinations for untyped relationship patterns
-    /// Map: (from_alias, to_alias) → Vec<TypeCombination>
-    /// Example: {("a", "b"): [(User, FOLLOWS, User), (User, AUTHORED, Post), ...]}
+    /// Map: `(from_alias, to_alias) → Vec<TypeCombination>`
+    /// Example: `{("a", "b"): [(User, FOLLOWS, User), (User, AUTHORED, Post), ...]}`
     /// Used when pattern inference finds ambiguous nodes that could match multiple types
     /// CTE generation will create UNION of all valid pattern combinations
     pattern_combinations: HashMap<(String, String), Vec<TypeCombination>>,
 
     /// Connected pattern group combinations (optimization - WIP)
-    /// Map: group_id → Vec<GroupCombination>
+    /// Map: `group_id → Vec<GroupCombination>`
     /// Example: {"a_b_c": [GroupCombination{...}, ...]}
     /// Used when multiple patterns share variables (e.g., `(a)-[r1]->(b)-[r2]->(c)` shares `b`)
     /// Each GroupCombination assigns types to all patterns in the group consistently

--- a/src/query_planner/translator/property_resolver.rs
+++ b/src/query_planner/translator/property_resolver.rs
@@ -31,10 +31,10 @@ pub enum NodePosition {
 /// CRITICAL: For denormalized patterns, the same node alias can appear in
 /// multiple edges with different roles! We track the edge_alias to distinguish:
 ///
-/// Example: MATCH (a)-[f]->(b)-[g]->(c)
+/// Example: `MATCH (a)-[f]->(b)-[g]->(c)`
 ///   Node 'b' has TWO mappings:
-///   - (b, f) → TO position, maps b.city → f.DestCityName
-///   - (b, g) → FROM position, maps b.city → g.OriginCityName
+///   - `(b, f)` → TO position, maps `b.city → f.DestCityName`
+///   - `(b, g)` → FROM position, maps `b.city → g.OriginCityName`
 #[derive(Debug, Clone)]
 pub struct AliasMapping {
     /// SQL table alias (e.g., "f", "u1", "flights_cte")
@@ -94,8 +94,8 @@ pub struct PropertyResolver {
 
     /// Graph-to-SQL alias mapping
     ///
-    /// Key: (node_alias, edge_alias_opt) - composite key for denormalized multi-hop
-    /// Value: Vec<AliasMapping> to support multiple roles for same node
+    /// Key: `(node_alias, edge_alias_opt)` - composite key for denormalized multi-hop
+    /// Value: `Vec<AliasMapping>` to support multiple roles for same node
     /// Examples:
     ///
     /// - Standard: "u" → [AliasMapping{sql_alias: "u1", ...}]

--- a/src/render_plan/cte_generation.rs
+++ b/src/render_plan/cte_generation.rs
@@ -35,7 +35,7 @@ pub struct CteGenerationContext {
     fixed_length_joins: HashMap<String, (String, String, Vec<super::Join>)>,
     /// Variable length specification for the path pattern
     pub spec: VariableLengthSpec,
-    /// Path variable name (e.g., "p" in MATCH p = (a)-[*]->(b))
+    /// Path variable name (e.g., "p" in `MATCH p = (a)-[*]->(b)`)
     pub path_variable: Option<String>,
     /// Shortest path mode for shortestPath() and allShortestPaths()
     pub shortest_path_mode: Option<ShortestPathMode>,
@@ -43,7 +43,7 @@ pub struct CteGenerationContext {
     pub relationship_types: Option<Vec<String>>,
     /// Edge ID identifier from schema (for RETURN relationships(p))
     pub edge_id: Option<Identifier>,
-    /// Relationship Cypher alias (e.g., "r" in (a)-[r*]->(b))
+    /// Relationship Cypher alias (e.g., "r" in `(a)-[r*]->(b)`)
     pub relationship_cypher_alias: Option<String>,
     /// Start node label (for polymorphic heterogeneous paths)
     pub start_node_label: Option<String>,
@@ -53,7 +53,7 @@ pub struct CteGenerationContext {
     pub is_optional: bool,
 
     /// **NEW (Feb 2026)**: Multi-type pattern combinations for UNION generation
-    /// Map: (from_alias, to_alias) → Vec<TypeCombination>
+    /// Map: `(from_alias, to_alias) → Vec<TypeCombination>`
     /// When set, CTE generation creates UNION of all pattern combinations
     pub pattern_combinations:
         Option<HashMap<(String, String), Vec<crate::query_planner::plan_ctx::TypeCombination>>>,

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -91,7 +91,7 @@ pub struct VlpEndpointInfo {
     pub start_id_col: String,
     /// End node ID column name
     pub end_id_col: String,
-    /// Path variable name (e.g., "p" in MATCH p = (a)-[*]->(b))
+    /// Path variable name (e.g., "p" in `MATCH p = (a)-[*]->(b)`)
     pub path_variable: Option<String>,
 }
 

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -117,7 +117,7 @@ pub struct RenderPlan {
     pub union: UnionItems,
     /// Fixed path information for simple (non-VLP) path patterns
     /// Contains path variable name and hop count for queries like:
-    /// MATCH p = (a)-[:T]->(b) RETURN length(p)
+    /// `MATCH p = (a)-[:T]->(b) RETURN length(p)`
     pub fixed_path_info: Option<FixedPathMetadata>,
     /// Flag indicating this is a multi-label node scan (labelless MATCH (n))
     /// When true, the SELECT items should NOT be overwritten by Projection
@@ -138,7 +138,7 @@ pub struct RenderPlan {
 pub struct FixedPathMetadata {
     /// Path variable name from Cypher (e.g., "p")
     pub path_variable: String,
-    /// Number of relationships/hops in the path (e.g., 1 for (a)-[r]->(b))
+    /// Number of relationships/hops in the path (e.g., 1 for `(a)-[r]->(b)`)
     pub hop_count: u32,
     /// List of node table aliases in order: [start_alias, intermediate1, ..., end_alias]
     pub node_aliases: Vec<String>,
@@ -247,8 +247,8 @@ pub enum JoinType {
 /// ARRAY JOIN items for ClickHouse
 /// Maps from Cypher UNWIND clauses (supports multiple for cartesian product)
 ///
-/// Example: UNWIND [1,2] AS x UNWIND [10,20] AS y
-/// Generates: ARRAY JOIN [1,2] AS x ARRAY JOIN [10,20] AS y
+/// Example: `UNWIND [1,2] AS x UNWIND [10,20] AS y`
+/// Generates: `ARRAY JOIN [1,2] AS x ARRAY JOIN [10,20] AS y`
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Default)]
 pub struct ArrayJoinItem(pub Vec<ArrayJoin>);
 

--- a/src/render_plan/property_expansion.rs
+++ b/src/render_plan/property_expansion.rs
@@ -96,7 +96,7 @@ pub struct ExpandedProperty {
 /// - Defaults to all properties if no requirements for this alias
 ///
 /// # Examples
-/// ```ignore
+/// ```text
 /// // Without pruning (all properties):
 /// expand_alias_properties_core("p", props, "person_id", None, false, None)
 /// → [person_id, firstName, lastName, age, ...]  // All 50 columns
@@ -279,7 +279,7 @@ pub fn expand_alias_to_projection_items_unified(
 /// Vector of SelectItems with RenderExpr expressions (pruned if requirements provided)
 ///
 /// # Examples
-/// ```ignore
+/// ```text
 /// // Without pruning (current behavior):
 /// expand_alias_to_select_items_unified("p", props, "id", None, false, Dot, None)
 /// → 200 SelectItems (all columns)

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -727,17 +727,17 @@ pub enum RenderExpr {
     /// Used in duration({days: 5}), point({x: 1, y: 2}), etc.
     MapLiteral(Vec<(String, RenderExpr)>),
 
-    /// Pattern count: pre-rendered SQL for size((n)-[:REL]->())
+    /// Pattern count: pre-rendered SQL for `size((n)-[:REL]->())`
     PatternCount(PatternCount),
 
-    /// Array subscript: array[index]
+    /// Array subscript: `array[index]`
     /// Access element at specified index (1-based in Cypher, 0-based in ClickHouse)
     ArraySubscript {
         array: Box<RenderExpr>,
         index: Box<RenderExpr>,
     },
 
-    /// Array slicing: array[from..to]
+    /// Array slicing: `array[from..to]`
     /// Extract subarray from index 'from' to 'to' (0-based, inclusive in Cypher)
     ArraySlicing {
         array: Box<RenderExpr>,

--- a/src/server/bolt_protocol/graph_objects.rs
+++ b/src/server/bolt_protocol/graph_objects.rs
@@ -123,7 +123,7 @@ impl Path {
         }
     }
 
-    /// Create a simple single-hop path: (start)-[rel]->(end)
+    /// Create a simple single-hop path: `(start)-[rel]->(end)`
     pub fn single_hop(start_node: Node, relationship: Relationship, end_node: Node) -> Self {
         // For a single hop path: node[0] -> rel[0] -> node[1]
         // Indices: [1, 1] means "go to node 1 via relationship with index 1"
@@ -142,7 +142,7 @@ impl Path {
     ///
     /// # Returns
     ///
-    /// A Vec<u8> containing the packstream-encoded bytes
+    /// A `Vec<u8>` containing the packstream-encoded bytes
     pub fn to_packstream(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -235,7 +235,7 @@ impl Node {
     ///
     /// # Returns
     ///
-    /// A Vec<u8> containing the packstream-encoded bytes
+    /// A `Vec<u8>` containing the packstream-encoded bytes
     pub fn to_packstream(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -301,7 +301,7 @@ impl Relationship {
     ///
     /// # Returns
     ///
-    /// A Vec<u8> containing the packstream-encoded bytes
+    /// A `Vec<u8>` containing the packstream-encoded bytes
     pub fn to_packstream(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
@@ -343,7 +343,7 @@ impl Relationship {
     ///
     /// # Returns
     ///
-    /// A Vec<u8> containing the packstream-encoded bytes
+    /// A `Vec<u8>` containing the packstream-encoded bytes
     pub fn to_unbound_packstream(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 

--- a/src/server/bolt_protocol/messages.rs
+++ b/src/server/bolt_protocol/messages.rs
@@ -269,8 +269,8 @@ impl BoltMessage {
 
     /// Extract authentication token from HELLO message
     /// Bolt 4.x can send either:
-    /// - 1 field: combined auth+metadata in field[0]
-    /// - 2 fields: metadata in field[0], auth in field[1]
+    /// - 1 field: combined auth+metadata in `field[0]`
+    /// - 2 fields: metadata in `field[0]`, auth in `field[1]`
     pub fn extract_auth_token(&self) -> Option<HashMap<String, Value>> {
         if self.signature == signatures::HELLO {
             if self.fields.len() >= 2 {
@@ -301,8 +301,8 @@ impl BoltMessage {
     /// Extract database name from HELLO message extra metadata
     /// Neo4j 4.0+ clients can specify database using "db" or "database" field
     /// Bolt 4.x can send either:
-    /// - 1 field: combined auth+metadata in field[0] (check for "db"/"database" key)
-    /// - 2 fields: metadata in field[0], auth in field[1]
+    /// - 1 field: combined auth+metadata in `field[0]` (check for "db"/"database" key)
+    /// - 2 fields: metadata in `field[0]`, auth in `field[1]`
     pub fn extract_database(&self) -> Option<String> {
         if self.signature == signatures::HELLO && !self.fields.is_empty() {
             if let BoltValue::Json(Value::Object(extra_map)) = &self.fields[0] {

--- a/src/server/bolt_protocol/mod.rs
+++ b/src/server/bolt_protocol/mod.rs
@@ -6,7 +6,7 @@
 //! existing Neo4j ecosystem tools.
 //!
 //! Reference: Neo4j Bolt Protocol Specification v4.4
-//! https://7687.org/bolt/bolt-protocol-message-specification-4.html
+//! <https://7687.org/bolt/bolt-protocol-message-specification-4.html>
 
 use crate::executor::QueryExecutor;
 use std::collections::HashMap;

--- a/src/server/models.rs
+++ b/src/server/models.rs
@@ -19,7 +19,7 @@ pub struct QueryRequest {
     pub view_parameters: Option<HashMap<String, Value>>,
     /// ClickHouse role name for RBAC via SET ROLE (requires database-managed users with granted roles)
     pub role: Option<String>,
-    /// Maximum number of inferred edge types for generic patterns like [*1] (default: 4)
+    /// Maximum number of inferred edge types for generic patterns like `[*1]` (default: 4)
     /// Set higher for GraphRAG use cases with many edge types. Reasonable values: 4-20.
     pub max_inferred_types: Option<usize>,
 }


### PR DESCRIPTION
## Summary

Eliminates **all 113 rustdoc warnings** on `cargo doc -p clickgraph` (plus 3 in `clickgraph-embedded`) by wrapping Cypher patterns and Rust generics that appear in `///` doc comments in backticks — so rustdoc stops parsing `[:FOLLOWS]`, `[r:TYPE]`, `Vec<u8>`, etc. as intra-doc links or HTML tags.

Continues the mechanical-hygiene arc that took clippy to zero (PRs #287–#302).

## Categories of warnings fixed

- **81 `unresolved link` warnings** — Cypher syntax in prose (`[:FOLLOWS]`, `(a)-[r]->(b)`, `[1,2,3]`, `array[index]`, `*1..3`, etc.) was being read as intra-doc-link `[X]`. Wrapped in single backticks or fenced as ` ```text ``` ` for multi-line examples.
- **10 `unclosed HTML tag` warnings** — `Vec<u8>`, `Vec<String>`, `Option<String>`, `Vec<TypeCombination>` etc. were parsed as HTML tags. Wrapped in backticks.
- **10 `links to private item` warnings** — `src/query_planner/optimizer/mod.rs` table-of-passes used `[FilterPushDown]`-style intra-doc links to non-pub types. Demoted to plain ``` `code` ``` text.
- **4 Rust-code-block warnings** — example blocks containing Cypher / pseudo-code were fenced as ` ``` `, so rustdoc tried to compile them as Rust. Re-fenced as ` ```text `.
- **3 misc** — Bolt spec URL → `<…>` autolink; one private-trait intra-doc link demoted; `AnalyzerPass` link replaced with plain code (the trait is `pub(crate)`).

## Bonus

`clickgraph-embedded::pseudo_random_suffix` was warning as "function never used" — its only caller (`Database::from_schema`) is `#[cfg(feature = "embedded")]` but the helper itself wasn't gated. Added the same cfg.

## Verification

- `cargo doc --no-deps -p clickgraph` → **0 warnings** (was 113)
- `cargo doc --no-deps -p clickgraph-embedded` → **0 warnings** (was 5: 3 doc + 2 lib)
- `cargo clippy --all-targets` → still 0 warnings
- `cargo fmt --all` → clean
- `cargo test` → **1,652 passed, 0 failed** (66 ignored, unchanged)

No code semantics change: every edit is inside `///` doc comments except the single `#[cfg]` gate on the random-suffix helper.

## Test plan
- [x] `cargo doc --no-deps -p clickgraph` produces no warnings
- [x] `cargo clippy --all-targets` still clean
- [x] `cargo test` passes
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)