### PR TITLE
feat(deltagraph): Databricks schema discovery (Phase 3)

### DIFF
--- a/clickgraph-tool/src/commands/schema.rs
+++ b/clickgraph-tool/src/commands/schema.rs
@@ -1,12 +1,14 @@
 use anyhow::{anyhow, Result};
 use clickgraph::graph_catalog::{
-    config::GraphSchemaConfig, llm_prompt, merge_batch_yaml, schema_discovery::SchemaDiscovery,
+    config::GraphSchemaConfig,
+    llm_prompt, merge_batch_yaml,
+    schema_discovery::{IntrospectResponse, SchemaDiscovery},
 };
 
 use crate::{
     config::CgConfig,
     llm::{extract_yaml, LlmClient},
-    schema_fmt,
+    schema_fmt, DialectArg,
 };
 
 /// `cg schema show` — print the loaded schema in a compact, agent-friendly format.
@@ -54,25 +56,44 @@ pub fn run_validate_schema(path: &str) -> Result<()> {
     Ok(())
 }
 
-/// `cg schema discover` — LLM-assisted schema discovery from ClickHouse.
+/// `cg schema discover` — LLM-assisted schema discovery.
+///
+/// Branches on `cfg.dialect`:
+/// - **ClickHouse** (default): introspects via `system.tables`/`system.columns`
+///   through a `clickhouse::Client`.
+/// - **Databricks** (requires the `databricks` build feature on `clickgraph-tool`):
+///   introspects via `SHOW TABLES IN catalog.schema` + `DESCRIBE TABLE EXTENDED`
+///   through the same `DatabricksSqlExecutor` `cg query --dialect databricks`
+///   uses. The `--catalog` flag (or `CG_DATABRICKS_CATALOG` / `DATABRICKS_CATALOG`
+///   env per the precedence in `config.rs`) supplies the catalog; `--database`
+///   reuses the existing flag as the Databricks "schema" name (Spark's two-level
+///   naming inside a catalog).
 pub async fn run_discover(
     database: &str,
+    catalog: Option<&str>,
     ch_url: &str,
     user: &str,
     password: &str,
     out: Option<&str>,
     cfg: &CgConfig,
 ) -> Result<()> {
-    // Build a clickhouse client directly
-    let ch_client = clickhouse::Client::default()
-        .with_url(ch_url)
-        .with_user(user)
-        .with_password(password);
-
-    eprintln!("Introspecting database '{}'...", database);
-    let introspect = SchemaDiscovery::introspect(&ch_client, database)
-        .await
-        .map_err(|e| anyhow!("Introspection failed: {}", e))?;
+    // Discovery prompts feed downstream LLM batches and care only about the
+    // table/column listing — both backends produce the same `IntrospectResponse`
+    // shape, so a single LLM path follows.
+    let (db_label, introspect) = match cfg.dialect {
+        DialectArg::Databricks => run_introspect_databricks(catalog, database, cfg).await?,
+        DialectArg::Clickhouse => {
+            let ch_client = clickhouse::Client::default()
+                .with_url(ch_url)
+                .with_user(user)
+                .with_password(password);
+            eprintln!("Introspecting ClickHouse database '{}'...", database);
+            let resp = SchemaDiscovery::introspect(&ch_client, database)
+                .await
+                .map_err(|e| anyhow!("Introspection failed: {}", e))?;
+            (database.to_string(), resp)
+        }
+    };
 
     eprintln!(
         "Found {} table(s). Generating schema with LLM...",
@@ -80,7 +101,7 @@ pub async fn run_discover(
     );
 
     // Format the discovery prompt(s)
-    let prompt_response = llm_prompt::format_discovery_prompt(database, &introspect.tables);
+    let prompt_response = llm_prompt::format_discovery_prompt(&db_label, &introspect.tables);
 
     let llm = LlmClient::from_config(&cfg.llm)?;
     eprintln!("Using {} model: {}", provider_name(&llm), llm.model);
@@ -224,4 +245,76 @@ fn provider_name(llm: &LlmClient) -> &str {
         crate::llm::LlmProvider::Anthropic => "Anthropic",
         crate::llm::LlmProvider::OpenAI => "OpenAI-compatible",
     }
+}
+
+// ── Databricks introspect path (Phase 3) ─────────────────────────────────────
+//
+// Feature-gated mirror of the ClickHouse path in `run_discover`. With the
+// feature off, the binary still compiles and `cg schema discover --dialect
+// databricks` exits with a clear rebuild error rather than a confusing
+// reqwest/connection trace.
+
+#[cfg(feature = "databricks")]
+async fn run_introspect_databricks(
+    catalog: Option<&str>,
+    schema: &str,
+    cfg: &CgConfig,
+) -> Result<(String, IntrospectResponse)> {
+    use clickgraph::executor::databricks_sql::{DatabricksConfig, DatabricksSqlExecutor};
+    use clickgraph::graph_catalog::databricks_probe::DatabricksProbe;
+
+    // Catalog precedence: CLI flag > CG_DATABRICKS_CATALOG / DATABRICKS_CATALOG
+    // > config.toml. Errors out up front rather than letting `SHOW TABLES IN`
+    // fail with a less-clear message from the warehouse.
+    let catalog = catalog
+        .map(str::to_string)
+        .or_else(|| cfg.databricks.catalog.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "Databricks catalog not set. Pass --catalog, or set \
+                 DATABRICKS_CATALOG / CG_DATABRICKS_CATALOG."
+            )
+        })?;
+    let host = cfg.databricks.hostname.as_deref().ok_or_else(|| {
+        anyhow!("DATABRICKS_HOST not set — see `cg schema discover --help` for env vars.")
+    })?;
+    let warehouse_id = cfg
+        .databricks
+        .warehouse_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("DATABRICKS_WAREHOUSE_ID not set."))?;
+    let token = cfg.databricks.token.as_deref().ok_or_else(|| {
+        anyhow!(
+            "DATABRICKS_TOKEN not set — provide it via env or [databricks].token in config.toml \
+             (env-only; never accepted on the command line)."
+        )
+    })?;
+
+    let mut dbc = DatabricksConfig::new(host, warehouse_id, token);
+    dbc.catalog = Some(catalog.clone());
+    dbc.schema = Some(schema.to_string());
+    dbc.base_url = cfg.databricks.base_url.clone();
+
+    let executor = DatabricksSqlExecutor::new(dbc)
+        .map_err(|e| anyhow!("Failed to open Databricks executor: {e}"))?;
+
+    let db_label = format!("{catalog}.{schema}");
+    eprintln!("Introspecting Databricks namespace '{db_label}'...");
+    let resp = DatabricksProbe::introspect(&executor, &catalog, schema)
+        .await
+        .map_err(|e| anyhow!("Databricks introspection failed: {e}"))?;
+    Ok((db_label, resp))
+}
+
+#[cfg(not(feature = "databricks"))]
+async fn run_introspect_databricks(
+    _catalog: Option<&str>,
+    _schema: &str,
+    _cfg: &CgConfig,
+) -> Result<(String, IntrospectResponse)> {
+    Err(anyhow!(
+        "`cg schema discover --dialect databricks` requires the `databricks` build feature. \
+         Rebuild cg with `cargo install clickgraph-tool --features databricks` \
+         (or use `--dialect clickhouse` against a ClickHouse staging copy)."
+    ))
 }

