### PR TITLE
fix(ci): scope release build to shipped crates only (no chdb on Windows)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,12 +64,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # We ship only the `clickgraph` server and `clickgraph-client` REPL as
+      # release artifacts. Building `--workspace` would pull in `clickgraph-ffi`
+      # and `clickgraph-tck`, which both enable the `embedded` feature on
+      # `clickgraph-embedded` → pulls in `chdb-rust` → requires `libchdb`, which
+      # has no Windows binary. Cargo feature unification means any single
+      # workspace crate enabling `embedded` infects the whole graph, so we use
+      # explicit `-p` flags to scope the build to just the shipped binaries.
       - name: Build & cross-compile binaries
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: build
           target: ${{ matrix.target }}
-          args: "--locked --release --workspace"
+          args: "--locked --release -p clickgraph -p clickgraph-client"
           strip: true
 
       - name: Package artifacts (Unix)


### PR DESCRIPTION
## Summary

The v0.6.7-dev release pipeline failed on the Windows target with:

> Failed to find or download libchdb: **Unsupported platform**

Root cause: \`cargo build --workspace\` builds every workspace member. \`clickgraph-ffi\` and \`clickgraph-tck\` both enable the \`embedded\` feature on \`clickgraph-embedded\`, which transitively pulls in \`chdb-rust\` → requires \`libchdb\`. chdb has no Windows binary, so the download step in chdb-rust's build.rs fails. Cargo feature unification means **any** workspace crate enabling \`embedded\` infects the whole build graph.

The release workflow only ships two binaries — \`clickgraph\` (server) and \`clickgraph-client\` (REPL). Neither pulls chdb directly. Switching from \`--workspace\` to explicit \`-p clickgraph -p clickgraph-client\` scopes the build to just those, sidestepping chdb entirely.

Same root cause as the v0.6.6-dev release-build failure on April 6 — never fixed because we only noticed when re-tagging today.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, delete + re-push v0.6.7-dev tag to re-trigger the release pipeline
- [ ] Confirm Windows build succeeds and uploads \`clickgraph-win-amd64.zip\` + \`clickgraph-client-win-amd64.zip\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)