### PR TITLE
feat(dialect): route array-literal syntax through FunctionMapper (Phase 1.3)

### DIFF
--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -23,6 +23,27 @@ use crate::render_plan::cte_generation::CteGenerationContext;
 use crate::render_plan::errors::RenderBuildError;
 use crate::render_plan::filter_pipeline::CategorizedFilters;
 
+/// Dialect-correct array literal. CH: `[a, b]`. Spark: `array(a, b)`.
+/// Thin shorthand over `FunctionMapper::array_literal` — CTE generation
+/// builds these in many places (path_edges, path_nodes).
+fn arr(elems: &str) -> String {
+    crate::sql_generator::function_mapper::current_function_mapper().array_literal(elems)
+}
+
+/// `arrayConcat(arr_expr, [scalar])` — appends a single scalar onto an
+/// array. Goes through `FunctionMapper` for both the function name
+/// (`arrayConcat` / `concat`) and the array literal shape (`[x]` /
+/// `array(x)`).
+fn arr_append(arr_expr: &str, scalar: &str) -> String {
+    let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+    format!(
+        "{}({}, {})",
+        mapper.array_concat(),
+        arr_expr,
+        mapper.array_literal(scalar)
+    )
+}
+
 /// Unified error type for CTE operations
 #[derive(Debug, thiserror::Error)]
 pub enum CteError {
@@ -726,15 +747,21 @@ impl FkEdgeCteStrategy {
             ),
             "1 as hop_count".to_string(),
             format!(
-                "[{}.{}] as path_edges",
-                self.pattern_ctx.left_node_alias, self.fk_column
+                "{} as path_edges",
+                arr(&format!(
+                    "{}.{}",
+                    self.pattern_ctx.left_node_alias, self.fk_column
+                ))
             ), // FK column represents the edge
             format!(
-                "[{}.{}, {}.{}] as path_nodes",
-                self.pattern_ctx.left_node_alias,
-                self.id_column,
-                self.pattern_ctx.right_node_alias,
-                self.id_column
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.{}, {}.{}",
+                    self.pattern_ctx.left_node_alias,
+                    self.id_column,
+                    self.pattern_ctx.right_node_alias,
+                    self.id_column
+                ))
             ),
         ];
 
@@ -788,12 +815,18 @@ impl FkEdgeCteStrategy {
             ),
             format!("{}.hop_count + 1 as hop_count", cte_name),
             format!(
-                "arrayConcat({}.path_edges, [{}.{}]) as path_edges",
-                cte_name, self.pattern_ctx.left_node_alias, self.fk_column
+                "{} as path_edges",
+                arr_append(
+                    &format!("{}.path_edges", cte_name),
+                    &format!("{}.{}", self.pattern_ctx.left_node_alias, self.fk_column),
+                )
             ),
             format!(
-                "arrayConcat({}.path_nodes, [{}.{}]) as path_nodes",
-                cte_name, self.pattern_ctx.right_node_alias, self.id_column
+                "{} as path_nodes",
+                arr_append(
+                    &format!("{}.path_nodes", cte_name),
+                    &format!("{}.{}", self.pattern_ctx.right_node_alias, self.id_column),
+                )
             ),
         ];
 
@@ -1009,15 +1042,18 @@ impl TraditionalCteStrategy {
             ),
             "1 as hop_count".to_string(),
             format!(
-                "[{}.{}] as path_edges",
-                self.pattern_ctx.rel_alias, rel_from_col
+                "{} as path_edges",
+                arr(&format!("{}.{}", self.pattern_ctx.rel_alias, rel_from_col))
             ), // Simplified edge tracking
             format!(
-                "[{}.{}, {}.{}] as path_nodes",
-                self.pattern_ctx.left_node_alias,
-                start_id_col,
-                self.pattern_ctx.right_node_alias,
-                end_id_col
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.{}, {}.{}",
+                    self.pattern_ctx.left_node_alias,
+                    start_id_col,
+                    self.pattern_ctx.right_node_alias,
+                    end_id_col
+                ))
             ),
         ];
 
@@ -1077,12 +1113,12 @@ impl TraditionalCteStrategy {
             ),
             format!("{}.hop_count + 1 as hop_count", cte_name),
             format!(
-                "arrayConcat({}.path_edges, [{}]) as path_edges",
-                cte_name, rel_from_col
+                "{} as path_edges",
+                arr_append(&format!("{}.path_edges", cte_name), &rel_from_col)
             ),
             format!(
-                "arrayConcat({}.path_nodes, [{}]) as path_nodes",
-                cte_name, end_id_col
+                "{} as path_nodes",
+                arr_append(&format!("{}.path_nodes", cte_name), &end_id_col)
             ),
         ];
 
