### PR TITLE
feat(embedded): Database::new_databricks() + dialect plumbing (Phase 2.2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/clickgraph-embedded/Cargo.toml
+++ b/clickgraph-embedded/Cargo.toml
@@ -10,6 +10,10 @@ license = "Apache-2.0"
 [features]
 default = []
 embedded = ["clickgraph/embedded"]
+# DeltaGraph Phase 2.2b: expose Database::new_databricks(). Forwards
+# to the upstream clickgraph crate's `databricks` feature, which gates
+# the executor + reqwest dep.
+databricks = ["clickgraph/databricks"]
 
 [dependencies]
 clickgraph = { path = "..", default-features = false }
@@ -24,3 +28,7 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3.2"
+# Mock HTTP server for the Databricks end-to-end test. Mirrors the
+# pattern in the upstream clickgraph crate; the test itself is gated
+# on `#[cfg(feature = "databricks")]`.
+wiremock = "0.6"

--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -100,13 +100,15 @@ impl<'db> Connection<'db> {
     pub fn query_to_sql(&self, cypher: &str) -> Result<String, EmbeddedError> {
         use clickgraph::clickhouse_query_generator::cypher_to_sql;
         use clickgraph::server::query_context::{
-            set_current_schema, with_query_context, QueryContext,
+            set_current_dialect, set_current_schema, with_query_context, QueryContext,
         };
         let schema = Arc::clone(&self.schema);
         let cypher = cypher.to_string();
+        let dialect = self.db.dialect;
         self.db.runtime.block_on(async move {
             let context = QueryContext::new(None);
             with_query_context(context, async move {
+                set_current_dialect(dialect);
                 set_current_schema(Arc::clone(&schema));
                 cypher_to_sql(&cypher, &schema, 100).map_err(EmbeddedError::Query)
             })
@@ -1118,12 +1120,14 @@ impl<'db> Connection<'db> {
     ) -> Result<QueryResult, EmbeddedError> {
         use clickgraph::clickhouse_query_generator::cypher_to_sql;
         use clickgraph::server::query_context::{
-            set_current_schema, with_query_context, QueryContext,
+            set_current_dialect, set_current_schema, with_query_context, QueryContext,
         };
         let schema = Arc::clone(&self.schema);
         let executor = Arc::clone(executor);
         let cypher = cypher.to_string();
+        let dialect = self.db.dialect;
         with_query_context(QueryContext::new(None), async move {
+            set_current_dialect(dialect);
             set_current_schema(Arc::clone(&schema));
             let compile_start = Instant::now();
             let final_sql = cypher_to_sql(&cypher, &schema, DEFAULT_MAX_CTE_DEPTH)
@@ -1807,6 +1811,7 @@ graph_schema:
                 .build()
                 .unwrap(),
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
+            dialect: clickgraph::sql_generator::SqlDialect::ClickHouse,
         }
     }
 
@@ -1862,6 +1867,7 @@ graph_schema:
                 .build()
                 .unwrap(),
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
+            dialect: clickgraph::sql_generator::SqlDialect::ClickHouse,
         };
         (db, captured)
     }
@@ -1897,6 +1903,7 @@ graph_schema:
                 .build()
                 .unwrap(),
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
+            dialect: clickgraph::sql_generator::SqlDialect::ClickHouse,
         }
     }
 

--- a/clickgraph-embedded/src/connection.rs
+++ b/clickgraph-embedded/src/connection.rs
@@ -1176,12 +1176,14 @@ impl<'db> Connection<'db> {
     ) -> Result<GraphResult, EmbeddedError> {
         use clickgraph::clickhouse_query_generator::cypher_to_sql_with_metadata;
         use clickgraph::server::query_context::{
-            set_current_schema, with_query_context, QueryContext,
+            set_current_dialect, set_current_schema, with_query_context, QueryContext,
         };
         let schema = Arc::clone(&self.schema);
         let executor = Arc::clone(executor);
         let cypher = cypher.to_string();
+        let dialect = self.db.dialect;
         with_query_context(QueryContext::new(None), async move {
+            set_current_dialect(dialect);
             set_current_schema(Arc::clone(&schema));
             let (sql, logical_plan, plan_ctx) =
                 cypher_to_sql_with_metadata(&cypher, &schema, DEFAULT_MAX_CTE_DEPTH)

--- a/clickgraph-embedded/src/database.rs
+++ b/clickgraph-embedded/src/database.rs
@@ -11,11 +11,14 @@ use async_trait::async_trait;
 use clickgraph::executor::chdb_embedded::ChdbExecutor;
 #[cfg(feature = "embedded")]
 pub use clickgraph::executor::chdb_embedded::StorageCredentials;
+#[cfg(feature = "databricks")]
+pub use clickgraph::executor::databricks_sql::{DatabricksConfig, DatabricksSqlExecutor};
 use clickgraph::executor::remote::RemoteClickHouseExecutor;
 use clickgraph::executor::{ExecutorError, QueryExecutor};
 use clickgraph::graph_catalog::config::GraphSchemaConfig;
 use clickgraph::graph_catalog::graph_schema::GraphSchema;
 use clickgraph::server::connection_pool::RoleConnectionPool;
+use clickgraph::sql_generator::SqlDialect;
 
 use super::error::EmbeddedError;
 
@@ -119,6 +122,11 @@ pub struct Database {
     /// guard (Phase 3 of the embedded-writes plan) to gate Cypher write
     /// clauses to the embedded chdb path only.
     pub(crate) executor_kind: clickgraph::query_planner::write_guard::ExecutorKind,
+    /// SQL dialect this database emits. `Connection::query_*` paths
+    /// stamp this onto the per-query `QueryContext` so that the shared
+    /// renderer routes through the right `FunctionMapper`. Default
+    /// `ClickHouse`; `new_databricks()` sets it to `Databricks`.
+    pub(crate) dialect: SqlDialect,
 }
 
 impl Database {
@@ -209,6 +217,7 @@ impl Database {
             schema,
             runtime,
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::EmbeddedChdb,
+            dialect: SqlDialect::ClickHouse,
         })
     }
 
@@ -232,6 +241,35 @@ impl Database {
             schema: Arc::new(graph_schema),
             runtime,
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::Remote,
+            dialect: SqlDialect::ClickHouse,
+        })
+    }
+
+    /// Open a database connected to a Databricks SQL Warehouse.
+    ///
+    /// Cypher is translated to Spark SQL locally (via the dialect-aware
+    /// renderer landed in Phase 1.x) and executed against the warehouse
+    /// over the Statement Execution API. Use `Connection::query_remote()`
+    /// to run queries — the same path used for the ClickHouse remote
+    /// executor; the dialect is selected via `Database::dialect`.
+    ///
+    /// Available only with the `databricks` feature enabled.
+    #[cfg(feature = "databricks")]
+    pub fn new_databricks(
+        schema_path: impl AsRef<Path>,
+        config: DatabricksConfig,
+    ) -> Result<Self, EmbeddedError> {
+        let graph_schema = load_graph_schema(schema_path.as_ref())?;
+        let runtime = build_runtime()?;
+        let executor = DatabricksSqlExecutor::new(config)
+            .map_err(|e| EmbeddedError::Executor(format!("Databricks executor: {e}")))?;
+        Ok(Database {
+            executor: Arc::new(NullExecutor),
+            remote_executor: Some(Arc::new(executor) as Arc<dyn QueryExecutor>),
+            schema: Arc::new(graph_schema),
+            runtime,
+            executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::Remote,
+            dialect: SqlDialect::Databricks,
         })
     }
 
@@ -282,6 +320,7 @@ impl Database {
             // guard rejects writes here — tests that need writes should
             // construct a chdb-backed Database via `new` instead.
             executor_kind: clickgraph::query_planner::write_guard::ExecutorKind::SqlOnly,
+            dialect: SqlDialect::ClickHouse,
         })
     }
 

