### PR TITLE
refactor(sql-gen): route ClickHouse function names through FunctionMapper trait

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -20,6 +20,7 @@ use crate::query_planner::logical_plan::LogicalPlan;
 use crate::render_plan::cte_generation::CteGenerationContext;
 use crate::render_plan::cte_manager::CteManager;
 use crate::render_plan::expression_utils::{flatten_addition_operands, has_string_operand};
+use crate::sql_generator::function_mapper::current_function_mapper;
 use crate::utils::cte_column_naming::cte_column_name;
 use crate::utils::cte_naming::generate_cte_name;
 
@@ -1197,12 +1198,13 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             let list_sql = render_expr_to_sql_string(&reduce.list, alias_mapping);
             let expr_sql = render_expr_to_sql_string(&reduce.expression, alias_mapping);
 
-            // Wrap numeric init values in toInt64() to prevent type mismatch
+            // Wrap numeric init values in a 64-bit integer cast to prevent
+            // type mismatch.
             let init_cast = if matches!(
                 *reduce.initial_value,
                 RenderExpr::Literal(Literal::Integer(_))
             ) {
-                format!("toInt64({})", init_sql)
+                format!("{}({})", current_function_mapper().cast_int64(), init_sql)
             } else {
                 init_sql
             };
@@ -4086,22 +4088,27 @@ pub fn extract_ctes_with_context(
                         };
 
                         // Generate start_id and end_id expressions for composite support
