### PR TITLE
release: prep v0.6.7-dev — version bump + CHANGELOG/STATUS refresh + audit dispositioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.7-dev] - 2026-05-04
+## [0.6.7-dev] - 2026-05-06
 
 ### 🚀 Features
 
@@ -19,7 +19,17 @@
 
 - **TCK 100%** (PR #273): All 402 read scenarios passing — fixed list indexing (negative indices + out-of-range → null), type validation, step-regex parsing, and DELETE detection regressions.
 
+- **Default HTTP port 7475** (#310): Changed from `8080` to `7475` to align with Neo4j Browser conventions (Neo4j HTTP is `7474`, ClickGraph sits one above) and avoid conflict with the common dev port. CLI / env override unchanged.
+
 ### 🧹 Infrastructure
+
+- **CI zero-warning enforcement** (#307): `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` now run as required CI checks, locking in the zero-warning state achieved by the cleanup arc (#287–#306).
+
+- **Per-crate clippy cleanup** (#305, #306): Cleared the remaining warnings in `clickgraph-embedded` (9 sites) and `clickgraph-tool` so every workspace crate now lints clean.
+
+- **Workspace MSRV alignment** (#308): Bumped `clickgraph-client`'s MSRV from 1.70 → 1.85 to match the workspace; removes the only outlier and lets `rust-toolchain` be a single value.
+
+- **Test-tree cleanup** (#309): Deleted 5 orphan test directories and 5 unused deprecated items flagged by clippy/dead-code analysis.
 
 - **Clippy zero-warnings** (PRs #287–#302, 16 PRs): The `cargo clippy --all-targets` count went from 68 to 0. Highlights:
   - Dropped the **`pattern_resolver` module** (#287): superseded by `TypeInference` since the unified type-inference pass landed; ~1,400 lines of dead code removed.
@@ -33,6 +43,10 @@
 
 ### 🐛 Bug Fixes
 
+- **Neo4j Browser 5.x compatibility** (#312): Browser 5.x's connect flow now lands cleanly. (a) `CALL dbms.components()` is intercepted in the Bolt handler and answered with the canonical `(name, versions, edition)` shape — without it Browser shows "Failed to check Neo4j version. Invalid version: ". (b) Browser's bundled `count(n) UNION ALL count(r)` and `db.labels() / db.relationshipTypes() / db.propertyKeys()` queries are short-circuited (the SQL generator can't UNION-ALL disjoint count projections). (c) ~12 read-only `SHOW` commands Browser issues to populate sidebars (`SHOW INDEXES`, `SHOW CONSTRAINTS`, `SHOW PROCEDURES`, `SHOW FUNCTIONS`, …) are stubbed with the canonical Neo4j 5.x field schema and zero rows. (d) Iterative click-to-expand is stable across canvas growth: relationship `element_id` generation is now unified across all code paths (canonical `Type:from->to-` form), so the same logical edge dedupes correctly across expansions from either endpoint. (e) Same-label directed relationships (e.g., `FOLLOWS:User→User`) carry schema-natural FK direction via new `r_from_id`/`r_to_id` projections from the multi-type VLP CTE, so expanding from either end produces an identical `element_id`. (f) Browser-compat trailing `-` sentinel on element_ids switches Browser into elementId-mode, preventing the legacy `parseInt → NaN → 0` collapse where every node ended up with id 0.
+
+- **shortestPath / allShortestPaths + COUNT regression** (#311): Several path-aggregation queries that regressed during the write-path landing are restored; test-stack glue cleanup.
+
 - **Browser expand regression** (#268): three root-cause fixes for Neo4j Browser node-expand path.
 - **FFI memory cap** (#271): `max_memory_usage_bytes` exposed in FFI `SystemConfig`.
 - **TCK list & equality semantics** (#273): list indexing (`l[i]` / `l[-i]` / out-of-range), type validation, regex-based step parsing, DELETE detection.
@@ -40,11 +54,16 @@
 ### 🔒 Security
 
 - **`rustls-webpki`** 0.103.10 → 0.103.13 (#274) — RUSTSEC-2026-0098 / 0099 / 0104.
+- **Audit dispositioning** — `cargo audit` is clean (0 vulnerabilities). Three transitive-only `unsound`/`unmaintained` warnings are explicitly dispositioned in `deny.toml`:
+  - **RUSTSEC-2025-0134** (`rustls-pemfile` unmaintained): pulled by `chdb-rust → reqwest 0.11`; functioning code path, upstream upgrade pending.
+  - **RUSTSEC-2026-0097** (`rand` 0.8.5 / 0.9.2 unsound): only triggers when a custom global logger calls `rand::rng()` during init. ClickGraph does not install such a logger, so the unsound pattern cannot be reached. Transitive via `tungstenite 0.21` and `quinn-proto`.
+- `cargo deny` and `cargo audit` continue to gate every PR via CI (workflow added in #178).
 
 ### 📚 Documentation
 
 - **Embedded-writes design plan** (#275, #276): `docs/design/embedded-writes.md` with phase decomposition, ID-generation strategy, and counter design.
 - **`motivation.md`** (#272): project motivation document.
+- **rustdoc broken-link sweep** (#304): fixed all 113 `--no-deps` rustdoc warnings; `cargo doc` is now warning-clean.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clickgraph"
-version = "0.6.6-dev"
+version = "0.6.7-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "clickgraph"
-version = "0.6.6-dev"
+version = "0.6.7-dev"
 edition = "2021"
 rust-version = "1.85"
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # ClickGraph Status
 
-*Updated: May 4, 2026*
+*Updated: May 6, 2026*
 
 ## Current Version: v0.6.7-dev
 
@@ -53,7 +53,7 @@ Supports server mode, embedded (in-process chdb), remote ClickHouse, and SQL-onl
 - **Property pruning**: Untyped queries skip tables missing referenced properties (10x–50x speedup)
 - **Multi-schema**: USE clause, per-request schema selection, GLOBAL_SCHEMAS registry
 - **Multi-tenancy**: Parameterized views with `tenant_id`, session commands (`CALL sys.set`)
-- **Neo4j Bolt v5.8**: Browser click-to-expand, schema procedures, session commands, EXPLAIN handling
+- **Neo4j Bolt v5.8**: Browser click-to-expand, schema procedures, session commands, EXPLAIN handling. Browser 5.x compat (v0.6.7+): `CALL dbms.components()` answered with canonical `(name, versions, edition)`; bundled `count(n) UNION ALL count(r)` and `db.labels()/relationshipTypes()/propertyKeys()` queries short-circuited; ~12 read-only `SHOW` commands stubbed with the canonical 5.x field schema; element_id format unified across all paths so iterative click-to-expand dedupes correctly across endpoints.
 - **Schema variations**: Standard, denormalized, FK-edge, polymorphic, composite ID, multi-tenant
 - **Query cache**: Keyed by query + schema + tenant_id + view_parameters
 - **LLM-powered schema discovery**: Interactive schema generation from natural language via Anthropic/OpenAI

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,11 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # RUSTSEC-2025-0134: rustls-pemfile is unmaintained, but this is a transitive
 # dependency of reqwest v0.11 which we cannot upgrade without a larger refactor.
 # Not a security vulnerability — the crate still functions correctly.
-ignore = ["RUSTSEC-2025-0134"]
+# RUSTSEC-2026-0097: rand 0.8.5 / 0.9.2 are unsound only when used with a
+# custom global logger that calls `rand::rng()` during init. Transitive only
+# (tungstenite 0.21 and quinn-proto). ClickGraph does not install a custom
+# logger that triggers this pattern, so the unsound path cannot be reached.
+ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2026-0097"]
 
 [licenses]
 # Allow common permissive and copyleft-compatible licenses


### PR DESCRIPTION
## Summary

Standard release-prep PR for **v0.6.7-dev**. Catches up everything that landed since the last CHANGELOG refresh (#303).

- **Version bump** — `Cargo.toml` 0.6.6-dev → 0.6.7-dev
- **CHANGELOG entries** for the 7 PRs that landed after #303:
  - #306, #307, #308, #309 — Infrastructure (clippy cleanup per crate, CI -D warnings, MSRV alignment, test-tree cleanup)
  - #310 — default HTTP port 8080 → 7475
  - #311 — shortestPath / allShortestPaths + COUNT regression + test-stack glue
  - #312 — Neo4j Browser 5.x compatibility (handshake + bundled-query intercepts + SHOW stubs + element_id format unification + dbms.components stub)
  - #304 — rustdoc broken-link sweep (Documentation)
- **STATUS.md** — bump date, add a one-line Browser 5.x compat note under the existing Bolt v5.8 bullet
- **Security audit dispositioning**:
  - Expanded Security section in CHANGELOG explicitly listing the 3 currently-allowed `cargo audit` warnings, what they are, where they come from, and why they're safe
  - Added `RUSTSEC-2026-0097` (rand unsound) to `deny.toml` ignore list with rationale — only triggers when a custom global logger calls `rand::rng()` during init, which we don't do

## Sanity sweep

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --release` ✅ 0 warnings
- `cargo test --release` ✅ 1630 passing / 0 failed
- `cargo audit` ✅ 0 vulnerabilities, 3 dispositioned warnings

## Test plan

- [ ] CI green on the PR (build, cargo audit, cargo deny, auto-approve)
- [ ] Spot-check that the CHANGELOG section reads correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)