### PR TITLE
feat(dialect): route alias quoting through FunctionMapper (Phase 1.4)

### DIFF
--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -3456,7 +3456,10 @@ pub(super) fn extract_outer_aggregation_info(
         .map(|item| {
             let expr: RenderExpr = match &item.expression {
                 crate::query_planner::logical_expr::LogicalExpr::ColumnAlias(alias) => {
-                    RenderExpr::Raw(format!("\"{}\"", alias.0))
+                    RenderExpr::Raw(
+                        crate::sql_generator::function_mapper::current_function_mapper()
+                            .quote_alias(&alias.0),
+                    )
                 }
                 crate::query_planner::logical_expr::LogicalExpr::AggregateFnCall(agg) => {
                     let args: Vec<RenderExpr> = agg
@@ -3467,7 +3470,11 @@ pub(super) fn extract_outer_aggregation_info(
                                 RenderExpr::Raw("*".to_string())
                             }
                             crate::query_planner::logical_expr::LogicalExpr::ColumnAlias(alias) => {
-                                RenderExpr::Raw(format!("\"{}\"", alias.0))
+                                RenderExpr::Raw(
+                                    crate::sql_generator::function_mapper::current_function_mapper(
+                                    )
+                                    .quote_alias(&alias.0),
+                                )
                             }
                             other => other
                                 .clone()
@@ -3496,9 +3503,10 @@ pub(super) fn extract_outer_aggregation_info(
         .expressions
         .iter()
         .map(|expr| match expr {
-            crate::query_planner::logical_expr::LogicalExpr::ColumnAlias(alias) => {
-                RenderExpr::Raw(format!("\"{}\"", alias.0))
-            }
+            crate::query_planner::logical_expr::LogicalExpr::ColumnAlias(alias) => RenderExpr::Raw(
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .quote_alias(&alias.0),
+            ),
             other => other
                 .clone()
                 .try_into()

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -26,11 +26,12 @@
 //!    `array(a, b)` and CH sees `[a, b]`. Asserted by
 //!    `vlp_under_databricks_dialect_emits_spark_spellings` below.
 //!
-//! 2. **Identifier / alias quoting**. The output uses `AS "b.id"` for
-//!    aliases with dots. CH treats `"…"` as a quoted identifier; Spark
-//!    treats `"…"` as a string literal and requires backticks. Need a
-//!    dialect-aware `quote_alias` helper, distinct from the existing
-//!    `quote_identifier` which is already CH-shaped.
+//! 2. **Identifier / alias quoting (Phase 1.4, done).** `AS "alias"`
+//!    sites in the rendering layer now route through
+//!    `FunctionMapper::quote_alias(&name)`, so Spark sees
+//!    `` AS `b.id` `` and CH sees `AS "b.id"` (existing behavior).
+//!    Spark parses double quotes as string literals, so backticks are
+//!    mandatory there. Asserted by the spellings test below.
 //!
 //! 3. **Aggregate functions via function_registry**. Functions like
 //!    Cypher `collect()` are mapped via the hardcoded `clickhouse_name`
@@ -45,9 +46,9 @@
 //!    various rendering paths.
 //!
 //! What this means for the abstraction: Phase 0.1–1.1 was about routing
-//! the *function name* layer; Phase 1.3 extended the same pattern to
-//! the *array literal* shape. The remaining work — identifier quoting
-//! and aggregate registry — fits the same shape, so the path is clear.
+//! the *function name* layer; Phase 1.3 routed array-literal shape;
+//! Phase 1.4 routed identifier quoting. The remaining work — aggregate
+//! registry routing and CAST type names — fits the same shape.
 
 use crate::{
     clickhouse_query_generator,
@@ -206,6 +207,18 @@ async fn vlp_under_clickhouse_dialect_emits_ch_spellings() {
         !sql.contains("array(toString("),
         "CH SQL leaked Spark array() literal"
     );
+
+    // Phase 1.4: alias quoting. CH keeps historical double-quote form
+    // for `AS` clauses. Backticks must NOT appear in the AS position
+    // (they may appear elsewhere from `quote_identifier`).
+    assert!(
+        sql.contains("AS \"b.id\""),
+        "expected CH double-quoted alias `AS \"b.id\"`; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("AS `b.id`"),
+        "CH SQL leaked Spark backtick alias quoting; got:\n{sql}"
+    );
 }
 
 /// Dump the Databricks output for visual inspection. Always passes —
@@ -282,5 +295,16 @@ async fn vlp_under_databricks_dialect_emits_spark_spellings() {
     assert!(
         !sql.contains(", [toString(") && !sql.contains("vp.path_nodes, ["),
         "Databricks SQL leaked CH bracket-style array literal; got:\n{sql}"
+    );
+
+    // Phase 1.4: alias quoting. Spark parses double-quoted identifiers
+    // as string literals, so the `AS` clause must use backticks.
+    assert!(
+        sql.contains("AS `b.id`"),
+        "expected Spark backtick alias `AS `b.id``; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("AS \"b.id\""),
+        "Databricks SQL leaked CH double-quoted alias; got:\n{sql}"
     );
 }

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -308,3 +308,56 @@ async fn vlp_under_databricks_dialect_emits_spark_spellings() {
         "Databricks SQL leaked CH double-quoted alias; got:\n{sql}"
     );
 }
+
+/// Aggregation path — exercises `build_outer_aggregate_select` and the
+/// `extract_outer_aggregation_info` rewrite where ColumnAlias references
+/// in GROUP BY / aggregate args get quoted via `quote_alias`. The plain
+/// VLP test above only covers the final-SELECT `AS` path, so this test
+/// guards the references-side routing from silently regressing back to
+/// double-quoted identifiers.
+#[tokio::test]
+async fn aggregation_under_databricks_uses_backtick_alias_refs() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id AS bid, count(a) AS ct")
+    })
+    .await;
+
+    // The aggregate result alias `ct` should emit `AS ` + backticks.
+    // Non-aggregate alias `bid` likewise. No double-quoted aliases.
+    assert!(
+        !sql.contains("AS \""),
+        "Databricks aggregation SQL leaked CH double-quoted alias; got:\n{sql}"
+    );
+    // Spot-check that at least one backtick alias appears in the AS
+    // position. The exact site varies by plan shape, so use a
+    // tolerant pattern.
+    assert!(
+        sql.contains("AS `"),
+        "expected Spark backtick alias in aggregation SQL; got:\n{sql}"
+    );
+}
+
+/// CH baseline for the aggregation path — guards against the CH side
+/// silently flipping to backticks when we touch this code in the future.
+#[tokio::test]
+async fn aggregation_under_clickhouse_keeps_double_quoted_alias_refs() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::ClickHouse,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id AS bid, count(a) AS ct")
+    })
+    .await;
+
+    // CH historically emits double-quoted aliases here. Verify both
+    // sites still produce the existing shape.
+    assert!(
+        sql.contains("AS \""),
+        "expected CH double-quoted alias in aggregation SQL; got:\n{sql}"
+    );
+}

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -2429,7 +2429,11 @@ fn build_union_inner_select(
         sql.push_str("      ");
         sql.push_str(&item.expression.to_sql());
         if let Some(alias) = &item.col_alias {
-            sql.push_str(&format!(" AS \"{}\"", alias.0));
+            sql.push_str(&format!(
+                " AS {}",
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .quote_alias(&alias.0)
+            ));
         }
         idx += 1;
         if idx < total_items {
@@ -2455,7 +2459,11 @@ fn build_union_inner_select(
         } else {
             col_sql.clone()
         };
-        sql.push_str(&format!("      {} AS \"{}\"", expr_sql, col_sql));
+        sql.push_str(&format!(
+            "      {} AS {}",
+            expr_sql,
+            crate::sql_generator::function_mapper::current_function_mapper().quote_alias(col_sql)
+        ));
         idx += 1;
         if idx < total_items {
             sql.push(',');
@@ -2568,9 +2576,19 @@ fn build_outer_aggregate_select(
                         agg_sql = agg_sql.replace(col_ref, &format!("`{}`", col_ref));
                     }
                 }
-                format!("{} AS \"{}\"", agg_sql, alias_str)
+                format!(
+                    "{} AS {}",
+                    agg_sql,
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .quote_alias(&alias_str)
+                )
             } else {
-                format!("`{}` AS \"{}\"", alias_str, alias_str)
+                format!(
+                    "`{}` AS {}",
+                    alias_str,
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .quote_alias(&alias_str)
+                )
             }
         })
         .collect();
