### PR TITLE
refactor(sql-gen): plumb dialect via QueryContext task-local [Phase 1.1]

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2668,6 +2668,40 @@ mod tests {
         );
     }
 
+    /// `emit_array_count_call` outside a task-local scope defaults to
+    /// ClickHouse — matching the pre-Phase-1.1 hardcoded behavior.
+    #[test]
+    fn emit_array_count_call_defaults_to_clickhouse() {
+        let sql = emit_array_count_call("x", "x IN (SELECT id FROM t)", "vp.path_nodes");
+        assert_eq!(
+            sql,
+            "arrayCount(x -> x IN (SELECT id FROM t), vp.path_nodes)"
+        );
+    }
+
+    /// When the task-local dialect is Databricks, the helper builds the
+    /// `size(filter(arr, x -> pred))` structural rewrite — Spark has no
+    /// `arrayCount` equivalent. Note `filter` reverses arg order (arr,
+    /// predicate) vs CH's (predicate, arr).
+    #[tokio::test]
+    async fn emit_array_count_call_databricks_uses_size_filter() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async {
+            emit_array_count_call("x", "x IN (SELECT id FROM t)", "vp.path_nodes")
+        })
+        .await;
+        assert_eq!(
+            sql,
+            "size(filter(vp.path_nodes, x -> x IN (SELECT id FROM t)))"
+        );
+    }
+
     /// Regression test: build_cte_column_map must use real column names from expressions,
     /// not CTE alias names like p1_a_user_id. When the FROM is a base table (e.g., social.users),
     /// correlated subqueries must reference `a.user_id`, not `a.p1_a_user_id`.
@@ -16181,12 +16215,7 @@ fn generate_list_comp_array_count(
         where_str
     );
 
-    let result = format!(
-        "{}(x -> x IN ({}), {})",
-        current_function_mapper().array_count(),
-        inner_select,
-        list_col
-    );
+    let result = emit_array_count_call("x", &format!("x IN ({})", inner_select), &list_col);
 
     log::info!(
         "🔧 array-count expression: {}",
@@ -16194,6 +16223,25 @@ fn generate_list_comp_array_count(
     );
 
     Some(result)
+}
+
+/// Emit an `arrayCount(lambda_var -> predicate, array)` call for the active
+/// dialect.
+///
+/// ClickHouse: `arrayCount(x -> pred, arr)` — single function, predicate-first.
+/// Databricks/Spark: `size(filter(arr, x -> pred))` — structural rewrite.
+/// Calling `FunctionMapper::array_count()` on the Databricks mapper panics;
+/// see `sql_generator::function_mapper::databricks` module docs.
+fn emit_array_count_call(lambda_var: &str, predicate: &str, array: &str) -> String {
+    match crate::server::query_context::get_current_dialect() {
+        crate::sql_generator::SqlDialect::Databricks => {
+            format!("size(filter({array}, {lambda_var} -> {predicate}))")
+        }
+        _ => format!(
+            "{}({lambda_var} -> {predicate}, {array})",
+            current_function_mapper().array_count()
+        ),
+    }
 }
 
 /// Fallback: generate arrayCount with the original tuple-based approach.
@@ -16238,12 +16286,10 @@ fn generate_list_comp_array_count_tuple_fallback(
         where_str
     );
 