--- a/clickgraph-tool/src/main.rs
+++ b/clickgraph-tool/src/main.rs
@@ -124,21 +124,30 @@ enum SchemaCommands {
         file: Option<String>,
     },
 
-    /// Discover schema from an existing ClickHouse database using LLM assistance
+    /// Discover schema via LLM assistance. Default targets ClickHouse;
+    /// with `--dialect databricks` targets a Databricks SQL Warehouse
+    /// catalog/schema (requires the `databricks` build feature).
     Discover {
-        /// ClickHouse database to introspect
+        /// Database (ClickHouse) or schema name within a catalog (Databricks)
         #[arg(long)]
         database: String,
 
-        /// ClickHouse URL (falls back to --clickhouse global flag)
+        /// Databricks catalog (required for --dialect databricks;
+        /// falls back to DATABRICKS_CATALOG / CG_DATABRICKS_CATALOG).
+        /// Ignored for ClickHouse.
+        #[arg(long)]
+        catalog: Option<String>,
+
+        /// ClickHouse URL (falls back to --clickhouse global flag).
+        /// Ignored for --dialect databricks.
         #[arg(long, env = "CG_CLICKHOUSE_URL")]
         clickhouse: Option<String>,
 
-        /// ClickHouse user
+        /// ClickHouse user. Ignored for --dialect databricks.
         #[arg(long, env = "CG_CLICKHOUSE_USER", default_value = "default")]
         user: String,
 
-        /// ClickHouse password
+        /// ClickHouse password. Ignored for --dialect databricks.
         #[arg(long, env = "CG_CLICKHOUSE_PASSWORD", default_value = "")]
         password: String,
 
@@ -208,18 +217,29 @@ async fn main() -> Result<()> {
             }
             SchemaCommands::Discover {
                 database,
+                catalog,
                 clickhouse,
                 user,
                 password,
                 out,
             } => {
-                let ch_url = clickhouse
-                    .or_else(|| cfg.clickhouse_url.clone())
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("No ClickHouse URL. Use --clickhouse or CG_CLICKHOUSE_URL.")
-                    })?;
+                // For ClickHouse the URL is required; for Databricks it's
+                // unused (the executor reads DATABRICKS_HOST etc.). Resolve
+                // it lazily so a missing CG_CLICKHOUSE_URL doesn't block
+                // the Databricks path.
+                let ch_url = match cfg.dialect {
+                    DialectArg::Clickhouse => clickhouse
+                        .or_else(|| cfg.clickhouse_url.clone())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "No ClickHouse URL. Use --clickhouse or CG_CLICKHOUSE_URL."
+                            )
+                        })?,
+                    DialectArg::Databricks => String::new(),
+                };
                 commands::schema::run_discover(
                     &database,
+                    catalog.as_deref(),
                     &ch_url,
                     &user,
                     &password,

--- a/clickgraph-tool/tests/databricks_query.rs
+++ b/clickgraph-tool/tests/databricks_query.rs
@@ -158,3 +158,38 @@ async fn cg_query_databricks_missing_credentials_errors_clearly() {
     .await
     .expect("cg invocation");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cg_schema_discover_databricks_without_catalog_errors_clearly() {
+    // Phase 3 wiring: `cg schema discover --dialect databricks` should
+    // require either --catalog or DATABRICKS_CATALOG / CG_DATABRICKS_CATALOG.
+    // A missing catalog should fail up front with the named field, not
+    // succeed and then explode with an unhelpful warehouse error.
+    let schema = write_schema();
+    let schema_path = schema.path().to_path_buf();
+    let tmp = tempfile::tempdir().expect("tmpdir");
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("cg")
+            .expect("bin")
+            .env_remove("DATABRICKS_CATALOG")
+            .env_remove("CG_DATABRICKS_CATALOG")
+            .env("DATABRICKS_HOST", "ignored.cloud.databricks.com")
+            .env("DATABRICKS_WAREHOUSE_ID", "wh-test")
+            .env("DATABRICKS_TOKEN", "dapi-test")
+            .env("XDG_CONFIG_HOME", tmp.path())
+            .arg("--schema")
+            .arg(&schema_path)
+            .arg("--dialect")
+            .arg("databricks")
+            .arg("schema")
+            .arg("discover")
+            .arg("--database")
+            .arg("graphs")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Databricks catalog not set"));
+    })
+    .await
+    .expect("cg invocation");
+}