@@ -3735,17 +3753,17 @@ impl SelectItems {
             // Only add AS clause if the alias differs from the expression
             // (already handled above for matching TableAlias case)
             if let Some(alias) = &item.col_alias {
+                let quoted = crate::sql_generator::function_mapper::current_function_mapper()
+                    .quote_alias(&alias.0);
                 if let RenderExpr::TableAlias(TableAlias(expr_alias)) = &item.expression {
                     // For UNWIND aliases that match OR for aliases that differ, we need the AS clause
                     if expr_alias != &alias.0 || unwind_aliases.contains(expr_alias) {
-                        sql.push_str(" AS \"");
-                        sql.push_str(&alias.0);
-                        sql.push('"');
+                        sql.push_str(" AS ");
+                        sql.push_str(&quoted);
                     }
                 } else {
-                    sql.push_str(" AS \"");
-                    sql.push_str(&alias.0);
-                    sql.push('"');
+                    sql.push_str(" AS ");
+                    sql.push_str(&quoted);
                 }
             }
             if i + 1 < self.items.len() {

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -59,6 +59,23 @@ impl FunctionMapper for ClickhouseFunctionMapper {
     }
 
     fn quote_alias(&self, name: &str) -> String {
-        format!("\"{name}\"")
+        // CH escapes `"` inside a double-quoted identifier by doubling it.
+        // Aliases inferred from raw return text can contain quotes
+        // (e.g., `RETURN 'a"b'` derives an alias from the literal),
+        // and naive wrapping would produce malformed SQL.
+        format!("\"{}\"", name.replace('"', "\"\""))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClickhouseFunctionMapper;
+    use super::FunctionMapper;
+
+    #[test]
+    fn quote_alias_escapes_embedded_double_quotes() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.quote_alias("b.id"), "\"b.id\"");
+        assert_eq!(m.quote_alias("x\"y"), "\"x\"\"y\"");
     }
 }

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -57,4 +57,8 @@ impl FunctionMapper for ClickhouseFunctionMapper {
     fn array_literal(&self, elems: &str) -> String {
         format!("[{elems}]")
     }
+
+    fn quote_alias(&self, name: &str) -> String {
+        format!("\"{name}\"")
+    }
 }

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -114,6 +114,13 @@ impl FunctionMapper for DatabricksFunctionMapper {
     fn array_literal(&self, elems: &str) -> String {
         format!("array({elems})")
     }
+
+    fn quote_alias(&self, name: &str) -> String {
+        // Spark parses `"foo"` as a string literal — backticks are the
+        // only valid identifier quote. `quote_identifier` uses backticks
+        // for both dialects so this stays consistent with that.
+        format!("`{name}`")
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +149,7 @@ mod tests {
         assert_eq!(m.empty_int64_array_cast(), "CAST(array() AS ARRAY<BIGINT>)");
         assert_eq!(m.array_literal(""), "array()");
         assert_eq!(m.array_literal("a, b"), "array(a, b)");
+        assert_eq!(m.quote_alias("b.id"), "`b.id`");
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -117,9 +117,12 @@ impl FunctionMapper for DatabricksFunctionMapper {
 
     fn quote_alias(&self, name: &str) -> String {
         // Spark parses `"foo"` as a string literal — backticks are the
-        // only valid identifier quote. `quote_identifier` uses backticks
-        // for both dialects so this stays consistent with that.
-        format!("`{name}`")
+        // only valid identifier quote. Spark escapes `` ` `` inside a
+        // backtick-quoted identifier by doubling it. Aliases inferred
+        // from raw return text can contain backticks, so escape before
+        // wrapping. `quote_identifier` uses backticks for both dialects
+        // so this stays consistent with that.
+        format!("`{}`", name.replace('`', "``"))
     }
 }
 
@@ -150,6 +153,9 @@ mod tests {
         assert_eq!(m.array_literal(""), "array()");
         assert_eq!(m.array_literal("a, b"), "array(a, b)");
         assert_eq!(m.quote_alias("b.id"), "`b.id`");
+        // Embedded backticks must be doubled, not left raw — otherwise
+        // an alias like `` x`y `` would prematurely close the quote.
+        assert_eq!(m.quote_alias("x`y"), "`x``y`");
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -86,13 +86,17 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// rendered expressions and pass them here.
     fn array_literal(&self, elems: &str) -> String;
 
-    /// Quote a column alias for an `AS` clause. CH: `"name"` (also
-    /// accepts backticks but the existing pipeline emits double quotes
-    /// here historically). Spark: `` `name` `` — Spark parses `"name"`
-    /// as a string literal, so backticks are mandatory. The bare
-    /// `quote_identifier` helper in `common.rs` is a separate concern
-    /// (it already uses backticks for both dialects since both accept
-    /// them for column refs).
+    /// Quote a column alias / aliased identifier. Used for both `AS`
+    /// clauses and references to those aliases elsewhere in the query
+    /// (e.g., GROUP BY, aggregate args after an inner-query rewrite).
+    /// CH: `"name"` (also accepts backticks but the existing pipeline
+    /// emits double quotes here historically). Spark: `` `name` `` —
+    /// Spark parses `"name"` as a string literal, so backticks are
+    /// mandatory. Each impl is responsible for escaping its own
+    /// delimiter inside `name` (CH doubles `"`, Spark doubles `` ` ``).
+    /// The bare `quote_identifier` helper in `common.rs` is a separate
+    /// concern — it already uses backticks for both dialects since
+    /// both accept them for plain column refs.
     fn quote_alias(&self, name: &str) -> String;
 }
 

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -85,6 +85,15 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// elements aren't known to the trait — callers join their own
     /// rendered expressions and pass them here.
     fn array_literal(&self, elems: &str) -> String;
+
+    /// Quote a column alias for an `AS` clause. CH: `"name"` (also
+    /// accepts backticks but the existing pipeline emits double quotes
+    /// here historically). Spark: `` `name` `` — Spark parses `"name"`
+    /// as a string literal, so backticks are mandatory. The bare
+    /// `quote_identifier` helper in `common.rs` is a separate concern
+    /// (it already uses backticks for both dialects since both accept
+    /// them for column refs).
+    fn quote_alias(&self, name: &str) -> String;
 }
 
 /// Returns the function mapper for the active SQL dialect, read from the


### PR DESCRIPTION
## Summary
- Adds `FunctionMapper::quote_alias(&name)` so the rendering layer emits CH's `AS "alias"` vs Spark/Databricks's `` AS `alias` `` automatically.
- Routes ~8 hardcoded sites in `to_sql_query.rs` and `plan_builder_helpers.rs`.
- Third of four syntactic-layer gaps identified in PR #323's spike-test docs (after Phase 1.3's array literals).

## Verification

Four spike tests now cover both dialects across two plan shapes:
- VLP final-SELECT alias path (existing)
- Aggregation alias references in `build_outer_aggregate_select` / `extract_outer_aggregation_info` (new in this PR)

**Actual Databricks output** for `MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.id`:
```sql
SELECT
      t.end_id AS `b.id`
FROM vlp_a_b AS t
```

Plus unit tests for `quote_alias` covering embedded-delimiter escaping (`` x`y `` → `` `x``y` `` for Spark; `x"y` → `"x""y"` for CH).

## Remaining gaps
Updated `databricks_emit_spike_tests.rs` module docs. Two syntactic gaps remain:
- **Aggregate function_registry** — `collect()` hardcoded to `groupArray` via `FunctionMapping.clickhouse_name`. Phase 1.5.
- **Type names in non-routed CASTs** — `UInt32`, `Float64`, etc., in various rendering paths. Not exercised by the spike yet.

## Review fixes (commit 8536b34)
Addressed 5 inline comments from Copilot:
1. `databricks.rs` `quote_alias`: escape embedded `` ` `` by doubling
2. `clickhouse.rs` `quote_alias`: escape embedded `"` by doubling
3. Trait doc clarifies `quote_alias` covers AS clauses AND references
4. Aggregation alias path now covered by dedicated tests
5. Updated PR description to match spike-test docs (both remaining gaps)

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --all` applied
- [x] All 1358 lib tests pass (5 new ones added)
- [x] Both `quote_alias` impls have escape-behavior unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)