### PR TITLE
test(executor): wiremock integration tests for Databricks executor (Phase 2.2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +518,7 @@ dependencies = [
  "tower-http",
  "uuid",
  "validator",
+ "wiremock",
 ]
 
 [[package]]
@@ -820,6 +831,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "derive_more"
@@ -1257,6 +1286,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1321,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1372,7 +1426,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1396,6 +1450,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1958,6 +2013,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2504,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -4196,6 +4261,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ async-trait = "0.1"
 anyhow = "1.0"
 test-case = "3.3"  # For PackStream tests
 serial_test = "3.2"  # For serializing tests that modify global state
+# Mock HTTP server for the Databricks executor's integration tests.
+# Unconditional dev-dep so `cargo test` always knows where to find it;
+# the tests themselves are gated on `#[cfg(feature = "databricks")]`,
+# so non-databricks builds don't pay the runtime cost.
+wiremock = "0.6"
 
 [[test]]
 name = "unit"

--- a/src/executor/databricks_sql.rs
+++ b/src/executor/databricks_sql.rs
@@ -588,9 +588,12 @@ mod wiremock_tests {
             .expect(1)
             .mount(&server)
             .await;
-        // Poll returns SUCCEEDED with the actual result.
+        // Poll returns SUCCEEDED with the actual result. Assert bearer
+        // auth on the GET too: Databricks requires authentication on
+        // every Statement Execution API call, including status reads.
         Mock::given(method("GET"))
             .and(path("/api/2.0/sql/statements/stmt-002"))
+            .and(bearer_token("dapi-test"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "statement_id": "stmt-002",
                 "status": { "state": "SUCCEEDED" },

--- a/src/executor/databricks_sql.rs
+++ b/src/executor/databricks_sql.rs
@@ -56,6 +56,12 @@ pub struct DatabricksConfig {
     /// warehouse default.
     pub catalog: Option<String>,
     pub schema: Option<String>,
+    /// Override the request base URL. When `None`, the executor sends
+    /// to `https://{hostname}`; integration tests set this to a
+    /// `wiremock::MockServer::uri()` so the same code paths run against
+    /// a localhost mock without touching the network. Production code
+    /// should leave this unset.
+    pub base_url: Option<String>,
 }
 
 impl DatabricksConfig {
@@ -74,6 +80,7 @@ impl DatabricksConfig {
             wait_timeout: Duration::from_secs(30),
             catalog: None,
             schema: None,
+            base_url: None,
         }
     }
 }
@@ -97,14 +104,22 @@ impl DatabricksSqlExecutor {
         Ok(Self { config, client })
     }
 
+    fn base_url(&self) -> String {
+        self.config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| format!("https://{}", self.config.hostname))
+    }
+
     fn submit_url(&self) -> String {
-        format!("https://{}/api/2.0/sql/statements", self.config.hostname)
+        format!("{}/api/2.0/sql/statements", self.base_url())
     }
 
     fn status_url(&self, statement_id: &str) -> String {
         format!(
-            "https://{}/api/2.0/sql/statements/{}",
-            self.config.hostname, statement_id
+            "{}/api/2.0/sql/statements/{}",
+            self.base_url(),
+            statement_id
         )
     }
 
@@ -486,5 +501,185 @@ mod tests {
         assert!(StatementState::Failed.is_terminal());
         assert!(StatementState::Canceled.is_terminal());
         assert!(StatementState::Closed.is_terminal());
+    }
+
+    #[test]
+    fn base_url_override_replaces_hostname_derivation() {
+        // wiremock-based integration tests rely on `base_url` to point
+        // at a localhost mock server. If this regression-test fails
+        // (e.g. someone reintroduces the hard-coded `https://` prefix),
+        // every integration test in this module silently bypasses
+        // the mock and hits the real internet. Lock the contract.
+        let mut c = cfg();
+        c.base_url = Some("http://127.0.0.1:12345".into());
+        let exec = DatabricksSqlExecutor::new(c).expect("client builds");
+        assert_eq!(
+            exec.submit_url(),
+            "http://127.0.0.1:12345/api/2.0/sql/statements"
+        );
+        assert_eq!(
+            exec.status_url("stmt-x"),
+            "http://127.0.0.1:12345/api/2.0/sql/statements/stmt-x"
+        );
+    }
+}
+
+/// Integration tests against a `wiremock::MockServer`. These exercise
+/// the full submit → poll → parse flow without touching the network:
+/// the executor's `base_url` is pointed at a localhost mock that
+/// serves canned JSON responses. Kept in a separate module so the
+/// unit tests above stay synchronous and dependency-free.
+#[cfg(test)]
+mod wiremock_tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{bearer_token, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn cfg_for(server: &MockServer) -> DatabricksConfig {
+        let mut c = DatabricksConfig::new("ignored-host", "wh-1234", "dapi-test");
+        c.base_url = Some(server.uri());
+        // Sleep between polls would slow tests down — keep at the
+        // default; we control how many polls happen via mock fixtures.
+        c
+    }
+
+    fn manifest_with_columns(cols: &[&str]) -> Value {
+        let cols: Vec<Value> = cols.iter().map(|n| json!({ "name": n })).collect();
+        json!({ "schema": { "columns": cols } })
+    }
+
+    #[tokio::test]
+    async fn submit_returns_succeeded_inline_in_one_call() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(bearer_token("dapi-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-001",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": manifest_with_columns(&["id", "name"]),
+                "result": { "data_array": [[1, "alice"], [2, "bob"]] }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let rows = exec
+            .execute_json("SELECT id, name FROM users", None)
+            .await
+            .expect("execute_json");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], json!(1));
+        assert_eq!(rows[1]["name"], json!("bob"));
+    }
+
+    #[tokio::test]
+    async fn submit_pending_then_poll_succeeded() {
+        let server = MockServer::start().await;
+        // Submit returns PENDING — no manifest or result yet.
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-002",
+                "status": { "state": "PENDING" }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Poll returns SUCCEEDED with the actual result.
+        Mock::given(method("GET"))
+            .and(path("/api/2.0/sql/statements/stmt-002"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-002",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": manifest_with_columns(&["x"]),
+                "result": { "data_array": [[42]] }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let rows = exec
+            .execute_json("SELECT 42", None)
+            .await
+            .expect("execute_json");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["x"], json!(42));
+    }
+
+    #[tokio::test]
+    async fn failed_state_surfaces_error_code_and_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-003",
+                "status": {
+                    "state": "FAILED",
+                    "error": {
+                        "error_code": "INVALID_SQL_SYNTAX",
+                        "message": "unexpected token at line 1"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let err = exec
+            .execute_json("SELEC 1", None)
+            .await
+            .expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("INVALID_SQL_SYNTAX") && msg.contains("unexpected token"),
+            "expected error code + message; got {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_401_becomes_remote_error_with_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_string("{\"error_code\":\"PERMISSION_DENIED\"}"),
+            )
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let err = exec
+            .execute_json("SELECT 1", None)
+            .await
+            .expect_err("should fail");
+        match err {
+            ExecutorError::Remote { status, body } => {
+                assert_eq!(status, 401);
+                assert!(body.contains("PERMISSION_DENIED"), "body: {body}");
+            }
+            other => panic!("expected Remote error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_text_rejects_format() {
+        // Doesn't hit the wire — `execute_text` errors out before any
+        // HTTP call. Test it here so the rejection path is exercised
+        // in the same module that documents the policy.
+        let server = MockServer::start().await;
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let err = exec
+            .execute_text("SELECT 1", "Pretty", None)
+            .await
+            .expect_err("should reject");
+        assert!(
+            matches!(err, ExecutorError::UnsupportedFormat(ref f) if f == "Pretty"),
+            "expected UnsupportedFormat(\"Pretty\"), got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Phase 2.2a — hardens the Phase 2.1 Databricks executor with 5 wiremock-based integration tests that exercise the full submit → poll → parse flow against fixture HTTP responses. No production wire-up yet; that's Phase 2.2b.

## What ships

- **5 wiremock integration tests** (gated on `#[cfg(feature = "databricks")]`):
  - \`submit_returns_succeeded_inline_in_one_call\`: SUCCEEDED in submit, INLINE result returned.
  - \`submit_pending_then_poll_succeeded\`: PENDING → poll → SUCCEEDED.
  - \`failed_state_surfaces_error_code_and_message\`: FAILED with error → \`QueryFailed\` carrying \`error_code\` + \`message\`.
  - \`http_401_becomes_remote_error_with_body\`: non-2xx → \`Remote { status, body }\` with the body preserved.
  - \`execute_text_rejects_format\`: \`execute_text\` errors out before any HTTP call.

- **\`base_url\` override on \`DatabricksConfig\`**: tests point this at \`MockServer::uri()\` to bypass the hard-coded \`https://\` prefix; production leaves it \`None\`. A unit test (\`base_url_override_replaces_hostname_derivation\`) pins the contract so a future scheme-hardcoding regression can't silently bypass the mock.

- **\`wiremock\` 0.6 as a normal dev-dep** — the tests themselves stay inside \`#[cfg(feature = \"databricks\")]\`, so non-databricks builds don't run them. Mockfree builds get a small extra compile dep for nothing; if that becomes a problem we can move it under a target/feature gate later.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` (default features) clean
- [x] \`cargo clippy --features databricks --all-targets -- -D warnings\` clean
- [x] \`cargo test -p clickgraph --lib\` — 1369/1369 (no regression)
- [x] \`cargo test -p clickgraph --features databricks --lib\` — 1384/1384 (15 unit + 5 wiremock for this module, up from 1378)

🤖 Generated with [Claude Code](https://claude.com/claude-code)