-    let result = format!(
-        "{}(x -> {} IN ({}), {})",
-        current_function_mapper().array_count(),
-        lambda_tuple,
-        inner_select,
-        list_col
+    let result = emit_array_count_call(
+        "x",
+        &format!("{} IN ({})", lambda_tuple, inner_select),
+        list_col,
     );
 
     log::info!(

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -915,7 +915,19 @@ impl SelectBuilder for LogicalPlan {
                                     );
 
                                     // Extract property from JSON blob.
-                                    // ClickHouse: `JSONExtractString(json_column, 'property_name')`.
+                                    // ClickHouse: `JSONExtractString(json_column, 'property_name')`
+                                    // Databricks: `get_json_object(json_column, '$.property_name')`
+                                    // Same call shape, but Spark needs the field encoded as a
+                                    // JSONPath. Function name comes from the mapper; the JSONPath
+                                    // prefix is a call-site choice (see
+                                    // `sql_generator::function_mapper::databricks` module docs).
+                                    let field_arg =
+                                        match crate::server::query_context::get_current_dialect() {
+                                            crate::sql_generator::SqlDialect::Databricks => {
+                                                format!("$.{}", col_name)
+                                            }
+                                            _ => col_name.to_string(),
+                                        };
                                     select_items.push(SelectItem {
                                         expression: RenderExpr::ScalarFnCall(ScalarFnCall {
                                             name: current_function_mapper()
@@ -931,9 +943,7 @@ impl SelectBuilder for LogicalPlan {
                                                         position
                                                     )),
                                                 }),
-                                                RenderExpr::Literal(Literal::String(
-                                                    col_name.to_string(),
-                                                )),
+                                                RenderExpr::Literal(Literal::String(field_arg)),
                                             ],
                                         }),
                                         col_alias: item

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -28,6 +28,23 @@ use crate::render_plan::SelectItem;
 use crate::sql_generator::function_mapper::current_function_mapper;
 use crate::utils::cte_column_naming::{cte_column_name, parse_cte_column};
 
+/// Build the second argument to a `JSONExtractString` / `get_json_object`
+/// call.
+///
+/// ClickHouse's `JSONExtractString(json, 'field')` takes a bare field name.
+/// Databricks/Spark's `get_json_object(json, '$.field')` requires JSONPath.
+/// Function name comes from `FunctionMapper::json_extract_string`; the
+/// argument shape is a call-site choice, handled here.
+///
+/// Dialect is read from the task-local `QueryContext`; outside a scope this
+/// defaults to ClickHouse (bare name).
+fn json_extract_field_arg(col_name: &str) -> String {
+    match crate::server::query_context::get_current_dialect() {
+        crate::sql_generator::SqlDialect::Databricks => format!("$.{}", col_name),
+        _ => col_name.to_string(),
+    }
+}
+
 /// SelectBuilder trait for extracting SELECT items from logical plans
 pub trait SelectBuilder {
     /// Extract SELECT items from the logical plan
@@ -915,19 +932,9 @@ impl SelectBuilder for LogicalPlan {
                                     );
 
                                     // Extract property from JSON blob.
-                                    // ClickHouse: `JSONExtractString(json_column, 'property_name')`
-                                    // Databricks: `get_json_object(json_column, '$.property_name')`
-                                    // Same call shape, but Spark needs the field encoded as a
-                                    // JSONPath. Function name comes from the mapper; the JSONPath
-                                    // prefix is a call-site choice (see
-                                    // `sql_generator::function_mapper::databricks` module docs).
-                                    let field_arg =
-                                        match crate::server::query_context::get_current_dialect() {
-                                            crate::sql_generator::SqlDialect::Databricks => {
-                                                format!("$.{}", col_name)
-                                            }
-                                            _ => col_name.to_string(),
-                                        };
+                                    // CH:        JSONExtractString(json, 'name')
+                                    // Databricks: get_json_object(json, '$.name')
+                                    // See `json_extract_field_arg` for the argument rewrite.
                                     select_items.push(SelectItem {
                                         expression: RenderExpr::ScalarFnCall(ScalarFnCall {
                                             name: current_function_mapper()
@@ -943,7 +950,9 @@ impl SelectBuilder for LogicalPlan {
                                                         position
                                                     )),
                                                 }),
-                                                RenderExpr::Literal(Literal::String(field_arg)),
+                                                RenderExpr::Literal(Literal::String(
+                                                    json_extract_field_arg(col_name),
+                                                )),
                                             ],
                                         }),
                                         col_alias: item