--- a/src/graph_catalog/databricks_probe.rs
+++ b/src/graph_catalog/databricks_probe.rs
@@ -42,7 +42,8 @@ fn validate_identifier(id: &str) -> Result<&str, String> {
     if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         return Err(format!(
             "identifier {id:?} contains characters outside [A-Za-z0-9_]; \
-             quote your name or pass an ASCII alphanumeric one"
+             pass an ASCII alphanumeric/underscore name \
+             (quoted/backticked identifiers are not supported)"
         ));
     }
     Ok(id)
@@ -73,7 +74,7 @@ impl DatabricksProbe {
             let columns = describe_columns(executor, catalog, schema, &table_name).await?;
             // Sample failures are non-fatal — a permission-denied SELECT
             // on a single table shouldn't kill discovery for the rest.
-            let sample = sample_rows(executor, catalog, schema, &table_name)
+            let sample = sample_rows(executor, catalog, schema, &table_name, &columns)
                 .await
                 .unwrap_or_default();
 
@@ -91,7 +92,7 @@ impl DatabricksProbe {
             "Review tables and columns above, then create your schema.\n\
              To generate a YAML draft, point `cg schema discover` (or the LLM-assisted \
              /schemas/draft endpoint) at the same catalog/schema:\n  \
-             cg --schema <yaml> --dialect databricks schema discover --catalog {catalog} --database {schema}"
+             cg --dialect databricks schema discover --catalog {catalog} --database {schema} --out schema.yaml"
         );
 
         Ok(IntrospectResponse {
@@ -132,7 +133,11 @@ async fn list_tables(
                 // Last-resort fallback for forked engines that return
                 // a single-column row without the canonical `tableName`
                 // header (e.g. a ClickHouse-style `Tables_in_<db>`).
+                // Guard with `len() == 1` so a multi-column row from
+                // an unknown engine can't accidentally pick a non-table
+                // field (e.g. `database`) as the table name.
                 row.as_object()
+                    .filter(|m| m.len() == 1)
                     .and_then(|m| m.values().next())
                     .and_then(Value::as_str)
             });
@@ -203,14 +208,42 @@ async fn describe_columns(
 /// JSON object keyed by column name — identical shape to what
 /// [`SchemaDiscovery::get_sample_data`] returns from ClickHouse, so
 /// downstream consumers don't branch on backend.
+///
+/// We explicitly list the discovered columns (capped at
+/// [`SAMPLE_COLUMN_CAP`]) instead of `SELECT *` — wide Delta tables
+/// can have hundreds of columns and complex nested types, and
+/// discovery is meant to be cheap. Each column name is backticked
+/// individually after validation so the SQL is injection-safe even
+/// when `DESCRIBE TABLE EXTENDED` returns an unexpected name.
+const SAMPLE_COLUMN_CAP: usize = 32;
+
 async fn sample_rows(
     executor: &DatabricksSqlExecutor,
     catalog: &str,
     schema: &str,
     table: &str,
+    columns: &[ColumnMetadata],
 ) -> Result<Vec<Value>, String> {
     let table = validate_identifier(table)?;
-    let sql = format!("SELECT * FROM `{catalog}`.`{schema}`.`{table}` LIMIT 3");
+    // Empty column list → no point sampling, return nothing.
+    if columns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut select_list = String::new();
+    for (i, col) in columns.iter().take(SAMPLE_COLUMN_CAP).enumerate() {
+        // Same identifier discipline as the catalog/schema/table:
+        // refuse anything outside [A-Za-z0-9_] rather than rely on
+        // backtick escaping to make a weird name safe.
+        let col_name = validate_identifier(&col.name)
+            .map_err(|e| format!("sample SELECT column rejected for {table}: {e}"))?;
+        if i > 0 {
+            select_list.push_str(", ");
+        }
+        select_list.push('`');
+        select_list.push_str(col_name);
+        select_list.push('`');
+    }
+    let sql = format!("SELECT {select_list} FROM `{catalog}`.`{schema}`.`{table}` LIMIT 3");
     executor
         .execute_json(&sql, None)
         .await
@@ -328,12 +361,15 @@ mod tests {
             .mount(&server)
             .await;
 
-        // 4. SELECT * FROM ... LIMIT 3 — single matcher serves both
-        // sample queries since we don't care about the per-table data
-        // for the response-shape assertion.
+        // 4. SELECT <cols> FROM ... LIMIT 3 — single matcher serves
+        // both sample queries since we don't care about the per-table
+        // data for the response-shape assertion. We match on the LIMIT
+        // 3 tail (stable across the new explicit-column SELECT and
+        // any future column-cap tweaks) rather than `SELECT *` so
+        // this stays in sync with the change away from `SELECT *`.
         Mock::given(method("POST"))
             .and(path("/api/2.0/sql/statements"))
-            .and(body_string_contains("SELECT * FROM"))
+            .and(body_string_contains("LIMIT 3"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "statement_id": "stmt-sample",
                 "status": { "state": "SUCCEEDED" },

--- a/src/graph_catalog/databricks_probe.rs
+++ b/src/graph_catalog/databricks_probe.rs
@@ -1,0 +1,396 @@
+//! Schema discovery against a Databricks SQL Warehouse (DeltaGraph Phase 3).
+//!
+//! Mirrors [`crate::graph_catalog::schema_discovery::SchemaDiscovery`]
+//! but drives the [`DatabricksSqlExecutor`] over Databricks' standard
+//! catalog DDL — `SHOW TABLES IN catalog.schema` and `DESCRIBE TABLE
+//! EXTENDED catalog.schema.table` — instead of ClickHouse's
+//! `system.tables` / `system.columns`. The returned `IntrospectResponse`
+//! shape is identical so downstream `cg schema discover` LLM prompts
+//! and `IntrospectHandler` HTTP responses work unchanged.
+//!
+//! ## What we deliberately skip
+//!
+//! - **Row count.** `SELECT count(*)` on a Databricks table can spin
+//!   up the warehouse and scan TBs. Discovery should be cheap; users
+//!   who want row counts can pull them post-hoc.
+//! - **Primary-key / sort-key metadata.** Databricks tables don't
+//!   surface enforced PKs via `DESCRIBE`. We leave `is_primary_key` /
+//!   `is_in_order_by` as `false` — `generate_suggestions` then falls
+//!   back to its name-heuristic path (`_id` / `_key` columns).
+//! - **Unity Catalog metadata** (owner, comment, properties). Not
+//!   needed for graph-schema authoring; would belong in a richer
+//!   `DESCRIBE TABLE EXTENDED` parser if and when downstream tooling
+//!   wants it.
+
+use crate::executor::databricks_sql::DatabricksSqlExecutor;
+use crate::executor::QueryExecutor;
+use crate::graph_catalog::schema_discovery::{
+    ColumnMetadata, IntrospectResponse, SchemaDiscovery, TableMetadata,
+};
+use serde_json::Value;
+
+/// Reject anything outside the conservative SQL-identifier shape that
+/// also matches the catalog/schema/table grammar Databricks uses for
+/// unquoted names. Quoted backtick names are rejected up front — the
+/// LLM-driven `cg schema discover` flow always passes plain names, and
+/// keeping the validator strict means there is no SQL-injection
+/// surface for callers that forget to scrub user input.
+fn validate_identifier(id: &str) -> Result<&str, String> {
+    if id.is_empty() {
+        return Err("identifier is empty".to_string());
+    }
+    if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(format!(
+            "identifier {id:?} contains characters outside [A-Za-z0-9_]; \
+             quote your name or pass an ASCII alphanumeric one"
+        ));
+    }
+    Ok(id)
+}
+
+pub struct DatabricksProbe;
+
+impl DatabricksProbe {
+    /// Discover tables in `catalog.schema` via SHOW TABLES, then for
+    /// each one fetch column metadata via DESCRIBE TABLE EXTENDED and
+    /// a 3-row sample via SELECT. Returns the same `IntrospectResponse`
+    /// shape `SchemaDiscovery::introspect` returns so cg and the HTTP
+    /// `schemas/draft` handler can consume either source.
+    pub async fn introspect(
+        executor: &DatabricksSqlExecutor,
+        catalog: &str,
+        schema: &str,
+    ) -> Result<IntrospectResponse, String> {
+        let catalog = validate_identifier(catalog)?;
+        let schema = validate_identifier(schema)?;
+
+        let tables = list_tables(executor, catalog, schema).await?;
+
+        let mut table_metadata = Vec::with_capacity(tables.len());
+        let mut suggestions = Vec::new();
+
+        for table_name in tables {
+            let columns = describe_columns(executor, catalog, schema, &table_name).await?;
+            // Sample failures are non-fatal — a permission-denied SELECT
+            // on a single table shouldn't kill discovery for the rest.
+            let sample = sample_rows(executor, catalog, schema, &table_name)
+                .await
+                .unwrap_or_default();
+
+            suggestions.extend(SchemaDiscovery::generate_suggestions(&table_name, &columns));
+
+            table_metadata.push(TableMetadata {
+                name: table_name,
+                columns,
+                row_count: None,
+                sample,
+            });
+        }
+
+        let next_step = format!(
+            "Review tables and columns above, then create your schema.\n\
+             To generate a YAML draft, point `cg schema discover` (or the LLM-assisted \
+             /schemas/draft endpoint) at the same catalog/schema:\n  \
+             cg --schema <yaml> --dialect databricks schema discover --catalog {catalog} --database {schema}"
+        );
+
+        Ok(IntrospectResponse {
+            database: format!("{catalog}.{schema}"),
+            tables: table_metadata,
+            next_step,
+            suggestions,
+        })
+    }
+}
+
+/// `SHOW TABLES IN catalog.schema` on Databricks returns rows shaped:
+///   { database: "schema_name", tableName: "users", isTemporary: false }
+/// We only need `tableName`. Temporary tables are filtered out — they
+/// won't survive past the SQL Warehouse session anyway.
+async fn list_tables(
+    executor: &DatabricksSqlExecutor,
+    catalog: &str,
+    schema: &str,
+) -> Result<Vec<String>, String> {
+    let sql = format!("SHOW TABLES IN `{catalog}`.`{schema}`");
+    let rows = executor
+        .execute_json(&sql, None)
+        .await
+        .map_err(|e| format!("SHOW TABLES failed: {e}"))?;
+
+    let mut tables = Vec::new();
+    for row in rows {
+        // `tableName` is the canonical column name in Spark/Databricks.
+        // We tolerate a single-column row shape (just the name) too,
+        // in case a forked warehouse returns the older `Tables_in_*`
+        // ClickHouse-like header.
+        let name = row
+            .get("tableName")
+            .and_then(Value::as_str)
+            .or_else(|| row.get("table_name").and_then(Value::as_str))
+            .or_else(|| {
+                // Last-resort fallback for forked engines that return
+                // a single-column row without the canonical `tableName`
+                // header (e.g. a ClickHouse-style `Tables_in_<db>`).
+                row.as_object()
+                    .and_then(|m| m.values().next())
+                    .and_then(Value::as_str)
+            });
+        let is_temp = row
+            .get("isTemporary")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let (Some(name), false) = (name, is_temp) {
+            // Skip system / Spark-internal listings if any leak through.
+            if !name.is_empty() {
+                tables.push(name.to_string());
+            }
+        }
+    }
+    tables.sort();
+    Ok(tables)
+}
+
+/// `DESCRIBE TABLE EXTENDED catalog.schema.table` returns one row per
+/// table column followed by separator / metadata rows. The separator
+/// is conventionally a row with `col_name = ""` and then sections
+/// starting with `# Detailed Table Information`, `# Partition Information`,
+/// `# Constraints`, etc. We stop at the first marker so the column
+/// vector contains exactly the table's real columns.
+async fn describe_columns(
+    executor: &DatabricksSqlExecutor,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ColumnMetadata>, String> {
+    let table = validate_identifier(table)?;
+    let sql = format!("DESCRIBE TABLE EXTENDED `{catalog}`.`{schema}`.`{table}`");
+    let rows = executor
+        .execute_json(&sql, None)
+        .await
+        .map_err(|e| format!("DESCRIBE TABLE EXTENDED failed for {table}: {e}"))?;
+
+    let mut columns = Vec::new();
+    for row in rows {
+        let col_name = row.get("col_name").and_then(Value::as_str).unwrap_or("");
+        // Empty `col_name` or a `#`-prefixed marker signals the start
+        // of the metadata block (Partition Information / Detailed
+        // Table Information / Constraints, etc.). Stop here so we
+        // don't try to parse those as columns.
+        if col_name.is_empty() || col_name.starts_with('#') {
+            break;
+        }
+        let data_type = row
+            .get("data_type")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        columns.push(ColumnMetadata {
+            name: col_name.to_string(),
+            data_type,
+            // Databricks `DESCRIBE` doesn't surface PK / sort-key
+            // metadata. Leaving these false makes `generate_suggestions`
+            // fall back to name-heuristic detection (_id / _key
+            // columns) which works the same on both backends.
+            is_primary_key: false,
+            is_in_order_by: false,
+        });
+    }
+    Ok(columns)
+}
+
+/// Fetch up to three sample rows for context. Returns each row as a
+/// JSON object keyed by column name — identical shape to what
+/// [`SchemaDiscovery::get_sample_data`] returns from ClickHouse, so
+/// downstream consumers don't branch on backend.
+async fn sample_rows(
+    executor: &DatabricksSqlExecutor,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Value>, String> {
+    let table = validate_identifier(table)?;
+    let sql = format!("SELECT * FROM `{catalog}`.`{schema}`.`{table}` LIMIT 3");
+    executor
+        .execute_json(&sql, None)
+        .await
+        .map_err(|e| format!("sample SELECT failed for {table}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_identifier_accepts_ascii_alnum_underscore() {
+        assert!(validate_identifier("users").is_ok());
+        assert!(validate_identifier("my_schema_2").is_ok());
+        assert!(validate_identifier("CamelCase").is_ok());
+        assert!(validate_identifier("_underscore_start").is_ok());
+    }
+
+    #[test]
+    fn validate_identifier_rejects_unsafe_input() {
+        // The whole point of the validator: anything that could break
+        // out of the backticked SQL identifier must fail loudly.
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("foo bar").is_err());
+        assert!(validate_identifier("foo`bar").is_err());
+        assert!(validate_identifier("foo;DROP TABLE x").is_err());
+        assert!(validate_identifier("a.b").is_err()); // qualified names pass each part separately
+    }
+
+    /// End-to-end probe over wiremock — covers the SHOW TABLES →
+    /// DESCRIBE TABLE EXTENDED → SELECT LIMIT 3 sequence and asserts
+    /// the response shape downstream consumers expect.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn introspect_against_wiremock_returns_expected_shape() {
+        use crate::executor::databricks_sql::{DatabricksConfig, DatabricksSqlExecutor};
+        use serde_json::json;
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        // Mount three matchers, each scoped to the SQL substring of the
+        // statement we expect. Order doesn't matter — wiremock dispatches
+        // on whichever matcher fits the incoming request.
+
+        // 1. SHOW TABLES IN `main`.`graphs`
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(body_string_contains("SHOW TABLES IN"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-show",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": { "schema": { "columns": [
+                    { "name": "database" },
+                    { "name": "tableName" },
+                    { "name": "isTemporary" }
+                ]}},
+                "result": { "data_array": [
+                    ["graphs", "users", false],
+                    ["graphs", "follows", false],
+                    ["graphs", "_temp_scratch", true]
+                ]}
+            })))
+            .mount(&server)
+            .await;
+
+        // 2. DESCRIBE TABLE EXTENDED for `users` — three real columns,
+        // then the metadata block we should stop parsing at.
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(body_string_contains(
+                "DESCRIBE TABLE EXTENDED `main`.`graphs`.`users`",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-desc-users",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": { "schema": { "columns": [
+                    { "name": "col_name" },
+                    { "name": "data_type" },
+                    { "name": "comment" }
+                ]}},
+                "result": { "data_array": [
+                    ["user_id", "bigint", null],
+                    ["full_name", "string", null],
+                    ["created_at", "timestamp", null],
+                    ["", "", ""],
+                    ["# Detailed Table Information", "", ""],
+                    ["Catalog", "main", ""],
+                    ["Database", "graphs", ""]
+                ]}
+            })))
+            .mount(&server)
+            .await;
+
+        // 3. DESCRIBE for `follows` — edge-shaped table to exercise
+        // `generate_suggestions`' edge_candidate path.
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(body_string_contains(
+                "DESCRIBE TABLE EXTENDED `main`.`graphs`.`follows`",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-desc-follows",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": { "schema": { "columns": [
+                    { "name": "col_name" },
+                    { "name": "data_type" },
+                    { "name": "comment" }
+                ]}},
+                "result": { "data_array": [
+                    ["follower_id", "bigint", null],
+                    ["followed_id", "bigint", null]
+                ]}
+            })))
+            .mount(&server)
+            .await;
+
+        // 4. SELECT * FROM ... LIMIT 3 — single matcher serves both
+        // sample queries since we don't care about the per-table data
+        // for the response-shape assertion.
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(body_string_contains("SELECT * FROM"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-sample",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": { "schema": { "columns": [
+                    { "name": "user_id" },
+                    { "name": "full_name" }
+                ]}},
+                "result": { "data_array": [
+                    [1, "alice"]
+                ]}
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config =
+            DatabricksConfig::new("ignored.cloud.databricks.com", "wh-probe", "dapi-probe");
+        config.base_url = Some(server.uri());
+        let executor = DatabricksSqlExecutor::new(config).expect("executor");
+
+        let resp = DatabricksProbe::introspect(&executor, "main", "graphs")
+            .await
+            .expect("introspect");
+
+        // database is `catalog.schema`, mirroring the way Databricks
+        // identifies a namespace in three-tier nomenclature.
+        assert_eq!(resp.database, "main.graphs");
+
+        // The temp table was filtered out; the rest survived and are
+        // sorted alphabetically (regression guard for the `tables.sort()`).
+        let names: Vec<&str> = resp.tables.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["follows", "users"]);
+
+        // Columns for `users` stopped at the metadata block — we
+        // should see exactly the three real columns, no `# Detailed…`
+        // or `Catalog` rows leaking through.
+        let users = resp
+            .tables
+            .iter()
+            .find(|t| t.name == "users")
+            .expect("users table");
+        let user_cols: Vec<&str> = users.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(user_cols, vec!["user_id", "full_name", "created_at"]);
+        assert_eq!(users.columns[0].data_type, "bigint");
+        assert_eq!(users.row_count, None, "we explicitly skip row_count");
+
+        // Suggestions: follows has two _id columns → edge_candidate.
+        // Pin this so a regression in `generate_suggestions` visibility
+        // (we bumped it to pub(crate) for this module) shows up here.
+        let follows_suggestions: Vec<&str> = resp
+            .suggestions
+            .iter()
+            .filter(|s| s.table == "follows")
+            .map(|s| s.suggestion_type.as_str())
+            .collect();
+        assert!(
+            follows_suggestions.contains(&"edge_candidate"),
+            "expected edge_candidate for two-id table; got {follows_suggestions:?}"
+        );
+    }
+}

--- a/src/graph_catalog/mod.rs
+++ b/src/graph_catalog/mod.rs
@@ -12,6 +12,14 @@ pub mod llm_prompt;
 pub mod node_classification;
 pub mod pattern_schema;
 pub mod schema_discovery;
+
+// DeltaGraph Phase 3: schema discovery against a Databricks SQL
+// Warehouse. Mirrors `schema_discovery` but drives the executor over
+// `SHOW TABLES IN catalog.schema` / `DESCRIBE TABLE EXTENDED` rather
+// than ClickHouse's `system.tables` / `system.columns`. Gated on the
+// `databricks` feature so the default build doesn't pull it in.
+#[cfg(feature = "databricks")]
+pub mod databricks_probe;
 pub mod schema_types;
 pub mod schema_validator;
 

--- a/src/graph_catalog/schema_discovery.rs
+++ b/src/graph_catalog/schema_discovery.rs
@@ -290,7 +290,10 @@ curl -X POST http://localhost:7475/schemas/draft -H 'Content-Type: application/j
     }
 
     /// Generate suggestions based on table structure
-    fn generate_suggestions(table_name: &str, columns: &[ColumnMetadata]) -> Vec<Suggestion> {
+    pub(crate) fn generate_suggestions(
+        table_name: &str,
+        columns: &[ColumnMetadata],
+    ) -> Vec<Suggestion> {
         let mut suggestions = Vec::new();
 
         // Check for primary key


### PR DESCRIPTION
## Summary

Ships Phase 3 of the DeltaGraph plan — catalog-based schema discovery for Databricks SQL Warehouses, mirroring the existing ClickHouse \`SchemaDiscovery\` so \`cg schema discover\` and the HTTP \`schemas/draft\` handler can target either backend.

**Three pieces land together:**

### 1. \`DatabricksProbe\` (src/graph_catalog/databricks_probe.rs, feature-gated)

New module introspecting via Databricks' standard catalog DDL:

- \`SHOW TABLES IN catalog.schema\` for table listing (filters temp tables, tolerates the older \`Tables_in_<db>\` single-column shape from forked engines)
- \`DESCRIBE TABLE EXTENDED catalog.schema.table\` for columns, stopping at the metadata block (\`# Detailed Table Information\` / \`# Partition Information\` / \`# Constraints\` rows)
- \`SELECT … LIMIT 3\` for sample data

Returns the same \`IntrospectResponse\` shape \`SchemaDiscovery\` returns, so downstream LLM prompts and HTTP handlers work unchanged. Bumps \`SchemaDiscovery::generate_suggestions\` to \`pub(crate)\` so the probe reuses the same \`_id\`/\`_key\` heuristic suggestions.

Deliberately skips:
- **\`row_count\`** — \`SELECT count(*)\` on Databricks can spin up the warehouse and scan TBs; discovery should stay cheap.
- **PK / sort-key metadata** — Databricks doesn't surface these via \`DESCRIBE\`; generate_suggestions falls back to name heuristics, same behavior either way.

### 2. \`cg schema discover --dialect databricks\` (clickgraph-tool)

The existing discover command now branches on \`cfg.dialect\`. New \`--catalog\` flag (or \`CG_DATABRICKS_CATALOG\` / \`DATABRICKS_CATALOG\` env per existing precedence) supplies the catalog; \`--database\` reuses for the Databricks \"schema\" name (Spark's two-level naming inside a catalog).

Without the \`databricks\` feature compiled in, \`cg schema discover --dialect databricks\` returns a clear rebuild error — same pattern as \`cg query --dialect databricks\` from PR #335.

### 3. Phase 3.2 (\`catalog:\` YAML field) deferred

The plan's third sub-item — an optional top-level \`catalog:\` field in GraphSchema YAML — is deferred to a follow-up. Today users put the qualified path in the \`database:\` field, and the probe takes catalog/schema as separate arguments, so the YAML format change isn't required for 3.1/3.3 to function.

## Tests

```
$ cargo test -p clickgraph --features databricks --lib graph_catalog::databricks_probe   # 3/3 pass
   - validate_identifier_accepts_ascii_alnum_underscore
   - validate_identifier_rejects_unsafe_input   (SQL-injection guard)
   - introspect_against_wiremock_returns_expected_shape   (full SHOW→DESCRIBE→SELECT)

$ cargo test -p clickgraph-tool --features databricks --test databricks_query   # 3/3 pass
   - cg_query_databricks_against_wiremock_prints_table_rows
   - cg_query_databricks_missing_credentials_errors_clearly
   - cg_schema_discover_databricks_without_catalog_errors_clearly   (new)

$ cargo clippy --all-targets --features databricks   # 0 warnings
$ cargo clippy --all-targets                         # 0 warnings (no-feature build)
$ cargo fmt --all --check                            # clean
```

## Test plan

- [x] Probe unit tests (validator + wiremock integration) pass
- [x] cg discover failure-path test passes
- [x] \`cg schema discover --help\` exposes the new \`--catalog\` flag
- [x] Both feature flavors build & lint clean
- [x] Existing tool tests unaffected (still 7 dialect tests + 2 smoke + 3 query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)