+                        let cast_str = current_function_mapper().cast_string();
                         let start_id_expr = match from_node_id {
-                            Identifier::Single(col) => format!("toString({from_table}.{col})"),
+                            Identifier::Single(col) => {
+                                format!("{cast_str}({from_table}.{col})")
+                            }
                             Identifier::Composite(cols) => {
                                 let parts: Vec<String> = cols
                                     .iter()
-                                    .map(|c| format!("toString({from_table}.{c})"))
+                                    .map(|c| format!("{cast_str}({from_table}.{c})"))
                                     .collect();
                                 format!("concat({})", parts.join(", '|', "))
                             }
                         };
                         let end_id_expr = match to_node_id {
-                            Identifier::Single(col) => format!("toString({to_table}.{col})"),
+                            Identifier::Single(col) => {
+                                format!("{cast_str}({to_table}.{col})")
+                            }
                             Identifier::Composite(cols) => {
                                 let parts: Vec<String> = cols
                                     .iter()
-                                    .map(|c| format!("toString({to_table}.{c})"))
+                                    .map(|c| format!("{cast_str}({to_table}.{c})"))
                                     .collect();
                                 format!("concat({})", parts.join(", '|', "))
                             }

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -31,6 +31,7 @@ use crate::render_plan::expression_utils::{
 // Note: Direction import commented out until Issue #1 (Undirected Multi-Hop SQL) is fixed
 // use crate::query_planner::logical_expr::Direction;
 use crate::query_planner::logical_plan::LogicalPlan;
+use crate::sql_generator::function_mapper::current_function_mapper;
 use std::collections::HashSet;
 
 /// Recursively rewrite TableAlias references that are in `with_aliases` to reference the CTE.
@@ -2766,11 +2767,12 @@ pub(super) fn normalize_union_branches(
                         let fixed_expr =
                             fix_invalid_table_aliases(&item.expression, &valid_aliases, &plan);
 
-                        // Wrap the expression in toString() for type compatibility
+                        // Wrap the expression in a string cast for type
+                        // compatibility across UNION branches.
                         SelectItem {
                             expression: RenderExpr::ScalarFnCall(
                                 super::render_expr::ScalarFnCall {
-                                    name: "toString".to_string(),
+                                    name: current_function_mapper().cast_string().to_string(),
                                     args: vec![fixed_expr],
                                 },
                             ),

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -50,6 +50,7 @@ use crate::query_planner::logical_expr::{Direction, LogicalExpr};
 use crate::query_planner::logical_plan::{GraphNode, GraphRel, LogicalPlan};
 use crate::query_planner::plan_ctx::PlanCtx;
 use crate::render_plan::plan_builder::RenderPlanBuilder;
+use crate::sql_generator::function_mapper::current_function_mapper;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -7045,12 +7046,13 @@ fn try_flatten_head_collect_map_literal(
                 if let Some(s) = scope {
                     prop_access = super::variable_scope::rewrite_render_expr(&prop_access, s);
                 }
+                let mapper = current_function_mapper();
                 let group_array = RenderExpr::AggregateFnCall(AggregateFnCall {
-                    name: "groupArray".to_string(),
+                    name: mapper.collect_list().to_string(),
                     args: vec![prop_access],
                 });
                 let head_expr = RenderExpr::ScalarFnCall(ScalarFnCall {
-                    name: "arrayElement".to_string(),
+                    name: mapper.array_element().to_string(),
                     args: vec![group_array, RenderExpr::Literal(Literal::Integer(1))],
                 });
 
@@ -7072,12 +7074,13 @@ fn try_flatten_head_collect_map_literal(
                 if let Some(s) = scope {
                     val_expr = super::variable_scope::rewrite_render_expr(&val_expr, s);
                 }
+                let mapper = current_function_mapper();
                 let group_array = RenderExpr::AggregateFnCall(AggregateFnCall {
-                    name: "groupArray".to_string(),
+                    name: mapper.collect_list().to_string(),
                     args: vec![val_expr],
                 });
                 let head_expr = RenderExpr::ScalarFnCall(ScalarFnCall {
-                    name: "arrayElement".to_string(),
+                    name: mapper.array_element().to_string(),
                     args: vec![group_array, RenderExpr::Literal(Literal::Integer(1))],
                 });
 
@@ -10634,8 +10637,10 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                         if agg.name == "count"
                                                             && !agg.args.is_empty()
                                                         {
-                                                            log::info!("🔧 OPTIONAL MATCH CTE body restructuring: converting count() to countIf() with WHERE filter");
-                                                            agg.name = "countIf".to_string();
+                                                            log::info!("🔧 OPTIONAL MATCH CTE body restructuring: converting count() to count-if with WHERE filter");
+                                                            agg.name = current_function_mapper()
+                                                                .count_if()
+                                                                .to_string();
                                                             agg.args.push(where_clone.clone());
                                                         }
                                                     }
@@ -11165,8 +11170,9 @@ pub(crate) fn build_chained_with_match_cte_plan(
                 // Result: forward + reverse edges materialized, weight CTE's
                 // expensive multi-table join evaluated exactly once.
                 let bidi_cte_name = format!("bidi_{}", cte_name);
+                let cast_u8 = current_function_mapper().cast_uint8();
                 let bidi_sql = format!(
-                    "SELECT source, target, weight, toUInt8(0) AS __depth FROM {cte} \
+                    "SELECT source, target, weight, {cast_u8}(0) AS __depth FROM {cte} \
                      UNION ALL \
                      SELECT target AS source, source AS target, weight, __depth + 1 \
                      FROM {bidi} WHERE __depth = 0",
@@ -12299,7 +12305,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                         items.push(RenderExpr::Literal(Literal::String("|".to_string())));
                                                     }
                                                     items.push(RenderExpr::ScalarFnCall(ScalarFnCall {
-                                                        name: "toString".to_string(),
+                                                        name: current_function_mapper().cast_string().to_string(),
                                                         args: vec![RenderExpr::Column(Column(
                                                             crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                                 format!("{}.{}", cte_alias, cte_col)
@@ -12320,7 +12326,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                 // Single ID: toString() to match the String type of
                                                 // start_id / end_id stored in the VLP CTE
                                                 RenderExpr::ScalarFnCall(ScalarFnCall {
-                                                    name: "toString".to_string(),
+                                                    name: current_function_mapper().cast_string().to_string(),
                                                     args: vec![RenderExpr::Column(Column(
                                                         crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                             format!("{}.{}", cte_alias, id_col_name)
@@ -12334,7 +12340,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                         // VLP start_id/end_id may be UInt64 or String depending on
                                         // generation path, and rhs_expr already uses toString().
                                         let lhs_expr = RenderExpr::ScalarFnCall(ScalarFnCall {
-                                            name: "toString".to_string(),
+                                            name: current_function_mapper().cast_string().to_string(),
                                             args: vec![RenderExpr::Column(Column(
                                                 crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                     format!("{}.{}", from_alias, vlp_id_col)
@@ -12494,7 +12500,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                 operator: Operator::Equal,
                                                 operands: vec![
                                                     RenderExpr::ScalarFnCall(ScalarFnCall {
-                                                        name: "toString".to_string(),
+                                                        name: current_function_mapper().cast_string().to_string(),
                                                         args: vec![RenderExpr::Column(Column(
                                                             crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                                 format!("{}.{}", from_alias, vlp_id_col)
@@ -12502,7 +12508,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                         ))],
                                                     }),
                                                     RenderExpr::ScalarFnCall(ScalarFnCall {
-                                                        name: "toString".to_string(),
+                                                        name: current_function_mapper().cast_string().to_string(),
                                                         args: vec![RenderExpr::Column(Column(
                                                             crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                                 format!("{}.{}", cte_alias, id_col_name)
@@ -16175,10 +16181,15 @@ fn generate_list_comp_array_count(
         where_str
     );
 
-    let result = format!("arrayCount(x -> x IN ({}), {})", inner_select, list_col);
+    let result = format!(
+        "{}(x -> x IN ({}), {})",
+        current_function_mapper().array_count(),
+        inner_select,
+        list_col
+    );
 
     log::info!(
-        "🔧 arrayCount expression: {}",
+        "🔧 array-count expression: {}",
         &result[..result.len().min(300)]
     );
 
@@ -16228,12 +16239,15 @@ fn generate_list_comp_array_count_tuple_fallback(
     );
 
     let result = format!(
-        "arrayCount(x -> {} IN ({}), {})",
-        lambda_tuple, inner_select, list_col
+        "{}(x -> {} IN ({}), {})",
+        current_function_mapper().array_count(),
+        lambda_tuple,
+        inner_select,
+        list_col
     );
 
     log::info!(
-        "🔧 arrayCount tuple fallback: {}",
+        "🔧 array-count tuple fallback: {}",
         &result[..result.len().min(300)]
     );
 
@@ -17430,7 +17444,7 @@ pub(super) fn build_id_render_expr(
                     items.push(RenderExpr::Literal(Literal::String("|".to_string())));
                 }
                 items.push(RenderExpr::ScalarFnCall(ScalarFnCall {
-                    name: "toString".to_string(),
+                    name: current_function_mapper().cast_string().to_string(),
                     args: vec![RenderExpr::PropertyAccessExp(PropertyAccess {
                         table_alias: TableAlias(alias.to_string()),
                         column: PropertyValue::Column(col.to_string()),

--- a/src/render_plan/property_expansion.rs
+++ b/src/render_plan/property_expansion.rs
@@ -30,6 +30,7 @@ use crate::query_planner::{
     },
     logical_plan::ProjectionItem,
 };
+use crate::sql_generator::function_mapper::current_function_mapper;
 
 use super::render_expr::{
     AggregateFnCall as RenderAggregateFnCall, ColumnAlias as RenderColumnAlias,
@@ -524,22 +525,24 @@ pub fn expand_collect_to_group_array(
         })
         .collect();
 
+    let collect_list = current_function_mapper().collect_list().to_string();
     if prop_exprs.len() == 1 {
-        // Single property: groupArray(prop) — no tuple needed.
-        // Avoids Array(Tuple(T)) vs Array(T) type mismatch when the collected
-        // array is later concatenated with another groupArray(prop) result.
+        // Single property: collect-list aggregate of the bare property — no
+        // tuple needed. Avoids `Array(Tuple(T))` vs `Array(T)` type mismatch
+        // when the collected array is later concatenated with another
+        // collect-list result.
         LogicalExpr::AggregateFnCall(AggregateFnCall {
-            name: "groupArray".to_string(),
+            name: collect_list,
             args: prop_exprs,
         })
     } else {
-        // Multiple properties: groupArray(tuple(prop1, prop2, ...))
+        // Multiple properties: collect-list over tuple(prop1, prop2, ...).
         let tuple_expr = LogicalExpr::ScalarFnCall(ScalarFnCall {
             name: "tuple".to_string(),
             args: prop_exprs,
         });
         LogicalExpr::AggregateFnCall(AggregateFnCall {
-            name: "groupArray".to_string(),
+            name: collect_list,
             args: vec![tuple_expr],
         })
     }

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -16,6 +16,7 @@ use crate::query_planner::logical_expr::{
     TableAlias as LogicalTableAlias,
 };
 use crate::query_planner::logical_plan::LogicalPlan;
+use crate::sql_generator::function_mapper::current_function_mapper;
 
 use super::errors::RenderBuildError;
 
@@ -1005,12 +1006,13 @@ impl TryFrom<LogicalExpr> for RenderExpr {
                         });
 
                 if has_non_literal && !all_non_literal_are_aliases {
+                    let cast_str = current_function_mapper().cast_string().to_string();
                     RenderExpr::List(
                         items
                             .into_iter()
                             .map(|e| {
                                 RenderExpr::ScalarFnCall(ScalarFnCall {
-                                    name: "toString".to_string(),
+                                    name: cast_str.clone(),
                                     args: vec![e],
                                 })
                             })

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -25,6 +25,7 @@ use crate::render_plan::render_expr::{
     TableAlias as RenderTableAlias,
 };
 use crate::render_plan::SelectItem;
+use crate::sql_generator::function_mapper::current_function_mapper;
 use crate::utils::cte_column_naming::{cte_column_name, parse_cte_column};
 
 /// SelectBuilder trait for extracting SELECT items from logical plans
@@ -913,11 +914,13 @@ impl SelectBuilder for LogicalPlan {
                                         cypher_alias, col_name, position, cte_alias
                                     );
 
-                                    // Extract property from JSON blob using JSONExtractString
-                                    // JSONExtractString(json_column, 'property_name')
+                                    // Extract property from JSON blob.
+                                    // ClickHouse: `JSONExtractString(json_column, 'property_name')`.
                                     select_items.push(SelectItem {
                                         expression: RenderExpr::ScalarFnCall(ScalarFnCall {
-                                            name: "JSONExtractString".to_string(),
+                                            name: current_function_mapper()
+                                                .json_extract_string()
+                                                .to_string(),
                                             args: vec![
                                                 RenderExpr::PropertyAccessExp(PropertyAccess {
                                                     table_alias: RenderTableAlias(
@@ -2130,16 +2133,18 @@ impl LogicalPlan {
                         col_alias: Some(ColumnAlias("_rel_properties".to_string())),
                     });
 
-                    // Extract relationship type from array (first element)
+                    // Extract relationship type from array (first element).
+                    // Both ClickHouse `arrayElement` and Spark `element_at` are
+                    // 1-indexed.
                     select_items.push(SelectItem {
                         expression: RenderExpr::ScalarFnCall(ScalarFnCall {
-                            name: "arrayElement".to_string(),
+                            name: current_function_mapper().array_element().to_string(),
                             args: vec![
                                 RenderExpr::PropertyAccessExp(PropertyAccess {
                                     table_alias: RenderTableAlias(cte_alias.clone()),
                                     column: PropertyValue::Column("path_relationships".to_string()),
                                 }),
-                                RenderExpr::Literal(Literal::Integer(1)), // ClickHouse arrays are 1-indexed
+                                RenderExpr::Literal(Literal::Integer(1)),
                             ],
                         }),
                         col_alias: Some(ColumnAlias("__rel_type__".to_string())),

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -1,0 +1,40 @@
+//! ClickHouse `FunctionMapper` — the canonical names used by the existing
+//! `clickhouse_query_generator` SQL emission path.
+
+use super::FunctionMapper;
+
+pub(crate) struct ClickhouseFunctionMapper;
+
+impl FunctionMapper for ClickhouseFunctionMapper {
+    fn collect_list(&self) -> &'static str {
+        "groupArray"
+    }
+
+    fn array_element(&self) -> &'static str {
+        "arrayElement"
+    }
+
+    fn count_if(&self) -> &'static str {
+        "countIf"
+    }
+
+    fn array_count(&self) -> &'static str {
+        "arrayCount"
+    }
+
+    fn json_extract_string(&self) -> &'static str {
+        "JSONExtractString"
+    }
+
+    fn cast_int64(&self) -> &'static str {
+        "toInt64"
+    }
+
+    fn cast_uint8(&self) -> &'static str {
+        "toUInt8"
+    }
+
+    fn cast_string(&self) -> &'static str {
+        "toString"
+    }
+}

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -13,13 +13,17 @@
 
 pub(crate) mod clickhouse;
 
-/// Returns the dialect-specific name and casting syntax for built-in SQL
-/// functions used by `render_plan` and downstream emission helpers.
+/// Returns the dialect-specific name for built-in SQL functions used by
+/// `render_plan` and downstream emission helpers.
 ///
-/// Methods returning `&'static str` give the canonical function name —
-/// callers compose `name(args...)` themselves. Methods returning `String`
-/// emit a complete fragment because the *shape* differs between dialects
-/// (e.g. ClickHouse `toInt64(x)` vs Spark SQL `CAST(x AS BIGINT)`).
+/// All methods return `&'static str`. IR construction sites use the bare
+/// name (it's later wrapped as `name(args)` by the SQL emitter); raw
+/// SQL emission sites compose `format!("{name}({args})", ...)` directly.
+/// This shape works for ClickHouse function-call syntax and for the
+/// function-call cast aliases Spark/Databricks also accepts (`string(x)`,
+/// `bigint(x)`, etc.). If a dialect ever needs full `CAST(x AS T)` syntax
+/// or a structural rewrite (e.g. `arrayJoin` → `LATERAL VIEW explode`),
+/// that becomes a dedicated method then — not a global redesign.
 pub(crate) trait FunctionMapper: Send + Sync {
     /// Collect into a list aggregate. CH: `groupArray`. Spark: `collect_list`.
     fn collect_list(&self) -> &'static str;
@@ -31,9 +35,9 @@ pub(crate) trait FunctionMapper: Send + Sync {
     fn count_if(&self) -> &'static str;
 
     /// Count of array elements matching a predicate.
-    /// CH: `arrayCount`. Spark: requires `size(filter(...))` wrapping —
-    /// the helper [`array_count_call`](Self::array_count_call) takes care
-    /// of the dialect difference.
+    /// CH: `arrayCount`. Spark needs structural rewriting to
+    /// `size(filter(...))` — the planned Databricks emitter handles this
+    /// at the call site once dialect is plumbed through (Phase 1).
     fn array_count(&self) -> &'static str;
 
     /// Extract JSON field as a string. CH: `JSONExtractString`.
@@ -55,9 +59,12 @@ pub(crate) trait FunctionMapper: Send + Sync {
 
 /// The default function mapper for the current build.
 ///
-/// `pub(crate)` because the trait is internal; once dialect selection is
-/// plumbed through `render_plan` (Phase 1), call sites will receive the
-/// mapper from the active emitter rather than this static accessor.
+/// The `FunctionMapper` trait itself is `pub(crate)` rather than using
+/// the sealed-supertrait pattern: external code can't name the trait,
+/// so it can't implement it either, and the simpler visibility rule is
+/// enough for now. Once dialect selection is plumbed through
+/// `render_plan` (Phase 1), call sites will receive the mapper from the
+/// active emitter rather than this static accessor.
 pub(crate) fn current_function_mapper() -> &'static dyn FunctionMapper {
     static CLICKHOUSE: clickhouse::ClickhouseFunctionMapper = clickhouse::ClickhouseFunctionMapper;
     &CLICKHOUSE

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -1,0 +1,64 @@
+//! Function-name mapping per dialect.
+//!
+//! `render_plan` and helpers construct synthetic SQL expressions that
+//! reference function names directly (e.g. `groupArray`, `arrayElement`).
+//! This module funnels those names through a `FunctionMapper` trait so
+//! Phase 1 can swap in a Databricks/Spark SQL implementation without
+//! grepping for string literals across the planner.
+//!
+//! ## Phase 0.2 status
+//! Only `ClickhouseFunctionMapper` is implemented. `current_function_mapper`
+//! returns it unconditionally; Phase 1 will replace this with a dialect-aware
+//! accessor once the dialect is plumbed through call sites.
+
+pub(crate) mod clickhouse;
+
+/// Returns the dialect-specific name and casting syntax for built-in SQL
+/// functions used by `render_plan` and downstream emission helpers.
+///
+/// Methods returning `&'static str` give the canonical function name —
+/// callers compose `name(args...)` themselves. Methods returning `String`
+/// emit a complete fragment because the *shape* differs between dialects
+/// (e.g. ClickHouse `toInt64(x)` vs Spark SQL `CAST(x AS BIGINT)`).
+pub(crate) trait FunctionMapper: Send + Sync {
+    /// Collect into a list aggregate. CH: `groupArray`. Spark: `collect_list`.
+    fn collect_list(&self) -> &'static str;
+
+    /// 1-based array indexing. CH: `arrayElement`. Spark: `element_at`.
+    fn array_element(&self) -> &'static str;
+
+    /// Conditional count. CH: `countIf`. Spark: `count_if` (DBR 13.1+).
+    fn count_if(&self) -> &'static str;
+
+    /// Count of array elements matching a predicate.
+    /// CH: `arrayCount`. Spark: requires `size(filter(...))` wrapping —
+    /// the helper [`array_count_call`](Self::array_count_call) takes care
+    /// of the dialect difference.
+    fn array_count(&self) -> &'static str;
+
+    /// Extract JSON field as a string. CH: `JSONExtractString`.
+    /// Spark: `get_json_object`.
+    fn json_extract_string(&self) -> &'static str;
+
+    /// Cast to 64-bit signed integer. CH: `toInt64`. Spark: `bigint`
+    /// (works as a function-call cast alias).
+    fn cast_int64(&self) -> &'static str;
+
+    /// Cast to 8-bit unsigned integer. CH: `toUInt8`. Spark has no
+    /// unsigned integer — the planned Databricks emitter will widen to
+    /// `tinyint` (signed) since the values used here fit.
+    fn cast_uint8(&self) -> &'static str;
+
+    /// Cast to string. CH: `toString`. Spark: `string` (function-call alias).
+    fn cast_string(&self) -> &'static str;
+}
+
+/// The default function mapper for the current build.
+///
+/// `pub(crate)` because the trait is internal; once dialect selection is
+/// plumbed through `render_plan` (Phase 1), call sites will receive the
+/// mapper from the active emitter rather than this static accessor.
+pub(crate) fn current_function_mapper() -> &'static dyn FunctionMapper {
+    static CLICKHOUSE: clickhouse::ClickhouseFunctionMapper = clickhouse::ClickhouseFunctionMapper;
+    &CLICKHOUSE
+}

--- a/src/sql_generator/mod.rs
+++ b/src/sql_generator/mod.rs
@@ -16,6 +16,7 @@ use crate::render_plan::RenderPlan;
 use serde::{Deserialize, Serialize};
 
 pub(crate) mod clickhouse;
+pub(crate) mod function_mapper;
 
 /// SQL dialect for query generation.
 ///


### PR DESCRIPTION
## Summary

Phase 0.2 of the DeltaGraph plan (see `docs/design/DELTAGRAPH_PLAN.md`). Hardcoded ClickHouse function-name string literals scattered across `render_plan/` now flow through a new crate-private `FunctionMapper` trait, so a future `DatabricksFunctionMapper` can swap them without grepping the planner for `groupArray`, `toString`, etc.

**Behavior is unchanged**: only `ClickhouseFunctionMapper` is implemented and `current_function_mapper()` returns it unconditionally. The trait is `pub(crate)`; Phase 1 will replace the static accessor with a dialect-aware one once dialect selection is plumbed through call sites.

## Sites routed (25 across 6 files)

| File | Count | Functions |
|---|---|---|
| `render_plan/property_expansion.rs` | 2 | `groupArray` |
| `render_plan/select_builder.rs` | 2 | `JSONExtractString`, `arrayElement` |
| `render_plan/plan_builder_utils.rs` | 13 | `groupArray`×2, `arrayElement`×2, `countIf`, `arrayCount`×2, `toString`×6, `toUInt8` |
| `render_plan/cte_extraction.rs` | 5 | `toInt64`, `toString`×4 |
| `render_plan/plan_builder_helpers.rs` | 1 | `toString` |
| `render_plan/render_expr.rs` | 1 | `toString` |

## API shape

`FunctionMapper` methods all return `&'static str`. IR construction sites use the bare name (later wrapped as `name(args)` by the SQL emitter); raw SQL emission sites compose `format!()` themselves. This works for ClickHouse function-call syntax and for the function-call cast aliases Spark/Databricks also accepts (`string(x)`, `bigint(x)`). If a dialect ever needs full `CAST(x AS T)` syntax or a structural rewrite (`arrayJoin` → `LATERAL VIEW explode`), that becomes a dedicated method then — not a redesign of this trait.

```rust
pub(crate) trait FunctionMapper: Send + Sync {
    fn collect_list(&self) -> &'static str;       // CH groupArray / Spark collect_list
    fn array_element(&self) -> &'static str;      // CH arrayElement / Spark element_at
    fn count_if(&self) -> &'static str;           // CH countIf / Spark count_if
    fn array_count(&self) -> &'static str;        // CH arrayCount / Spark size(filter(...))
    fn json_extract_string(&self) -> &'static str;// CH JSONExtractString / Spark get_json_object
    fn cast_int64(&self) -> &'static str;         // CH toInt64 / Spark bigint
    fn cast_uint8(&self) -> &'static str;         // CH toUInt8 / Spark tinyint
    fn cast_string(&self) -> &'static str;        // CH toString / Spark string
}
```

## Visibility, not the sealed pattern

External code can't implement this trait because it can't even name it (`pub(crate)`). That's the same end-state as the Rust-idiomatic sealed-supertrait pattern, with less ceremony. Earlier wording in the PR description that called the trait "sealed" was imprecise — fixed in 3543945 (doc-only follow-up).

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p clickgraph` — 1344 lib + 279 integration + 36 misc tests, **zero failures** (same totals as PR #316)
- [x] Two test asserts at `property_expansion.rs:854,877` checking `agg.name == "groupArray"` still pass — the ClickHouse mapper still returns that name

## Follow-ups

- Phase 0.5 — split `plan_builder_utils.rs` (12K-line regression hotspot). Worth doing independently before Phase 1.
- Phase 1 spike — minimal `DatabricksEmitter` + `DatabricksFunctionMapper` covering SELECT/FROM/WHERE, to validate the trait shape against a real second dialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)