### PR TITLE
refactor: clear per-crate clippy warnings (tool + embedded)

### DIFF
--- a/clickgraph-embedded/src/result_display.rs
+++ b/clickgraph-embedded/src/result_display.rs
@@ -762,6 +762,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a literal formatting test input, not π
     fn test_format_value_float_frac() {
         assert_eq!(format_value(&Value::Float64(3.14)), "3.14");
     }

--- a/clickgraph-embedded/src/value.rs
+++ b/clickgraph-embedded/src/value.rs
@@ -217,6 +217,40 @@ impl From<JsonValue> for Value {
     }
 }
 
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Null => write!(f, "NULL"),
+            Value::Bool(b) => write!(f, "{}", b),
+            Value::Int64(n) => write!(f, "{}", n),
+            Value::Float64(n) => write!(f, "{}", n),
+            Value::String(s) | Value::Date(s) | Value::Timestamp(s) | Value::UUID(s) => {
+                write!(f, "{}", s)
+            }
+            Value::List(items) => {
+                write!(f, "[")?;
+                for (i, v) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", v)?;
+                }
+                write!(f, "]")
+            }
+            Value::Map(pairs) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in pairs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}: {}", k, v)?;
+                }
+                write!(f, "}}")
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,6 +452,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a literal SQL-formatting test input, not π
     fn test_sql_literal_int64_and_float64() {
         assert_eq!(Value::Int64(42).to_sql_literal().unwrap(), "42");
         assert_eq!(Value::Int64(-1).to_sql_literal().unwrap(), "-1");
@@ -470,39 +505,5 @@ mod tests {
     fn test_sql_literal_list_and_map_return_err() {
         assert!(Value::List(vec![]).to_sql_literal().is_err());
         assert!(Value::Map(vec![]).to_sql_literal().is_err());
-    }
-}
-
-impl std::fmt::Display for Value {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Value::Null => write!(f, "NULL"),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Int64(n) => write!(f, "{}", n),
-            Value::Float64(n) => write!(f, "{}", n),
-            Value::String(s) | Value::Date(s) | Value::Timestamp(s) | Value::UUID(s) => {
-                write!(f, "{}", s)
-            }
-            Value::List(items) => {
-                write!(f, "[")?;
-                for (i, v) in items.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", v)?;
-                }
-                write!(f, "]")
-            }
-            Value::Map(pairs) => {
-                write!(f, "{{")?;
-                for (i, (k, v)) in pairs.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}: {}", k, v)?;
-                }
-                write!(f, "}}")
-            }
-        }
     }
 }

--- a/clickgraph-embedded/tests/chdb_e2e.rs
+++ b/clickgraph-embedded/tests/chdb_e2e.rs
@@ -15,6 +15,8 @@
 //! **Note**: chdb supports only one session per process, so all tests share
 //! a single `Database` via `LazyLock`.
 
+#![cfg(feature = "embedded")]
+
 use std::sync::LazyLock;
 
 use clickgraph_embedded::{Connection, Database, SystemConfig};

--- a/clickgraph-embedded/tests/hybrid_e2e.rs
+++ b/clickgraph-embedded/tests/hybrid_e2e.rs
@@ -10,6 +10,8 @@
 //! **Note**: chdb supports only one session per process, so all tests share
 //! a single `Database` via `LazyLock`.
 
+#![cfg(feature = "embedded")]
+
 use std::process::Command;
 use std::sync::LazyLock;
 

--- a/clickgraph-tool/src/config.rs
+++ b/clickgraph-tool/src/config.rs
@@ -77,13 +77,13 @@ impl CgConfig {
 
         // ClickHouse user: explicit CLI/env > config file > "default"
         let ch_user = ch_user
-            .or_else(|| file_cfg.clickhouse.user.as_deref())
+            .or(file_cfg.clickhouse.user.as_deref())
             .unwrap_or("default")
             .to_string();
 
         // ClickHouse password: explicit CLI/env > config file > ""
         let ch_password = ch_password
-            .or_else(|| file_cfg.clickhouse.password.as_deref())
+            .or(file_cfg.clickhouse.password.as_deref())
             .unwrap_or("")
             .to_string();
 


### PR DESCRIPTION
## Summary

Continues the per-crate clippy cleanup. Default workspace `cargo clippy --all-targets` stays at 0; this clears warnings/errors that only surface when CI lints these crates directly:

### `clickgraph-tool` (`cargo clippy -p clickgraph-tool --all-targets`): 0 (was 4)

- **`redundant_closure`** ×2 in `config.rs:79,85`: `or_else(|| file_cfg.clickhouse.user.as_deref())` → `or(file_cfg.clickhouse.user.as_deref())`. The arg is already `Option<&str>`, no laziness needed.

### `clickgraph-embedded` (`cargo clippy -p clickgraph-embedded --all-targets`): 0 (was 2 errors + 1 warning)

- **`Database::new` not found** in `tests/chdb_e2e.rs`, `tests/hybrid_e2e.rs`: those tests call `Database::new` which is `#[cfg(feature = "embedded")]`-gated, but the test files themselves weren't, so they hard-errored when linting without `--features embedded`. Added `#![cfg(feature = "embedded")]` at the top of both files.
- **`approx_constant`** ×2 in `result_display.rs:766` and `value.rs:424`: literal `3.14` in formatting tests was flagged "did you mean `f64::consts::PI`?". It is *not* π — it's a deliberate fractional input chosen because it round-trips exactly through `Display`/`to_sql_literal`. Added `#[allow(clippy::approx_constant)]` on the two tests with rationale.
- **`items_after_test_module`** in `value.rs:221`: `mod tests` block was sitting in the middle of the file with `impl Display for Value` appearing *after* it. Moved `mod tests` to the bottom of the file. (Pure refactor — no logic change.)

## Verification

- `cargo clippy -p clickgraph-tool --all-targets` → 0 warnings
- `cargo clippy -p clickgraph-embedded --all-targets` → 0 warnings, 0 errors
- `cargo clippy --all-targets` (workspace default) → still 0
- `cargo fmt --all` → clean
- `cargo test` → **1,652 passing, 0 failing** (66 ignored, unchanged)

## Test plan
- [x] All four per-crate clippy invocations clean
- [x] Workspace clippy still clean
- [x] `cargo test` passes
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)