### PR TITLE
feat(ffi): expose Database::open_databricks() behind databricks feature

### DIFF
--- a/clickgraph-ffi/AGENTS.md
+++ b/clickgraph-ffi/AGENTS.md
@@ -48,6 +48,8 @@ It exposes `nodes() → Vec<GraphNode>`, `edges() → Vec<GraphEdge>`,
 `node_count()`, `edge_count()`. `GraphNode` and `GraphEdge` are UniFFI records.
 `StoreStats` is a record with `nodes_stored` and `edges_stored` counts.
 `RemoteConfig` is a record for configuring remote ClickHouse connections.
+`DatabricksConfig` (behind the `databricks` cargo feature) is the analogue for
+Databricks SQL Warehouses; expose via `Database::open_databricks(...)`.
 
 ### Error Mapping
 `ClickGraphError` is a UniFFI-exported enum with variants:
@@ -76,3 +78,23 @@ All map from `EmbeddedError` via `From` impl.
 4. Regenerate Go: `uniffi-bindgen-go ...`
 5. Regenerate Python: `uniffi-bindgen generate --library ... --language python`
 6. Update language-specific wrapper classes if needed
+
+### Feature-Gated Surface (Databricks)
+
+When the FFI is built with `--features databricks`, the cdylib additionally
+exports `DatabricksConfig` and `Database.open_databricks(schema, config)`.
+Distributions targeting Databricks users should:
+
+```bash
+cargo build -p clickgraph-ffi --release --features databricks
+uniffi-bindgen generate --library target/release/libclickgraph_ffi.so \
+    --language python -o clickgraph-py/clickgraph/
+# (mv clickgraph_ffi.py _ffi.py per existing convention)
+uniffi-bindgen-go --library target/release/libclickgraph_ffi.so \
+    --out-dir clickgraph-go/clickgraph_ffi/
+```
+
+If you skip `--features databricks` at build time, the resulting `_ffi.py` /
+Go bindings simply won't carry the Databricks symbols — callers will hit
+`AttributeError` / undefined method, not a runtime crash. Pre-built wheels &
+Go modules should always be built with the feature on.

--- a/clickgraph-ffi/Cargo.toml
+++ b/clickgraph-ffi/Cargo.toml
@@ -11,6 +11,13 @@ license = "Apache-2.0"
 crate-type = ["cdylib"]
 name = "clickgraph_ffi"
 
+[features]
+default = []
+# Forwards to clickgraph-embedded/databricks (which forwards to
+# clickgraph/databricks). When enabled, the FFI cdylib exposes
+# `Database::open_databricks(...)` and the `DatabricksConfig` record.
+databricks = ["clickgraph-embedded/databricks"]
+
 [dependencies]
 clickgraph-embedded = { path = "../clickgraph-embedded", features = ["embedded"] }
 uniffi = "0.29"

--- a/clickgraph-ffi/src/lib.rs
+++ b/clickgraph-ffi/src/lib.rs
@@ -157,6 +157,31 @@ pub struct RemoteConfig {
 }
 
 // ---------------------------------------------------------------------------
+// DatabricksConfig — connection details for a Databricks SQL Warehouse
+//                    (Phase 4.4: DeltaGraph dialect through FFI bindings)
+// ---------------------------------------------------------------------------
+
+/// Connection parameters for a Databricks SQL Warehouse.
+///
+/// All execution flows through the Statement Execution API at
+/// `https://{hostname}/api/2.0/sql/statements`. The hostname is the
+/// workspace host (e.g. `dbc-abc123-456d.cloud.databricks.com`); the
+/// warehouse_id identifies the SQL warehouse compute. The token is a
+/// PAT (Personal Access Token) starting with `dapi…`.
+///
+/// Optional `base_url_override` lets tests and dev workflows point at a
+/// mock or proxy instead of the real workspace — leave it `None` in
+/// production.
+#[cfg(feature = "databricks")]
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct DatabricksConfig {
+    pub hostname: String,
+    pub warehouse_id: String,
+    pub token: String,
+    pub base_url_override: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // GraphNode / GraphEdge / GraphResult — structured graph output
 // ---------------------------------------------------------------------------
 
@@ -470,6 +495,37 @@ impl Database {
         Ok(Arc::new(Connection {
             db: Arc::clone(&self.inner),
             query_timeout_ms: std::sync::atomic::AtomicU64::new(0),
+        }))
+    }
+}
+
+#[cfg(feature = "databricks")]
+#[uniffi::export]
+impl Database {
+    /// Open a database backed by a Databricks SQL Warehouse.
+    ///
+    /// Cypher is translated locally to Spark SQL (via the dialect-aware
+    /// renderer landed in Phase 1.x) and executed against the warehouse
+    /// over the Statement Execution API. Use `Connection.query_remote()`
+    /// — the same remote path the ClickHouse executor uses; the dialect
+    /// is selected by `Database::dialect`.
+    ///
+    /// Available only when the upstream `databricks` feature is enabled.
+    #[uniffi::constructor]
+    pub fn open_databricks(
+        schema_path: String,
+        config: DatabricksConfig,
+    ) -> Result<Arc<Self>, ClickGraphError> {
+        let mut rust_config = clickgraph_embedded::DatabricksConfig::new(
+            &config.hostname,
+            &config.warehouse_id,
+            &config.token,
+        );
+        rust_config.base_url = config.base_url_override;
+        let db = RustDatabase::new_databricks(&schema_path, rust_config)
+            .map_err(|e| ClickGraphError::DatabaseError { msg: e.to_string() })?;
+        Ok(Arc::new(Database {
+            inner: Arc::new(db),
         }))
     }
 }


### PR DESCRIPTION
## Summary

DeltaGraph **Phase 4.4** (FFI piece) — exposes Databricks connectivity through the UniFFI bridge so Go and Python consumers can use it with the same `Database`/`Connection` shape they already know.

- New `databricks` cargo feature on `clickgraph-ffi` that forwards through `clickgraph-embedded` to the upstream executor.
- New `DatabricksConfig` uniffi::Record + `Database::open_databricks(schema, config)` constructor (in a cfg-gated impl block, so default builds are unchanged).
- AGENTS.md documents the feature gate and the binding regeneration recipe.

Python `_ffi.py` and Go bindings are not regenerated in this PR — those go in distribution-build artifacts (built with `--features databricks`). When distributions are cut, the existing recipe in AGENTS.md applies.

## Test plan

- [x] `cargo build -p clickgraph-ffi` — default build unchanged
- [x] `cargo build -p clickgraph-ffi --features databricks` — adds Databricks symbol
- [x] `cargo clippy -p clickgraph-ffi --features databricks --all-targets` — clean
- [x] Underlying `Database::new_databricks` already covered by 3 wiremock-based e2e tests in `clickgraph-embedded` (PR #331)

🤖 Generated with [Claude Code](https://claude.com/claude-code)