### PR TITLE
refactor: clear 9 clippy warnings in clickgraph-embedded

### DIFF
--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -21,6 +21,9 @@ use super::write_helpers;
 /// Default maximum CTE recursion depth for Cypher→SQL translation.
 const DEFAULT_MAX_CTE_DEPTH: u32 = 100;
 
+/// One pending edge insertion: `(from_raw_id, to_raw_id, properties)`.
+type PendingEdge = (String, String, HashMap<String, Value>);
+
 /// A connection to an embedded ClickGraph database.
 ///
 /// # Example
@@ -222,8 +225,7 @@ impl<'db> Connection<'db> {
         }
 
         // Group edges by type, extracting raw IDs from element_id strings
-        let mut edges_by_type: HashMap<String, Vec<(String, String, HashMap<String, Value>)>> =
-            HashMap::new();
+        let mut edges_by_type: HashMap<String, Vec<PendingEdge>> = HashMap::new();
         for edge in graph.edges() {
             let (_, from_raw_id) = parse_element_id(&edge.from_id).ok_or_else(|| {
                 EmbeddedError::Validation(format!("Invalid from element_id: {}", edge.from_id))
@@ -267,7 +269,7 @@ impl<'db> Connection<'db> {
     ) -> Result<String, EmbeddedError> {
         let node_schema = self.get_node_schema(label)?;
         let id_columns = node_schema.node_id.id.columns();
-        let id_col_strs: Vec<&str> = id_columns.iter().copied().collect();
+        let id_col_strs: Vec<&str> = id_columns.to_vec();
         let property_mappings =
             write_helpers::extract_property_mappings(&node_schema.property_mappings);
         write_helpers::validate_properties(&properties, &property_mappings, &id_col_strs)?;
@@ -476,7 +478,7 @@ impl<'db> Connection<'db> {
         }
         let node_schema = self.get_node_schema(label)?;
         let id_columns = node_schema.node_id.id.columns();
-        let id_col_strs: Vec<&str> = id_columns.iter().copied().collect();
+        let id_col_strs: Vec<&str> = id_columns.to_vec();
         let id_key = id_columns.first().copied().unwrap_or("id");
         let property_mappings =
             write_helpers::extract_property_mappings(&node_schema.property_mappings);
@@ -636,7 +638,7 @@ impl<'db> Connection<'db> {
         let node_schema = self.get_node_schema(label)?;
         write_helpers::check_writable(&node_schema.source, label)?;
         let id_columns = node_schema.node_id.id.columns();
-        let id_col_strs: Vec<&str> = id_columns.iter().copied().collect();
+        let id_col_strs: Vec<&str> = id_columns.to_vec();
         let property_mappings =
             write_helpers::extract_property_mappings(&node_schema.property_mappings);
         write_helpers::validate_properties(&filters, &property_mappings, &id_col_strs)?;
@@ -688,7 +690,7 @@ impl<'db> Connection<'db> {
         let node_schema = self.get_node_schema(label)?;
         write_helpers::check_writable(&node_schema.source, label)?;
         let id_columns = node_schema.node_id.id.columns();
-        let id_col_strs: Vec<&str> = id_columns.iter().copied().collect();
+        let id_col_strs: Vec<&str> = id_columns.to_vec();
         let property_mappings =
             write_helpers::extract_property_mappings(&node_schema.property_mappings);
         let (transformed_json, line_count) =
@@ -755,7 +757,7 @@ impl<'db> Connection<'db> {
         let node_schema = self.get_node_schema(label)?;
         write_helpers::check_writable(&node_schema.source, label)?;
         let id_columns = node_schema.node_id.id.columns();
-        let id_col_strs: Vec<&str> = id_columns.iter().copied().collect();
+        let id_col_strs: Vec<&str> = id_columns.to_vec();
         let property_mappings =
             write_helpers::extract_property_mappings(&node_schema.property_mappings);
         let sql = write_helpers::build_import_file_sql(

--- a/clickgraph-embedded/src/graph_result.rs
+++ b/clickgraph-embedded/src/graph_result.rs
@@ -107,6 +107,12 @@ pub struct GraphResultBuilder {
     seen_edges: HashSet<String>,
 }
 
+impl Default for GraphResultBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GraphResultBuilder {
     pub fn new() -> Self {
         Self {

--- a/clickgraph-embedded/src/result_display.rs
+++ b/clickgraph-embedded/src/result_display.rs
@@ -97,7 +97,7 @@ pub fn format_value(val: &Value) -> String {
                 return format_packed_edge_value(m);
             }
             let mut pairs: Vec<_> = m.iter().collect();
-            pairs.sort_by_key(|(k, _)| k.clone());
+            pairs.sort_by_key(|(k, _)| (*k).clone());
             let s: Vec<String> = pairs
                 .iter()
                 .map(|(k, v)| format!("{}: {}", k, format_map_value(v)))
@@ -359,7 +359,7 @@ pub fn format_json_value(v: &serde_json::Value) -> String {
         }
         serde_json::Value::Object(m) => {
             let mut pairs: Vec<_> = m.iter().collect();
-            pairs.sort_by_key(|(k, _)| k.clone());
+            pairs.sort_by_key(|(k, _)| (*k).clone());
             let s: Vec<String> = pairs
                 .iter()
                 .map(|(k, v)| format!("{k}: {}", format_json_value(v)))
@@ -500,7 +500,7 @@ pub fn format_rel_from_cols(cols_and_vals: &[(String, Value)], rel_type: &str) -
 
     let mut props: Vec<(String, String)> = cols_and_vals
         .iter()
-        .filter(|(col, _)| !INTERNAL_FIELDS.iter().any(|f| col.as_str() == *f))
+        .filter(|(col, _)| !INTERNAL_FIELDS.contains(&col.as_str()))
         .map(|(col, val)| (col.clone(), format_value(val)))
         .filter(|(_, v)| is_visible_prop_str(v))
         .collect();


### PR DESCRIPTION
## Summary

Clears all 9 clippy warnings on `cargo clippy -p clickgraph-embedded --lib`. These don't fire on the default workspace clippy (which doesn't enable the `embedded` feature) but they do fire when CI lints that crate directly.

All mechanical fixes:

- **`suspicious_double_ref_op`** ×2 in `result_display.rs` (lines 100, 362): `pairs: Vec<(&K, &V)>` from `m.iter().collect()` makes the closure arg `&(&K, &V)`, so `k.clone()` was cloning the outer `&` reference. Use `(*k).clone()`.
- **`manual_contains`** (`result_display.rs:503`): `iter().any(|f| col.as_str() == *f)` → `INTERNAL_FIELDS.contains(&col.as_str())`.
- **`new_without_default`** (`graph_result.rs`): added `Default` impl for `GraphResultBuilder` delegating to `new()`.
- **`iter_cloned_collect`** ×5 in `connection.rs` (lines 270/479/639/691/758): `id_columns.iter().copied().collect::<Vec<&str>>()` → `id_columns.to_vec()`.
- **`type_complexity`** (`connection.rs:225`): factored `(String, String, HashMap<String, Value>)` into a `PendingEdge` alias.

## Verification

- `cargo clippy -p clickgraph-embedded --lib` → 0 warnings (was 9)
- `cargo clippy --all-targets` (workspace default) → still 0
- `cargo doc --no-deps -p clickgraph-tool -p clickgraph-embedded -p clickgraph-client` → 0 warnings
- `cargo fmt --all` → clean
- `cargo test` → 1,652 passing, 0 failing (66 ignored, unchanged)

## Test plan
- [x] `cargo clippy -p clickgraph-embedded --lib` clean
- [x] `cargo clippy --all-targets` still clean
- [x] `cargo test` passes
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)