### PR TITLE
test(deltagraph): local Spark/Delta smoke harness (GA correctness gate)

### DIFF
--- a/tests/spark_smoke/seed_and_query.py
+++ b/tests/spark_smoke/seed_and_query.py
@@ -1,0 +1,130 @@
+"""Container-side helper for the Spark smoke tests.
+
+Runs inside `deltaio/delta-docker:latest`. Seeds a tiny LDBC slice as Delta
+tables under /tmp/ldbc_warehouse, then executes the SQL passed in SMOKE_SQL
+and prints the result rows.
+
+Bind-mount this file read-only into the container; the warehouse stays
+container-local so host/container uid mismatches don't break Delta log
+creation.
+"""
+import os
+import sys
+from pyspark.sql import SparkSession
+from delta import configure_spark_with_delta_pip
+
+WAREHOUSE = "/tmp/ldbc_warehouse"
+
+
+def build_spark() -> SparkSession:
+    builder = (
+        SparkSession.builder
+        .appName("clickgraph-spark-smoke")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.warehouse.dir", WAREHOUSE)
+        .config("spark.sql.ansi.enabled", "false")
+    )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    return spark
+
+
+def seed(spark: SparkSession) -> None:
+    spark.sql("CREATE DATABASE IF NOT EXISTS ldbc")
+
+    spark.sql(f"""
+    CREATE OR REPLACE TABLE ldbc.Person (
+        id            BIGINT,
+        firstName     STRING,
+        lastName      STRING,
+        gender        STRING,
+        birthday      DATE,
+        creationDate  TIMESTAMP,
+        locationIP    STRING,
+        browserUsed   STRING,
+        email         ARRAY<STRING>,
+        speaks        ARRAY<STRING>
+    ) USING DELTA LOCATION '{WAREHOUSE}/Person'
+    """)
+    # id=18 (Eve) deliberately has no IS_LOCATED_IN edge — OPTIONAL MATCH test relies on this.
+    spark.sql("""
+    INSERT INTO ldbc.Person VALUES
+        (14, 'Alice', 'Anderson', 'female', DATE'1990-01-15', TIMESTAMP'2010-01-01 10:00:00', '10.0.0.1', 'Firefox', ARRAY('alice@example.com'), ARRAY('en')),
+        (15, 'Bob',   'Brown',    'male',   DATE'1985-06-20', TIMESTAMP'2010-02-02 11:00:00', '10.0.0.2', 'Chrome',  ARRAY('bob@example.com'),   ARRAY('en')),
+        (16, 'Carol', 'Clark',    'female', DATE'1992-09-30', TIMESTAMP'2010-03-03 12:00:00', '10.0.0.3', 'Safari',  ARRAY('carol@example.com'), ARRAY('en')),
+        (17, 'Dan',   'Davis',    'male',   DATE'1988-04-04', TIMESTAMP'2010-04-04 13:00:00', '10.0.0.4', 'Firefox', ARRAY('dan@example.com'),   ARRAY('en')),
+        (18, 'Eve',   'Evans',    'female', DATE'1995-12-12', TIMESTAMP'2010-05-05 14:00:00', '10.0.0.5', 'Chrome',  ARRAY('eve@example.com'),   ARRAY('en'))
+    """)
+
+    spark.sql(f"""
+    CREATE OR REPLACE TABLE ldbc.Place (
+        id    BIGINT,
+        name  STRING,
+        url   STRING,
+        type  STRING
+    ) USING DELTA LOCATION '{WAREHOUSE}/Place'
+    """)
+    spark.sql("""
+    INSERT INTO ldbc.Place VALUES
+        (1000, 'Springfield',   'http://places/Springfield',  'City'),
+        (2000, 'United_States', 'http://places/USA',          'Country'),
+        (3000, 'North_America', 'http://places/NorthAmerica', 'Continent')
+    """)
+
+    spark.sql(f"""
+    CREATE OR REPLACE TABLE ldbc.Person_isLocatedIn_Place (
+        PersonId      BIGINT,
+        CityId        BIGINT,
+        creationDate  TIMESTAMP
+    ) USING DELTA LOCATION '{WAREHOUSE}/Person_isLocatedIn_Place'
+    """)
+    # Persons 14..17 live in Springfield; Eve (18) deliberately has no edge.
+    spark.sql("""
+    INSERT INTO ldbc.Person_isLocatedIn_Place VALUES
+        (14, 1000, TIMESTAMP'2010-01-01 10:00:00'),
+        (15, 1000, TIMESTAMP'2010-02-02 11:00:00'),
+        (16, 1000, TIMESTAMP'2010-03-03 12:00:00'),
+        (17, 1000, TIMESTAMP'2010-04-04 13:00:00')
+    """)
+
+    # Friend graph rooted at id=14:
+    #   14 -knows-> 15  (forward 1-hop)
+    #   15 -knows-> 16  (reachable in 2 hops from 14)
+    #   17 -knows-> 14  (reverse edge — 17 is a friend via the reverse CTE branch)
+    spark.sql(f"""
+    CREATE OR REPLACE TABLE ldbc.Person_knows_Person (
+        Person1Id     BIGINT,
+        Person2Id     BIGINT,
+        creationDate  TIMESTAMP
+    ) USING DELTA LOCATION '{WAREHOUSE}/Person_knows_Person'
+    """)
+    spark.sql("""
+    INSERT INTO ldbc.Person_knows_Person VALUES
+        (14, 15, TIMESTAMP'2020-01-01 00:00:00'),
+        (15, 16, TIMESTAMP'2020-01-02 00:00:00'),
+        (17, 14, TIMESTAMP'2020-01-03 00:00:00')
+    """)
+
+
+def main() -> int:
+    sql = os.environ.get("SMOKE_SQL")
+    if not sql:
+        print("SMOKE_SQL env var not set", file=sys.stderr)
+        return 2
+
+    spark = build_spark()
+    seed(spark)
+
+    print("=" * 70)
+    print("SQL:")
+    print(sql)
+    print("=" * 70)
+    print("RESULT:")
+    spark.sql(sql).show(truncate=False)
+    spark.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/spark_smoke/test_smoke.py
+++ b/tests/spark_smoke/test_smoke.py
@@ -1,0 +1,191 @@
+"""End-to-end smoke: Cypher → cg (databricks dialect) → Spark SQL → Delta tables.
+
+Skipped unless CLICKGRAPH_SPARK_TESTS=1. Requires:
+  - `cg` binary built with `--features databricks`
+    (env CG_BIN overrides path; default `target/release/cg`)
+  - Docker daemon, `deltaio/delta-docker:latest` pullable
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import json
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = REPO_ROOT / "benchmarks" / "ldbc_snb" / "schemas" / "ldbc_snb_complete.yaml"
+HARNESS_DIR = Path(__file__).parent
+SEED_SCRIPT = HARNESS_DIR / "seed_and_query.py"
+IMAGE = os.environ.get("CG_SPARK_IMAGE", "deltaio/delta-docker:latest")
+
+
+def _resolve_cg_bin() -> Path | None:
+    """CG_BIN env override → cargo metadata target_directory → repo-relative target."""
+    env_override = os.environ.get("CG_BIN")
+    if env_override:
+        return Path(env_override)
+    try:
+        meta = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
+        )
+        target_dir = Path(json.loads(meta.stdout)["target_directory"])
+        candidate = target_dir / "release" / "cg"
+        if candidate.exists():
+            return candidate
+    except (subprocess.SubprocessError, json.JSONDecodeError, KeyError, OSError):
+        pass
+    fallback = REPO_ROOT / "target" / "release" / "cg"
+    return fallback if fallback.exists() else None
+
+
+def _require_env() -> Path:
+    if os.environ.get("CLICKGRAPH_SPARK_TESTS") != "1":
+        pytest.skip("CLICKGRAPH_SPARK_TESTS=1 not set")
+    cg = _resolve_cg_bin()
+    if cg is None:
+        pytest.skip("cg binary not found — build with `cargo build --release -p clickgraph-tool --features databricks`")
+    if shutil.which("docker") is None:
+        pytest.skip("docker not on PATH")
+    return cg
+
+
+def _generate_sql(cg_bin: Path, cypher: str) -> str:
+    """Invoke cg to translate a Cypher query into Spark SQL."""
+    result = subprocess.run(
+        [str(cg_bin), "--schema", str(SCHEMA), "--dialect", "databricks", "sql", cypher],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _run_in_container(sql: str) -> str:
+    """Execute SQL against a freshly-seeded Delta warehouse inside the image."""
+    result = subprocess.run(
+        [
+            "docker", "run", "--rm", "--entrypoint", "bash",
+            "-v", f"{HARNESS_DIR}:/workspace:ro",
+            "-e", f"SMOKE_SQL={sql}",
+            IMAGE,
+            "-c", "python3 /workspace/seed_and_query.py",
+        ],
+        capture_output=True, text=True, timeout=300,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"spark run failed (rc={result.returncode}):\nSTDERR:\n{result.stderr}\nSTDOUT:\n{result.stdout}"
+        )
+    return result.stdout
+
+
+def _table_rows(output: str) -> list[list[str]]:
+    """Parse spark `show()` ASCII table output into [[cell, ...], ...] (data rows only)."""
+    rows: list[list[str]] = []
+    in_table = False
+    seen_header = False
+    for line in output.splitlines():
+        if re.match(r"^\+[-+]+\+$", line):
+            in_table = True
+            continue
+        if in_table and line.startswith("|"):
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if not seen_header:
+                seen_header = True
+                continue
+            rows.append(cells)
+    return rows
+
+
+def test_short1_flat_join():
+    cg_bin = _require_env()
+    cypher = (
+        "MATCH (n:Person {id: 14})-[:IS_LOCATED_IN]->(p:City) "
+        "RETURN n.firstName AS firstName, p.id AS cityId"
+    )
+    sql = _generate_sql(cg_bin, cypher)
+    out = _run_in_container(sql)
+    rows = _table_rows(out)
+    assert rows == [["Alice", "1000"]], f"unexpected rows: {rows}\n--- full output ---\n{out}"
+
+
+def test_knows_vlp_recursive_cte():
+    """Undirected KNOWS *1..2 → two recursive CTEs unioned. Stresses the
+    biggest local-Spark unknown: recursive CTE on Delta."""
+    cg_bin = _require_env()
+    cypher = (
+        "MATCH (p:Person {id: 14})-[:KNOWS*1..2]-(friend:Person) "
+        "RETURN DISTINCT friend.id AS friendId, friend.firstName AS firstName "
+        "ORDER BY friendId"
+    )
+    sql = _generate_sql(cg_bin, cypher)
+    out = _run_in_container(sql)
+    rows = _table_rows(out)
+    assert rows == [["15", "Bob"], ["16", "Carol"], ["17", "Dan"]], (
+        f"unexpected rows: {rows}\n--- full output ---\n{out}"
+    )
+
+
+def test_collect_and_count_aggregation():
+    """Exercises FunctionMapper: cypher `collect()` → Spark `collect_list()`,
+    plus `count()` over a bidirectional KNOWS UNION ALL with GROUP BY."""
+    cg_bin = _require_env()
+    cypher = (
+        "MATCH (p:Person {id: 14})-[:KNOWS]-(friend:Person) "
+        "RETURN p.firstName AS anchor, count(friend) AS friendCount, "
+        "collect(friend.firstName) AS friends"
+    )
+    sql = _generate_sql(cg_bin, cypher)
+    assert "collect_list" in sql, f"expected collect→collect_list translation:\n{sql}"
+    out = _run_in_container(sql)
+    rows = _table_rows(out)
+    assert len(rows) == 1, f"expected single aggregated row, got: {rows}"
+    anchor, count, friends = rows[0]
+    assert anchor == "Alice"
+    assert count == "2"
+    # collect_list order over UNION ALL isn't deterministic — compare as a set.
+    parsed = {f.strip() for f in friends.strip("[]").split(",")}
+    assert parsed == {"Bob", "Dan"}, f"unexpected friend set: {parsed}"
+
+
+def test_optional_match_null_safe_filter():
+    """OPTIONAL MATCH must emit LEFT JOIN with NULL-safe schema filter so
+    persons without an IS_LOCATED_IN edge still appear (Eve, id=18)."""
+    cg_bin = _require_env()
+    cypher = (
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:IS_LOCATED_IN]->(c:City) "
+        "RETURN p.firstName AS firstName, c.name AS cityName ORDER BY p.id"
+    )
+    sql = _generate_sql(cg_bin, cypher)
+    assert "LEFT JOIN" in sql, f"expected LEFT JOIN for OPTIONAL MATCH:\n{sql}"
+    assert "IS NULL" in sql, f"expected NULL-safe schema filter:\n{sql}"
+    out = _run_in_container(sql)
+    rows = _table_rows(out)
+    expected = [
+        ["Alice", "Springfield"],
+        ["Bob", "Springfield"],
+        ["Carol", "Springfield"],
+        ["Dan", "Springfield"],
+        ["Eve", "NULL"],  # Spark `.show()` renders NULL literally
+    ]
+    assert rows == expected, f"unexpected rows: {rows}\n--- full output ---\n{out}"
+
+
+def test_string_functions_mapping():
+    """`toUpper` → `upper`, `length` → `length`, `STARTS WITH` → `startsWith`."""
+    cg_bin = _require_env()
+    cypher = (
+        'MATCH (p:Person) WHERE p.firstName STARTS WITH "A" '
+        "RETURN toUpper(p.firstName) AS upperName, length(p.firstName) AS nameLen "
+        "ORDER BY p.id"
+    )
+    sql = _generate_sql(cg_bin, cypher)
+    assert "upper(" in sql.lower(), f"expected upper() translation:\n{sql}"
+    assert "startswith(" in sql.lower(), f"expected startsWith translation:\n{sql}"
+    out = _run_in_container(sql)
+    rows = _table_rows(out)
+    assert rows == [["ALICE", "5"]], f"unexpected rows: {rows}\n--- full output ---\n{out}"

--- a/tests/spark_smoke/test_smoke.py
+++ b/tests/spark_smoke/test_smoke.py
@@ -2,29 +2,34 @@
 
 Skipped unless CLICKGRAPH_SPARK_TESTS=1. Requires:
   - `cg` binary built with `--features databricks`
-    (env CG_BIN overrides path; default `target/release/cg`)
-  - Docker daemon, `deltaio/delta-docker:latest` pullable
+    (env CG_BIN overrides path; resolved via `cargo metadata`)
+  - Docker daemon, image pullable (default pinned via DEFAULT_IMAGE below;
+    override with CG_SPARK_IMAGE)
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
-import json
+# Pinned tag rather than `:latest` so upstream image updates can't silently
+# change the Spark/Delta versions under the GA correctness gate. Bump
+# deliberately when validating against a newer image.
+DEFAULT_IMAGE = "deltaio/delta-docker:4.1.0"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA = REPO_ROOT / "benchmarks" / "ldbc_snb" / "schemas" / "ldbc_snb_complete.yaml"
 HARNESS_DIR = Path(__file__).parent
-SEED_SCRIPT = HARNESS_DIR / "seed_and_query.py"
-IMAGE = os.environ.get("CG_SPARK_IMAGE", "deltaio/delta-docker:latest")
+IMAGE = os.environ.get("CG_SPARK_IMAGE", DEFAULT_IMAGE)
 
 
-def _resolve_cg_bin() -> Path | None:
+def _resolve_cg_bin() -> Optional[Path]:
     """CG_BIN env override → cargo metadata target_directory → repo-relative target."""
     env_override = os.environ.get("CG_BIN")
     if env_override:


### PR DESCRIPTION
## Summary

- Lands a pytest harness under `tests/spark_smoke/` that runs **Cypher → cg --dialect databricks → Spark SQL → Delta tables** inside `deltaio/delta-docker:latest`. Validates the *correctness gate §1* parking spot from `docs/deltagraph/GA_READINESS.md` without needing a Databricks workspace.
- 5 tests covering the highest-risk DeltaGraph surfaces: flat 2-JOIN translation, `WITH RECURSIVE` for VLP `KNOWS *1..2`, `collect()` → `collect_list()` mapping + bidirectional UNION ALL, `OPTIONAL MATCH` with `OR alias.id IS NULL` schema-filter wrapping (the complex-1 fix), and string-function translation (`toUpper`/`length`/`STARTS WITH`).
- Gated behind `CLICKGRAPH_SPARK_TESTS=1` (mirrors `CLICKGRAPH_CHDB_TESTS=1`); skips cleanly without it. Auto-resolves the `cg` binary via `cargo metadata` so `CARGO_TARGET_DIR` overrides work.

## Why Spark 4.x rather than 3.5

Apache Spark 3.5 doesn't have `WITH RECURSIVE` in upstream — only DBR's backport on top of its 3.5 fork does. `deltaio/delta-docker:latest` ships Spark 4.1.1, which has recursive CTE natively. Version skew vs DBR is documented as a known harness limitation; "passes locally" ≠ "passes on Databricks" and the real warehouse remains the source of truth.

## How to run locally

```bash
cargo build --release -p clickgraph-tool --features databricks
CLICKGRAPH_SPARK_TESTS=1 pytest tests/spark_smoke/ -v
```

5 tests pass in ~66s (one fresh container per test, ~13s overhead each).

## Test plan

- [x] All 5 tests green with `CLICKGRAPH_SPARK_TESTS=1`
- [x] All 5 tests skip cleanly without the env var (verified in 0.01s)
- [x] `cargo build --release -p clickgraph-tool --features databricks` succeeds
- [x] cg-emitted SQL inspected per test to confirm dialect translation (assertions on `collect_list`, `LEFT JOIN`, `IS NULL`, `upper(`, `startswith(`)
- [ ] CI doesn't have docker — tests will skip there, which is the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)