@@ -2500,5 +2509,33 @@ impl LogicalPlan {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Outside a task-local scope (or with default ClickHouse dialect), the
+    /// JSON-extract argument is the bare field name — matching CH's
+    /// `JSONExtractString(json, 'name')` shape.
+    #[test]
+    fn json_extract_field_arg_defaults_to_bare_name() {
+        assert_eq!(json_extract_field_arg("OriginCityName"), "OriginCityName");
+    }
+
+    /// Inside a Databricks task-local scope, the argument becomes a JSONPath
+    /// (`$.field`) — matching `get_json_object(json, '$.name')`.
+    #[tokio::test]
+    async fn json_extract_field_arg_databricks_uses_jsonpath() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let arg = with_query_context(ctx, async { json_extract_field_arg("OriginCityName") }).await;
+        assert_eq!(arg, "$.OriginCityName");
     }
 }

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -36,11 +36,21 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::graph_catalog::graph_schema::GraphSchema;
+use crate::sql_generator::SqlDialect;
 
 /// Per-query context holding all query-scoped state
 /// This replaces multiple scattered task_local!/thread_local! declarations
 #[derive(Debug, Clone, Default)]
 pub struct QueryContext {
+    /// SQL dialect to target for this query. Drives both function-name
+    /// mapping ([`crate::sql_generator::function_mapper::for_dialect`]) and
+    /// the few structural rewrites that can't be expressed as a name swap
+    /// (e.g. `arrayCount` → `size(filter(...))` for Databricks/Spark).
+    ///
+    /// Defaults to ClickHouse so call sites outside a task-local scope —
+    /// notably unit tests — keep emitting CH SQL unchanged.
+    pub dialect: SqlDialect,
+
     /// Schema name for this query (from USE clause or request parameter)
     pub schema_name: Option<String>,
 
@@ -138,6 +148,26 @@ where
     F: Future<Output = R>,
 {
     QUERY_CONTEXT.scope(RefCell::new(context), f).await
+}
+
+// ============================================================================
+// DIALECT ACCESSORS
+// ============================================================================
+
+/// Get the SQL dialect for the current query.
+/// Returns [`SqlDialect::ClickHouse`] when called outside a task-local
+/// scope (e.g. unit tests), matching the historical hard-coded behavior.
+pub fn get_current_dialect() -> SqlDialect {
+    QUERY_CONTEXT
+        .try_with(|ctx| ctx.borrow().dialect)
+        .unwrap_or_default()
+}
+
+/// Set the SQL dialect for the current query (typically once at entry).
+pub fn set_current_dialect(dialect: SqlDialect) {
+    let _ = QUERY_CONTEXT.try_with(|ctx| {
+        ctx.borrow_mut().dialect = dialect;
+    });
 }
 
 // ============================================================================

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -3,10 +3,11 @@
 //! This is the second consumer of the [`FunctionMapper`] trait, added as
 //! Phase 1.0 of the DeltaGraph refactor. Its purpose is to validate the
 //! shape of the trait by exercising every method against a real second
-//! dialect. The Databricks SQL emitter itself is not yet wired in;
-//! `current_function_mapper()` still returns ClickHouse. Phase 1.1 will
-//! plumb the dialect through call sites so this mapper gets used at
-//! emission time.
+//! dialect. Phase 1.1 wired the dialect through the rendering pipeline
+//! via the task-local `QueryContext`: `current_function_mapper()` now
+//! reads from there and defaults to ClickHouse outside a scope. The
+//! Databricks SQL emitter itself (`DatabricksEmitter::emit`) still isn't
+//! implemented — that's Phase 1.2.
 //!
 //! ### Spelling references
 //! - <https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-functions-builtin>
@@ -14,12 +15,14 @@
 //!
 //! ### Known structural gap: `array_count`
 //!
-//! ClickHouse's `arrayCount(arr, x -> pred)` has no equivalent single
-//! function in Spark — the idiom is `size(filter(arr, x -> pred))`.
-//! That's a *structural* rewrite, not a name swap, so
+//! ClickHouse's `arrayCount(x -> pred, arr)` (predicate first) has no
+//! equivalent single function in Spark — the idiom is
+//! `size(filter(arr, x -> pred))` (arg order reversed, and wrapped in
+//! `size`). That's a *structural* rewrite, not a name swap, so
 //! `FunctionMapper::array_count(&self) -> &'static str` can't express
 //! it. This method panics; the two call sites in
-//! `plan_builder_utils.rs` branch on dialect and build the
+//! `plan_builder_utils.rs` go through the helper
+//! `emit_array_count_call` which branches on dialect and builds the
 //! `size(filter(...))` form directly when running against Databricks
 //! (added in Phase 1.1).
 //!
@@ -55,10 +58,14 @@ impl FunctionMapper for DatabricksFunctionMapper {
 
     fn array_count(&self) -> &'static str {
         // Structural mismatch — see module docs. No single function name.
+        // Phase 1.1 resolved this at the call sites via
+        // `emit_array_count_call` in `plan_builder_utils.rs`; the panic
+        // stays as a tripwire for any future caller that doesn't go
+        // through the helper.
         unimplemented!(
-            "DatabricksFunctionMapper::array_count: Spark has no `arrayCount(arr, pred)`; \
-             use `size(filter(arr, pred))` at the call site. This panics so callers can't \
-             silently emit broken SQL — Phase 1.1 will rework the API or the call site."
+            "DatabricksFunctionMapper::array_count: Spark has no `arrayCount(pred, arr)`; \
+             use `size(filter(arr, pred))` at the call site (see emit_array_count_call). \
+             This panics so callers can't silently emit broken SQL."
         );
     }
 
@@ -137,7 +144,7 @@ mod tests {
     /// `size(filter(...))` directly when Databricks is active, so they
     /// never reach this method.
     #[test]
-    #[should_panic(expected = "Spark has no `arrayCount")]
+    #[should_panic(expected = "Spark has no `arrayCount(pred, arr)`")]
     fn databricks_array_count_panics() {
         let m = for_dialect(SqlDialect::Databricks);
         m.array_count();

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -12,25 +12,25 @@
 //! - <https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-functions-builtin>
 //! - Apache Spark SQL function reference
 //!
-//! ### Known structural gaps (panic with TODO until Phase 1.1)
+//! ### Known structural gap: `array_count`
 //!
-//! **`array_count`**: ClickHouse's `arrayCount(arr, x -> pred)` has no
-//! equivalent single function in Spark — the idiom is
-//! `size(filter(arr, x -> pred))`. That's a *structural* rewrite, not a
-//! name swap, so `FunctionMapper::array_count(&self) -> &'static str`
-//! can't express it.
+//! ClickHouse's `arrayCount(arr, x -> pred)` has no equivalent single
+//! function in Spark — the idiom is `size(filter(arr, x -> pred))`.
+//! That's a *structural* rewrite, not a name swap, so
+//! `FunctionMapper::array_count(&self) -> &'static str` can't express
+//! it. This method panics; the two call sites in
+//! `plan_builder_utils.rs` branch on dialect and build the
+//! `size(filter(...))` form directly when running against Databricks
+//! (added in Phase 1.1).
 //!
-//! **`json_extract_string`**: CH's `JSONExtractString(blob, 'field')` takes
-//! a bare field name; Spark's `get_json_object(blob, '$.field')` takes a
-//! JSONPath. Same name shape but the second argument needs structural
-//! rewriting. Returning `"get_json_object"` would silently emit broken
-//! SQL.
+//! ### Resolved gap (Phase 1.1): `json_extract_string`
 //!
-//! Both panic with a TODO so callers can't accidentally produce wrong
-//! output. Phase 1.1 will pick a strategy — likely widening the call
-//! sites in `select_builder.rs` and `plan_builder_utils.rs` rather than
-//! widening the trait, since each gap has only one call site and the
-//! structural choice belongs there.
+//! CH's `JSONExtractString(blob, 'field')` takes a bare field name;
+//! Spark's `get_json_object(blob, '$.field')` takes a JSONPath. The
+//! mapper returns `"get_json_object"`; the call site in
+//! `select_builder.rs` prepends `$.` to the field name when the active
+//! dialect is Databricks. The mapper-level structural gap is gone —
+//! only the *argument shape* differs, and that lives at the call site.
 
 use super::FunctionMapper;
 
@@ -63,17 +63,10 @@ impl FunctionMapper for DatabricksFunctionMapper {
     }
 
     fn json_extract_string(&self) -> &'static str {
-        // Structural mismatch — see module docs. CH passes the property as a
-        // bare field name (`'OriginCityName'`); Spark's `get_json_object`
-        // wants a JSONPath (`'$.OriginCityName'`). The call site builds the
-        // function args, so it must do the rewrite. Panicking here prevents
-        // silent breakage if a future caller forgets.
-        unimplemented!(
-            "DatabricksFunctionMapper::json_extract_string: Spark's `get_json_object` \
-             requires a JSONPath argument (`$.field`) but the existing call site passes a \
-             bare field name. Phase 1.1 must rewrite the argument at the call site before \
-             this mapping can be used."
-        );
+        // The function name is a clean swap; the *argument* needs JSONPath
+        // shape (`$.field` instead of `field`). The call site in
+        // `select_builder.rs` does that rewrite — see Phase 1.1 module docs.
+        "get_json_object"
     }
 
     fn cast_int64(&self) -> &'static str {
@@ -125,6 +118,7 @@ mod tests {
         assert_eq!(m.collect_list(), "collect_list");
         assert_eq!(m.array_element(), "element_at");
         assert_eq!(m.count_if(), "count_if");
+        assert_eq!(m.json_extract_string(), "get_json_object");
         assert_eq!(m.cast_int64(), "bigint");
         assert_eq!(m.cast_uint8(), "tinyint");
         assert_eq!(m.cast_string(), "string");
@@ -138,8 +132,10 @@ mod tests {
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.
-    /// The panic is intentional — Phase 1.1 must either widen the trait or
-    /// rewrite the single call site to build `size(filter(...))` directly.
+    /// The panic is intentional — the two call sites in
+    /// `plan_builder_utils.rs` branch on dialect and build
+    /// `size(filter(...))` directly when Databricks is active, so they
+    /// never reach this method.
     #[test]
     #[should_panic(expected = "Spark has no `arrayCount")]
     fn databricks_array_count_panics() {
@@ -147,23 +143,34 @@ mod tests {
         m.array_count();
     }
 
-    /// Documented structural gap: `get_json_object` needs a JSONPath
-    /// argument; the call site passes a bare field name. Phase 1.1 must
-    /// rewrite the argument before the mapping can be used.
+    /// Outside a task-local scope `current_function_mapper()` defaults to
+    /// ClickHouse — the historical hardcoded behavior. Tests that don't
+    /// opt into a context keep emitting CH SQL.
     #[test]
-    #[should_panic(expected = "requires a JSONPath argument")]
-    fn databricks_json_extract_string_panics() {
-        let m = for_dialect(SqlDialect::Databricks);
-        m.json_extract_string();
-    }
-
-    /// `current_function_mapper()` still returns ClickHouse — Phase 1.1
-    /// hasn't plumbed dialect through call sites yet.
-    #[test]
-    fn current_mapper_still_clickhouse() {
+    fn current_mapper_defaults_to_clickhouse_outside_scope() {
         assert_eq!(
             super::super::current_function_mapper().cast_string(),
             "toString"
         );
+    }
+
+    /// Inside a task-local scope with `dialect: Databricks`,
+    /// `current_function_mapper()` returns the Databricks mapper. This is
+    /// the Phase 1.1 plumbing — once Phase 1.2's emitter sets the dialect
+    /// in the context, every `current_function_mapper()` call site flips
+    /// to Databricks spellings automatically.
+    #[tokio::test]
+    async fn current_mapper_follows_task_local_dialect() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let s = with_query_context(ctx, async {
+            super::super::current_function_mapper().cast_string()
+        })
+        .await;
+        assert_eq!(s, "string");
     }
 }

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -80,16 +80,20 @@ pub(crate) trait FunctionMapper: Send + Sync {
     fn empty_int64_array_cast(&self) -> &'static str;
 }
 
-/// The default function mapper for the current build.
+/// Returns the function mapper for the active SQL dialect, read from the
+/// task-local [`QueryContext`].
 ///
-/// The `FunctionMapper` trait itself is `pub(crate)` rather than using
-/// the sealed-supertrait pattern: external code can't name the trait,
-/// so it can't implement it either, and the simpler visibility rule is
-/// enough for now. Once dialect selection is plumbed through
-/// `render_plan` (Phase 1.1), call sites will receive the mapper from the
-/// active emitter rather than this static accessor.
+/// Outside a task-local scope (notably unit tests), this defaults to
+/// ClickHouse — matching the historical hard-coded behavior so existing
+/// tests don't need to opt in to a context.
+///
+/// The trait itself stays `pub(crate)`: external code can't name it, so
+/// it can't implement it either, and the simpler visibility rule is
+/// enough for now.
+///
+/// [`QueryContext`]: crate::server::query_context::QueryContext
 pub(crate) fn current_function_mapper() -> &'static dyn FunctionMapper {
-    for_dialect(crate::sql_generator::SqlDialect::ClickHouse)
+    for_dialect(crate::server::query_context::get_current_dialect())
 }
 
 /// Returns the function mapper for an explicit dialect.


### PR DESCRIPTION
## Summary

Phase 1.1: thread the active SQL dialect through the rendering pipeline via the existing `QueryContext` task-local, and resolve the two structural gaps the [Phase 1.0 spike (#321)](https://github.com/genezhang/clickgraph/pull/321) surfaced.

**The key trick**: rather than threading a `dialect: SqlDialect` parameter through ~20 function signatures across `render_plan/`, this PR adds one field to `QueryContext` and updates `current_function_mapper()` to read from the task-local. Every existing `current_function_mapper()` call site automatically becomes dialect-aware — zero churn outside the three sites that need *structural* (not just naming) dialect awareness.

## What changed

### Plumbing (~30 LOC)

| | |
|---|---|
| `QueryContext::dialect` | New field, defaults to `ClickHouse`. |
| `get_current_dialect()` / `set_current_dialect()` | Accessors matching the existing pattern in `query_context.rs`. |
| `current_function_mapper()` | Now reads dialect from task-local. Outside a scope it defaults to ClickHouse, so existing tests stay byte-identical. |

### Structural gap #1 — `json_extract_string` (resolved)

The Phase 1.0 panic was overcautious — `JSONExtractString(json, 'field')` → `get_json_object(json, '$.field')` is a **function-name swap plus an argument-shape rewrite**, not a true structural rewrite. The mapper now returns `"get_json_object"` for Databricks; the single call site in `select_builder.rs` prepends `$.` when active dialect is Databricks.

### Structural gap #2 — `array_count` (resolved via call-site helper)

This one genuinely *is* a structural rewrite:
- ClickHouse: `arrayCount(x -> pred, arr)` — predicate-first
- Spark: `size(filter(arr, x -> pred))` — wrapped, arg order reversed

Mapper-level `array_count()` still panics for Databricks (tripwire). Both call sites in `plan_builder_utils.rs` now go through `emit_array_count_call(lambda_var, predicate, array)` which branches on dialect.

## Tests

4 new tests, 1665/1665 passing:
- `emit_array_count_call_defaults_to_clickhouse` — outside task scope.
- `emit_array_count_call_databricks_uses_size_filter` — with `dialect: Databricks` in scope.
- `current_mapper_defaults_to_clickhouse_outside_scope`.
- `current_mapper_follows_task_local_dialect`.

## Phase 1.2 (next)

Write `DatabricksEmitter::emit()`. It will set `dialect: Databricks` in the `QueryContext` before delegating to the rendering pipeline; everything we built in Phase 0.1–1.1 flows through automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)