@@ -1585,12 +1621,18 @@ impl DenormalizedCteStrategy {
             format!("{}.{} as end_id", self.pattern_ctx.rel_alias, self.to_col),
             "1 as hop_count".to_string(),
             format!(
-                "[{}.{}] as path_edges",
-                self.pattern_ctx.rel_alias, self.from_col
+                "{} as path_edges",
+                arr(&format!("{}.{}", self.pattern_ctx.rel_alias, self.from_col))
             ), // Simplified edge tracking
             format!(
-                "[{}.{}, {}.{}] as path_nodes",
-                self.pattern_ctx.rel_alias, self.from_col, self.pattern_ctx.rel_alias, self.to_col
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.{}, {}.{}",
+                    self.pattern_ctx.rel_alias,
+                    self.from_col,
+                    self.pattern_ctx.rel_alias,
+                    self.to_col
+                ))
             ),
         ];
 
@@ -1628,8 +1670,8 @@ impl DenormalizedCteStrategy {
             format!("next.{} as start_id", self.from_col),
             format!("next.{} as end_id", self.to_col),
             "vp.hop_count + 1".to_string(),
-            format!("arrayConcat(vp.path_edges, [next.{}])", self.from_col), // Extend edge path array
-            format!("arrayConcat(vp.path_nodes, [next.{}])", self.to_col), // Extend node path array
+            arr_append("vp.path_edges", &format!("next.{}", self.from_col)), // Extend edge path array
+            arr_append("vp.path_nodes", &format!("next.{}", self.to_col)), // Extend node path array
         ];
 
         // Add properties from the next table occurrence
@@ -1912,12 +1954,15 @@ impl MixedAccessCteStrategy {
             format!("{}.end_id", embedded_node_alias),
             "1 as hop_count".to_string(),
             format!(
-                "[{}.{}] as path_edges",
-                self.pattern_ctx.rel_alias, self.join_col
+                "{} as path_edges",
+                arr(&format!("{}.{}", self.pattern_ctx.rel_alias, self.join_col))
             ), // Edge represented by join column
             format!(
-                "[{}.start_id, {}.end_id] as path_nodes",
-                joined_node_alias, embedded_node_alias
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.start_id, {}.end_id",
+                    joined_node_alias, embedded_node_alias
+                ))
             ),
         ];
 
@@ -1999,12 +2044,12 @@ impl MixedAccessCteStrategy {
             format!("{}.{}", embedded_node_alias, VLP_END_ID_COLUMN),
             format!("{}.hop_count + 1 as hop_count", cte_name),
             format!(
-                "arrayConcat({}.path_edges, [{}]) as path_edges",
-                cte_name, self.join_col
+                "{} as path_edges",
+                arr_append(&format!("{}.path_edges", cte_name), &self.join_col)
             ),
             format!(
-                "arrayConcat({}.path_nodes, [{}]) as path_nodes",
-                cte_name, VLP_END_ID_COLUMN
+                "{} as path_nodes",
+                arr_append(&format!("{}.path_nodes", cte_name), VLP_END_ID_COLUMN)
             ),
         ];
 
@@ -2328,12 +2373,18 @@ impl EdgeToEdgeCteStrategy {
             format!("{}.{} as end_id", self.pattern_ctx.rel_alias, self.to_col),
             "1 as hop_count".to_string(),
             format!(
-                "[{}.{}] as path_edges",
-                self.pattern_ctx.rel_alias, self.from_col
+                "{} as path_edges",
+                arr(&format!("{}.{}", self.pattern_ctx.rel_alias, self.from_col))
             ), // Simplified edge tracking
             format!(
-                "[{}.{}, {}.{}] as path_nodes",
-                self.pattern_ctx.rel_alias, self.from_col, self.pattern_ctx.rel_alias, self.to_col
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.{}, {}.{}",
+                    self.pattern_ctx.rel_alias,
+                    self.from_col,
+                    self.pattern_ctx.rel_alias,
+                    self.to_col
+                ))
             ),
         ];
 
