### PR TITLE
chore(deny): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,12 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # custom global logger that calls `rand::rng()` during init. Transitive only
 # (tungstenite 0.21 and quinn-proto). ClickGraph does not install a custom
 # logger that triggers this pattern, so the unsound path cannot be reached.
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2026-0097"]
+# RUSTSEC-2026-0173: proc-macro-error2 is unmaintained. Compile-time-only
+# transitive dependency pulled in via validator → validator_derive (a
+# proc-macro crate); it never ships in any runtime artifact and is not a
+# security vulnerability. Removing it requires validator_derive to migrate
+# off it upstream — ignore until a validator release drops the dependency.
+ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2026-0097", "RUSTSEC-2026-0173"]
 
 [licenses]
 # Allow common permissive and copyleft-compatible licenses


### PR DESCRIPTION
## Summary

The `cargo deny` security check fails on **RUSTSEC-2026-0173** — `proc-macro-error2` is now flagged **unmaintained**:

```
error[unmaintained]: proc-macro-error2 is unmaintained
  ID: RUSTSEC-2026-0173
advisories FAILED, bans ok, licenses ok, sources ok
```

It's a **compile-time-only transitive dependency** (`validator` → `validator_derive`, a proc-macro crate), never present in any runtime artifact, and the advisory is *unmaintained* — not a security vulnerability. Dropping it requires `validator_derive` to migrate off it upstream.

## Change

Add `RUSTSEC-2026-0173` to the existing `[advisories].ignore` list in `deny.toml` with a justifying comment, consistent with the other ignored unmaintained/unsound transitive advisories (`RUSTSEC-2025-0134`, `RUSTSEC-2026-0097`). `bans`, `licenses`, and `sources` already pass, so this unblocks the `cargo deny` gate.

## Testing

- `deny.toml` validated as well-formed TOML.
- CI `cargo deny` on this PR is the authoritative check (a prebuilt cargo-deny couldn't be run locally in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)