### PR TITLE
test(spark-smoke): seed canonical LDBC mini dataset on Delta

### DIFF
--- a/tests/spark_smoke/mini_delta_seed.sql
+++ b/tests/spark_smoke/mini_delta_seed.sql
@@ -1,0 +1,325 @@
+-- LDBC SNB Mini Dataset — Delta translation of benchmarks/ldbc_snb/data/mini_dataset.sql
+-- Schema renamed ldbc_mini → ldbc to match benchmarks/ldbc_snb/schemas/ldbc_snb_complete.yaml
+-- Types preserved from ClickHouse layout (epoch-millis BIGINT for dates) so the
+-- canonical schema's column mappings apply unchanged.
+
+CREATE DATABASE IF NOT EXISTS ldbc;
+
+-- Place hierarchy: Continent -> Country -> City
+CREATE OR REPLACE TABLE ldbc.Place (
+    id BIGINT, name STRING, url STRING, type STRING
+) USING DELTA;
+
+INSERT INTO ldbc.Place VALUES
+(1, 'Earth', 'http://dbpedia.org/resource/Earth', 'Continent'),
+(2, 'Europe', 'http://dbpedia.org/resource/Europe', 'Continent'),
+(3, 'United_States', 'http://dbpedia.org/resource/United_States', 'Country'),
+(4, 'Germany', 'http://dbpedia.org/resource/Germany', 'Country'),
+(5, 'Angola', 'http://dbpedia.org/resource/Angola', 'Country'),
+(6, 'Colombia', 'http://dbpedia.org/resource/Colombia', 'Country'),
+(7, 'New_York', 'http://dbpedia.org/resource/New_York', 'City'),
+(8, 'Berlin', 'http://dbpedia.org/resource/Berlin', 'City'),
+(9, 'Munich', 'http://dbpedia.org/resource/Munich', 'City'),
+(10, 'Bogota', 'http://dbpedia.org/resource/Bogota', 'City');
+
+CREATE OR REPLACE TABLE ldbc.Place_isPartOf_Place (
+    Place1Id BIGINT, Place2Id BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Place_isPartOf_Place VALUES
+(7, 3), (8, 4), (9, 4), (10, 6), (3, 2), (4, 2), (5, 1), (6, 2);
+
+CREATE OR REPLACE TABLE ldbc.Organisation (
+    id BIGINT, type STRING, name STRING, url STRING
+) USING DELTA;
+
+INSERT INTO ldbc.Organisation VALUES
+(1, 'University', 'MIT', 'http://dbpedia.org/resource/MIT'),
+(2, 'University', 'TU_Berlin', 'http://dbpedia.org/resource/TU_Berlin'),
+(3, 'Company', 'Google', 'http://dbpedia.org/resource/Google'),
+(4, 'Company', 'SAP', 'http://dbpedia.org/resource/SAP');
+
+CREATE OR REPLACE TABLE ldbc.Organisation_isLocatedIn_Place (
+    OrganisationId BIGINT, PlaceId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Organisation_isLocatedIn_Place VALUES
+(1, 3), (2, 4), (3, 3), (4, 4);
+
+CREATE OR REPLACE TABLE ldbc.Tag (
+    id BIGINT, name STRING, url STRING
+) USING DELTA;
+
+INSERT INTO ldbc.Tag VALUES
+(1, 'Databases', 'http://dbpedia.org/resource/Database'),
+(2, 'Graphs', 'http://dbpedia.org/resource/Graph'),
+(3, 'ClickHouse', 'http://dbpedia.org/resource/ClickHouse'),
+(4, 'Rust', 'http://dbpedia.org/resource/Rust'),
+(5, 'Music', 'http://dbpedia.org/resource/Music');
+
+CREATE OR REPLACE TABLE ldbc.TagClass (
+    id BIGINT, name STRING, url STRING
+) USING DELTA;
+
+INSERT INTO ldbc.TagClass VALUES
+(1, 'Technology', 'http://dbpedia.org/resource/Technology'),
+(2, 'Science', 'http://dbpedia.org/resource/Science'),
+(3, 'Entertainment', 'http://dbpedia.org/resource/Entertainment');
+
+CREATE OR REPLACE TABLE ldbc.Tag_hasType_TagClass (
+    TagId BIGINT, TagClassId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Tag_hasType_TagClass VALUES
+(1, 1), (2, 1), (3, 1), (4, 1), (5, 3);
+
+CREATE OR REPLACE TABLE ldbc.TagClass_isSubclassOf_TagClass (
+    TagClass1Id BIGINT, TagClass2Id BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.TagClass_isSubclassOf_TagClass VALUES
+(1, 2);
+
+CREATE OR REPLACE TABLE ldbc.Person (
+    creationDate BIGINT, id BIGINT, firstName STRING, lastName STRING,
+    gender STRING, birthday BIGINT, locationIP STRING, browserUsed STRING,
+    speaks ARRAY<STRING>, email ARRAY<STRING>
+) USING DELTA;
+
+INSERT INTO ldbc.Person VALUES
+(1262304000000, 1, 'Alice', 'Smith', 'female', 631152000000, '1.1.1.1', 'Chrome', ARRAY('en'), ARRAY('alice@example.com')),
+(1262390400000, 2, 'Bob', 'Jones', 'male', 662688000000, '2.2.2.2', 'Firefox', ARRAY('en','de'), ARRAY('bob@example.com')),
+(1262476800000, 3, 'Carol', 'Williams', 'female', 694224000000, '3.3.3.3', 'Safari', ARRAY('de'), ARRAY('carol@example.com')),
+(1262563200000, 4, 'Dave', 'Brown', 'male', 725846400000, '4.4.4.4', 'Chrome', ARRAY('en'), ARRAY('dave@example.com')),
+(1262649600000, 5, 'Eve', 'Davis', 'female', 757382400000, '5.5.5.5', 'Firefox', ARRAY('en','es'), ARRAY('eve@example.com'));
+
+CREATE OR REPLACE TABLE ldbc.Person_isLocatedIn_Place (
+    creationDate BIGINT, PersonId BIGINT, CityId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_isLocatedIn_Place VALUES
+(1262304000000, 1, 7), (1262390400000, 2, 8), (1262476800000, 3, 9),
+(1262563200000, 4, 7), (1262649600000, 5, 10);
+
+CREATE OR REPLACE TABLE ldbc.Person_hasInterest_Tag (
+    creationDate BIGINT, PersonId BIGINT, TagId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_hasInterest_Tag VALUES
+(1262304000000, 1, 1), (1262304000000, 1, 2),
+(1262390400000, 2, 1), (1262390400000, 2, 3),
+(1262476800000, 3, 4), (1262476800000, 3, 5),
+(1262563200000, 4, 2), (1262563200000, 4, 4),
+(1262649600000, 5, 5);
+
+-- Schema YAML declares WORK_AT.to_id = CompanyId and STUDY_AT.to_id = UniversityId
+-- (matches LDBC SF CSV layout). Original mini_dataset.sql used `OrganisationId`
+-- which diverges; renamed here so the canonical schema mappings apply unchanged.
+CREATE OR REPLACE TABLE ldbc.Person_workAt_Organisation (
+    creationDate BIGINT, PersonId BIGINT, CompanyId BIGINT, workFrom INT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_workAt_Organisation VALUES
+(1262304000000, 1, 3, 2015), (1262390400000, 2, 4, 2018), (1262649600000, 5, 3, 2020);
+
+CREATE OR REPLACE TABLE ldbc.Person_studyAt_Organisation (
+    creationDate BIGINT, PersonId BIGINT, UniversityId BIGINT, classYear INT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_studyAt_Organisation VALUES
+(1262304000000, 1, 1, 2010), (1262390400000, 2, 2, 2012), (1262476800000, 3, 2, 2014);
+
+CREATE OR REPLACE TABLE ldbc.Person_knows_Person (
+    creationDate BIGINT, Person1Id BIGINT, Person2Id BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_knows_Person VALUES
+(1262304000000, 1, 2), (1262304000000, 2, 1),
+(1262390400000, 1, 3), (1262390400000, 3, 1),
+(1262476800000, 2, 3), (1262476800000, 3, 2),
+(1262563200000, 3, 4), (1262563200000, 4, 3),
+(1262649600000, 4, 5), (1262649600000, 5, 4);
+
+CREATE OR REPLACE TABLE ldbc.Forum (
+    creationDate BIGINT, id BIGINT, title STRING
+) USING DELTA;
+
+INSERT INTO ldbc.Forum VALUES
+(1275350400000, 1, 'Wall of Alice'),
+(1275436800000, 2, 'Wall of Bob'),
+(1275523200000, 3, 'Tech Discussion');
+
+CREATE OR REPLACE TABLE ldbc.Forum_hasModerator_Person (
+    creationDate BIGINT, ForumId BIGINT, PersonId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Forum_hasModerator_Person VALUES
+(1275350400000, 1, 1), (1275436800000, 2, 2), (1275523200000, 3, 3);
+
+CREATE OR REPLACE TABLE ldbc.Forum_hasMember_Person (
+    creationDate BIGINT, ForumId BIGINT, PersonId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Forum_hasMember_Person VALUES
+(1275350400000, 1, 1), (1275350400000, 1, 2), (1275350400000, 1, 3),
+(1275436800000, 2, 2), (1275436800000, 2, 4),
+(1275523200000, 3, 1), (1275523200000, 3, 2), (1275523200000, 3, 3),
+(1275523200000, 3, 4), (1275523200000, 3, 5);
+
+CREATE OR REPLACE TABLE ldbc.Forum_hasTag_Tag (
+    creationDate BIGINT, ForumId BIGINT, TagId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Forum_hasTag_Tag VALUES
+(1275523200000, 3, 1), (1275523200000, 3, 2), (1275523200000, 3, 3);
+
+CREATE OR REPLACE TABLE ldbc.Post (
+    creationDate BIGINT, id BIGINT, imageFile STRING, locationIP STRING,
+    browserUsed STRING, language STRING, content STRING, length INT
+) USING DELTA;
+
+INSERT INTO ldbc.Post VALUES
+(1275350400000, 101, '', '1.1.1.1', 'Chrome', 'en', 'Hello from Alice', 16),
+(1275436800000, 102, '', '2.2.2.2', 'Firefox', 'en', 'Bob writes about databases', 26),
+(1276041600000, 103, '', '1.1.1.1', 'Chrome', 'en', 'Alice on graphs', 15),
+(1276128000000, 104, 'photo.jpg', '3.3.3.3', 'Safari', 'de', '', 0),
+(1270000000000, 105, '', '2.2.2.2', 'Firefox', 'en', 'Old post by Bob', 15),
+(1278000000000, 106, '', '4.4.4.4', 'Chrome', 'en', 'Dave on Rust', 12);
+
+CREATE OR REPLACE TABLE ldbc.Post_hasCreator_Person (
+    creationDate BIGINT, PostId BIGINT, PersonId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Post_hasCreator_Person VALUES
+(1275350400000, 101, 1), (1275436800000, 102, 2), (1276041600000, 103, 1),
+(1276128000000, 104, 3), (1270000000000, 105, 2), (1278000000000, 106, 4);
+
+CREATE OR REPLACE TABLE ldbc.Post_isLocatedIn_Place (
+    creationDate BIGINT, PostId BIGINT, PlaceId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Post_isLocatedIn_Place VALUES
+(1275350400000, 101, 3), (1275436800000, 102, 4), (1276041600000, 103, 3),
+(1276128000000, 104, 4), (1270000000000, 105, 4), (1278000000000, 106, 3);
+
+CREATE OR REPLACE TABLE ldbc.Post_hasTag_Tag (
+    creationDate BIGINT, PostId BIGINT, TagId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Post_hasTag_Tag VALUES
+(1275350400000, 101, 1), (1275436800000, 102, 1), (1275436800000, 102, 3),
+(1276041600000, 103, 2), (1276128000000, 104, 5), (1270000000000, 105, 1),
+(1278000000000, 106, 4);
+
+CREATE OR REPLACE TABLE ldbc.Forum_containerOf_Post (
+    creationDate BIGINT, ForumId BIGINT, PostId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Forum_containerOf_Post VALUES
+(1275350400000, 1, 101), (1276041600000, 1, 103),
+(1275436800000, 2, 102), (1270000000000, 2, 105),
+(1276128000000, 3, 104), (1278000000000, 3, 106);
+
+CREATE OR REPLACE TABLE ldbc.Comment (
+    creationDate BIGINT, id BIGINT, locationIP STRING, browserUsed STRING,
+    content STRING, length INT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment VALUES
+(1275523200000, 201, '2.2.2.2', 'Firefox', 'Great post Alice!', 17),
+(1275609600000, 202, '3.3.3.3', 'Safari', 'I agree with Bob', 16),
+(1275696000000, 203, '4.4.4.4', 'Chrome', 'Interesting discussion', 21),
+(1276214400000, 204, '1.1.1.1', 'Chrome', 'Nice photo Carol', 16),
+(1276300800000, 205, '5.5.5.5', 'Firefox', 'Love this topic', 15);
+
+CREATE OR REPLACE TABLE ldbc.Comment_hasCreator_Person (
+    creationDate BIGINT, CommentId BIGINT, PersonId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment_hasCreator_Person VALUES
+(1275523200000, 201, 2), (1275609600000, 202, 3), (1275696000000, 203, 4),
+(1276214400000, 204, 1), (1276300800000, 205, 5);
+
+CREATE OR REPLACE TABLE ldbc.Comment_isLocatedIn_Place (
+    creationDate BIGINT, CommentId BIGINT, PlaceId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment_isLocatedIn_Place VALUES
+(1275523200000, 201, 4), (1275609600000, 202, 4), (1275696000000, 203, 3),
+(1276214400000, 204, 3), (1276300800000, 205, 6);
+
+CREATE OR REPLACE TABLE ldbc.Comment_hasTag_Tag (
+    creationDate BIGINT, CommentId BIGINT, TagId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment_hasTag_Tag VALUES
+(1275523200000, 201, 1), (1275609600000, 202, 1), (1275696000000, 203, 2),
+(1276214400000, 204, 5), (1276300800000, 205, 4);
+
+CREATE OR REPLACE TABLE ldbc.Comment_replyOf_Post (
+    creationDate BIGINT, CommentId BIGINT, PostId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment_replyOf_Post VALUES
+(1275523200000, 201, 101), (1275609600000, 202, 102), (1275696000000, 203, 101),
+(1276214400000, 204, 104), (1276300800000, 205, 106);
+
+CREATE OR REPLACE TABLE ldbc.Comment_replyOf_Comment (
+    creationDate BIGINT, Comment1Id BIGINT, Comment2Id BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Comment_replyOf_Comment VALUES
+(1275696000000, 203, 201);
+
+CREATE OR REPLACE TABLE ldbc.Person_likes_Post (
+    creationDate BIGINT, PersonId BIGINT, PostId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_likes_Post VALUES
+(1275400000000, 2, 101), (1275500000000, 3, 101), (1275600000000, 1, 102),
+(1276200000000, 4, 103), (1276300000000, 5, 106);
+
+CREATE OR REPLACE TABLE ldbc.Person_likes_Comment (
+    creationDate BIGINT, PersonId BIGINT, CommentId BIGINT
+) USING DELTA;
+
+INSERT INTO ldbc.Person_likes_Comment VALUES
+(1275600000000, 1, 201), (1275700000000, 2, 202), (1276400000000, 3, 204);
+
+-- Views for unified Message type
+CREATE OR REPLACE VIEW ldbc.Message AS
+SELECT creationDate, id, locationIP, browserUsed, content, length, imageFile, language, 'Post' AS type
+FROM ldbc.Post
+UNION ALL
+SELECT creationDate, id, locationIP, browserUsed, content, length, '' AS imageFile, '' AS language, 'Comment' AS type
+FROM ldbc.Comment;
+
+CREATE OR REPLACE VIEW ldbc.Message_hasCreator_Person AS
+SELECT creationDate, PostId AS MessageId, PersonId FROM ldbc.Post_hasCreator_Person
+UNION ALL
+SELECT creationDate, CommentId AS MessageId, PersonId FROM ldbc.Comment_hasCreator_Person;
+
+CREATE OR REPLACE VIEW ldbc.Person_likes_Message AS
+SELECT creationDate, PersonId, PostId AS MessageId FROM ldbc.Person_likes_Post
+UNION ALL
+SELECT creationDate, PersonId, CommentId AS MessageId FROM ldbc.Person_likes_Comment;
+
+CREATE OR REPLACE VIEW ldbc.Comment_replyOf_Message AS
+SELECT creationDate, CommentId, PostId AS MessageId FROM ldbc.Comment_replyOf_Post
+UNION ALL
+SELECT creationDate, Comment1Id AS CommentId, Comment2Id AS MessageId FROM ldbc.Comment_replyOf_Comment;
+
+CREATE OR REPLACE VIEW ldbc.Message_replyOf_Message AS
+SELECT CommentId AS MessageId, PostId AS TargetMessageId, creationDate FROM ldbc.Comment_replyOf_Post
+UNION ALL
+SELECT Comment1Id AS MessageId, Comment2Id AS TargetMessageId, creationDate FROM ldbc.Comment_replyOf_Comment;
+
+CREATE OR REPLACE VIEW ldbc.Message_hasTag_Tag AS
+SELECT creationDate, PostId AS MessageId, TagId FROM ldbc.Post_hasTag_Tag
+UNION ALL
+SELECT creationDate, CommentId AS MessageId, TagId FROM ldbc.Comment_hasTag_Tag;
+
+CREATE OR REPLACE VIEW ldbc.Message_isLocatedIn_Place AS
+SELECT creationDate, PostId AS MessageId, PlaceId FROM ldbc.Post_isLocatedIn_Place
+UNION ALL
+SELECT creationDate, CommentId AS MessageId, PlaceId FROM ldbc.Comment_isLocatedIn_Place;

--- a/tests/spark_smoke/seed_and_query.py
+++ b/tests/spark_smoke/seed_and_query.py
@@ -1,19 +1,23 @@
 """Container-side helper for the Spark smoke tests.
 
-Runs inside `deltaio/delta-docker:latest`. Seeds a tiny LDBC slice as Delta
-tables under /tmp/ldbc_warehouse, then executes the SQL passed in SMOKE_SQL
-and prints the result rows.
+Runs inside `deltaio/delta-docker:4.1.0`. Seeds the LDBC SNB mini dataset
+as Delta tables under /tmp/ldbc_warehouse from `mini_delta_seed.sql`
+(translation of benchmarks/ldbc_snb/data/mini_dataset.sql), then executes
+the SQL passed in SMOKE_SQL and prints the result rows.
 
-Bind-mount this file read-only into the container; the warehouse stays
+Bind-mount this directory read-only into the container; the warehouse stays
 container-local so host/container uid mismatches don't break Delta log
 creation.
 """
 import os
 import sys
+from pathlib import Path
+
 from pyspark.sql import SparkSession
 from delta import configure_spark_with_delta_pip
 
 WAREHOUSE = "/tmp/ldbc_warehouse"
+SEED_FILE = Path(__file__).parent / "mini_delta_seed.sql"
 
 
 def build_spark() -> SparkSession:
@@ -30,81 +34,36 @@ def build_spark() -> SparkSession:
     return spark
 
 
+def _split_statements(sql_text: str) -> list[str]:
+    """Split a `;`-terminated SQL script into individual statements.
+
+    The seed file is hand-written with no semicolons inside string literals,
+    so a naive split on `;` is safe here. Comments (`-- ...` lines) and
+    blank lines are tolerated.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    for raw in sql_text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("--"):
+            continue
+        buf.append(line)
+        if line.endswith(";"):
+            stmt = "\n".join(buf).rstrip(";").strip()
+            if stmt:
+                statements.append(stmt)
+            buf = []
+    if buf:
+        tail = "\n".join(buf).strip()
+        if tail:
+            statements.append(tail)
+    return statements
+
+
 def seed(spark: SparkSession) -> None:
-    spark.sql("CREATE DATABASE IF NOT EXISTS ldbc")
-
-    spark.sql(f"""
-    CREATE OR REPLACE TABLE ldbc.Person (
-        id            BIGINT,
-        firstName     STRING,
-        lastName      STRING,
-        gender        STRING,
-        birthday      DATE,
-        creationDate  TIMESTAMP,
-        locationIP    STRING,
-        browserUsed   STRING,
-        email         ARRAY<STRING>,
-        speaks        ARRAY<STRING>
-    ) USING DELTA LOCATION '{WAREHOUSE}/Person'
-    """)
-    # id=18 (Eve) deliberately has no IS_LOCATED_IN edge — OPTIONAL MATCH test relies on this.
-    spark.sql("""
-    INSERT INTO ldbc.Person VALUES
-        (14, 'Alice', 'Anderson', 'female', DATE'1990-01-15', TIMESTAMP'2010-01-01 10:00:00', '10.0.0.1', 'Firefox', ARRAY('alice@example.com'), ARRAY('en')),
-        (15, 'Bob',   'Brown',    'male',   DATE'1985-06-20', TIMESTAMP'2010-02-02 11:00:00', '10.0.0.2', 'Chrome',  ARRAY('bob@example.com'),   ARRAY('en')),
-        (16, 'Carol', 'Clark',    'female', DATE'1992-09-30', TIMESTAMP'2010-03-03 12:00:00', '10.0.0.3', 'Safari',  ARRAY('carol@example.com'), ARRAY('en')),
-        (17, 'Dan',   'Davis',    'male',   DATE'1988-04-04', TIMESTAMP'2010-04-04 13:00:00', '10.0.0.4', 'Firefox', ARRAY('dan@example.com'),   ARRAY('en')),
-        (18, 'Eve',   'Evans',    'female', DATE'1995-12-12', TIMESTAMP'2010-05-05 14:00:00', '10.0.0.5', 'Chrome',  ARRAY('eve@example.com'),   ARRAY('en'))
-    """)
-
-    spark.sql(f"""
-    CREATE OR REPLACE TABLE ldbc.Place (
-        id    BIGINT,
-        name  STRING,
-        url   STRING,
-        type  STRING
-    ) USING DELTA LOCATION '{WAREHOUSE}/Place'
-    """)
-    spark.sql("""
-    INSERT INTO ldbc.Place VALUES
-        (1000, 'Springfield',   'http://places/Springfield',  'City'),
-        (2000, 'United_States', 'http://places/USA',          'Country'),
-        (3000, 'North_America', 'http://places/NorthAmerica', 'Continent')
-    """)
-
-    spark.sql(f"""
-    CREATE OR REPLACE TABLE ldbc.Person_isLocatedIn_Place (
-        PersonId      BIGINT,
-        CityId        BIGINT,
-        creationDate  TIMESTAMP
-    ) USING DELTA LOCATION '{WAREHOUSE}/Person_isLocatedIn_Place'
-    """)
-    # Persons 14..17 live in Springfield; Eve (18) deliberately has no edge.
-    spark.sql("""
-    INSERT INTO ldbc.Person_isLocatedIn_Place VALUES
-        (14, 1000, TIMESTAMP'2010-01-01 10:00:00'),
-        (15, 1000, TIMESTAMP'2010-02-02 11:00:00'),
-        (16, 1000, TIMESTAMP'2010-03-03 12:00:00'),
-        (17, 1000, TIMESTAMP'2010-04-04 13:00:00')
-    """)
-
-    # Friend graph rooted at id=14:
-    #   14 -knows-> 15  (forward 1-hop)
-    #   15 -knows-> 16  (reachable in 2 hops from 14)
-    #   17 -knows-> 14  (reverse edge — 17 is a friend via the reverse CTE branch)
-    spark.sql(f"""
-    CREATE OR REPLACE TABLE ldbc.Person_knows_Person (
-        Person1Id     BIGINT,
-        Person2Id     BIGINT,
-        creationDate  TIMESTAMP
-    ) USING DELTA LOCATION '{WAREHOUSE}/Person_knows_Person'
-    """)
-    spark.sql("""
-    INSERT INTO ldbc.Person_knows_Person VALUES
-        (14, 15, TIMESTAMP'2020-01-01 00:00:00'),
-        (15, 16, TIMESTAMP'2020-01-02 00:00:00'),
-        (17, 14, TIMESTAMP'2020-01-03 00:00:00')
-    """)
+    sql_text = SEED_FILE.read_text()
+    for stmt in _split_statements(sql_text):
+        spark.sql(stmt)
 
 
 def main() -> int:

--- a/tests/spark_smoke/test_smoke.py
+++ b/tests/spark_smoke/test_smoke.py
@@ -107,40 +107,46 @@ def _table_rows(output: str) -> list[list[str]]:
 
 
 def test_short1_flat_join():
+    """Flat MATCH with inline id filter + IS_LOCATED_IN traversal.
+    Mini dataset: Person id=1 (Alice) lives in Place id=7 (New_York)."""
     cg_bin = _require_env()
     cypher = (
-        "MATCH (n:Person {id: 14})-[:IS_LOCATED_IN]->(p:City) "
+        "MATCH (n:Person {id: 1})-[:IS_LOCATED_IN]->(p:City) "
         "RETURN n.firstName AS firstName, p.id AS cityId"
     )
     sql = _generate_sql(cg_bin, cypher)
     out = _run_in_container(sql)
     rows = _table_rows(out)
-    assert rows == [["Alice", "1000"]], f"unexpected rows: {rows}\n--- full output ---\n{out}"
+    assert rows == [["Alice", "7"]], f"unexpected rows: {rows}\n--- full output ---\n{out}"
 
 
 def test_knows_vlp_recursive_cte():
     """Undirected KNOWS *1..2 → two recursive CTEs unioned. Stresses the
-    biggest local-Spark unknown: recursive CTE on Delta."""
+    biggest local-Spark unknown: recursive CTE on Delta.
+    Mini dataset KNOWS edges (anchored at id=1): 1↔2, 1↔3, 2↔3, 3↔4, 4↔5.
+    Reachable from 1 at 1..2 hops (excluding self): {2,3,4}."""
     cg_bin = _require_env()
     cypher = (
-        "MATCH (p:Person {id: 14})-[:KNOWS*1..2]-(friend:Person) "
+        "MATCH (p:Person {id: 1})-[:KNOWS*1..2]-(friend:Person) "
+        "WHERE friend.id <> p.id "
         "RETURN DISTINCT friend.id AS friendId, friend.firstName AS firstName "
         "ORDER BY friendId"
     )
     sql = _generate_sql(cg_bin, cypher)
     out = _run_in_container(sql)
     rows = _table_rows(out)
-    assert rows == [["15", "Bob"], ["16", "Carol"], ["17", "Dan"]], (
+    assert rows == [["2", "Bob"], ["3", "Carol"], ["4", "Dave"]], (
         f"unexpected rows: {rows}\n--- full output ---\n{out}"
     )
 
 
 def test_collect_and_count_aggregation():
     """Exercises FunctionMapper: cypher `collect()` → Spark `collect_list()`,
-    plus `count()` over a bidirectional KNOWS UNION ALL with GROUP BY."""
+    plus `count()` with GROUP BY on a directed KNOWS traversal.
+    Anchor=1: KNOWS outgoing edges → 2 (Bob), 3 (Carol)."""
     cg_bin = _require_env()
     cypher = (
-        "MATCH (p:Person {id: 14})-[:KNOWS]-(friend:Person) "
+        "MATCH (p:Person {id: 1})-[:KNOWS]->(friend:Person) "
         "RETURN p.firstName AS anchor, count(friend) AS friendCount, "
         "collect(friend.firstName) AS friends"
     )
@@ -152,18 +158,21 @@ def test_collect_and_count_aggregation():
     anchor, count, friends = rows[0]
     assert anchor == "Alice"
     assert count == "2"
-    # collect_list order over UNION ALL isn't deterministic — compare as a set.
+    # collect_list order isn't guaranteed — compare as a set.
     parsed = {f.strip() for f in friends.strip("[]").split(",")}
-    assert parsed == {"Bob", "Dan"}, f"unexpected friend set: {parsed}"
+    assert parsed == {"Bob", "Carol"}, f"unexpected friend set: {parsed}"
 
 
 def test_optional_match_null_safe_filter():
-    """OPTIONAL MATCH must emit LEFT JOIN with NULL-safe schema filter so
-    persons without an IS_LOCATED_IN edge still appear (Eve, id=18)."""
+    """OPTIONAL MATCH against a virtual-label target (:University, filter
+    type='University') must emit LEFT JOIN with NULL-safe schema filter so
+    persons without a STUDY_AT edge still appear.
+    Mini dataset STUDY_AT: persons 1→MIT, 2→TU_Berlin, 3→TU_Berlin only;
+    persons 4 (Dave) and 5 (Eve) have no STUDY_AT edge."""
     cg_bin = _require_env()
     cypher = (
-        "MATCH (p:Person) OPTIONAL MATCH (p)-[:IS_LOCATED_IN]->(c:City) "
-        "RETURN p.firstName AS firstName, c.name AS cityName ORDER BY p.id"
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:STUDY_AT]->(u:University) "
+        "RETURN p.firstName AS firstName, u.name AS uniName ORDER BY p.id"
     )
     sql = _generate_sql(cg_bin, cypher)
     assert "LEFT JOIN" in sql, f"expected LEFT JOIN for OPTIONAL MATCH:\n{sql}"
@@ -171,17 +180,18 @@ def test_optional_match_null_safe_filter():
     out = _run_in_container(sql)
     rows = _table_rows(out)
     expected = [
-        ["Alice", "Springfield"],
-        ["Bob", "Springfield"],
-        ["Carol", "Springfield"],
-        ["Dan", "Springfield"],
-        ["Eve", "NULL"],  # Spark `.show()` renders NULL literally
+        ["Alice", "MIT"],
+        ["Bob", "TU_Berlin"],
+        ["Carol", "TU_Berlin"],
+        ["Dave", "NULL"],
+        ["Eve", "NULL"],
     ]
     assert rows == expected, f"unexpected rows: {rows}\n--- full output ---\n{out}"
 
 
 def test_string_functions_mapping():
-    """`toUpper` → `upper`, `length` → `length`, `STARTS WITH` → `startsWith`."""
+    """`toUpper` → `upper`, `length` → `length`, `STARTS WITH` → `startsWith`.
+    Only Alice (id=1) has a firstName starting with 'A'."""
     cg_bin = _require_env()
     cypher = (
         'MATCH (p:Person) WHERE p.firstName STARTS WITH "A" '


### PR DESCRIPTION
## Summary

- Replace the hand-rolled 5-Person seed (PR #343) with the full LDBC SNB mini dataset (38 tables, 5 Persons + Forum/Post/Comment/Tag graph) translated to Delta from `benchmarks/ldbc_snb/data/mini_dataset.sql`.
- Refactor `seed_and_query.py` to load statements from a new checked-in `mini_delta_seed.sql` instead of hand-writing them in Python.
- Adapt the 5 existing smokes to assert against the canonical IDs/topology while preserving each test's specific risk surface (flat JOIN, bidirectional VLP recursive CTE, FunctionMapper, OPTIONAL MATCH NULL-safe schema-filter wrap, string-fn translation).
- **Bonus finding**: `mini_dataset.sql` uses `OrganisationId` for workAt/studyAt edge tables, but the canonical schema and LDBC SF CSV layout use `CompanyId` / `UniversityId`. Delta translation uses the canonical names so the schema YAML applies unchanged.

This is **M1 of the LDBC sweep work** outlined in `docs/deltagraph/GA_READINESS.md` §1 — replacing the placeholder seed with the actual canonical dataset. M2 (query-driven sweep over the 36 official bi/complex/short queries) and M3 (result-set diff vs ClickGraph) follow.

## Test plan

- [x] `CLICKGRAPH_SPARK_TESTS=1 pytest tests/spark_smoke/ -v` → 5 passed in ~97s on `deltaio/delta-docker:4.1.0`
- [x] Smoke harness still gated correctly — skips without `CLICKGRAPH_SPARK_TESTS=1`
- [x] No changes touching non-test code

🤖 Generated with [Claude Code](https://claude.com/claude-code)