@@ -2572,10 +2623,19 @@ impl CoupledCteStrategy {
             format!("{}.{} as start_id", self.unified_alias, self.from_col),
             format!("{}.{} as end_id", self.unified_alias, self.to_col),
             "1 as hop_count".to_string(), // For coupled edges, each row represents 1 "logical" hop
-            format!("[{}.{}] as path_edges", self.unified_alias, self.from_col),
             format!(
-                "[{}.{}, {}.{}] as path_nodes",
-                self.unified_alias, self.from_col, self.unified_alias, self.to_col
+                "{} as path_edges",
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .array_literal(&format!("{}.{}", self.unified_alias, self.from_col))
+            ),
+            format!(
+                "{} as path_nodes",
+                crate::sql_generator::function_mapper::current_function_mapper().array_literal(
+                    &format!(
+                        "{}.{}, {}.{}",
+                        self.unified_alias, self.from_col, self.unified_alias, self.to_col
+                    )
+                )
             ),
         ];
 

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -746,7 +746,8 @@ fn render_rhs_to_sql(expr: &LogicalExpr, as_string: bool) -> String {
                 .iter()
                 .map(|i| render_rhs_to_sql(i, as_string))
                 .collect();
-            format!("[{}]", rendered.join(", "))
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&rendered.join(", "))
         }
         _ => {
             // Fallback: try to render via RenderExpr conversion and SQL generation

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -20,14 +20,11 @@
 //! flip cleanly. Run `print_databricks_vlp_sql` with `--nocapture` to
 //! see the full output. The remaining gaps for Phase 1.3+:
 //!
-//! 1. **Array-literal syntax**. Generated SQL contains
-//!    `[start_node.id, end_node.id]` and `concat(vp.path_nodes,
-//!    [end_node.id])`. CH supports `[a, b]`; Spark requires
-//!    `array(a, b)`. These literals are spelled directly in the
-//!    rendering layer (not routed through `FunctionMapper`). Fix
-//!    candidate: add `FunctionMapper::array_literal_open/close()` or a
-//!    helper `emit_array_literal(elems)` mirroring the pattern from
-//!    Phase 0.4b.
+//! 1. **Array-literal syntax (Phase 1.3, done).** `format!("[{...}]")`
+//!    sites in the rendering layer now go through
+//!    `FunctionMapper::array_literal(&elems)`, so Spark sees
+//!    `array(a, b)` and CH sees `[a, b]`. Asserted by
+//!    `vlp_under_databricks_dialect_emits_spark_spellings` below.
 //!
 //! 2. **Identifier / alias quoting**. The output uses `AS "b.id"` for
 //!    aliases with dots. CH treats `"…"` as a quoted identifier; Spark
@@ -40,7 +37,7 @@
 //!    field on `FunctionMapping` in
 //!    `emitters/clickhouse/function_registry.rs`, not `FunctionMapper`.
 //!    So `collect(n.name)` still emits `groupArray(...)` under
-//!    Databricks dialect. Phase 1.3 should make the registry
+//!    Databricks dialect. A follow-up phase should make the registry
 //!    dialect-aware (or split into per-dialect registries).
 //!
 //! 4. **Type names in non-routed CASTs**. The current spike doesn't
@@ -48,10 +45,9 @@
 //!    various rendering paths.
 //!
 //! What this means for the abstraction: Phase 0.1–1.1 was about routing
-//! the *function name* layer. The remaining work is routing the
-//! *syntactic layer* — array literals, identifier quoting, type names.
-//! All three lend themselves to the same pattern (FunctionMapper-style
-//! method or call-site helper) so the path is clear, not blocked.
+//! the *function name* layer; Phase 1.3 extended the same pattern to
+//! the *array literal* shape. The remaining work — identifier quoting
+//! and aggregate registry — fits the same shape, so the path is clear.
 
 use crate::{
     clickhouse_query_generator,
@@ -194,11 +190,21 @@ async fn vlp_under_clickhouse_dialect_emits_ch_spellings() {
         sql.contains("CAST([] AS Array(String))"),
         "expected CH empty-array cast in VLP CTE; got:\n{sql}"
     );
+    // The VLP recursive case builds `[end_id]` to append onto path_nodes.
+    // Under CH dialect this stays as bracket-syntax array literal.
+    assert!(
+        sql.contains("arrayConcat(vp.path_nodes, [") || sql.contains("[toString("),
+        "expected CH bracket-style array literal in VLP path append; got:\n{sql}"
+    );
     // Spark spellings must NOT appear under CH dialect.
     assert!(!sql.contains("ARRAY<STRING>"), "CH SQL leaked Spark type");
     assert!(
         !sql.contains("array_contains"),
         "CH SQL leaked Spark function name"
+    );
+    assert!(
+        !sql.contains("array(toString("),
+        "CH SQL leaked Spark array() literal"
     );
 }
 
@@ -261,5 +267,20 @@ async fn vlp_under_databricks_dialect_emits_spark_spellings() {
     assert!(
         !sql.contains("CAST([] AS Array(String))"),
         "Databricks SQL leaked CH empty-array cast; got:\n{sql}"
+    );
+
+    // Phase 1.3: array literals now route through FunctionMapper.
+    // The VLP recursive case builds `array(end_id)` to append onto
+    // path_nodes under Databricks dialect (CH builds `[end_id]`).
+    assert!(
+        sql.contains("concat(vp.path_nodes, array("),
+        "expected Spark `array(...)` literal in VLP path append; got:\n{sql}"
+    );
+    // No bracket-style array literals should leak into Databricks SQL.
+    // (We allow `[` to appear in other contexts like `Array(String)`
+    // type names inside CH-only output, but those shouldn't show up here.)
+    assert!(
+        !sql.contains(", [toString(") && !sql.contains("vp.path_nodes, ["),
+        "Databricks SQL leaked CH bracket-style array literal; got:\n{sql}"
     );
 }

--- a/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
+++ b/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
@@ -295,13 +295,14 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
             format!("CAST({}, '{}')", default, ch_type)
         };
 
