### PR TITLE
feat(cg): --dialect flag for cg sql/validate/query --sql-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -577,14 +593,17 @@ name = "clickgraph-tool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clickgraph",
  "clickgraph-embedded",
  "clickhouse",
  "dirs",
+ "predicates",
  "reqwest 0.12.24",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml 0.8.23",
 ]
@@ -863,6 +882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1061,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2005,6 +2039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,7 +2265,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -3815,6 +3859,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/clickgraph-embedded/src/database.rs
+++ b/clickgraph-embedded/src/database.rs
@@ -342,10 +342,23 @@ impl Database {
     /// emits SQL for the requested dialect (e.g. Databricks/Spark) instead
     /// of the default ClickHouse spellings. Used by `cg --dialect …` to
     /// translate without needing a live warehouse.
+    ///
+    /// Returns `EmbeddedError::Validation` for dialects whose emitter is
+    /// not yet implemented (PostgreSQL, DuckDB, MySQL, SQLite). Only
+    /// `ClickHouse` and `Databricks` are accepted today.
     pub fn sql_only_with_dialect(
         schema_path: impl AsRef<Path>,
         dialect: SqlDialect,
     ) -> Result<Self, EmbeddedError> {
+        match dialect {
+            SqlDialect::ClickHouse | SqlDialect::Databricks => {}
+            other => {
+                return Err(EmbeddedError::Validation(format!(
+                    "SqlDialect::{other:?} is not yet implemented for SQL emission; \
+                     supported dialects: ClickHouse, Databricks"
+                )));
+            }
+        }
         let mut db = Self::sql_only(schema_path)?;
         db.dialect = dialect;
         Ok(db)
@@ -412,4 +425,59 @@ fn pseudo_random_suffix() -> String {
         .duration_since(UNIX_EPOCH)
         .map(|d| format!("{}", d.subsec_nanos()))
         .unwrap_or_else(|_| "0".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const MINIMAL_SCHEMA: &str = r#"
+name: db_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+  edges: []
+"#;
+
+    fn write_schema() -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(MINIMAL_SCHEMA.as_bytes()).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    #[test]
+    fn sql_only_with_dialect_accepts_supported_dialects() {
+        let schema = write_schema();
+        let db_ch = Database::sql_only_with_dialect(schema.path(), SqlDialect::ClickHouse);
+        assert!(db_ch.is_ok());
+        let db_dx = Database::sql_only_with_dialect(schema.path(), SqlDialect::Databricks);
+        assert!(db_dx.is_ok());
+    }
+
+    #[test]
+    fn sql_only_with_dialect_rejects_unimplemented_dialects() {
+        // Guards against the runtime panic that `emitter_for(<x>)` would
+        // otherwise produce for not-yet-implemented dialects. Copilot
+        // (PR #332) flagged the original unconditional acceptance.
+        let schema = write_schema();
+        for d in [
+            SqlDialect::PostgreSQL,
+            SqlDialect::DuckDB,
+            SqlDialect::MySQL,
+            SqlDialect::SQLite,
+        ] {
+            match Database::sql_only_with_dialect(schema.path(), d) {
+                Ok(_) => panic!("expected validation error for {d:?}"),
+                Err(EmbeddedError::Validation(_)) => {}
+                Err(e) => panic!("expected Validation error, got {e:?} for {d:?}"),
+            }
+        }
+    }
 }

--- a/clickgraph-embedded/src/database.rs
+++ b/clickgraph-embedded/src/database.rs
@@ -335,6 +335,21 @@ impl Database {
         let graph_schema = load_graph_schema(schema_path.as_ref())?;
         Self::from_executor(Arc::new(graph_schema), Arc::new(NullExecutor))
     }
+
+    /// Open a database in SQL-only mode with a chosen `SqlDialect`.
+    ///
+    /// Same as [`sql_only`](Self::sql_only) but the resulting `Database`
+    /// emits SQL for the requested dialect (e.g. Databricks/Spark) instead
+    /// of the default ClickHouse spellings. Used by `cg --dialect …` to
+    /// translate without needing a live warehouse.
+    pub fn sql_only_with_dialect(
+        schema_path: impl AsRef<Path>,
+        dialect: SqlDialect,
+    ) -> Result<Self, EmbeddedError> {
+        let mut db = Self::sql_only(schema_path)?;
+        db.dialect = dialect;
+        Ok(db)
+    }
 }
 
 /// A no-op executor for SQL-only mode. Returns an error if execution is attempted.

--- a/clickgraph-embedded/src/lib.rs
+++ b/clickgraph-embedded/src/lib.rs
@@ -46,6 +46,7 @@ pub mod result_display;
 pub mod value;
 pub(crate) mod write_helpers;
 
+pub use clickgraph::sql_generator::SqlDialect;
 pub use connection::Connection;
 pub use cypher_loader::LoadStats;
 #[cfg(feature = "embedded")]

--- a/clickgraph-tool/AGENTS.md
+++ b/clickgraph-tool/AGENTS.md
@@ -21,6 +21,19 @@ cg schema discover --clickhouse <url> --database <db> --out <file>  # LLM-assist
 cg schema diff <old.yaml> <new.yaml>                  # Node/relationship diff
 ```
 
+### Dialect (`--dialect`, `CG_DIALECT`)
+
+```
+cg --dialect databricks sql      --schema <file> "<cypher>"  # Emit Spark SQL
+cg --dialect databricks validate --schema <file> "<cypher>"  # Plan under Spark dialect
+cg --dialect databricks query    --schema <file> --sql-only "<cypher>"  # Spark SQL via query path
+```
+
+Values: `clickhouse` (default) or `databricks`. Currently used by the SQL-emission
+paths (`sql`, `validate`, `query --sql-only`); executing against Databricks via
+`cg query` (without `--sql-only`) is not yet wired — use `--sql-only` and pipe
+into your warehouse.
+
 ## Architecture
 
 ```

--- a/clickgraph-tool/AGENTS.md
+++ b/clickgraph-tool/AGENTS.md
@@ -34,6 +34,16 @@ paths (`sql`, `validate`, `query --sql-only`); executing against Databricks via
 `cg query` (without `--sql-only`) is not yet wired — use `--sql-only` and pipe
 into your warehouse.
 
+The dialect can also be set in `~/.config/cg/config.toml` as a top-level key:
+
+```toml
+dialect = "databricks"   # or "clickhouse"
+```
+
+Precedence: `--dialect` flag > `CG_DIALECT` env > `config.toml` > default
+(`clickhouse`). An unrecognized config-file value warns to stderr and falls
+back to the default rather than failing silently.
+
 ## Architecture
 
 ```

--- a/clickgraph-tool/Cargo.toml
+++ b/clickgraph-tool/Cargo.toml
@@ -24,3 +24,8 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 anyhow = "1.0"
 toml = "0.8"
 dirs = "5"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"

--- a/clickgraph-tool/src/commands/query.rs
+++ b/clickgraph-tool/src/commands/query.rs
@@ -6,6 +6,7 @@ use clickgraph_embedded::{
 };
 
 use crate::config::CgConfig;
+use crate::DialectArg;
 
 /// `cg sql` — translate Cypher to SQL and print it.
 pub fn run_sql(cypher: &str, cfg: &CgConfig) -> Result<()> {
@@ -24,7 +25,8 @@ pub fn run_validate(cypher: &str, cfg: &CgConfig) -> Result<()> {
 /// Translate Cypher → SQL using sql_only mode (no executor needed).
 fn translate(cypher: &str, cfg: &CgConfig) -> Result<String> {
     let path = cfg.require_schema()?;
-    let db = Database::sql_only(path).map_err(|e| anyhow!("{}", e))?;
+    let db = Database::sql_only_with_dialect(path, cfg.dialect.to_sql_dialect())
+        .map_err(|e| anyhow!("{}", e))?;
     let conn = Connection::new(&db).map_err(|e| anyhow!("{}", e))?;
     conn.query_to_sql(cypher).map_err(|e| anyhow!("{}", e))
 }
@@ -35,6 +37,14 @@ pub async fn run_query(cypher: &str, sql_only: bool, format: &str, cfg: &CgConfi
 
     if sql_only {
         return run_sql(cypher, cfg);
+    }
+
+    if matches!(cfg.dialect, DialectArg::Databricks) {
+        return Err(anyhow!(
+            "`cg query --dialect databricks` execution is not yet wired up — use `--sql-only` \
+             (or `cg sql --dialect databricks <query>`) to print Spark SQL, or run that SQL \
+             against a Databricks SQL Warehouse separately."
+        ));
     }
 
     let ch_url = cfg

--- a/clickgraph-tool/src/config.rs
+++ b/clickgraph-tool/src/config.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use serde::Deserialize;
 
+use crate::DialectArg;
+
 /// Runtime configuration for cg, resolved from (priority order):
 /// 1. CLI flags / env vars
 /// 2. ~/.config/cg/config.toml
@@ -12,6 +14,7 @@ pub struct CgConfig {
     pub ch_user: String,
     pub ch_password: String,
     pub ch_database: Option<String>,
+    pub dialect: DialectArg,
     pub llm: LlmConfig,
 }
 
@@ -31,6 +34,8 @@ struct FileConfig {
     schema: FileSchemaSection,
     #[serde(default)]
     clickhouse: FileClickHouseSection,
+    #[serde(default)]
+    dialect: Option<String>,
     #[serde(default)]
     llm: FileLlmSection,
 }
@@ -64,6 +69,7 @@ impl CgConfig {
         ch_user: Option<&str>,
         ch_password: Option<&str>,
         ch_database: &Option<String>,
+        dialect: Option<DialectArg>,
     ) -> Result<Self> {
         let file_cfg = load_file_config();
 
@@ -114,12 +120,17 @@ impl CgConfig {
                 .or(file_cfg.llm.max_tokens),
         };
 
+        let dialect = dialect
+            .or_else(|| file_cfg.dialect.as_deref().and_then(parse_dialect))
+            .unwrap_or_default();
+
         Ok(CgConfig {
             schema_path,
             clickhouse_url,
             ch_user,
             ch_password,
             ch_database,
+            dialect,
             llm,
         })
     }
@@ -131,6 +142,14 @@ impl CgConfig {
                 "No schema file specified. Use --schema <file> or set CG_SCHEMA env var."
             )
         })
+    }
+}
+
+fn parse_dialect(s: &str) -> Option<DialectArg> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "clickhouse" | "ch" => Some(DialectArg::Clickhouse),
+        "databricks" | "spark" => Some(DialectArg::Databricks),
+        _ => None,
     }
 }
 

--- a/clickgraph-tool/src/config.rs
+++ b/clickgraph-tool/src/config.rs
@@ -120,9 +120,22 @@ impl CgConfig {
                 .or(file_cfg.llm.max_tokens),
         };
 
-        let dialect = dialect
-            .or_else(|| file_cfg.dialect.as_deref().and_then(parse_dialect))
-            .unwrap_or_default();
+        // Dialect resolution: CLI flag/env wins, then config file. A
+        // present-but-invalid config-file value warns to stderr and falls
+        // back to the default — silent ignore was masking typos.
+        let dialect = match dialect {
+            Some(d) => d,
+            None => match file_cfg.dialect.as_deref() {
+                Some(s) => parse_dialect(s).unwrap_or_else(|| {
+                    eprintln!(
+                        "Warning: ignoring unknown `dialect = \"{s}\"` in config.toml \
+                         (expected `clickhouse` or `databricks`); using default."
+                    );
+                    DialectArg::default()
+                }),
+                None => DialectArg::default(),
+            },
+        };
 
         Ok(CgConfig {
             schema_path,

--- a/clickgraph-tool/src/main.rs
+++ b/clickgraph-tool/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod commands;
 mod config;
@@ -7,6 +7,23 @@ mod llm;
 mod schema_fmt;
 
 use config::CgConfig;
+
+#[derive(Copy, Clone, Debug, ValueEnum, Default)]
+#[clap(rename_all = "lowercase")]
+pub enum DialectArg {
+    #[default]
+    Clickhouse,
+    Databricks,
+}
+
+impl DialectArg {
+    pub fn to_sql_dialect(self) -> clickgraph_embedded::SqlDialect {
+        match self {
+            DialectArg::Clickhouse => clickgraph_embedded::SqlDialect::ClickHouse,
+            DialectArg::Databricks => clickgraph_embedded::SqlDialect::Databricks,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -34,6 +51,10 @@ struct Cli {
     /// ClickHouse database to query
     #[arg(long, env = "CG_CLICKHOUSE_DATABASE", global = true)]
     ch_database: Option<String>,
+
+    /// Target SQL dialect for Cypher translation
+    #[arg(long, env = "CG_DIALECT", global = true, value_enum)]
+    dialect: Option<DialectArg>,
 
     #[command(subcommand)]
     command: Commands,
@@ -145,6 +166,7 @@ async fn main() -> Result<()> {
         cli.ch_user.as_deref(),
         cli.ch_password.as_deref(),
         &cli.ch_database,
+        cli.dialect,
     )?;
 
     match cli.command {

--- a/clickgraph-tool/tests/dialect_flag.rs
+++ b/clickgraph-tool/tests/dialect_flag.rs
@@ -1,0 +1,144 @@
+//! Integration tests for the `cg --dialect …` global flag (Phase 4.2).
+//!
+//! These spawn the actual `cg` binary so they exercise the same clap +
+//! config + Database wiring an end user hits. They do NOT need a live
+//! ClickHouse or Databricks warehouse — `cg sql` translates only, and
+//! `cg validate` plans only.
+
+use std::io::Write;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::NamedTempFile;
+
+const SOCIAL_YAML: &str = r#"
+name: cg_dialect_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+  edges:
+    - type: FOLLOWS
+      database: test_db
+      table: follows
+      from_node: User
+      to_node: User
+      from_id: follower_id
+      to_id: followed_id
+      property_mappings: {}
+"#;
+
+fn write_schema() -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("tempfile");
+    f.write_all(SOCIAL_YAML.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+#[test]
+fn cg_sql_default_emits_clickhouse_spellings() {
+    let schema = write_schema();
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("sql")
+        .arg("MATCH (u:User) RETURN collect(u.user_id) AS ids")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("groupArray("));
+}
+
+#[test]
+fn cg_sql_dialect_databricks_emits_spark_spellings() {
+    // `cg sql --dialect databricks` is the contract: same Cypher,
+    // Spark spelling. If FunctionMapper routing breaks for any
+    // reason this test fails before it ever leaves the build.
+    let schema = write_schema();
+    let assert = Command::cargo_bin("cg")
+        .expect("bin")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("--dialect")
+        .arg("databricks")
+        .arg("sql")
+        .arg("MATCH (u:User) RETURN collect(u.user_id) AS ids")
+        .assert()
+        .success();
+    assert
+        .stdout(predicate::str::contains("collect_list("))
+        .stdout(predicate::str::contains("groupArray(").not());
+}
+
+#[test]
+fn cg_dialect_databricks_via_env() {
+    let schema = write_schema();
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .env("CG_DIALECT", "databricks")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("sql")
+        .arg("MATCH (u:User) RETURN collect(u.user_id) AS ids")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("collect_list("));
+}
+
+#[test]
+fn cg_validate_accepts_dialect_flag() {
+    let schema = write_schema();
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("--dialect")
+        .arg("databricks")
+        .arg("validate")
+        .arg("MATCH (u:User) RETURN u.name")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK"));
+}
+
+#[test]
+fn cg_query_databricks_without_sql_only_errors_clearly() {
+    // Execution against Databricks isn't wired through `cg query` yet
+    // (Phase 4.2 ships the dialect flag only). The user gets a clear
+    // pointer to `--sql-only` or `cg sql --dialect databricks` instead
+    // of a confusing ClickHouse-URL error.
+    let schema = write_schema();
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("--dialect")
+        .arg("databricks")
+        .arg("query")
+        .arg("MATCH (u:User) RETURN u.name")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--sql-only"));
+}
+
+#[test]
+fn cg_query_databricks_sql_only_prints_spark_sql() {
+    let schema = write_schema();
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("--dialect")
+        .arg("databricks")
+        .arg("query")
+        .arg("--sql-only")
+        .arg("MATCH (u:User) RETURN collect(u.user_id) AS ids")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("collect_list("));
+}

--- a/clickgraph-tool/tests/dialect_flag.rs
+++ b/clickgraph-tool/tests/dialect_flag.rs
@@ -127,6 +127,31 @@ fn cg_query_databricks_without_sql_only_errors_clearly() {
 }
 
 #[test]
+fn cg_config_file_unknown_dialect_warns_and_falls_back() {
+    // A typo in `dialect = …` in config.toml previously fell back to
+    // ClickHouse silently. Now `cg` warns on stderr so misconfiguration
+    // is visible. We override the XDG config directory via env so the
+    // user's real config is not touched.
+    let schema = write_schema();
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let cfg_dir = tmp.path().join("cg");
+    std::fs::create_dir_all(&cfg_dir).expect("mkdir");
+    std::fs::write(cfg_dir.join("config.toml"), "dialect = \"sparksql\"\n").expect("cfg");
+
+    Command::cargo_bin("cg")
+        .expect("bin")
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("sql")
+        .arg("MATCH (u:User) RETURN u.name")
+        .assert()
+        .success()
+        // Still produces SQL — fall-back is non-fatal.
+        .stderr(predicate::str::contains("sparksql"));
+}
+
+#[test]
 fn cg_query_databricks_sql_only_prints_spark_sql() {
     let schema = write_schema();
     Command::cargo_bin("cg")


### PR DESCRIPTION
## Summary

DeltaGraph **Phase 4.2** — adds a `--dialect` flag to the `cg` CLI so agents and CI pipelines can translate Cypher to Spark SQL without needing a live Databricks warehouse.

- `clickgraph-embedded` re-exports `SqlDialect` and gains `Database::sql_only_with_dialect(path, dialect)`.
- `cg --dialect [clickhouse|databricks]` global flag, also via `CG_DIALECT` env.
- `cg query --dialect databricks` without `--sql-only` errors with a clear pointer instead of a confusing CH-URL message — full Databricks execution through `cg query` is a follow-up.

## Test plan

- [x] `cargo test -p clickgraph-tool --test dialect_flag` — 6 / 6 pass
- [x] `cargo test -p clickgraph-embedded --features databricks --tests` — 145 lib + 3 databricks_e2e + 10 integration pass
- [x] `cargo test -p clickgraph --lib` — 1369 pass, 11 ignored (unchanged)
- [x] `cargo clippy --all-targets -p clickgraph-tool -p clickgraph-embedded` — clean
- [x] `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)