### PR TITLE
fix(render-plan): rewrite raw CTE-name qualifiers to FROM/JOIN alias

### DIFF
--- a/src/render_plan/variable_scope.rs
+++ b/src/render_plan/variable_scope.rs
@@ -1107,6 +1107,21 @@ fn fix_orphan_table_aliases_impl(
         }
     }
 
+    // Also rewrite raw CTE-name qualifiers (e.g., `with_friend_cte_1.col`) to
+    // the JOIN/FROM alias they were bound to (`friend.col`). ClickHouse accepts
+    // either form, but Spark/Delta only resolves against the alias actually
+    // used in FROM/JOIN — leaving the CTE name in place produces
+    // UNRESOLVED_COLUMN on Spark. Upstream construction sites can emit either
+    // form depending on the path; this final pass normalizes them.
+    for (cte_name, from_alias) in &cte_name_to_from_alias {
+        if cte_name == from_alias {
+            continue;
+        }
+        alias_replacements
+            .entry(cte_name.clone())
+            .or_insert_with(|| from_alias.clone());
+    }
+
     if alias_replacements.is_empty() {
         return; // No orphaned aliases to fix
     }

--- a/tests/spark_smoke/test_ldbc_sweep.py
+++ b/tests/spark_smoke/test_ldbc_sweep.py
@@ -69,17 +69,10 @@ EXPECTED_FAILURES: dict[str, str] = {
     "bi-8":       "[B] PARSE_SYNTAX_ERROR near `ARRAY` — VLP CTE generation",
     "bi-12":      "[B] PARSE_SYNTAX_ERROR — surfaced after FunctionMapper closure",
     "complex-10": "[B] PARSE_SYNTAX_ERROR near `\"posts\"` — double-quote identifier vs Spark backtick",
-    # C. CTE column resolution (alias mismatch: `with_*_cte_N.col` vs `<scope>.col`)
-    "bi-1":       "[C] CTE alias mismatch",
-    "bi-2":       "[C] CTE alias mismatch",
-    "bi-5":       "[C] CTE alias mismatch",
-    "bi-14":      "[C] CTE alias mismatch",
-    "complex-1":  "[C] CTE alias mismatch",
-    "complex-3":  "[C] CTE alias mismatch",
-    "complex-4":  "[C] CTE alias mismatch",
-    "complex-7":  "[C] CTE alias mismatch",
-    "complex-9":  "[C] CTE alias mismatch: with_friend_cte_N.p6_friend_id vs friend.p6_friend_id",
-    "complex-11": "[C] CTE alias mismatch: with_friend_cte_N.p6_friend_id vs friend.p6_friend_id",
+    # C. Other resolution issues — distinct from the dialect-agnostic
+    # `with_*_cte_N.col` → `alias.col` rewrite (which now passes 8 queries).
+    "bi-14":     "[C] CTE chain: same alias `person1` rebound across 5 chained CTEs; final CTE's `person1.score` doesn't resolve against the previous CTE's schema",
+    "complex-3": "[C] schema mapping: `t5.CountryId` emitted for Place_isPartOf_Place rel (no such column — Place→Place rel uses PlaceId)",
 }
 
 PARAM_REF = re.compile(r"\$([a-zA-Z_]\w*)")


### PR DESCRIPTION
## Summary

Unlocks **8 LDBC queries on Spark/Delta** (Category C from the sweep): `bi-1`, `bi-2`, `bi-5`, `complex-1`, `complex-4`, `complex-7`, `complex-9`, `complex-11`.

Sweep result: **15p / 21xf / 5s → 23p / 13xf / 5s.**

## Problem

After a WITH→CTE barrier, downstream SELECT items could be emitted qualified by the CTE table name (`with_friend_cte_1.p6_friend_id`) even when the same CTE was JOINed under a user-facing alias (`INNER JOIN with_friend_cte_1 AS friend`). ClickHouse silently accepts either qualifier; Spark/Delta resolves only against the alias actually bound in FROM/JOIN, producing `UNRESOLVED_COLUMN`.

Two render-plan construction paths (`rewrite_with_aliases_to_cte`, `rewrite_table_aliases_to_cte`) build `PropertyAccess { table_alias: cte_name, ... }` directly. Both leaked CH-only resolution behaviour into the emitted SQL.

## Fix

Extend `fix_orphan_table_aliases_impl` (`src/render_plan/variable_scope.rs`) so its `alias_replacements` map also includes `cte_name → from_alias` entries for any CTE referenced from FROM/JOIN. The existing `rewrite_expr_table_aliases` walker then normalizes any stray CTE-name qualifier in SELECT/WHERE/GROUP BY/ORDER BY/HAVING/JOIN-ON to the bound alias.

- Skips entries where `cte_name == from_alias` (no-op)
- Uses `entry().or_insert_with` so prior orphan-alias mappings win on collision

## Stragglers

Two queries that were tagged `[C]` in PR #347 remain failing for distinct reasons (now retagged):

- **bi-14** — same alias `person1` rebound across 5 chained CTEs. `person1.score` in the 5th CTE doesn't resolve against the 4th CTE's schema.
- **complex-3** — `t5.CountryId` emitted for a `Place_isPartOf_Place` rel (no such column — Place→Place edge uses `PlaceId`).

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets --features databricks` clean
- [x] `cargo test --lib` — 1370 passed
- [x] `CLICKGRAPH_SPARK_TESTS=1 pytest tests/spark_smoke/test_ldbc_sweep.py` — **23p / 13xf / 5s** (was 15/21/5); no regressions on the original 15 passing
- [x] `pytest --runxfail` confirms the 8 newly-passing queries return correct results, not just no-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)