+        let empty_str_arr = crate::sql_generator::function_mapper::current_function_mapper()
+            .empty_string_array_cast();
         format!(
-            "SELECT '' AS end_type, {} AS end_id, {} AS start_id, '' AS start_type, \
+            "SELECT '' AS end_type, {end_id_sql} AS end_id, {start_id_sql} AS start_id, '' AS start_type, \
              '{{}}' AS end_properties, '{{}}' AS start_properties, \
-             0 AS hop_count, CAST([], 'Array(String)') AS path_relationships, \
-             CAST([], 'Array(String)') AS rel_properties, \
-             CAST([], 'Array(String)') AS path_nodes WHERE 0 = 1",
-            end_id_sql, start_id_sql
+             0 AS hop_count, {empty_str_arr} AS path_relationships, \
+             {empty_str_arr} AS rel_properties, \
+             {empty_str_arr} AS path_nodes WHERE 0 = 1"
         )
     }
 
@@ -625,8 +626,10 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         // hop_count = 0
         items.push("0 AS hop_count".to_string());
         // empty path arrays
-        items.push("CAST([], 'Array(String)') AS path_relationships".to_string());
-        items.push("CAST([], 'Array(String)') AS rel_properties".to_string());
+        let empty_str_arr = crate::sql_generator::function_mapper::current_function_mapper()
+            .empty_string_array_cast();
+        items.push(format!("{empty_str_arr} AS path_relationships"));
+        items.push(format!("{empty_str_arr} AS rel_properties"));
         // path_nodes = [start_id] for zero-hop path
         let path_node_id_sql = if let Ok(id) = self.get_node_id_column(start_type) {
             let id_sql = id.to_sql_native(&start_alias_sql);
@@ -638,7 +641,11 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         } else {
             format!("toString({}.id)", start_alias_sql)
         };
-        items.push(format!("[{}] AS path_nodes", path_node_id_sql));
+        items.push(format!(
+            "{} AS path_nodes",
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&path_node_id_sql)
+        ));
 
         let mut sql = format!(
             "SELECT {}\nFROM {} {}",
@@ -1370,7 +1377,11 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
             .iter()
             .map(|hop| format!("'{}'", hop.rel_type))
             .collect();
-        items.push(format!("[{}] AS path_relationships", rel_types.join(", ")));
+        items.push(format!(
+            "{} AS path_relationships",
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&rel_types.join(", "))
+        ));
 
         // 🔧 FIX: Add rel_properties for RETURN r support
         // Generate array of JSON objects containing relationship properties for each hop
@@ -1440,7 +1451,11 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
                 }
             })
             .collect();
-        items.push(format!("[{}] AS rel_properties", rel_props.join(", ")));
+        items.push(format!(
+            "{} AS rel_properties",
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&rel_props.join(", "))
+        ));
 
         // Add path_nodes for nodes(p) function support
         // Build array of all node IDs in the path: [start_id, intermediate..., end_id]
@@ -1461,7 +1476,11 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
                 }
             })
             .collect();
