### PR TITLE
chore: align clickgraph-client MSRV with workspace (1.70 → 1.85)

### DIFF
--- a/clickgraph-client/Cargo.toml
+++ b/clickgraph-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clickgraph-client"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.85"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary

`clickgraph-client/Cargo.toml` declared `rust-version = "1.70"` while every other workspace member uses `"1.85"`:

```
$ grep "^rust-version" Cargo.toml clickgraph-*/Cargo.toml
Cargo.toml:rust-version = "1.85"
clickgraph-client/Cargo.toml:rust-version = "1.70"   ← outlier
clickgraph-tool/Cargo.toml:rust-version = "1.85"
clickgraph-ffi/Cargo.toml:rust-version = "1.85"
clickgraph-tck/Cargo.toml:rust-version = "1.85"
clickgraph-embedded/Cargo.toml:rust-version = "1.85"
```

CI itself runs `toolchain: 1.92.0`. The `1.70` value was inherited from PR #146 (Mar 2025, schema-discovery feature) when `clickgraph-client` was first added and was never bumped along with the rest of the workspace.

The declaration is also misleading in practice: `rustyline = "15.0.0"` and `reqwest = "0.12"` already require well above 1.70, so this crate has not actually built on 1.70 for a long time.

## Why now

After #307 made CI fail on any clippy warning, the workspace is uniformly clean — and any inconsistency in declared metadata becomes more visible. Trivial mechanical alignment.

## What changed

One line:
```diff
- rust-version = "1.70"
+ rust-version = "1.85"
```

## Verification

- `cargo build -p clickgraph-client` → success
- `cargo clippy -p clickgraph-client --all-targets -- -D warnings` → 0 warnings
- `cargo clippy --all-targets -- -D warnings` (workspace) → 0 warnings

## Test plan
- [x] `cargo build -p clickgraph-client`
- [x] `cargo clippy -p clickgraph-client --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)