### PR TITLE
fix(release): cfg-gate jemalloc allocator on non-MSVC targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-#[cfg(feature = "jemalloc")]
+// jemalloc is only available on non-MSVC targets — Cargo.toml gates the dep
+// with `[target.'cfg(not(target_env = "msvc"))'.dependencies]`. Mirror the
+// guard here so Windows MSVC builds use the system allocator. Without this,
+// the default `jemalloc` feature is on for Windows but the crate isn't,
+// producing E0433 ("unresolved module `tikv_jemallocator`").
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
## Summary

After #314 unblocked the chdb-on-Windows failure, the v0.6.7-dev release pipeline ran into a second Windows-only error:

\`\`\`
error[E0433]: cannot find module or crate \`tikv_jemallocator\` in this scope
 --> src\main.rs:3:46
\`\`\`

Root cause: \`Cargo.toml\` declares the dep with a \`cfg(not(target_env = \"msvc\"))\` target gate, but the \`jemalloc\` feature is in \`default-features\`. On Windows MSVC the feature is enabled but the crate is absent, so \`main.rs\`'s \`#[cfg(feature = \"jemalloc\")]\` block compiles but references a missing module.

Fix: mirror the \`cfg(not(target_env = \"msvc\"))\` guard at the use site, so Windows MSVC falls back to the system allocator. Linux/macOS builds still get jemalloc as before.

## Test plan

- [x] \`cargo build --release -p clickgraph\` clean on Linux
- [ ] After merge, retag v0.6.7-dev to re-trigger the release pipeline
- [ ] Confirm Windows build succeeds and uploads zip artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)