--- a/clickgraph-embedded/src/lib.rs
+++ b/clickgraph-embedded/src/lib.rs
@@ -51,6 +51,8 @@ pub use cypher_loader::LoadStats;
 #[cfg(feature = "embedded")]
 pub use database::StorageCredentials;
 pub use database::{Database, RemoteConfig, SystemConfig};
+#[cfg(feature = "databricks")]
+pub use database::{DatabricksConfig, DatabricksSqlExecutor};
 pub use error::EmbeddedError;
 pub use export::{ExportFormat, ExportOptions};
 pub use graph_result::{GraphEdge, GraphNode, GraphResult, GraphResultBuilder, StoreStats};

--- a/clickgraph-embedded/tests/databricks_e2e.rs
+++ b/clickgraph-embedded/tests/databricks_e2e.rs
@@ -58,15 +58,20 @@ fn cfg_for(server: &MockServer) -> DatabricksConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn query_remote_against_databricks_mock_returns_rows_and_uses_spark_dialect() {
+async fn query_remote_against_databricks_mock_returns_rows() {
+    // End-to-end happy path: assert that columns, row count, AND
+    // individual cell values all flow correctly through the
+    // Spark-JSON → `Value` conversion that
+    // `clickgraph-embedded::Connection` does after `execute_json`
+    // hands back the mocked response.
+    //
+    // (SQL-side dialect verification — that the request body uses
+    // Spark spellings — lives in
+    // `databricks_database_emits_spark_sql_for_collect` below. Here
+    // we only check the request/response wiring.)
     let server = MockServer::start().await;
     let schema_file = write_schema_to_tempfile();
 
-    // Match a POST that has the Spark-style backtick alias quoting in
-    // its `statement` field. This is the load-bearing assertion that
-    // the dialect plumbing actually flipped — under the CH dialect the
-    // emitted SQL would use double-quoted aliases (`AS "..."`), which
-    // would NOT match here.
     Mock::given(method("POST"))
         .and(path("/api/2.0/sql/statements"))
         .and(bearer_token("dapi-token"))
@@ -111,6 +116,80 @@ async fn query_remote_against_databricks_mock_returns_rows_and_uses_spark_dialec
     let (cols, rows) = result;
     assert_eq!(cols, vec!["u.user_id", "u.name"]);
     assert_eq!(rows.len(), 2);
+
+    // Cell-level assertions — guard the JSON→Value conversion path.
+    // Without these a regression that mis-typed cells (e.g., int→string)
+    // would only break downstream consumers, not this test.
+    use clickgraph_embedded::Value;
+    assert_eq!(rows[0][0], Value::Int64(1));
+    assert_eq!(rows[0][1], Value::String("alice".to_string()));
+    assert_eq!(rows[1][0], Value::Int64(2));
+    assert_eq!(rows[1][1], Value::String("bob".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_remote_graph_under_databricks_uses_spark_dialect() {
+    // Regression guard for the dialect plumbing in `query_graph_async`:
+    // Connection::query_remote_graph() goes through a different
+    // codepath than query_remote() — if it doesn't stamp the dialect
+    // on the QueryContext, generated SQL falls back to ClickHouse
+    // even when the Database is Databricks-backed.
+    let server = MockServer::start().await;
+    let schema_file = write_schema_to_tempfile();
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_partial_json(json!({ "warehouse_id": "wh-test" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-graph",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [
+                { "name": "u" }
+            ]}},
+            "result": { "data_array": [] }
+        })))
+        .mount(&server)
+        .await;
+
+    tokio::task::spawn_blocking({
+        let path = schema_file.path().to_path_buf();
+        let config = cfg_for(&server);
+        move || {
+            let db = Database::new_databricks(path, config).expect("Database::new_databricks");
+            let conn = Connection::new(&db).expect("Connection::new");
+            // A plain node return is enough — it flows through
+            // query_remote_graph → query_graph_async (the second path
+            // that needed dialect plumbing) and emits `AS` clauses
+            // for the projected columns. Under Spark those use
+            // backtick quoting; under CH double quotes. The body
+            // inspection below pins which one we got.
+            let _ = conn
+                .query_remote_graph("MATCH (u:User) RETURN u")
+                .expect("query_remote_graph");
+        }
+    })
+    .await
+    .expect("spawn_blocking");
+
+    let received = server.received_requests().await.expect("received_requests");
+    let body_json: serde_json::Value =
+        serde_json::from_slice(&received[0].body).expect("body json");
+    let sql = body_json["statement"]
+        .as_str()
+        .expect("statement is a string");
+
+    // Spark uses backtick alias quoting; CH uses double quotes.
+    // Either form proves SQL was generated; the choice of quotes
+    // proves the dialect actually flipped in query_graph_async.
+    assert!(
+        sql.contains("AS `"),
+        "expected Spark backtick alias quoting in query_remote_graph SQL — \
+         dialect plumbing missing in query_graph_async? got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("AS \""),
+        "query_remote_graph leaked CH double-quoted aliases; got:\n{sql}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/clickgraph-embedded/tests/databricks_e2e.rs
+++ b/clickgraph-embedded/tests/databricks_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end Databricks test for `clickgraph-embedded`.
+//!
+//! Builds a `Database::new_databricks(...)` pointed at a `wiremock`
+//! server, then runs a Cypher query through `Connection::query_remote`.
+//! Verifies:
+//! - The Cypher → SQL translation happens under the Spark dialect
+//!   (so `Database::dialect` is honored end-to-end).
+//! - The SQL is POSTed to the Statement Execution API with PAT auth.
+//! - The INLINE JSON response is parsed back into a `QueryResult` with
+//!   the right columns and values.
+//!
+//! Gated on `#[cfg(feature = "databricks")]` — non-databricks builds
+//! skip the file entirely.
+
+#![cfg(feature = "databricks")]
+
+use std::io::Write;
+
+use clickgraph_embedded::{Connection, Database, DatabricksConfig};
+use serde_json::json;
+use tempfile::NamedTempFile;
+use wiremock::matchers::{bearer_token, body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SOCIAL_YAML: &str = r#"
+name: social_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+  edges:
+    - type: FOLLOWS
+      database: test_db
+      table: follows
+      from_node: User
+      to_node: User
+      from_id: follower_id
+      to_id: followed_id
+      property_mappings: {}
+"#;
+
+fn write_schema_to_tempfile() -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("tempfile");
+    f.write_all(SOCIAL_YAML.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn cfg_for(server: &MockServer) -> DatabricksConfig {
+    let mut c = DatabricksConfig::new("ignored.cloud.databricks.com", "wh-test", "dapi-token");
+    c.base_url = Some(server.uri());
+    c
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_remote_against_databricks_mock_returns_rows_and_uses_spark_dialect() {
+    let server = MockServer::start().await;
+    let schema_file = write_schema_to_tempfile();
+
+    // Match a POST that has the Spark-style backtick alias quoting in
+    // its `statement` field. This is the load-bearing assertion that
+    // the dialect plumbing actually flipped — under the CH dialect the
+    // emitted SQL would use double-quoted aliases (`AS "..."`), which
+    // would NOT match here.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(bearer_token("dapi-token"))
+        .and(body_partial_json(json!({ "warehouse_id": "wh-test" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-e2e",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [
+                { "name": "u.user_id" },
+                { "name": "u.name" }
+            ]}},
+            "result": { "data_array": [
+                [1, "alice"],
+                [2, "bob"]
+            ]}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let db = tokio::task::spawn_blocking({
+        let path = schema_file.path().to_path_buf();
+        let config = cfg_for(&server);
+        move || Database::new_databricks(path, config).expect("Database::new_databricks")
+    })
+    .await
+    .expect("spawn_blocking");
+
+    let result = tokio::task::spawn_blocking(move || {
+        let conn = Connection::new(&db).expect("Connection::new");
+        let result = conn
+            .query_remote("MATCH (u:User) RETURN u.user_id, u.name LIMIT 2")
+            .expect("query_remote");
+        let col_names: Vec<String> = result.get_column_names().to_vec();
+        let row_values: Vec<Vec<clickgraph_embedded::Value>> =
+            result.map(|row| row.values().to_vec()).collect();
+        (col_names, row_values)
+    })
+    .await
+    .expect("spawn_blocking");
+
+    let (cols, rows) = result;
+    assert_eq!(cols, vec!["u.user_id", "u.name"]);
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn databricks_database_emits_spark_sql_for_collect() {
+    // Tighter contract test: pin that the SQL actually crossing the
+    // wire uses Spark spellings the FunctionMapper routes (e.g.
+    // `collect_list` for Cypher `collect()`). If a future regression
+    // drops the dialect-stamping step in `query_with_executor_async`
+    // this assertion fails before the `expect(1)` does.
+    let server = MockServer::start().await;
+    let schema_file = write_schema_to_tempfile();
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_partial_json(json!({ "warehouse_id": "wh-test" })))
+        // The submitted SQL is the `statement` field. wiremock's
+        // body_partial_json only does exact-match for nested values,
+        // so we use a custom matcher via the path/method combo above
+        // and verify the SQL shape by extracting it from request
+        // log below.
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-collect",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [
+                { "name": "ids" }
+            ]}},
+            "result": { "data_array": [[ [1, 2, 3] ]] }
+        })))
+        .mount(&server)
+        .await;
+
+    tokio::task::spawn_blocking({
+        let path = schema_file.path().to_path_buf();
+        let config = cfg_for(&server);
+        move || {
+            let db = Database::new_databricks(path, config).expect("Database::new_databricks");
+            let conn = Connection::new(&db).expect("Connection::new");
+            let _ = conn
+                .query_remote("MATCH (u:User) RETURN collect(u.user_id) AS ids")
+                .expect("query_remote");
+        }
+    })
+    .await
+    .expect("spawn_blocking");
+
+    // Inspect the request body that wiremock captured.
+    let received = server.received_requests().await.expect("received_requests");
+    assert_eq!(received.len(), 1, "expected exactly one POST");
+    let body = std::str::from_utf8(&received[0].body).expect("utf8 body");
+    let body_json: serde_json::Value = serde_json::from_str(body).expect("body json");
+    let sql = body_json["statement"]
+        .as_str()
+        .expect("statement is a string");
+
+    assert!(
+        sql.contains("collect_list("),
+        "expected Spark `collect_list(...)` in SQL crossing the wire; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("groupArray("),
+        "Databricks-bound SQL leaked CH `groupArray`; got:\n{sql}"
+    );
+}

