### PR TITLE
ci: lock in zero-warning state via -D warnings + fmt --all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         components: rustfmt, clippy
 
     - name: Code format check
-      run: cargo fmt -- --check
+      run: cargo fmt --all -- --check
 
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy --all-targets -- -D warnings
 
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
## Summary

After PRs #287–#306 cleared 68+ clippy warnings and 113 rustdoc warnings to reach a true 0-warning state, lock it in by making CI fail on any new warning. Tiny diff, zero risk — the workspace already passes both commands locally today.

## What changed

`.github/workflows/ci.yml`:

```diff
- run: cargo fmt -- --check
+ run: cargo fmt --all -- --check

- run: cargo clippy
+ run: cargo clippy --all-targets -- -D warnings
```

## Why each flag

- **`--all`** on `cargo fmt`: without it, only the root crate is checked; workspace members (`clickgraph-tool`, `clickgraph-embedded`, `clickgraph-client`, `clickgraph-ffi`) were silently skipped. The arc-of-cleanup PRs all ran `cargo fmt --all`, but CI was effectively only enforcing it on `clickgraph` itself.
- **`--all-targets`** on `cargo clippy`: includes tests, benches, examples — the per-crate clippy work in #305/#306 found warnings that only surface in those targets.
- **`-- -D warnings`**: turns any clippy warning into a CI failure. Without this, warnings can accumulate silently across PRs (which is exactly how 68+ warnings built up before the cleanup).

## Verification

Locally on this branch:
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo test` → 1,652 passing, 0 failing (unchanged)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] CI on this PR completes the new step successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)