-        items.push(format!("[{}] AS path_nodes", path_node_exprs.join(", ")));
+        items.push(format!(
+            "{} AS path_nodes",
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&path_node_exprs.join(", "))
+        ));
 
         items
     }

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -58,8 +58,11 @@ fn flatten_list_addition_operands_logical(
         _ => {
             let sql = ToSql::to_sql(expr)?;
             if is_known_scalar_logical(expr) {
-                // Wrap scalar as single-element array for arrayConcat compatibility
-                Ok(vec![format!("[{}]", sql)])
+                // Wrap scalar as single-element array for arrayConcat/concat compatibility
+                Ok(vec![
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .array_literal(&sql),
+                ])
             } else {
                 Ok(vec![sql])
             }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -281,8 +281,11 @@ fn flatten_list_addition_operands(expr: &RenderExpr) -> Vec<String> {
         _ => {
             let sql = expr.to_sql();
             if is_known_scalar(expr) {
-                // Wrap scalar as single-element array for arrayConcat compatibility
-                vec![format!("[{}]", sql)]
+                // Wrap scalar as single-element array for arrayConcat/concat compatibility
+                vec![
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .array_literal(&sql),
+                ]
             } else {
                 vec![sql]
             }
@@ -4459,9 +4462,8 @@ impl RenderExpr {
                     .map(|e| e.to_sql())
                     .collect::<Vec<_>>()
                     .join(", ");
-                // Use array literal syntax [...] for ClickHouse
-                // This works for both ARRAY JOIN (UNWIND) and IN clauses
-                format!("[{}]", inner)
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .array_literal(&inner)
             }
             RenderExpr::ScalarFnCall(fn_call) => {
                 // Check for special functions that need custom handling
@@ -5147,7 +5149,8 @@ impl RenderExpr {
 
                 let render_result = |expr: &RenderExpr| -> String {
                     if has_list_branch && matches!(expr, RenderExpr::Literal(Literal::Null)) {
-                        "[]".to_string()
+                        crate::sql_generator::function_mapper::current_function_mapper()
+                            .array_literal("")
                     } else {
                         expr.to_sql()
                     }
@@ -5169,7 +5172,8 @@ impl RenderExpr {
                         .map(|e| render_result(e))
                         .unwrap_or_else(|| {
                             if has_list_branch {
-                                "[]".to_string()
+                                crate::sql_generator::function_mapper::current_function_mapper()
+                                    .array_literal("")
                             } else {
                                 "NULL".to_string()
                             }

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -63,6 +63,14 @@ fn emit_cycle_check(id_expr: &str) -> String {
     format!("NOT {array_contains}(vp.path_nodes, {id_expr})")
 }
 
+/// Emit a dialect-correct array literal. CH: `[a, b]`. Spark: `array(a, b)`.
+/// Thin shorthand over `FunctionMapper::array_literal` — VLP code builds
+/// these in many places (path_nodes, path_relationships, scalar→array
+/// wrappers for arrayConcat).
+fn arr(elems: &str) -> String {
+    current_function_mapper().array_literal(elems)
+}
+
 /// Property to include in the CTE (column name and which node it belongs to)
 #[derive(Debug, Clone)]
 pub struct NodeProperty {
@@ -660,25 +668,29 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // For now, return the first relationship type if available, otherwise a placeholder
         if let Some(ref types) = self.relationship_types {
             if let Some(first_type) = types.first() {
-                format!("['{}'] as path_relationships", first_type)
+                format!(
+                    "{} as path_relationships",
+                    arr(&format!("'{}'", first_type))
+                )
             } else {
-                "[] as path_relationships".to_string()
+                format!("{} as path_relationships", arr(""))
             }
         } else {
-            "[] as path_relationships".to_string()
+            format!("{} as path_relationships", arr(""))
         }
     }
 
     /// Get relationship type array for appending in recursive case
     fn get_relationship_type_array(&self) -> String {
+        let mapper = crate::sql_generator::function_mapper::current_function_mapper();
         if let Some(ref types) = self.relationship_types {
             if let Some(first_type) = types.first() {
-                format!("['{}']", first_type)
+                mapper.array_literal(&format!("'{}'", first_type))
             } else {
-                "[]".to_string()
+                mapper.array_literal("")
             }
         } else {
-            "[]".to_string()
+            mapper.array_literal("")
         }
     }
 
@@ -1230,17 +1242,19 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // IMPORTANT: Use FROM+WHERE to read BFS hop level instead of scalar subqueries.
         // Scalar subqueries referencing recursive CTEs inside other CTEs cause ClickHouse
         // to hang (CTE inlining re-evaluates the entire recursion chain).
+        let target_nodes_arr = arr(target_id.as_str());
+        let source_scalar_arr = arr(&format!("ew.{source}"));
         let recon_sql = format!(
             "{recon_cte} AS (\n    \
              SELECT CAST({target_id} AS Int64) AS node_id,\n           \
              bfs_target.hop AS remaining,\n           \
-             CAST([{target_id}] AS Array(Int64)) AS path_nodes,\n           \
+             CAST({target_nodes_arr} AS Array(Int64)) AS path_nodes,\n           \
              toFloat64(0) AS total_weight\n    \
              FROM {bfs_cte} AS bfs_target\n    \
              WHERE bfs_target.node_id = CAST({target_id} AS Int64)\n    \
              UNION ALL\n    \
              SELECT ew.{source} AS node_id, pr.remaining - 1 AS remaining,\n           \
-             {ac}([ew.{source}], pr.path_nodes) AS path_nodes,\n           \
+             {ac}({source_scalar_arr}, pr.path_nodes) AS path_nodes,\n           \
              pr.total_weight + ew.{weight} AS total_weight\n    \
              FROM {recon_cte} pr\n    \
              JOIN {weight_cte} ew ON ew.{target_col} = pr.node_id\n    \
@@ -1737,8 +1751,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
             format!("{empty_str_arr} as path_relationships"), // Minimal placeholder when path data not needed
             // Add path_nodes for UNWIND nodes(p) support - for zero hop, just the start node
             format!(
-                "[{}.{}] as path_nodes",
-                self.start_node_alias, self.start_node_id_column
+                "{} as path_nodes",
+                arr(&format!(
+                    "{}.{}",
+                    self.start_node_alias, self.start_node_id_column
+                ))
             ),
         ];
 
@@ -1871,12 +1888,15 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 (Identifier::Single(_), Identifier::Single(_))
                 | (Identifier::Composite(_), Identifier::Composite(_)) => {
                     format!(
-                        "[{}, {}] as path_nodes",
-                        emit_id_expr(&self.start_node_alias, &start_id_identifier),
-                        emit_id_expr(&self.end_node_alias, &end_id_identifier),
+                        "{} as path_nodes",
+                        arr(&format!(
+                            "{}, {}",
+                            emit_id_expr(&self.start_node_alias, &start_id_identifier),
+                            emit_id_expr(&self.end_node_alias, &end_id_identifier),
+                        ))
                     )
                 }
-                _ => "[] as path_nodes".to_string(),
+                _ => format!("{} as path_nodes", arr("")),
             };
 
             // Build property selections
@@ -2037,9 +2057,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
     fn generate_multi_hop_base_case(&self, hop_count: u32) -> String {
         // This is a simplified version - in practice, we'd need to handle
         // different relationship types and intermediate node types
+        let empty_arr = arr("");
         format!(
-            "    -- Multi-hop base case for {} hops (simplified)\n    SELECT NULL as start_id, NULL as end_id, {} as hop_count, [] as path_relationships\n    WHERE false  -- Placeholder",
-            hop_count, hop_count
+            "    -- Multi-hop base case for {hop_count} hops (simplified)\n    SELECT NULL as start_id, NULL as end_id, {hop_count} as hop_count, {empty_arr} as path_relationships\n    WHERE false  -- Placeholder"
         )
     }
     /// Generate weighted base case using pre-computed edge weight CTE
@@ -2061,8 +2081,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         let empty_str_arr = current_function_mapper().empty_string_array_cast();
         let path_rel_expr = format!("{empty_str_arr} AS path_relationships");
+        let path_nodes_arr = arr(&format!("ew.{}, ew.{}", wc.source_column, wc.target_column));
         format!(
-            "    SELECT\n        ew.{source} AS start_id,\n        ew.{target} AS end_id,\n        1 AS hop_count,\n        ew.{weight} AS total_weight,\n        [ew.{source}, ew.{target}] AS path_nodes,\n        {path_rel_expr} \n    FROM {cte} ew{where_clause}",
+            "    SELECT\n        ew.{source} AS start_id,\n        ew.{target} AS end_id,\n        1 AS hop_count,\n        ew.{weight} AS total_weight,\n        {path_nodes_arr} AS path_nodes,\n        {path_rel_expr} \n    FROM {cte} ew{where_clause}",
             source = wc.source_column,
             target = wc.target_column,
             weight = wc.weight_column,
@@ -2087,9 +2108,10 @@ impl<'a> VariableLengthCteGenerator<'a> {
             format!("{empty_str_arr} AS path_relationships")
         };
         let cycle_pred = emit_cycle_check(&format!("ew.{}", wc.target_column));
+        let target_scalar_arr = arr(&format!("ew.{}", wc.target_column));
 
         format!(
-            "    SELECT\n        vp.start_id,\n        ew.{target} AS end_id,\n        vp.hop_count + 1 AS hop_count,\n        vp.total_weight + ew.{weight} AS total_weight,\n        {ac}(vp.path_nodes, [ew.{target}]) AS path_nodes,\n        {path_rel_col}\n    FROM {cte_name} vp\n    JOIN {weight_cte} ew ON ew.{source} = vp.end_id\n    WHERE vp.hop_count < {max_hops}\n      AND {cycle_pred}",
+            "    SELECT\n        vp.start_id,\n        ew.{target} AS end_id,\n        vp.hop_count + 1 AS hop_count,\n        vp.total_weight + ew.{weight} AS total_weight,\n        {ac}(vp.path_nodes, {target_scalar_arr}) AS path_nodes,\n        {path_rel_col}\n    FROM {cte_name} vp\n    JOIN {weight_cte} ew ON ew.{source} = vp.end_id\n    WHERE vp.hop_count < {max_hops}\n      AND {cycle_pred}",
             target = wc.target_column,
             weight = wc.weight_column,
             source = wc.source_column,
@@ -2149,8 +2171,10 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         // end_id selection (composite-aware) and path_nodes extension
         let end_id_selection = format!("{end_id_expr_str} as end_id");
-        let path_nodes_selection =
-            format!("{ac}(vp.path_nodes, [{end_id_expr_str}]) as path_nodes");
+        let path_nodes_selection = format!(
+            "{ac}(vp.path_nodes, {}) as path_nodes",
+            arr(&end_id_expr_str)
+        );
 
         // Build property selections for recursive case
         let mut select_items = vec![
@@ -2402,8 +2426,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
         // Track intermediate node IDs in path_nodes
         select_items.push(format!(
-            "{ac}(vp.path_nodes, [intermediate_node.{}]) as path_nodes",
-            intermediate_id_col
+            "{ac}(vp.path_nodes, {}) as path_nodes",
+            arr(&format!("intermediate_node.{}", intermediate_id_col))
         ));
 
         // Add properties: start properties pass through, end properties NOT available yet
@@ -2477,9 +2501,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
     fn generate_fk_edge_base_case(&self, hop_count: u32) -> String {
         if hop_count != 1 {
             // Multi-hop base case not yet supported for FK-edge
+            let empty_arr = arr("");
             return format!(
-                "    -- Multi-hop base case for {} hops (FK-edge - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {} as hop_count, [] as path_relationships, [] as path_nodes\n    WHERE false",
-                hop_count, hop_count
+                "    -- Multi-hop base case for {hop_count} hops (FK-edge - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {hop_count} as hop_count, {empty_arr} as path_relationships, {empty_arr} as path_nodes\n    WHERE false"
             );
         }
 
@@ -2502,11 +2526,14 @@ impl<'a> VariableLengthCteGenerator<'a> {
             select_items.push(format!("{empty_str_arr} as path_relationships"));
         }
         select_items.push(format!(
-            "[{}.{}, {}.{}] as path_nodes",
-            self.start_node_alias,
-            self.start_node_id_column,
-            self.end_node_alias,
-            self.end_node_id_column
+            "{} as path_nodes",
+            arr(&format!(
+                "{}.{}, {}.{}",
+                self.start_node_alias,
+                self.start_node_id_column,
+                self.end_node_alias,
+                self.end_node_id_column
+            ))
         ));
 
         // Add properties for start and end nodes
@@ -2630,8 +2657,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
         // APPEND the new node to path_nodes
         select_items.push(format!(
-            "{ac}(vp.path_nodes, [{}.{}]) as path_nodes",
-            "new_end", self.end_node_id_column
+            "{ac}(vp.path_nodes, {}) as path_nodes",
+            arr(&format!("new_end.{}", self.end_node_id_column))
         ));
 
         // Add properties: start properties from CTE, end properties from new joined node
@@ -2716,8 +2743,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
         // PREPEND the new node to path_nodes
         select_items.push(format!(
-            "{ac}([{}.{}], vp.path_nodes) as path_nodes",
-            "new_start", self.start_node_id_column
+            "{ac}({}, vp.path_nodes) as path_nodes",
+            arr(&format!("new_start.{}", self.start_node_id_column))
         ));
 
         // Add properties: end properties from CTE, start properties from new joined node
@@ -2796,9 +2823,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         if hop_count != 1 {
             // Multi-hop base case not yet supported for denormalized
+            let empty_arr = arr("");
             return format!(
-                "    -- Multi-hop base case for {} hops (denormalized - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {} as hop_count, [] as path_relationships, [] as path_nodes\n    WHERE false",
-                hop_count, hop_count
+                "    -- Multi-hop base case for {hop_count} hops (denormalized - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {hop_count} as hop_count, {empty_arr} as path_relationships, {empty_arr} as path_nodes\n    WHERE false"
             );
         }
 
@@ -2821,11 +2848,14 @@ impl<'a> VariableLengthCteGenerator<'a> {
             select_items.push(format!("{empty_str_arr} as path_relationships"));
         }
         select_items.push(format!(
-            "[{}.{}, {}.{}] as path_nodes",
-            self.relationship_alias,
-            self.relationship_from_column,
-            self.relationship_alias,
-            self.relationship_to_column
+            "{} as path_nodes",
+            arr(&format!(
+                "{}.{}, {}.{}",
+                self.relationship_alias,
+                self.relationship_from_column,
+                self.relationship_alias,
+                self.relationship_to_column
+            ))
         ));
 
         // Generate JSON property blobs for start and end nodes (denormalized)
@@ -2939,7 +2969,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
                     }
                 })
                 .unwrap_or_else(|| "'{}'".to_string());
-            select_items.push(format!("[{}] AS rel_properties", rel_props_json));
+            select_items.push(format!(
+                "{} AS rel_properties",
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .array_literal(&rel_props_json)
+            ));
         }
 
         // Add start_type and end_type discriminators for transform_vlp_path()
@@ -3046,8 +3080,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
             select_items.push(format!("{empty_str_arr} as path_relationships"));
         }
         select_items.push(format!(
-            "{ac}(vp.path_nodes, [{}.{}]) as path_nodes",
-            self.relationship_alias, self.relationship_to_column
+            "{ac}(vp.path_nodes, {}) as path_nodes",
+            arr(&format!(
+                "{}.{}",
+                self.relationship_alias, self.relationship_to_column
+            ))
         ));
 
         // Add denormalized properties as JSON blobs matching base case columns.
@@ -3117,8 +3154,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 })
                 .unwrap_or_else(|| "'{}'".to_string());
             select_items.push(format!(
-                "{ac}(vp.rel_properties, [{}]) as rel_properties",
-                rel_props_json
+                "{ac}(vp.rel_properties, {}) as rel_properties",
+                arr(&rel_props_json)
             ));
 
             // start_type / end_type: carry forward from CTE
@@ -3227,9 +3264,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
     fn generate_mixed_base_case(&self, hop_count: u32) -> String {
         if hop_count != 1 {
             // Multi-hop base case not yet supported for mixed
+            let empty_arr = arr("");
             return format!(
-                "    -- Multi-hop base case for {} hops (mixed - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {} as hop_count, [] as path_relationships, [] as path_nodes\n    WHERE false",
-                hop_count, hop_count
+                "    -- Multi-hop base case for {hop_count} hops (mixed - not yet supported)\n    SELECT NULL as start_id, NULL as end_id, {hop_count} as hop_count, {empty_arr} as path_relationships, {empty_arr} as path_nodes\n    WHERE false"
             );
         }
 
@@ -3268,8 +3305,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
             select_items.push(format!("{empty_str_arr} as path_relationships"));
         }
         select_items.push(format!(
-            "[{}, {}] as path_nodes",
-            start_id_expr, end_id_expr
+            "{} as path_nodes",
+            arr(&format!("{}, {}", start_id_expr, end_id_expr))
         ));
 
         // Add properties for non-denormalized nodes
@@ -3398,8 +3435,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
         // path_nodes always maintained for cycle detection
         select_items.push(format!(
-            "{ac}(vp.path_nodes, [{}]) as path_nodes",
-            end_id_expr
+            "{ac}(vp.path_nodes, {}) as path_nodes",
+            arr(&end_id_expr)
         ));
 
         // Add properties - start from CTE, end from joined node (if not denorm)

--- a/src/sql_generator/emitters/clickhouse/write_to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/write_to_sql.rs
@@ -157,7 +157,8 @@ fn render_expr_inline(expr: &crate::render_plan::render_expr::RenderExpr) -> Str
         RenderExpr::Raw(raw) => raw.clone(),
         RenderExpr::List(items) => {
             let parts = items.iter().map(render_expr_inline).collect::<Vec<_>>();
-            format!("[{}]", parts.join(", "))
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .array_literal(&parts.join(", "))
         }
         RenderExpr::ScalarFnCall(fn_call) => {
             let args = fn_call

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -53,4 +53,8 @@ impl FunctionMapper for ClickhouseFunctionMapper {
     fn empty_int64_array_cast(&self) -> &'static str {
         "CAST([] AS Array(Int64))"
     }
+
+    fn array_literal(&self, elems: &str) -> String {
+        format!("[{elems}]")
+    }
 }

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -110,6 +110,10 @@ impl FunctionMapper for DatabricksFunctionMapper {
     fn empty_int64_array_cast(&self) -> &'static str {
         "CAST(array() AS ARRAY<BIGINT>)"
     }
+
+    fn array_literal(&self, elems: &str) -> String {
+        format!("array({elems})")
+    }
 }
 
 #[cfg(test)]
@@ -136,6 +140,8 @@ mod tests {
             "CAST(array() AS ARRAY<STRING>)"
         );
         assert_eq!(m.empty_int64_array_cast(), "CAST(array() AS ARRAY<BIGINT>)");
+        assert_eq!(m.array_literal(""), "array()");
+        assert_eq!(m.array_literal("a, b"), "array(a, b)");
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -78,6 +78,13 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// Empty `Array(Int64)` literal with explicit cast. CH:
     /// `CAST([] AS Array(Int64))`. Spark: `CAST(array() AS ARRAY<BIGINT>)`.
     fn empty_int64_array_cast(&self) -> &'static str;
+
+    /// Array literal with the given comma-separated elements. CH:
+    /// `[a, b, c]`. Spark: `array(a, b, c)`. Empty input (`""`) yields
+    /// `[]` / `array()` respectively. Returned as `String` because the
+    /// elements aren't known to the trait — callers join their own
+    /// rendered expressions and pass them here.
+    fn array_literal(&self, elems: &str) -> String;
 }
 
 /// Returns the function mapper for the active SQL dialect, read from the


### PR DESCRIPTION
## Summary
- Adds `FunctionMapper::array_literal(&elems)` so the rendering layer emits CH's `[a, b]` vs Databricks's `array(a, b)` automatically based on the active task-local dialect.
- Routes ~40 hardcoded `format!(\"[{...}]\")` and `\"CAST([], 'Array(String)')\"` sites across `render_plan/` and `sql_generator/emitters/clickhouse/`.
- Extends Phase 0.1–1.1's "route the function name" pattern to the "route the array literal shape" surface — the second of three syntactic-layer gaps identified in PR #323's spike test docs.

## Verification

**Spike test** (`vlp_under_databricks_dialect_emits_spark_spellings`) now asserts:
- `concat(vp.path_nodes, array(end_node.id))` — both function-name (Phase 1.1) and array-literal (Phase 1.3) layers flip together
- No bare `arrayConcat` / no bare `[start_node.id, ...]` leaks into Databricks output

**Actual Databricks output** for `MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.id`:
```sql
SELECT
    start_node.id as start_id,
    end_node.id as end_id,
    1 as hop_count,
    CAST(array() AS ARRAY<STRING>) as path_relationships,
    array(start_node.id, end_node.id) as path_nodes
...
    concat(vp.path_nodes, array(end_node.id)) as path_nodes
WHERE vp.hop_count < 3
  AND NOT array_contains(vp.path_nodes, end_node.id)
```

## Remaining gaps (Phase 1.4+)
Updated `databricks_emit_spike_tests.rs` module docs to reflect array-literal as resolved. Two syntactic gaps remain (independent of this PR):
1. **Identifier / alias quoting** — `\"b.id\"` vs `` `b.id` ``
2. **Aggregate function_registry** — `collect()` hardcoded to `groupArray` via `clickhouse_name` field

## Implementation notes

Two private helpers added to keep call sites readable:
- `arr(elems)` — thin shorthand over `FunctionMapper::array_literal`
- `arr_append(arr_expr, scalar)` — combines `array_concat` + literal for the common "append scalar onto path array" pattern. Also routes `arrayConcat → concat` since these lines were being touched anyway.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --all` applied
- [x] All 1670 Rust tests pass
- [x] Spike test asserts Databricks `array(...)` syntax + Spark `concat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)