--- a/src/executor/databricks_sql.rs
+++ b/src/executor/databricks_sql.rs
@@ -42,7 +42,11 @@ use super::{ExecutorError, QueryExecutor};
 /// `hostname` is the workspace host (no scheme, no trailing slash) —
 /// e.g. `dbc-abc123-def4.cloud.databricks.com`. `warehouse_id` is the
 /// SQL Warehouse target; `token` is a personal access token.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is implemented manually to redact the PAT — matching how
+/// `RemoteConfig` redacts its password. Logging a `DatabricksConfig`
+/// via `{:?}` is safe and will print `********` in place of the token.
+#[derive(Clone)]
 pub struct DatabricksConfig {
     pub hostname: String,
     pub warehouse_id: String,
@@ -82,6 +86,23 @@ impl DatabricksConfig {
             schema: None,
             base_url: None,
         }
+    }
+}
+
+impl std::fmt::Debug for DatabricksConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact the PAT — matches RemoteConfig's password redaction.
+        // Anything reachable via `{:?}` (logs, panics, error chains) must
+        // not leak the token.
+        f.debug_struct("DatabricksConfig")
+            .field("hostname", &self.hostname)
+            .field("warehouse_id", &self.warehouse_id)
+            .field("token", &"********")
+            .field("wait_timeout", &self.wait_timeout)
+            .field("catalog", &self.catalog)
+            .field("schema", &self.schema)
+            .field("base_url", &self.base_url)
+            .finish()
     }
 }
 
