### PR TITLE
feat(deltagraph): Bolt e2e boot test + QUICKSTART docs (Phase 4.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,12 @@ path = "tests/rust/e2e/mod.rs"
 name = "deltagraph_bin"
 path = "tests/rust/bin/deltagraph_smoke.rs"
 required-features = ["databricks"]
+
+# Bolt-level boot regression for `deltagraph` (Phase 4.3). Spawns the
+# subprocess against wiremock and completes the Bolt v5 handshake to
+# prove the server boots end-to-end in Databricks mode without
+# tripping any ClickHouse-specific init.
+[[test]]
+name = "deltagraph_bolt_e2e"
+path = "tests/rust/bin/deltagraph_bolt_e2e.rs"
+required-features = ["databricks"]

--- a/docs/deltagraph/QUICKSTART.md
+++ b/docs/deltagraph/QUICKSTART.md
@@ -1,0 +1,214 @@
+# DeltaGraph Quickstart
+
+DeltaGraph turns a Databricks SQL Warehouse into a Cypher-queryable graph
+database. Same Cypher you'd send to Neo4j; the server translates it to
+Spark SQL and executes against your warehouse over the Statement
+Execution API. Neo4j Browser, NeoDash, graph-notebook, and any other
+Bolt v5 client connect unchanged.
+
+This document walks through the manual setup: build, configure, point
+Neo4j Browser at the server, run sample Cypher.
+
+> ⚠️ **Status:** DeltaGraph ships in `v0.6.7-dev`. Phases 1.x–4.3 are
+> complete: dialect routing, executor, embedded API, FFI, `cg` CLI,
+> server binary, Bolt e2e. Phase 3 (catalog discovery) and Phase 5
+> (full release) are still ahead. Treat this as an early-adopter path
+> until v0.7.0 lands.
+
+## Prerequisites
+
+- A Databricks workspace with at least one **SQL Warehouse** running.
+- A **Personal Access Token** (PAT) with `SELECT` on the catalog/schema
+  you want to query. OAuth M2M is on the roadmap; PAT is the only auth
+  method today.
+- A **schema YAML** describing how your tables map to a graph
+  (`benchmarks/social_network/schemas/social_benchmark.yaml` is the
+  smallest example in the repo).
+- Rust 1.85+ to build from source. We do not yet ship pre-built
+  `deltagraph` release artifacts.
+
+## 1. Build
+
+```bash
+cargo build --release --features databricks --bin deltagraph
+```
+
+The `databricks` feature pulls in the executor and its `reqwest`
+client. The default build (no feature) produces only `clickgraph`,
+which talks to ClickHouse — that binary is unaffected by this work.
+
+## 2. Configure the environment
+
+The server reads these env vars at startup:
+
+| Variable                     | Required | Purpose                                                              |
+| ---------------------------- | -------- | -------------------------------------------------------------------- |
+| `DATABRICKS_HOST`            | yes      | Workspace hostname, no scheme. `dbc-abc123-def4.cloud.databricks.com` |
+| `DATABRICKS_WAREHOUSE_ID`    | yes      | Target SQL Warehouse ID (find under SQL Warehouses in the UI)         |
+| `DATABRICKS_TOKEN`           | yes      | Personal access token. **Env-only; never accepted as a flag.**       |
+| `DATABRICKS_CATALOG`         | no       | Default catalog for unqualified table names                          |
+| `DATABRICKS_SCHEMA`          | no       | Default schema for unqualified table names                           |
+| `GRAPH_CONFIG_PATH`          | yes      | Path to your graph-schema YAML                                       |
+
+The token deliberately has no CLI flag — exposing it on the command
+line would leak via `ps`, shell history, and CI log uploads.
+
+## 3. Start the server
+
+```bash
+./target/release/deltagraph
+```
+
+You'll see:
+
+```
+DeltaGraph v0.6.7-dev
+
+🧱 DeltaGraph mode: routing queries through a Databricks SQL Warehouse
+✓ Schema initialization complete (YAML mode, 1 schema(s) registered)
+✓ Successfully bound HTTP listener to 0.0.0.0:7475
+Successfully bound Bolt listener to 0.0.0.0:7687
+ClickGraph server is running
+  HTTP API: http://0.0.0.0:7475
+  Bolt Protocol: bolt://0.0.0.0:7687
+```
+
+By default the server starts in Neo4j compat mode (so Neo4j Browser
+recognises it as a Neo4j 5.x server) and accepts unauthenticated
+connections. The compat mode is the headline feature for the Browser
+demo; pass `--disable-neo4j-compat` if you want the raw ClickGraph
+identity.
+
+## 4. Point Neo4j Browser at it
+
+Open Neo4j Browser (web or desktop). Connect with:
+
+```
+Connection URI:  bolt://localhost:7687
+Authentication:  no auth   (or: Basic, username `neo4j`, any password)
+```
+
+You should land on the standard Browser welcome page. Click the
+schema icon in the sidebar to list node labels — they'll come from
+your YAML.
+
+### Sample queries (assuming the social-network schema)
+
+```cypher
+// Count all users
+MATCH (u:User) RETURN count(u) AS users;
+
+// Top followers
+MATCH (u:User)<-[:FOLLOWS]-(f:User)
+RETURN u.name AS user, count(f) AS followers
+ORDER BY followers DESC
+LIMIT 10;
+
+// Friends-of-friends (variable-length path)
+MATCH (me:User {user_id: 42})-[:FOLLOWS*2..2]->(fof:User)
+WHERE fof.user_id <> 42
+RETURN DISTINCT fof.name AS friend_of_friend
+LIMIT 25;
+```
+
+Each query is translated to Spark SQL locally, posted to your
+warehouse's Statement Execution API, and the result is mapped back
+into the Bolt response Browser expects. Use Browser's "Query Plan" or
+the equivalent HTTP probe (below) to see the actual SQL.
+
+## 5. Inspect the generated SQL (without executing)
+
+For debugging the translation:
+
+```bash
+curl -s -X POST http://localhost:7475/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User) RETURN u.name LIMIT 5","sql_only":true}' \
+  | jq -r .sql
+```
+
+This returns the Spark SQL the executor would have sent, without
+touching the warehouse. Equivalent to:
+
+```bash
+cg --schema schema.yaml --dialect databricks sql "MATCH (u:User) RETURN u.name LIMIT 5"
+```
+
+## What works today
+
+- Read queries: `MATCH`, `WHERE`, `RETURN`, `WITH`, `ORDER BY`, `LIMIT`,
+  `SKIP`, `DISTINCT`, `OPTIONAL MATCH`, `UNWIND`, `UNION ALL`.
+- Variable-length paths (`*1..n`), shortest path, multi-hop traversals.
+- Aggregations: `count`, `sum`, `avg`, `min`, `max`, `collect`.
+- String / numeric / date / list / map functions — all routed through
+  the dialect-aware `FunctionMapper` (e.g. `collect()` → `collect_list`,
+  `toInt64()` → `bigint`).
+- Pattern comprehension, list comprehension, `CASE` expressions.
+- Neo4j Browser, NeoDash, graph-notebook, neo4rs, any Bolt v5 client.
+
+## What's not in this iteration
+
+- **Writes** (`CREATE`, `SET`, `DELETE`, `MERGE`). DeltaGraph is read-only
+  against Databricks for now — embedded chdb is the write target. Phase 5
+  may add limited write support via `INSERT INTO` for Delta tables.
+- **OAuth M2M.** PAT is the only supported auth.
+- **External-link result chunks.** Large result sets (>25 MB) currently
+  fail with an error from the Statement Execution API. The executor
+  uses `INLINE`/`JSON_ARRAY` disposition; switching to `EXTERNAL_LINKS`
+  for large results is a Phase 5 deliverable.
+- **`CALL` subqueries** (e.g. LDBC bi-16) — same gap as ClickGraph;
+  inherited from the shared planner.
+- **Schema discovery from Unity Catalog** (`SHOW TABLES IN catalog.schema`,
+  `DESCRIBE TABLE EXTENDED`). Phase 3 ships this; until then your YAML
+  is hand-authored or generated via `cg schema discover` against a
+  ClickHouse staging copy.
+
+## Pointing `cg` at the same warehouse
+
+The `cg` CLI also supports `--dialect databricks` for ad-hoc queries
+without the full server:
+
+```bash
+export DATABRICKS_HOST=...
+export DATABRICKS_WAREHOUSE_ID=...
+export DATABRICKS_TOKEN=...
+
+# Translate (no execution):
+cg --schema schema.yaml --dialect databricks sql "MATCH (u:User) RETURN u.name"
+
+# Execute against the warehouse (requires `cg` built with --features databricks):
+cargo install --path clickgraph-tool --features databricks --force
+cg --schema schema.yaml --dialect databricks query "MATCH (u:User) RETURN u.name LIMIT 5"
+```
+
+`cg` shares the same `DATABRICKS_*` env names, plus `CG_DATABRICKS_*`
+overrides if you want to scope settings to `cg` alone without leaking
+into a running `deltagraph` server.
+
+## Troubleshooting
+
+**`DATABRICKS_HOST not set`** — env var is missing or scrubbed. Check
+that you didn't `env -i` the shell, and that `direnv` (if used) loaded
+the right `.envrc`.
+
+**`401 Unauthorized` from the executor** — PAT is invalid, expired, or
+lacks `SELECT` on the catalog/schema. Verify with `curl` against
+`https://$DATABRICKS_HOST/api/2.0/sql/warehouses/$DATABRICKS_WAREHOUSE_ID`.
+
+**Browser shows "Could not connect"** — the server's Bolt port is bound
+to `0.0.0.0` by default. Check `lsof -i :7687` on the server host. If
+running in Docker, expose the port (`-p 7687:7687`).
+
+**Query returns "Cannot resolve column …"** — the Cypher property names
+in your query don't match the `property_mappings` in your schema YAML.
+This is the most common source of friction; double-check the YAML.
+
+**Slow first query** — Databricks SQL Warehouses scale to zero by
+default. The first query after idle takes 30–90s for the warehouse to
+warm up. Subsequent queries are sub-second.
+
+## Where to file feedback
+
+Issues go in the main ClickGraph repo with the `dialect:databricks`
+label. The DeltaGraph design doc is at
+[`docs/design/DELTAGRAPH_PLAN.md`](../design/DELTAGRAPH_PLAN.md).

--- a/docs/deltagraph/QUICKSTART.md
+++ b/docs/deltagraph/QUICKSTART.md
@@ -149,8 +149,10 @@ cg --schema schema.yaml --dialect databricks sql "MATCH (u:User) RETURN u.name L
 ## What's not in this iteration
 
 - **Writes** (`CREATE`, `SET`, `DELETE`, `MERGE`). DeltaGraph is read-only
-  against Databricks for now — embedded chdb is the write target. Phase 5
-  may add limited write support via `INSERT INTO` for Delta tables.
+  against Databricks; embedded chdb is the only write target today.
+  Write support against Delta tables is not on the current roadmap and
+  has no committed timeline — track [the DeltaGraph plan](../design/DELTAGRAPH_PLAN.md)
+  for any change in scope.
 - **OAuth M2M.** PAT is the only supported auth.
 - **External-link result chunks.** Large result sets (>25 MB) currently
   fail with an error from the Statement Execution API. The executor

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -652,6 +652,96 @@ fn build_databricks_config() -> Result<crate::executor::databricks_sql::Databric
     // deltagraph subprocess test in tests/rust/bin/ to redirect HTTP
     // at a wiremock URL. Production callers leave this unset — the
     // executor falls back to `https://{hostname}`.
-    cfg.base_url = std::env::var("DATABRICKS_BASE_URL").ok();
+    //
+    // Security guardrail: a misconfigured override would otherwise send
+    // the PAT in plaintext to whatever endpoint is named. We accept
+    // either an `https://` URL (any host, real workspaces) or `http://`
+    // restricted to loopback (wiremock-style tests). Anything else is
+    // rejected up front, and any successful override produces a single
+    // `log::warn!` so a stray production setting can't be silent.
+    if let Ok(raw) = std::env::var("DATABRICKS_BASE_URL") {
+        validate_databricks_base_url(&raw)?;
+        log::warn!(
+            "⚠ DATABRICKS_BASE_URL override in use ({raw}); the PAT will be sent there. \
+             This env var is intended for tests against a local mock — unset it for production."
+        );
+        cfg.base_url = Some(raw);
+    }
     Ok(cfg)
+}
+
+/// Reject overrides that would silently leak the PAT to a non-localhost
+/// plaintext endpoint. Loopback HTTP is allowed (wiremock); arbitrary
+/// HTTP is not. Anything that fails to parse or uses a non-http(s)
+/// scheme is rejected with a clear message rather than being passed
+/// through.
+#[cfg(feature = "databricks")]
+fn validate_databricks_base_url(raw: &str) -> Result<(), String> {
+    // Minimal parsing — we don't want to pull in the `url` crate just
+    // for this check. Match `https://...` unconditionally; `http://`
+    // only when the host segment is `localhost` or `127.0.0.1` (with
+    // optional port). Anything else is rejected.
+    if let Some(rest) = raw.strip_prefix("https://") {
+        if rest.is_empty() {
+            return Err("DATABRICKS_BASE_URL is empty after https://".to_string());
+        }
+        return Ok(());
+    }
+    if let Some(rest) = raw.strip_prefix("http://") {
+        let host = rest.split(['/', ':']).next().unwrap_or("");
+        if host == "localhost" || host == "127.0.0.1" {
+            return Ok(());
+        }
+        return Err(format!(
+            "DATABRICKS_BASE_URL rejected: `http://` is only allowed for loopback (localhost, \
+             127.0.0.1) to avoid leaking the PAT in plaintext. For real workspaces use https:// \
+             or unset the variable. Got host={host:?}"
+        ));
+    }
+    Err(format!(
+        "DATABRICKS_BASE_URL rejected: must start with `https://` (or `http://localhost…` for \
+         tests). Got: {raw:?}"
+    ))
+}
+
+#[cfg(all(test, feature = "databricks"))]
+mod databricks_base_url_validation_tests {
+    use super::validate_databricks_base_url;
+
+    #[test]
+    fn accepts_https_for_real_workspaces() {
+        assert!(validate_databricks_base_url("https://dbc-abc-def.cloud.databricks.com").is_ok());
+        assert!(
+            validate_databricks_base_url("https://dbc-abc-def.cloud.databricks.com/api/").is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_http_for_loopback_tests() {
+        // wiremock + mock server hosts — anything bound to loopback.
+        assert!(validate_databricks_base_url("http://127.0.0.1:55555").is_ok());
+        assert!(validate_databricks_base_url("http://localhost:55555/api/2.0/sql").is_ok());
+    }
+
+    #[test]
+    fn rejects_plaintext_http_to_external_hosts() {
+        // The whole point of the validator: a typo'd
+        // `DATABRICKS_BASE_URL=http://workspace.example.com` would
+        // POST the PAT in plaintext. Block it up front.
+        let err = validate_databricks_base_url("http://workspace.example.com").unwrap_err();
+        assert!(err.contains("loopback"), "got: {err}");
+        let err = validate_databricks_base_url("http://192.168.1.10:8080").unwrap_err();
+        assert!(err.contains("loopback"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_schemes() {
+        // ftp/gopher/no-scheme — anything that wouldn't reach the
+        // executor's reqwest client cleanly should fail loudly here
+        // rather than producing a confusing runtime error later.
+        assert!(validate_databricks_base_url("workspace.example.com").is_err());
+        assert!(validate_databricks_base_url("ftp://workspace.example.com").is_err());
+        assert!(validate_databricks_base_url("").is_err());
+        assert!(validate_databricks_base_url("https://").is_err());
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -647,5 +647,11 @@ fn build_databricks_config() -> Result<crate::executor::databricks_sql::Databric
         crate::executor::databricks_sql::DatabricksConfig::new(hostname, warehouse_id, token);
     cfg.catalog = std::env::var("DATABRICKS_CATALOG").ok();
     cfg.schema = std::env::var("DATABRICKS_SCHEMA").ok();
+    // Test-only override for the executor's request base URL. Honored
+    // by the executor (`DatabricksConfig.base_url`) and used by the
+    // deltagraph subprocess test in tests/rust/bin/ to redirect HTTP
+    // at a wiremock URL. Production callers leave this unset — the
+    // executor falls back to `https://{hostname}`.
+    cfg.base_url = std::env::var("DATABRICKS_BASE_URL").ok();
     Ok(cfg)
 }

--- a/tests/rust/bin/deltagraph_bolt_e2e.rs
+++ b/tests/rust/bin/deltagraph_bolt_e2e.rs
@@ -1,0 +1,192 @@
+//! End-to-end Bolt boot test for the `deltagraph` binary (Phase 4.3).
+//!
+//! Spawns the actual `deltagraph` server subprocess against a wiremock
+//! Databricks endpoint, waits for the Bolt TCP port to bind, then
+//! performs the Bolt v5 handshake (magic preamble + version proposal,
+//! expect server to pick a version). This proves three things end-to-end:
+//!
+//!   1. The Databricks dispatch in `server::run_with_config` actually
+//!      builds an executor from `DATABRICKS_*` env vars (the
+//!      `DATABRICKS_BASE_URL` redirection knob keeps us off the real
+//!      workspace).
+//!   2. The HTTP + Bolt servers boot to a listening state — i.e., none
+//!      of the ClickHouse-specific server init code path got tripped by
+//!      mistake when `databricks=true`.
+//!   3. Bolt protocol works unchanged against a Databricks-backed
+//!      AppState — the handshake step proves the listener is wired,
+//!      not just bound.
+//!
+//! What this test does NOT do: drive a Cypher query end-to-end through
+//! Bolt → Databricks. That requires a full PackStream client + RUN/PULL
+//! sequencing, which is the natural follow-up once we add neo4rs (or
+//! similar) as a dev-dep. The current scope is deliberately the
+//! cheapest credible regression net for "Bolt + Databricks boot."
+//!
+//! Gated on `feature = "databricks"` because `deltagraph` itself is.
+
+#![cfg(feature = "databricks")]
+
+use std::io::Write;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::process::{Child, Command};
+use tokio::time::sleep;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Use unusual port range to avoid colliding with a dev server on the
+// default 7475/7687. If a parallel test invocation needs different
+// ports, factor this into an allocator — for one test this is fine.
+const HTTP_PORT: u16 = 17_475;
+const BOLT_PORT: u16 = 17_687;
+
+const TEST_SCHEMA_YAML: &str = r#"
+name: deltagraph_bolt_e2e
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+  edges:
+    - type: FOLLOWS
+      database: test_db
+      table: follows
+      from_node: User
+      to_node: User
+      from_id: follower_id
+      to_id: followed_id
+      property_mappings: {}
+"#;
+
+fn write_schema() -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("tempfile");
+    f.write_all(TEST_SCHEMA_YAML.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+/// Poll the Bolt port until something accepts a TCP connection or the
+/// deadline expires. A bare `tokio::time::sleep` would race against
+/// slow CI machines; an unbounded loop would mask hung subprocesses.
+async fn wait_for_bolt_listen(deadline: Duration) -> std::io::Result<TcpStream> {
+    let start = Instant::now();
+    loop {
+        match TcpStream::connect(("127.0.0.1", BOLT_PORT)).await {
+            Ok(s) => return Ok(s),
+            Err(_) if start.elapsed() < deadline => sleep(Duration::from_millis(100)).await,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Run the canonical Bolt v5 handshake against an open TCP stream:
+/// 4-byte magic preamble (0x60 0x60 0xB0 0x17), then 4 version slots
+/// (each 4 bytes, big-endian; trailing zeros for unused slots).
+/// The server replies with 4 bytes — either the chosen version or
+/// zeros if no proposed version is supported.
+async fn bolt_handshake(stream: &mut TcpStream) -> std::io::Result<[u8; 4]> {
+    // Magic + propose [5.4, 5.0, 4.4, 0] — `deltagraph` advertises
+    // through Bolt 5.x, so 5.4 should win. The fallback slots let an
+    // older server (or a future one with narrower support) still pick
+    // something rather than rejecting outright.
+    let mut preamble = vec![0x60u8, 0x60, 0xB0, 0x17];
+    preamble.extend_from_slice(&0x0000_0504u32.to_be_bytes()); // 5.4
+    preamble.extend_from_slice(&0x0000_0500u32.to_be_bytes()); // 5.0
+    preamble.extend_from_slice(&0x0000_0404u32.to_be_bytes()); // 4.4
+    preamble.extend_from_slice(&0u32.to_be_bytes()); //          empty
+    stream.write_all(&preamble).await?;
+
+    let mut chosen = [0u8; 4];
+    stream.read_exact(&mut chosen).await?;
+    Ok(chosen)
+}
+
+/// `kill_on_drop(true)` doesn't terminate the spawned process
+/// immediately on `Child` drop — it just sends SIGKILL asynchronously
+/// and forgets. For test cleanup that races a next test that wants the
+/// same ports, we wrap the child so the test can wait for it to exit.
+struct ChildGuard(Option<Child>);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deltagraph_boots_and_completes_bolt_handshake() {
+    // wiremock for the Databricks SQL endpoint — the server initializes
+    // the executor on startup but doesn't immediately call it; this
+    // exists in case any startup probe ever does.
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-test",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [] }},
+            "result": { "data_array": [] }
+        })))
+        .mount(&mock)
+        .await;
+
+    let schema = write_schema();
+    let mock_uri = mock.uri();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_deltagraph"))
+        .env("GRAPH_CONFIG_PATH", schema.path())
+        .env("DATABRICKS_HOST", "ignored.cloud.databricks.com")
+        .env("DATABRICKS_WAREHOUSE_ID", "wh-bolt-e2e")
+        .env("DATABRICKS_TOKEN", "dapi-bolt-e2e")
+        .env("DATABRICKS_BASE_URL", &mock_uri)
+        // Quiet the binary's own logs so test output stays useful.
+        // server boot messages go through env_logger.
+        .env("RUST_LOG", "error")
+        .arg("--http-port")
+        .arg(HTTP_PORT.to_string())
+        .arg("--bolt-port")
+        .arg(BOLT_PORT.to_string())
+        .arg("--disable-neo4j-compat")
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn deltagraph");
+    let mut guard = ChildGuard(Some(child));
+
+    // 10 seconds is generous; on a developer laptop the server is
+    // listening in under 1s. CI machines under load can take longer.
+    let mut bolt = wait_for_bolt_listen(Duration::from_secs(10))
+        .await
+        .expect("deltagraph did not bind Bolt port within 10s — likely a startup crash");
+
+    let chosen = bolt_handshake(&mut bolt)
+        .await
+        .expect("Bolt handshake failed — server is up but did not respond to preamble");
+
+    // A non-zero 4-byte response means the server picked a Bolt
+    // version. We don't pin the exact bytes because the server's
+    // supported version set may shift; what we care about is that
+    // *some* version was accepted (the Bolt protocol layer didn't
+    // get tripped by the Databricks-backed AppState).
+    assert!(
+        chosen != [0, 0, 0, 0],
+        "server returned all-zero Bolt version (= 'no version supported'). \
+         Bolt protocol negotiation is broken in deltagraph; got bytes {:?}",
+        chosen
+    );
+
+    // Clean shutdown so the ports are free for subsequent runs.
+    if let Some(mut child) = guard.0.take() {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+    }
+}

--- a/tests/rust/bin/deltagraph_bolt_e2e.rs
+++ b/tests/rust/bin/deltagraph_bolt_e2e.rs
@@ -27,6 +27,7 @@
 #![cfg(feature = "databricks")]
 
 use std::io::Write;
+use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::{Duration, Instant};
 
 use serde_json::json;
@@ -38,11 +39,19 @@ use tokio::time::sleep;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-// Use unusual port range to avoid colliding with a dev server on the
-// default 7475/7687. If a parallel test invocation needs different
-// ports, factor this into an allocator — for one test this is fine.
-const HTTP_PORT: u16 = 17_475;
-const BOLT_PORT: u16 = 17_687;
+/// Ask the OS for a free TCP port on localhost. We bind a
+/// `std::net::TcpListener` to `127.0.0.1:0`, read the assigned port,
+/// then drop the listener. There's a small race where another process
+/// could grab the port between drop and the subprocess binding it —
+/// in practice this is rare on a CI box and beats hard-coding ports
+/// that would collide between parallel test runs or with a dev server
+/// already on the default 7475/7687.
+fn pick_free_port() -> u16 {
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
 
 const TEST_SCHEMA_YAML: &str = r#"
 name: deltagraph_bolt_e2e
@@ -76,10 +85,10 @@ fn write_schema() -> NamedTempFile {
 /// Poll the Bolt port until something accepts a TCP connection or the
 /// deadline expires. A bare `tokio::time::sleep` would race against
 /// slow CI machines; an unbounded loop would mask hung subprocesses.
-async fn wait_for_bolt_listen(deadline: Duration) -> std::io::Result<TcpStream> {
+async fn wait_for_bolt_listen(addr: SocketAddr, deadline: Duration) -> std::io::Result<TcpStream> {
     let start = Instant::now();
     loop {
-        match TcpStream::connect(("127.0.0.1", BOLT_PORT)).await {
+        match TcpStream::connect(addr).await {
             Ok(s) => return Ok(s),
             Err(_) if start.elapsed() < deadline => sleep(Duration::from_millis(100)).await,
             Err(e) => return Err(e),
@@ -93,15 +102,16 @@ async fn wait_for_bolt_listen(deadline: Duration) -> std::io::Result<TcpStream> 
 /// The server replies with 4 bytes — either the chosen version or
 /// zeros if no proposed version is supported.
 async fn bolt_handshake(stream: &mut TcpStream) -> std::io::Result<[u8; 4]> {
-    // Magic + propose [5.4, 5.0, 4.4, 0] — `deltagraph` advertises
-    // through Bolt 5.x, so 5.4 should win. The fallback slots let an
-    // older server (or a future one with narrower support) still pick
-    // something rather than rejecting outright.
+    // Magic + propose four current Bolt 5.x minors. Server's
+    // SUPPORTED_VERSIONS today is 5.8 → 5.0; offering the latest
+    // three keeps the test forward-compatible if 5.0/5.1 are dropped
+    // later, and 4.4 stays as a wide-net fallback. Negotiation picks
+    // the highest version supported by both sides.
     let mut preamble = vec![0x60u8, 0x60, 0xB0, 0x17];
-    preamble.extend_from_slice(&0x0000_0504u32.to_be_bytes()); // 5.4
-    preamble.extend_from_slice(&0x0000_0500u32.to_be_bytes()); // 5.0
+    preamble.extend_from_slice(&0x0000_0508u32.to_be_bytes()); // 5.8
+    preamble.extend_from_slice(&0x0000_0507u32.to_be_bytes()); // 5.7
+    preamble.extend_from_slice(&0x0000_0506u32.to_be_bytes()); // 5.6
     preamble.extend_from_slice(&0x0000_0404u32.to_be_bytes()); // 4.4
-    preamble.extend_from_slice(&0u32.to_be_bytes()); //          empty
     stream.write_all(&preamble).await?;
 
     let mut chosen = [0u8; 4];
@@ -109,16 +119,25 @@ async fn bolt_handshake(stream: &mut TcpStream) -> std::io::Result<[u8; 4]> {
     Ok(chosen)
 }
 
-/// `kill_on_drop(true)` doesn't terminate the spawned process
-/// immediately on `Child` drop — it just sends SIGKILL asynchronously
-/// and forgets. For test cleanup that races a next test that wants the
-/// same ports, we wrap the child so the test can wait for it to exit.
+/// `tokio::process::Child` with `kill_on_drop(true)` sends SIGKILL on
+/// drop but does not reap the process — the kernel keeps a zombie
+/// entry until `wait()` is called. For panic-path cleanup (where the
+/// test's explicit `child.wait().await` is skipped) we hand the child
+/// off to a detached `wait()` task so the OS reclaims the entry and
+/// releases the bound ports immediately rather than at process exit.
+/// `try_current()` is required because the Drop may run after the
+/// `#[tokio::test]` runtime has shut down.
 struct ChildGuard(Option<Child>);
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.0.take() {
             let _ = child.start_kill();
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = child.wait().await;
+                });
+            }
         }
     }
 }
@@ -143,6 +162,12 @@ async fn deltagraph_boots_and_completes_bolt_handshake() {
     let schema = write_schema();
     let mock_uri = mock.uri();
 
+    // Dynamic ports avoid colliding with a dev `deltagraph`/`clickgraph`
+    // on the default 7475/7687 and let parallel test runs coexist.
+    let http_port = pick_free_port();
+    let bolt_port = pick_free_port();
+    let bolt_addr: SocketAddr = format!("127.0.0.1:{bolt_port}").parse().unwrap();
+
     let child = Command::new(env!("CARGO_BIN_EXE_deltagraph"))
         .env("GRAPH_CONFIG_PATH", schema.path())
         .env("DATABRICKS_HOST", "ignored.cloud.databricks.com")
@@ -153,9 +178,9 @@ async fn deltagraph_boots_and_completes_bolt_handshake() {
         // server boot messages go through env_logger.
         .env("RUST_LOG", "error")
         .arg("--http-port")
-        .arg(HTTP_PORT.to_string())
+        .arg(http_port.to_string())
         .arg("--bolt-port")
-        .arg(BOLT_PORT.to_string())
+        .arg(bolt_port.to_string())
         .arg("--disable-neo4j-compat")
         .kill_on_drop(true)
         .spawn()
@@ -164,7 +189,7 @@ async fn deltagraph_boots_and_completes_bolt_handshake() {
 
     // 10 seconds is generous; on a developer laptop the server is
     // listening in under 1s. CI machines under load can take longer.
-    let mut bolt = wait_for_bolt_listen(Duration::from_secs(10))
+    let mut bolt = wait_for_bolt_listen(bolt_addr, Duration::from_secs(10))
         .await
         .expect("deltagraph did not bind Bolt port within 10s — likely a startup crash");
 


### PR DESCRIPTION
## Summary

Ships Phase 4.3 of the DeltaGraph plan — automated regression coverage that `deltagraph` boots end-to-end in Databricks mode and exposes Bolt unchanged, plus a manual Neo4j Browser walkthrough that turns this into the user-promised killer demo.

### What ships

**Automated test** (`tests/rust/bin/deltagraph_bolt_e2e.rs`):
Spawns the real `deltagraph` subprocess against a wiremock Databricks endpoint, waits up to 10s for the Bolt port to bind, then completes the Bolt v5 handshake (4-byte magic + 4 version slots → server picks a version). Proves:
- `server::run_with_config`'s Databricks dispatch actually builds an executor from `DATABRICKS_*` env vars
- HTTP + Bolt servers boot to a listening state — no ClickHouse-specific init was tripped by mistake when `databricks=true`
- Bolt protocol negotiation works against a Databricks-backed `AppState`

Runs in **~110ms** on a developer laptop.

**Server change** (`src/server/mod.rs`): `build_databricks_config` now reads an optional `DATABRICKS_BASE_URL` env var that redirects the executor's HTTP client at a wiremock URL. Documented in-source as test-only; production users leave it unset.

**Docs** (`docs/deltagraph/QUICKSTART.md`): end-user walkthrough — build with `--features databricks`, configure `DATABRICKS_HOST/WAREHOUSE_ID/TOKEN` (token is env-only — never a flag), point Neo4j Browser at `bolt://localhost:7687`, run sample Cypher (count, top followers, friends-of-friends VLP), inspect generated Spark SQL via `--sql-only` or `cg`, troubleshoot common failures.

### What's deferred to a follow-up

Driving an actual RUN/PULL query through Bolt end-to-end would require `neo4rs` as a dev-dep (+ its tokio/tower/h2 transitive tree). The current scope is the cheapest credible regression net for \"deltagraph boots + speaks Bolt\"; the next natural step is a query-level e2e that asserts a `MATCH (u) RETURN ...` round-trips through Bolt to wiremock with `collect_list(` in the SQL body.

## Tests

```
$ cargo test --features databricks --test deltagraph_bolt_e2e   # 1/1 passes in ~110ms
$ cargo test --features databricks --test deltagraph_bin        # 2/2 smoke tests still pass
$ cargo clippy --all-targets --features databricks              # 0 warnings
$ cargo clippy --all-targets                                    # 0 warnings (no-feature build)
$ cargo fmt --all --check                                       # clean
```

## Test plan

- [x] `cargo build --bin deltagraph --features databricks` produces working binary
- [x] `cargo test --features databricks --test deltagraph_bolt_e2e` — Bolt handshake passes
- [x] `cargo test --features databricks --test deltagraph_bin` — existing smoke tests unaffected
- [x] `cargo clippy --all-targets` — 0 warnings, both feature flavors
- [x] `cargo fmt --all --check` clean
- [x] QUICKSTART.md walks through the Neo4j Browser demo path with concrete sample queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)