### PR TITLE
fix(deltagraph): make shortestPath BFS run on Spark/Delta

### DIFF
--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -693,3 +693,168 @@ async fn tostring_under_databricks_emits_string() {
         "Databricks SQL leaked CH `toString`; got:\n{sql}"
     );
 }
+
+/// BFS shortestPath target branch under Databricks emits the structural
+/// `min(CASE WHEN ... THEN ... END)` form for the conditional min, not
+/// CH's `minIf(val, cond)`. Spark has no `minIf` — this is the load-bearing
+/// rewrite for complex-13. Pairs with `count_if` for the existence guard.
+#[tokio::test]
+async fn shortestpath_bfs_under_databricks_uses_min_if_rewrite() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql(
+            "MATCH p = shortestPath((a:User {id: 1})-[:FOLLOWS*]-(b:User {id: 2})) \
+             RETURN length(p) AS hops",
+        )
+    })
+    .await;
+
+    // The target branch must use `count_if(...)` for the existence guard
+    // (Spark spelling, not CH's `countIf`).
+    assert!(
+        sql.contains("count_if("),
+        "expected Spark `count_if(...)` in BFS target branch; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("countIf("),
+        "Databricks BFS SQL leaked CH `countIf`; got:\n{sql}"
+    );
+    // The conditional min must collapse to `min(CASE WHEN cond THEN val END)`
+    // since Spark has no `minIf`. Match the call-shape boundary so an
+    // unrelated `min(` elsewhere can't satisfy the assertion alone.
+    assert!(
+        sql.contains("min(CASE WHEN"),
+        "expected Spark `min(CASE WHEN ...)` conditional-min rewrite; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("minIf("),
+        "Databricks BFS SQL leaked CH `minIf`; got:\n{sql}"
+    );
+}
+
+/// CH baseline for the BFS target branch — confirms the CH side still
+/// uses native `countIf` and `minIf` byte-for-byte (no accidental cross-
+/// dialect bleed from the Databricks rewrite).
+#[tokio::test]
+async fn shortestpath_bfs_under_clickhouse_keeps_native_min_if() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::ClickHouse,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql(
+            "MATCH p = shortestPath((a:User {id: 1})-[:FOLLOWS*]-(b:User {id: 2})) \
+             RETURN length(p) AS hops",
+        )
+    })
+    .await;
+
+    assert!(
+        sql.contains("countIf("),
+        "expected CH `countIf(...)` in BFS target branch; got:\n{sql}"
+    );
+    assert!(
+        sql.contains("minIf("),
+        "expected CH `minIf(...)` in BFS target branch; got:\n{sql}"
+    );
+}
+
+/// Undirected BFS shortestPath under Databricks collapses the
+/// anchor/forward/reverse 3-branch recursive UNION ALL into a single
+/// recursive branch joined against a bidirectional sub-UNION ALL over
+/// the rel table. Spark requires exactly two children under a recursive
+/// UNION ALL (anchor + recursive) — three children fail with
+/// INVALID_RECURSIVE_CTE. This shape is the structural rewrite that
+/// unblocks complex-13.
+#[tokio::test]
+async fn shortestpath_bfs_under_databricks_collapses_undirected_to_single_branch() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql(
+            "MATCH p = shortestPath((a:User {id: 1})-[:FOLLOWS*]-(b:User {id: 2})) \
+             RETURN length(p) AS hops",
+        )
+    })
+    .await;
+
+    // The single-branch recursive body should reference `neighbor.node_id`
+    // — the alias of the bidirectional sub-UNION inside the JOIN.
+    assert!(
+        sql.contains("neighbor.node_id"),
+        "expected Spark single-branch recursive form joining against `neighbor`; got:\n{sql}"
+    );
+    // And the bidirectional sub-UNION over the rel table must be present
+    // as a non-recursive inner UNION ALL. Loose match on the structural
+    // hint — the exact column names depend on the schema's rel keys.
+    assert!(
+        sql.contains("AS neighbor ON neighbor.prev = b.node_id"),
+        "expected Spark bidirectional sub-UNION joined as `neighbor`; got:\n{sql}"
+    );
+    // The legacy 3-branch shape would have a *second* `FROM <bfs_cte> b`
+    // (the reverse recursive branch) per BFS CTE. shortestPath emits two
+    // BFS CTEs total (one per direction in the bidirectional outer UNION),
+    // so the rewritten Spark form has exactly one `b` JOIN per BFS CTE = 2.
+    // The legacy 3-branch shape would have 4 (2 BFS CTEs × 2 branches).
+    let count_b_alias = sql.matches(" b\n    JOIN ").count();
+    assert_eq!(
+        count_b_alias, 2,
+        "expected exactly one recursive branch per BFS CTE (2 total); got {count_b_alias}:\n{sql}"
+    );
+}
+
+/// CH baseline for the undirected BFS shape — confirms the existing
+/// 3-branch (anchor + forward + reverse) recursive UNION ALL is preserved
+/// byte-for-byte. ClickHouse accepts N-ary recursive UNION ALL.
+#[tokio::test]
+async fn shortestpath_bfs_under_clickhouse_keeps_three_branch_undirected() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::ClickHouse,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql(
+            "MATCH p = shortestPath((a:User {id: 1})-[:FOLLOWS*]-(b:User {id: 2})) \
+             RETURN length(p) AS hops",
+        )
+    })
+    .await;
+
+    // CH path uses the legacy 2 recursive branches (forward + reverse).
+    // `neighbor` alias should NOT appear — that's the Spark-only rewrite.
+    assert!(
+        !sql.contains("neighbor.node_id"),
+        "CH BFS SQL must not use Spark `neighbor` sub-UNION rewrite; got:\n{sql}"
+    );
+    // Confirm both recursive branches present in each BFS CTE — 2 BFS CTEs
+    // × 2 branches each = 4 occurrences of `<bfs> b\n    JOIN`.
+    let count_b_alias = sql.matches(" b\n    JOIN ").count();
+    assert_eq!(
+        count_b_alias, 4,
+        "expected two recursive branches per BFS CTE on CH (4 total); got {count_b_alias}:\n{sql}"
+    );
+}
+
+/// `is_integer_literal` is the guard that keeps the Databricks anchor
+/// cast from wrapping non-numeric IDs. Direct unit test — covers the
+/// shape via the cypher_to_sql path elsewhere but locks the predicate
+/// itself so refactors don't silently regress it.
+#[test]
+fn is_integer_literal_recognises_only_integers() {
+    use crate::sql_generator::emitters::clickhouse::variable_length_cte::is_integer_literal;
+    assert!(is_integer_literal("14"));
+    assert!(is_integer_literal("-42"));
+    assert!(is_integer_literal("0"));
+    // Not integers: column refs, string literals, floats, empty, bare minus.
+    assert!(!is_integer_literal("p.id"));
+    assert!(!is_integer_literal("'abc'"));
+    assert!(!is_integer_literal("3.14"));
+    assert!(!is_integer_literal(""));
+    assert!(!is_integer_literal("-"));
+    assert!(!is_integer_literal("123abc"));
+}

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -1603,21 +1603,22 @@ pub(crate) fn rewrite_expr_for_vlp(
             // Rewrite to: ifNull(t.hop_count, toInt64(-1))
             if let Some(ref case_expr) = case.expr {
                 if is_vlp_path_is_null(case_expr, path_variable) {
-                    // Use minOrNull() aggregate so we always get exactly one row:
-                    // - No path: VLP CTE returns 0 rows → minOrNull() returns NULL → ifNull gives -1
-                    // - Path exists: VLP CTE returns 1 row → minOrNull() returns hop_count
-                    // Note: ClickHouse min() returns 0 for empty sets (not NULL), so minOrNull is required.
-                    // The 64-bit-int cast wraps minOrNull to avoid type mismatch (UInt64 vs Int64(-1)).
-                    let cast64 = crate::sql_generator::function_mapper::current_function_mapper()
-                        .cast_int64()
-                        .to_string();
+                    // Use the NULL-on-empty min aggregate so we always get exactly one row:
+                    // - No path: VLP CTE returns 0 rows → returns NULL → ifNull gives -1
+                    // - Path exists: VLP CTE returns 1 row → returns hop_count
+                    // CH: `minOrNull` is required because CH's plain `min` returns 0 for
+                    // empty input; Spark's `min` already returns NULL for empty input,
+                    // so the FunctionMapper resolves this name per dialect.
+                    let fmap = crate::sql_generator::function_mapper::current_function_mapper();
+                    let cast64 = fmap.cast_int64().to_string();
+                    let min_or_null = fmap.min_or_null().to_string();
                     return RenderExpr::ScalarFnCall(ScalarFnCall {
                         name: "ifNull".to_string(),
                         args: vec![
                             RenderExpr::ScalarFnCall(ScalarFnCall {
                                 name: cast64.clone(),
                                 args: vec![RenderExpr::AggregateFnCall(AggregateFnCall {
-                                    name: "minOrNull".to_string(),
+                                    name: min_or_null,
                                     args: vec![RenderExpr::Column(Column(PropertyValue::Column(
                                         "t.hop_count".to_string(),
                                     )))],

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -71,6 +71,19 @@ fn arr(elems: &str) -> String {
     current_function_mapper().array_literal(elems)
 }
 
+/// Whether `s` looks like a bare integer literal (digits, optional leading
+/// `-`). Used to scope the Spark BFS anchor cast to numeric IDs — column
+/// references inherit their column's type and string-keyed IDs would break
+/// under a numeric cast, so neither should be wrapped.
+pub(crate) fn is_integer_literal(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    match bytes.first() {
+        Some(b'-') if bytes.len() > 1 => bytes[1..].iter().all(|b| b.is_ascii_digit()),
+        Some(b) if b.is_ascii_digit() => bytes.iter().all(|b| b.is_ascii_digit()),
+        _ => false,
+    }
+}
+
 /// Property to include in the CTE (column name and which node it belongs to)
 #[derive(Debug, Clone)]
 pub struct NodeProperty {
@@ -1159,13 +1172,19 @@ impl<'a> VariableLengthCteGenerator<'a> {
             format!("{forward}{reverse}")
         };
 
-        // Build BFS CTE. On Spark/Databricks the anchor `node_id` literal
-        // would be inferred as `INT` (32-bit), but the recursive branch
+        // Build BFS CTE. On Spark/Databricks a bare integer literal in the
+        // anchor is inferred as `INT` (32-bit), but the recursive branch
         // pulls `node_id` from a BIGINT rel column — Spark refuses to merge
         // them under `UNION ALL` (`CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE`).
-        // Explicitly cast the anchor to int64 there. ClickHouse promotes
-        // small-int literals automatically, so its anchor stays unchanged.
-        let anchor_start = if matches!(dialect, crate::sql_generator::SqlDialect::Databricks) {
+        // Explicitly cast the anchor to int64 there. Only apply when the
+        // start_id is an integer literal (digits with optional leading `-`):
+        // column references (`p.id`) already inherit the column's type, and
+        // string literals (`'abc'`) would break under a numeric cast and
+        // shouldn't be touched. ClickHouse promotes small-int literals
+        // automatically, so its anchor stays unchanged either way.
+        let anchor_start = if matches!(dialect, crate::sql_generator::SqlDialect::Databricks)
+            && is_integer_literal(&start_id)
+        {
             format!("{}({})", fmap.cast_int64(), start_id)
         } else {
             start_id.clone()

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -1087,56 +1087,96 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // Build the BFS recursive CTE name (without _inner suffix)
         let bfs_cte_name = format!("{}_bfs", self.cte_name);
 
-        // Forward direction branch: from_col → to_col
-        let forward_recursive = format!(
-            "    SELECT DISTINCT rel.{to_col} AS node_id, b.hop + 1 AS hop\n    \
-             FROM {bfs_cte} b\n    \
-             JOIN {rel_table} rel ON rel.{from_col} = b.node_id\n    \
-             WHERE b.hop < {max_hops}\n      \
-             AND rel.{to_col} NOT IN (SELECT node_id FROM {bfs_cte}){stop_at_target}",
-            to_col = to_col,
-            bfs_cte = bfs_cte_name,
-            rel_table = rel_table,
-            from_col = from_col,
-            max_hops = max_hops,
-            stop_at_target = target_id
-                .as_ref()
-                .map(|t| format!("\n      AND b.node_id != {}", t))
-                .unwrap_or_default(),
-        );
+        let stop_at_target = target_id
+            .as_ref()
+            .map(|t| format!("\n      AND b.node_id != {}", t))
+            .unwrap_or_default();
 
-        // Reverse direction branch (for undirected edges): to_col → from_col
-        let reverse_recursive = if self.is_undirected {
+        // Recursive body. ClickHouse accepts N-ary `UNION ALL` for recursive
+        // CTEs, so an undirected edge is emitted as two separate recursive
+        // branches (forward + reverse). Spark/Databricks requires exactly
+        // two children under the recursive `UNION ALL` (anchor + recursive),
+        // so the undirected case is collapsed to a single recursive branch
+        // that joins against a bidirectional sub-`UNION ALL` over the rel
+        // table. The bidirectional sub-`UNION ALL` is non-recursive, so it
+        // doesn't run afoul of the 2-child rule.
+        let dialect = crate::server::query_context::get_current_dialect();
+        let recursive_body = if self.is_undirected
+            && matches!(dialect, crate::sql_generator::SqlDialect::Databricks)
+        {
             format!(
-                "\n    UNION ALL\n    \
-                 SELECT DISTINCT rel.{from_col} AS node_id, b.hop + 1 AS hop\n    \
+                "    SELECT DISTINCT neighbor.node_id AS node_id, b.hop + 1 AS hop\n    \
                  FROM {bfs_cte} b\n    \
-                 JOIN {rel_table} rel ON rel.{to_col} = b.node_id\n    \
+                 JOIN (\n        \
+                     SELECT {from_col} AS prev, {to_col} AS node_id FROM {rel_table}\n        \
+                     UNION ALL\n        \
+                     SELECT {to_col} AS prev, {from_col} AS node_id FROM {rel_table}\n    \
+                 ) AS neighbor ON neighbor.prev = b.node_id\n    \
                  WHERE b.hop < {max_hops}\n      \
-                 AND rel.{from_col} NOT IN (SELECT node_id FROM {bfs_cte}){stop_at_target}",
-                from_col = from_col,
+                 AND neighbor.node_id NOT IN (SELECT node_id FROM {bfs_cte}){stop_at_target}",
                 bfs_cte = bfs_cte_name,
                 rel_table = rel_table,
+                from_col = from_col,
                 to_col = to_col,
                 max_hops = max_hops,
-                stop_at_target = target_id
-                    .as_ref()
-                    .map(|t| format!("\n      AND b.node_id != {}", t))
-                    .unwrap_or_default(),
+                stop_at_target = stop_at_target,
             )
         } else {
-            String::new()
+            // ClickHouse path — and Spark directed case — keep the original
+            // 2- or 3-branch UNION ALL form (matches CH behavior byte-for-byte
+            // when not undirected on Databricks).
+            let forward = format!(
+                "    SELECT DISTINCT rel.{to_col} AS node_id, b.hop + 1 AS hop\n    \
+                 FROM {bfs_cte} b\n    \
+                 JOIN {rel_table} rel ON rel.{from_col} = b.node_id\n    \
+                 WHERE b.hop < {max_hops}\n      \
+                 AND rel.{to_col} NOT IN (SELECT node_id FROM {bfs_cte}){stop_at_target}",
+                to_col = to_col,
+                bfs_cte = bfs_cte_name,
+                rel_table = rel_table,
+                from_col = from_col,
+                max_hops = max_hops,
+                stop_at_target = stop_at_target,
+            );
+            let reverse = if self.is_undirected {
+                format!(
+                    "\n    UNION ALL\n    \
+                     SELECT DISTINCT rel.{from_col} AS node_id, b.hop + 1 AS hop\n    \
+                     FROM {bfs_cte} b\n    \
+                     JOIN {rel_table} rel ON rel.{to_col} = b.node_id\n    \
+                     WHERE b.hop < {max_hops}\n      \
+                     AND rel.{from_col} NOT IN (SELECT node_id FROM {bfs_cte}){stop_at_target}",
+                    from_col = from_col,
+                    bfs_cte = bfs_cte_name,
+                    rel_table = rel_table,
+                    to_col = to_col,
+                    max_hops = max_hops,
+                    stop_at_target = stop_at_target,
+                )
+            } else {
+                String::new()
+            };
+            format!("{forward}{reverse}")
         };
 
-        // Build BFS CTE
+        // Build BFS CTE. On Spark/Databricks the anchor `node_id` literal
+        // would be inferred as `INT` (32-bit), but the recursive branch
+        // pulls `node_id` from a BIGINT rel column — Spark refuses to merge
+        // them under `UNION ALL` (`CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE`).
+        // Explicitly cast the anchor to int64 there. ClickHouse promotes
+        // small-int literals automatically, so its anchor stays unchanged.
+        let anchor_start = if matches!(dialect, crate::sql_generator::SqlDialect::Databricks) {
+            format!("{}({})", fmap.cast_int64(), start_id)
+        } else {
+            start_id.clone()
+        };
         let bfs_cte_sql = format!(
             "{bfs_cte} AS (\n    \
-             SELECT {start_id} AS node_id, {cast_u16}(0) AS hop\n    \
-             UNION ALL\n{forward}{reverse}\n)",
+             SELECT {anchor_start} AS node_id, {cast_u16}(0) AS hop\n    \
+             UNION ALL\n{recursive_body}\n)",
             bfs_cte = bfs_cte_name,
-            start_id = start_id,
-            forward = forward_recursive,
-            reverse = reverse_recursive,
+            anchor_start = anchor_start,
+            recursive_body = recursive_body,
         );
 
         // Build result wrapper CTE that matches VLP output schema.
@@ -1145,19 +1185,22 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // - hop_count for length(path) → t.hop_count rewriting
         // - NULL hop_count when target not reached → ifNull() pattern works
         let result_select = if let Some(ref target) = target_id {
-            // BFS target branch: both countIf and minIf are ClickHouse-only
-            // aggregate forms. Spark has `count_if` (single-arg) but no
-            // `minIf` equivalent — the whole conditional-min pattern needs
-            // a structural rewrite to `min(CASE WHEN cond THEN val END)` to
-            // run on Spark. Until that lands, keep both as CH-native so the
-            // dialect mismatch surfaces as a single UNRESOLVED_ROUTINE rather
-            // than mixed half-translated SQL.
+            // BFS target branch — pair-rewrite the conditional count/min
+            // through the FunctionMapper so both dialects emit valid SQL:
+            //   CH:    countIf(cond) > 0, minIf(val, cond)
+            //   Spark: count_if(cond) > 0, min(CASE WHEN cond THEN val END)
+            // The outer CASE … ELSE NULL is redundant under standard `min`
+            // semantics (empty match → NULL anyway) but kept for clarity
+            // and to leave the CH emission byte-identical to its prior form.
+            let cond = format!("node_id = {target}");
+            let count_if = fmap.count_if();
+            let conditional_min = fmap.min_if(&format!("{cast_u16}(hop)"), &cond);
             format!(
                 "{name} AS (\n    SELECT\n        \
                  {start_id} AS start_id,\n        \
                  {target} AS end_id,\n        \
-                 CASE WHEN countIf(node_id = {target}) > 0\n            \
-                 THEN minIf({cast_u16}(hop), node_id = {target})\n            \
+                 CASE WHEN {count_if}({cond}) > 0\n            \
+                 THEN {conditional_min}\n            \
                  ELSE NULL END AS hop_count,\n        \
                  {empty_str_arr} AS path_relationships,\n        \
                  {empty_i64_arr} AS path_nodes\n    \

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -18,6 +18,14 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         "countIf"
     }
 
+    fn min_if(&self, val: &str, cond: &str) -> String {
+        format!("minIf({val}, {cond})")
+    }
+
+    fn min_or_null(&self) -> &'static str {
+        "minOrNull"
+    }
+
     fn array_count(&self) -> &'static str {
         "arrayCount"
     }
@@ -93,5 +101,20 @@ mod tests {
         let m = ClickhouseFunctionMapper;
         assert_eq!(m.quote_alias("b.id"), "\"b.id\"");
         assert_eq!(m.quote_alias("x\"y"), "\"x\"\"y\"");
+    }
+
+    #[test]
+    fn min_if_emits_native_clickhouse_form() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(
+            m.min_if("toUInt16(hop)", "node_id = 14"),
+            "minIf(toUInt16(hop), node_id = 14)"
+        );
+    }
+
+    #[test]
+    fn min_or_null_uses_clickhouse_specific_name() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.min_or_null(), "minOrNull");
     }
 }

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -56,6 +56,21 @@ impl FunctionMapper for DatabricksFunctionMapper {
         "count_if"
     }
 
+    fn min_if(&self, val: &str, cond: &str) -> String {
+        // Spark has no `minIf`. `min` ignores NULLs in ANSI SQL, so a
+        // `CASE WHEN cond THEN val END` (no ELSE → NULL) reproduces
+        // `minIf(val, cond)` exactly: matching rows contribute `val`,
+        // non-matching rows contribute NULL and get dropped by `min`.
+        format!("min(CASE WHEN {cond} THEN {val} END)")
+    }
+
+    fn min_or_null(&self) -> &'static str {
+        // Spark's `min` already returns NULL on empty input (ANSI), so the
+        // CH-only `minOrNull` quirk doesn't apply — plain `min` is the
+        // direct equivalent.
+        "min"
+    }
+
     fn array_count(&self) -> &'static str {
         // Structural mismatch — see module docs. No single function name.
         // Phase 1.1 resolved this at the call sites via
@@ -165,6 +180,11 @@ mod tests {
         assert_eq!(m.collect_list(), "collect_list");
         assert_eq!(m.array_element(), "element_at");
         assert_eq!(m.count_if(), "count_if");
+        assert_eq!(
+            m.min_if("int(hop)", "node_id = 14"),
+            "min(CASE WHEN node_id = 14 THEN int(hop) END)"
+        );
+        assert_eq!(m.min_or_null(), "min");
         assert_eq!(m.json_extract_string(), "get_json_object");
         assert_eq!(m.cast_int64(), "bigint");
         assert_eq!(m.cast_uint8(), "tinyint");

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -39,6 +39,21 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// Conditional count. CH: `countIf`. Spark: `count_if` (DBR 13.1+).
     fn count_if(&self) -> &'static str;
 
+    /// Conditional minimum: minimum of `val` over rows where `cond` is true.
+    /// CH: `minIf(val, cond)`. Spark has no `minIf`, so we rewrite to
+    /// `min(CASE WHEN cond THEN val END)` — `min` ignores NULLs, so rows
+    /// where `cond` is false drop out exactly like `minIf` does. Takes
+    /// pre-rendered SQL fragments because the structural form differs;
+    /// callers paste the result directly into surrounding SQL.
+    fn min_if(&self, val: &str, cond: &str) -> String;
+
+    /// NULL-on-empty minimum. CH: `minOrNull` (CH's bare `min` returns 0
+    /// for an empty input set, not NULL). Spark/ANSI `min` already returns
+    /// NULL for empty input, so this maps to plain `min`. Used by the
+    /// `CASE path IS NULL THEN -1 ELSE length(path) END` VLP rewrite,
+    /// where the "no path" branch must reliably surface as NULL.
+    fn min_or_null(&self) -> &'static str;
+
     /// Count of array elements matching a predicate.
     /// CH: `arrayCount`. Spark needs structural rewriting to
     /// `size(filter(...))` — the planned Databricks emitter handles this

--- a/tests/spark_smoke/test_ldbc_sweep.py
+++ b/tests/spark_smoke/test_ldbc_sweep.py
@@ -62,8 +62,7 @@ EXPECTED_FAILURES: dict[str, str] = {
     "bi-17":      "[A] FunctionMapper: `toUnixTimestamp64Milli` leaking in duration-arithmetic path",
     "complex-5":  "[A] FunctionMapper: `countIf(cond, val)` rewritten to `count_if(cond, val)` but Spark `count_if` takes 1 arg",
     "complex-12": "[A] FunctionMapper: `formatRowNoNewline` not mapped (composite-key emission helper)",
-    "complex-13": "[A] FunctionMapper: `minIf(cond, val)` — needs structural rewrite to `min(CASE WHEN cond THEN val END)` on Spark",
-    "complex-14": "[A] FunctionMapper: `minIf` — same as complex-13",
+    "complex-14": "[D] unsupported: query uses GDS (`gds.graph.project.cypher`, `gds.shortestPath.dijkstra.stream`) which we don't translate; once past shortestPath BFS, the trailing `WITH 42 AS dummy` carries through and downstream column refs fail with INVALID_EXTRACT_BASE_FIELD_TYPE",
     "short-2":    "[A] FunctionMapper: `formatRowNoNewline` not mapped",
     # B. Parse errors
     "bi-8":       "[B] PARSE_SYNTAX_ERROR near `ARRAY` — VLP CTE generation",

--- a/tests/spark_smoke/test_ldbc_sweep.py
+++ b/tests/spark_smoke/test_ldbc_sweep.py
@@ -54,6 +54,8 @@ KNOWN_SKIPS: dict[str, str] = {
 #   A. FunctionMapper gaps — CH-native fn name leaking into Spark SQL
 #   B. Parse errors — syntax the dialect emitter shouldn't produce on Spark
 #   C. CTE column resolution — alias mismatch between CTE def and downstream ref
+#   D. Unsupported language features — query uses Cypher constructs we don't
+#      translate (GDS procedures, CALL subqueries, etc.); orthogonal to A-C
 EXPECTED_FAILURES: dict[str, str] = {
     # A. FunctionMapper gaps — residual unmapped routines after the
     #    anyLast / countIf / temporal-extraction / has / toString sweep.


### PR DESCRIPTION
## Summary

Three dialect-aware fixes in the BFS shortestPath emitter so the same Cypher translates and executes correctly on both ClickHouse and Spark/Delta. ClickHouse SQL stays byte-identical; all divergence flows through `FunctionMapper`.

- **`min_if(val, cond)` mapper method.** CH: `minIf(val, cond)` (unchanged). Spark: `min(CASE WHEN cond THEN val END)` — ANSI `min` ignores NULLs, so non-matching rows drop out exactly like `minIf`. Used by the BFS target branch (`CASE WHEN countIf(...) > 0 THEN minIf(...)`).
- **`min_or_null()` mapper method.** CH `min` returns 0 on empty input, so the `CASE path IS NULL` VLP rewrite uses `minOrNull` to reliably surface NULL. Spark `min` already returns NULL on empty input, so it resolves to plain `min` — eliminates a CH-only function name leaking into Spark SQL.
- **Undirected-edge BFS structural rewrite for Spark.** Spark requires exactly two children under a recursive `UNION ALL` (anchor + recursive); previously undirected emitted three branches (anchor + forward + reverse). Collapse to a single recursive branch joined against a bidirectional sub-`UNION ALL` over the rel table. ClickHouse accepts N-ary recursive UNION and keeps the original shape.
- **Anchor type-cast on Spark.** `SELECT 14 AS node_id` is INT in Spark but recursive branch pulls BIGINT — `UNION ALL` rejects the merge with `CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE`. Explicitly cast the anchor to int64 via `cast_int64()`. CH promotes int literals automatically and keeps its bare form.

## Sweep result

Spark/Delta LDBC sweep: **23 → 24 passing**. complex-13 (`shortestPath` with `CASE path IS NULL`) flips green. complex-14 retagged — its actual failure is GDS library calls (`gds.graph.project.cypher`, `gds.shortestPath.dijkstra.stream`) which we don't translate; that's a new \`[D]\` category, not a function-mapper gap.

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt --all && cargo clippy --all-targets`
- [x] `cargo test --lib` (1372 passed; FunctionMapper unit tests cover both `min_if` and `min_or_null` per dialect)
- [x] CH emission of shortestPath BFS is byte-identical via spot-check
- [x] Spark sweep: complex-13 passes end-to-end; no regressions on the 23 prior passers

🤖 Generated with [Claude Code](https://claude.com/claude-code)