@@ -501,6 +522,26 @@ mod tests {
         assert!(StatementState::Failed.is_terminal());
         assert!(StatementState::Canceled.is_terminal());
         assert!(StatementState::Closed.is_terminal());
+    }
+
+    #[test]
+    fn debug_redacts_token() {
+        // Critical: anything that reaches `{:?}` must NOT contain the
+        // raw PAT. This matches RemoteConfig's password redaction.
+        let c = DatabricksConfig::new(
+            "ws.cloud.databricks.com",
+            "wh-1",
+            "dapi-SECRET-TOKEN-MUST-NOT-LEAK",
+        );
+        let s = format!("{c:?}");
+        assert!(!s.contains("SECRET"), "token leaked into Debug output: {s}");
+        assert!(
+            s.contains("********"),
+            "expected `********` in redacted Debug; got: {s}"
+        );
+        // The other fields should still be visible for triage.
+        assert!(s.contains("ws.cloud.databricks.com"));
+        assert!(s.contains("wh-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wires the Phase 2.1 executor into the `clickgraph-embedded` API. End-to-end, this is the **first time Cypher → Spark SQL → Databricks Statement Execution API → Spark JSON → `Value` works through the public API.** A user enabling the `databricks` feature can now write:

```rust
let db = Database::new_databricks("schema.yaml", DatabricksConfig::new(host, wh, token))?;
let conn = Connection::new(&db)?;
let result = conn.query_remote("MATCH (u:User) RETURN u.name LIMIT 10")?;
```

…and the SQL crossing the wire is correct Spark SQL — `collect_list`, backtick aliases, the works.

## What ships

- **`clickgraph-embedded/Cargo.toml`** gains a `databricks` feature that forwards to `clickgraph/databricks`. `wiremock` is added as a normal dev-dep (the test itself stays inside `#[cfg(feature = \"databricks\")]`).
- **`Database` gains a `dialect: SqlDialect` field.** All existing constructors default to `ClickHouse`; the new `new_databricks()` constructor (feature-gated) sets it to `Databricks`. The field is what the renderer reads at SQL-emission time via the task-local `QueryContext`.
- **The load-bearing line:** `Connection::query_to_sql` and `query_with_executor_async` now stamp `set_current_dialect(self.db.dialect)` after entering the `with_query_context` scope. This is what flips the Phase 1.x routing to Spark spellings end-to-end.
- **Test-helper struct literals** in `connection.rs` get the new field initialized to `ClickHouse` so existing unit tests stay green.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p clickgraph -p clickgraph-embedded -p clickgraph-client -p clickgraph-tool --all-targets -- -D warnings` clean (default)
- [x] same with `--features clickgraph-embedded/databricks,clickgraph/databricks` clean
- [x] `cargo test -p clickgraph --lib` — 1369/1369 (unchanged)
- [x] `cargo test -p clickgraph --features databricks --lib` — 1384/1384 (unchanged)
- [x] `cargo test -p clickgraph-embedded --tests` — 12/12 (10 existing + 2 new e2e, latter only with `--features databricks`)

## End-to-end tests

Two `wiremock`-backed tests in `clickgraph-embedded/tests/databricks_e2e.rs`:
- `query_remote_against_databricks_mock_returns_rows_and_uses_spark_dialect`: full POST/parse cycle with PAT auth, asserting column names and row count.
- `databricks_database_emits_spark_sql_for_collect`: pulls the captured request body out of wiremock and asserts the submitted SQL contains `collect_list(` (Spark) and NOT `groupArray(` (CH). If a future regression drops the `set_current_dialect` call, this test fails loudly before any wire-format assertion does.

Doctest failures in `clickgraph-embedded` are pre-existing on main (they call `Database::new` without `--features embedded`) — verified by stashing this PR's changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)