### PR TITLE
feat(server): observability — /metrics (Prometheus), /stats, /stats/queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ async-trait = "0.1"
 anyhow = "1.0"
 test-case = "3.3"  # For PackStream tests
 serial_test = "3.2"  # For serializing tests that modify global state
+tower = { version = "0.5", features = ["util"] }  # ServiceExt::oneshot for router tests
 # Mock HTTP server for the Databricks executor's integration tests.
 # Unconditional dev-dep so `cargo test` always knows where to find it;
 # the tests themselves are gated on `#[cfg(feature = "databricks")]`,

--- a/docs/wiki/API-Reference-HTTP.md
+++ b/docs/wiki/API-Reference-HTTP.md
@@ -677,6 +677,66 @@ curl http://localhost:8080/health
 
 ---
 
+## Observability / Stats
+
+Aggregate metrics, a Prometheus scrape target, and a slow-query log. Cover both
+the HTTP and Bolt query paths. Enabled by default
+(`CLICKGRAPH_METRICS_ENABLED=true`); when disabled these endpoints return `404`.
+
+### GET /metrics
+
+Prometheus exposition format (`Content-Type: text/plain; version=0.0.4`) — point
+a Prometheus scraper here. Exposes query counters (`clickgraph_queries_total`,
+`..._by_type_total{type=…}`, `..._errors_total{class=…}`), in-flight gauge,
+per-phase latency histograms (`clickgraph_query_duration_seconds_bucket{phase=…,
+le=…}` for `total`/`parse`/`plan`/`render`/`sqlgen`/`exec`), result-row and
+ClickHouse byte counters, plus cache and connection-pool gauges. Labels are
+bounded (never raw query text, role, or tenant).
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+### GET /stats
+
+JSON snapshot for humans/dashboards: uptime, version, query counters by type and
+error class, latency percentiles (p50/p95/p99 + mean) per phase, cache
+hit-rate, connection-pool stats (`null` in embedded/Databricks modes), and
+ClickHouse transfer bytes.
+
+```bash
+curl http://localhost:8080/stats | jq
+```
+
+### GET /stats/queries
+
+Slow-query ring buffer for ad-hoc performance debugging.
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `recent`  | 20 | Most recent queries, newest first |
+| `slowest` | 20 | Top-N by total time |
+
+Each record carries `timestamp_ms`, `query_type`, `total_ms`, `exec_ms`,
+`result_rows`, `outcome` (`ok` or an error class), and — only when
+`CLICKGRAPH_METRICS_QUERY_PREVIEW=true` — a truncated `query_preview`.
+
+```bash
+curl "http://localhost:8080/stats/queries?recent=10&slowest=10" | jq
+```
+
+**Configuration** (env vars):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `CLICKGRAPH_METRICS_ENABLED` | `true` | Enable the endpoints + recording |
+| `CLICKGRAPH_SLOW_QUERY_CAPACITY` | `128` | Ring buffer size (≤10000) |
+| `CLICKGRAPH_SLOW_QUERY_THRESHOLD_MS` | `0` | Only ring queries ≥ this many ms (0 = all) |
+| `CLICKGRAPH_METRICS_QUERY_PREVIEW` | `false` | Retain truncated query text in the ring (JSON only) |
+| `CLICKGRAPH_METRICS_CH_SUMMARY` | `false` | Capture true `X-ClickHouse-Summary` stats (remote mode; opt-in) |
+
+---
+
 ## Error Handling
 
 ### Error Response Format

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,36 @@ pub struct ServerConfig {
 
     /// Maximum concurrent queries. 0 = unlimited. Default: 64.
     pub max_concurrent_queries: usize,
+
+    /// Whether the observability registry and `/metrics` /`/stats` endpoints
+    /// are enabled. When false the endpoints return 404 and recording is a
+    /// cheap no-op. Default: true.
+    pub metrics_enabled: bool,
+
+    /// Capacity of the in-memory slow-query ring buffer surfaced by
+    /// `/stats/queries`. Default: 128.
+    #[validate(range(
+        min = 1,
+        max = 10000,
+        message = "Slow-query capacity must be between 1 and 10000"
+    ))]
+    pub slow_query_capacity: usize,
+
+    /// Only queries whose total time is at least this many milliseconds are
+    /// pushed into the slow-query ring. 0 = record every query (the ring then
+    /// retains the most recent N). Default: 0.
+    pub slow_query_threshold_ms: u64,
+
+    /// Capture true ClickHouse-side execution stats (read_rows/read_bytes/
+    /// elapsed) by reading the `X-ClickHouse-Summary` response header via a
+    /// direct request path. Off by default — the default path uses the
+    /// `clickhouse` crate, which does not expose that header. Remote mode only.
+    pub metrics_ch_summary: bool,
+
+    /// Include a truncated preview of the Cypher text in the slow-query ring
+    /// (JSON only, never a Prometheus label). Off by default for environments
+    /// where query text may carry sensitive values.
+    pub metrics_query_preview: bool,
 }
 
 impl Default for ServerConfig {
@@ -108,6 +138,11 @@ impl Default for ServerConfig {
             query_timeout_secs: 300,
             max_request_body_bytes: 1_048_576, // 1 MB
             max_concurrent_queries: 64,
+            metrics_enabled: true,
+            slow_query_capacity: 128,
+            slow_query_threshold_ms: 0,
+            metrics_ch_summary: false,
+            metrics_query_preview: false,
         }
     }
 }
@@ -130,6 +165,11 @@ impl ServerConfig {
             query_timeout_secs: parse_env_var("CLICKGRAPH_QUERY_TIMEOUT_SECS", "300")?,
             max_request_body_bytes: parse_env_var("CLICKGRAPH_MAX_REQUEST_BODY_BYTES", "1048576")?,
             max_concurrent_queries: parse_env_var("CLICKGRAPH_MAX_CONCURRENT_QUERIES", "64")?,
+            metrics_enabled: parse_env_var("CLICKGRAPH_METRICS_ENABLED", "true")?,
+            slow_query_capacity: parse_env_var("CLICKGRAPH_SLOW_QUERY_CAPACITY", "128")?,
+            slow_query_threshold_ms: parse_env_var("CLICKGRAPH_SLOW_QUERY_THRESHOLD_MS", "0")?,
+            metrics_ch_summary: parse_env_var("CLICKGRAPH_METRICS_CH_SUMMARY", "false")?,
+            metrics_query_preview: parse_env_var("CLICKGRAPH_METRICS_QUERY_PREVIEW", "false")?,
         };
 
         config.validate()?;
@@ -153,6 +193,14 @@ impl ServerConfig {
             query_timeout_secs: cli.query_timeout_secs,
             max_request_body_bytes: cli.max_request_body_bytes,
             max_concurrent_queries: cli.max_concurrent_queries,
+            // Metrics knobs are operational and env-only (no CLI flag); read
+            // them from the environment so `from_cli` (the live startup path)
+            // still honors CLICKGRAPH_METRICS_* / CLICKGRAPH_SLOW_QUERY_*.
+            metrics_enabled: parse_env_var("CLICKGRAPH_METRICS_ENABLED", "true")?,
+            slow_query_capacity: parse_env_var("CLICKGRAPH_SLOW_QUERY_CAPACITY", "128")?,
+            slow_query_threshold_ms: parse_env_var("CLICKGRAPH_SLOW_QUERY_THRESHOLD_MS", "0")?,
+            metrics_ch_summary: parse_env_var("CLICKGRAPH_METRICS_CH_SUMMARY", "false")?,
+            metrics_query_preview: parse_env_var("CLICKGRAPH_METRICS_QUERY_PREVIEW", "false")?,
         };
 
         config.validate()?;
@@ -193,6 +241,11 @@ impl ServerConfig {
         self.query_timeout_secs = other.query_timeout_secs;
         self.max_request_body_bytes = other.max_request_body_bytes;
         self.max_concurrent_queries = other.max_concurrent_queries;
+        self.metrics_enabled = other.metrics_enabled;
+        self.slow_query_capacity = other.slow_query_capacity;
+        self.slow_query_threshold_ms = other.slow_query_threshold_ms;
+        self.metrics_ch_summary = other.metrics_ch_summary;
+        self.metrics_query_preview = other.metrics_query_preview;
     }
 }
 
@@ -263,6 +316,25 @@ mod tests {
     fn test_empty_host() {
         let config = ServerConfig {
             http_host: "".to_string(), // Invalid
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_metrics_defaults() {
+        let config = ServerConfig::default();
+        assert!(config.metrics_enabled);
+        assert_eq!(config.slow_query_capacity, 128);
+        assert_eq!(config.slow_query_threshold_ms, 0);
+        assert!(!config.metrics_ch_summary);
+        assert!(!config.metrics_query_preview);
+    }
+
+    #[test]
+    fn test_invalid_slow_query_capacity() {
+        let config = ServerConfig {
+            slow_query_capacity: 10_001, // Invalid (> 10000)
             ..Default::default()
         };
         assert!(config.validate().is_err());

--- a/src/executor/remote.rs
+++ b/src/executor/remote.rs
@@ -2,15 +2,22 @@
 //!
 //! This is a thin wrapper that makes the existing connection pool implement
 //! the `QueryExecutor` trait, preserving all existing behaviour (role-based
-//! pools, cluster round-robin, etc.) with no functional change.
+//! pools, cluster round-robin, etc.).
+//!
+//! It also records observability stats (Phase A): the bytes received from
+//! ClickHouse for each query are pushed into the per-query metrics slot (a
+//! no-op outside a metrics scope). The richer `X-ClickHouse-Summary`
+//! (read_rows/read_bytes) is not exposed by the `clickhouse` crate and is a
+//! gated follow-up.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::io::AsyncBufReadExt;
 
 use super::{ExecutorError, QueryExecutor};
 use crate::server::connection_pool::RoleConnectionPool;
+use crate::server::metrics::record_ch_network_bytes;
 
 /// SQL executor that delegates to a remote ClickHouse server via HTTP.
 ///
@@ -26,6 +33,28 @@ impl RemoteClickHouseExecutor {
     }
 }
 
+/// Drain a `fetch_bytes` cursor into one buffer and record the bytes received.
+///
+/// Reading the raw chunks (rather than `.lines()`, which consumes the cursor)
+/// lets us call `received_bytes()` afterwards for the Phase A network-bytes
+/// metric. The full response was already buffered before processing, so this
+/// is memory-equivalent to the previous line-streaming path.
+async fn drain_cursor(
+    mut cursor: clickhouse::query::BytesCursor,
+    sql: &str,
+) -> Result<Vec<u8>, ExecutorError> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = cursor.next().await.map_err(|e| {
+        log::error!("ClickHouse read failed. SQL was:\n{}\nError: {}", sql, e);
+        ExecutorError::Io(e.to_string())
+    })? {
+        let chunk: Bytes = chunk;
+        buf.extend_from_slice(&chunk);
+    }
+    record_ch_network_bytes(cursor.received_bytes());
+    Ok(buf)
+}
+
 #[async_trait]
 impl QueryExecutor for RemoteClickHouseExecutor {
     async fn execute_json(
@@ -34,25 +63,18 @@ impl QueryExecutor for RemoteClickHouseExecutor {
         role: Option<&str>,
     ) -> Result<Vec<Value>, ExecutorError> {
         let client = self.pool.get_client(role).await;
-        let mut lines = client
-            .query(sql)
-            .fetch_bytes("JSONEachRow")
-            .map_err(|e| {
-                log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
-                ExecutorError::QueryFailed(e.to_string())
-            })?
-            .lines();
+        let cursor = client.query(sql).fetch_bytes("JSONEachRow").map_err(|e| {
+            log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
+            ExecutorError::QueryFailed(e.to_string())
+        })?;
+        let buf = drain_cursor(cursor, sql).await?;
 
         let mut rows = Vec::new();
-        while let Some(line) = lines
-            .next_line()
-            .await
-            .map_err(|e| ExecutorError::Io(e.to_string()))?
-        {
-            if line.trim().is_empty() {
+        for line in buf.split(|&b| b == b'\n') {
+            if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            let value: Value = serde_json::from_str(&line).map_err(|e| {
+            let value: Value = serde_json::from_slice(line).map_err(|e| {
                 log::error!("Failed to parse JSON from ClickHouse response: {}", e);
                 ExecutorError::Parse(e.to_string())
             })?;
@@ -68,23 +90,18 @@ impl QueryExecutor for RemoteClickHouseExecutor {
         role: Option<&str>,
     ) -> Result<String, ExecutorError> {
         let client = self.pool.get_client(role).await;
-        let mut lines = client
-            .query(sql)
-            .fetch_bytes(format)
-            .map_err(|e| {
-                log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
-                ExecutorError::QueryFailed(e.to_string())
-            })?
-            .lines();
+        let cursor = client.query(sql).fetch_bytes(format).map_err(|e| {
+            log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
+            ExecutorError::QueryFailed(e.to_string())
+        })?;
+        let buf = drain_cursor(cursor, sql).await?;
 
-        let mut rows = Vec::new();
-        while let Some(line) = lines
-            .next_line()
-            .await
-            .map_err(|e| ExecutorError::Io(e.to_string()))?
-        {
-            rows.push(line);
+        let mut text = String::from_utf8(buf).map_err(|e| ExecutorError::Parse(e.to_string()))?;
+        // Preserve the previous behaviour of joining lines without a trailing
+        // newline (ClickHouse terminates each row, incl. the last, with `\n`).
+        if text.ends_with('\n') {
+            text.pop();
         }
-        Ok(rows.join("\n"))
+        Ok(text)
     }
 }

--- a/src/server/bolt_protocol/handler.rs
+++ b/src/server/bolt_protocol/handler.rs
@@ -18,6 +18,9 @@ use crate::clickhouse_query_generator;
 use crate::executor::QueryExecutor;
 use crate::open_cypher_parser;
 use crate::query_planner;
+use crate::server::handlers::QueryPerformanceMetrics;
+use crate::server::metrics::{self, ErrorClass, Outcome, QuerySample};
+use crate::server::GLOBAL_SERVER_METRICS;
 
 /// Execution plan for procedure-only queries (extracted before async execution)
 #[derive(Debug)]
@@ -1687,7 +1690,13 @@ impl BoltHandler {
         // Note: id() predicates with encoded values are decoded in FilterTagging pass
         use crate::server::query_context::{with_query_context, QueryContext};
         let ctx = QueryContext::new(schema_name.clone());
-        match with_query_context(
+
+        // Observability: the Bolt path doesn't build per-phase timings like the
+        // HTTP handler, so record only total/exec latency under a coarse "bolt"
+        // type. The in-flight guard + CH-stats scope mirror the HTTP path.
+        let _inflight = GLOBAL_SERVER_METRICS.get().map(|r| r.in_flight_guard());
+        let run_start = std::time::Instant::now();
+        let exec_result = metrics::with_ch_stats_scope(with_query_context(
             ctx,
             self.execute_cypher_query(
                 &query,
@@ -1697,9 +1706,10 @@ impl BoltHandler {
                 role,
                 view_parameters,
             ),
-        )
-        .await
-        {
+        ))
+        .await;
+
+        let (messages, outcome) = match exec_result {
             Ok(result_metadata) => {
                 // Update context to streaming state
                 {
@@ -1708,7 +1718,7 @@ impl BoltHandler {
                 }
 
                 // Return success with query metadata
-                Ok(vec![BoltMessage::success(result_metadata)])
+                (vec![BoltMessage::success(result_metadata)], Outcome::Ok)
             }
             Err(query_error) => {
                 let error_code = query_error.error_code().to_string();
@@ -1723,9 +1733,31 @@ impl BoltHandler {
                 // Don't update state - let client send RESET to recover
                 // Setting to Failed would close the connection
 
-                Ok(vec![BoltMessage::failure(error_code, error_message)])
+                (
+                    vec![BoltMessage::failure(error_code, error_message)],
+                    Outcome::Err(ErrorClass::Exec),
+                )
             }
+        };
+
+        if let Some(reg) = GLOBAL_SERVER_METRICS.get() {
+            let elapsed = run_start.elapsed().as_secs_f64();
+            let m = QueryPerformanceMetrics {
+                total_time: elapsed,
+                execution_time: elapsed,
+                query_type: "bolt".to_string(),
+                ..QueryPerformanceMetrics::default()
+            };
+            reg.record_query(&QuerySample {
+                metrics: &m,
+                outcome,
+                has_phase_breakdown: false,
+                query_text: Some(&query),
+                ch: metrics::current_ch_stats(),
+            });
         }
+
+        Ok(messages)
     }
 
     /// Handle PULL message (fetch query results)

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -21,11 +21,26 @@ use crate::{
 
 use super::{
     graph_catalog,
+    metrics::{self, ErrorClass, Outcome, QuerySample},
     models::{GraphQueryResponse, OutputFormat, QueryRequest, QueryStats, SqlOnlyResponse},
     parameter_substitution, query_cache,
     query_context::{with_query_context, QueryContext},
-    AppState, GLOBAL_QUERY_CACHE,
+    AppState, GLOBAL_QUERY_CACHE, GLOBAL_SERVER_METRICS,
 };
+
+/// Record a completed query into the global registry (no-op if metrics are off
+/// or uninitialized). Pulls any ClickHouse-side stats captured for this query.
+fn record_query(metrics: &QueryPerformanceMetrics, query_text: &str, outcome: Outcome) {
+    if let Some(reg) = GLOBAL_SERVER_METRICS.get() {
+        reg.record_query(&QuerySample {
+            metrics,
+            outcome,
+            has_phase_breakdown: true,
+            query_text: Some(query_text),
+            ch: metrics::current_ch_stats(),
+        });
+    }
+}
 
 /// Merge view_parameters and query parameters into a single HashMap
 ///
@@ -174,6 +189,136 @@ pub async fn simple_test_handler() -> impl IntoResponse {
     "Hello from simple test"
 }
 
+/// JSON helper: current query-cache metrics, or `null` when the cache is absent.
+fn cache_metrics_json() -> serde_json::Value {
+    match GLOBAL_QUERY_CACHE.get() {
+        Some(cache) => {
+            let m = cache.metrics();
+            serde_json::json!({
+                "hits": m.hits,
+                "misses": m.misses,
+                "evictions": m.evictions,
+                "hit_rate": m.hit_rate(),
+                "size": m.size,
+                "size_bytes": m.size_bytes,
+                "max_entries": m.max_entries,
+                "max_size_bytes": m.max_size_bytes,
+            })
+        }
+        None => serde_json::Value::Null,
+    }
+}
+
+/// JSON helper: connection-pool stats, or `null` in embedded/Databricks modes.
+async fn pool_stats_json(app_state: &AppState) -> serde_json::Value {
+    match &app_state.pool {
+        Some(pool) => {
+            let s = pool.stats().await;
+            serde_json::json!({
+                "total_role_pools": s.total_role_pools,
+                "roles": s.roles,
+                "node_count": s.node_count,
+                "cluster_name": s.cluster_name,
+            })
+        }
+        None => serde_json::Value::Null,
+    }
+}
+
+/// `GET /metrics` — Prometheus exposition format. 404 when metrics are disabled.
+pub async fn metrics_handler(State(app_state): State<Arc<AppState>>) -> Response {
+    let Some(reg) = GLOBAL_SERVER_METRICS.get() else {
+        return (StatusCode::NOT_FOUND, "metrics not initialized").into_response();
+    };
+    if !reg.enabled() {
+        return (StatusCode::NOT_FOUND, "metrics disabled").into_response();
+    }
+
+    let mut out = String::with_capacity(2048);
+    reg.render_prometheus(&mut out);
+
+    // Append cache + pool gauges (sourced from their own registries).
+    use std::fmt::Write;
+    if let Some(cache) = GLOBAL_QUERY_CACHE.get() {
+        let m = cache.metrics();
+        let _ = writeln!(out, "# TYPE clickgraph_cache_hits_total counter");
+        let _ = writeln!(out, "clickgraph_cache_hits_total {}", m.hits);
+        let _ = writeln!(out, "# TYPE clickgraph_cache_misses_total counter");
+        let _ = writeln!(out, "clickgraph_cache_misses_total {}", m.misses);
+        let _ = writeln!(out, "# TYPE clickgraph_cache_evictions_total counter");
+        let _ = writeln!(out, "clickgraph_cache_evictions_total {}", m.evictions);
+        let _ = writeln!(out, "# TYPE clickgraph_cache_size gauge");
+        let _ = writeln!(out, "clickgraph_cache_size {}", m.size);
+        let _ = writeln!(out, "# TYPE clickgraph_cache_size_bytes gauge");
+        let _ = writeln!(out, "clickgraph_cache_size_bytes {}", m.size_bytes);
+    }
+    if let Some(pool) = &app_state.pool {
+        let s = pool.stats().await;
+        let _ = writeln!(out, "# TYPE clickgraph_pool_role_pools gauge");
+        let _ = writeln!(out, "clickgraph_pool_role_pools {}", s.total_role_pools);
+        let _ = writeln!(out, "# TYPE clickgraph_pool_node_count gauge");
+        let _ = writeln!(out, "clickgraph_pool_node_count {}", s.node_count);
+    }
+
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; version=0.0.4"),
+        )],
+        out,
+    )
+        .into_response()
+}
+
+/// `GET /stats` — JSON snapshot of counters, latency percentiles, cache, pool.
+pub async fn stats_handler(State(app_state): State<Arc<AppState>>) -> Response {
+    let Some(reg) = GLOBAL_SERVER_METRICS.get() else {
+        return (StatusCode::NOT_FOUND, "metrics not initialized").into_response();
+    };
+    if !reg.enabled() {
+        return (StatusCode::NOT_FOUND, "metrics disabled").into_response();
+    }
+
+    let snapshot = reg.snapshot();
+    let body = serde_json::json!({
+        "service": "clickgraph",
+        "version": env!("CARGO_PKG_VERSION"),
+        "metrics": snapshot,
+        "cache": cache_metrics_json(),
+        "pool": pool_stats_json(&app_state).await,
+    });
+    Json(body).into_response()
+}
+
+/// `GET /stats/queries?recent=N&slowest=N` — slow-query ring buffer view.
+pub async fn stats_queries_handler(
+    State(_app_state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
+    let Some(reg) = GLOBAL_SERVER_METRICS.get() else {
+        return (StatusCode::NOT_FOUND, "metrics not initialized").into_response();
+    };
+    if !reg.enabled() {
+        return (StatusCode::NOT_FOUND, "metrics disabled").into_response();
+    }
+
+    let parse_n = |key: &str, default: usize| {
+        params
+            .get(key)
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(default)
+            .min(1000)
+    };
+    let recent = parse_n("recent", 20);
+    let slowest = parse_n("slowest", 20);
+
+    Json(serde_json::json!({
+        "recent": reg.recent_queries(recent),
+        "slowest": reg.slowest_queries(slowest),
+    }))
+    .into_response()
+}
+
 pub async fn query_handler(
     State(app_state): State<Arc<AppState>>,
     Json(payload): Json<QueryRequest>,
@@ -187,6 +332,9 @@ pub async fn query_handler(
                     "Query rejected: max concurrent queries ({}) reached",
                     app_state.config.max_concurrent_queries
                 );
+                if let Some(reg) = GLOBAL_SERVER_METRICS.get() {
+                    reg.record_error(ErrorClass::Capacity);
+                }
                 return Ok((
                     StatusCode::SERVICE_UNAVAILABLE,
                     Json(serde_json::json!({
@@ -200,6 +348,11 @@ pub async fn query_handler(
     } else {
         None
     };
+
+    // Increment the in-flight gauge for the lifetime of this request. The RAII
+    // guard decrements on every return path (incl. the many early returns and
+    // panics) in this handler.
+    let _inflight = GLOBAL_SERVER_METRICS.get().map(|reg| reg.in_flight_guard());
 
     let start_time = Instant::now();
     let metrics = QueryPerformanceMetrics::new();
@@ -925,7 +1078,9 @@ pub async fn query_handler(
     // - Automatically cleaned up when the task completes
     let context = QueryContext::new(Some(schema_name.clone()));
 
-    with_query_context(context, async move {
+    // Scope a ClickHouse-stats slot around the whole inner run so the executor
+    // can record per-query CH stats that the finalization sites read back.
+    let result = metrics::with_ch_stats_scope(with_query_context(context, async move {
         query_handler_inner(
             app_state,
             payload,
@@ -938,8 +1093,31 @@ pub async fn query_handler(
             metrics,
         )
         .await
-    })
-    .await
+    }))
+    .await;
+
+    // Successful queries are recorded with full phase breakdown at the inner
+    // finalization sites; here we capture the error outcomes. Every `Err` from
+    // the inner handler carries an HTTP status we can classify, and we still
+    // know the total wall time (`start_time` is `Copy`) — so failures land in
+    // the slow-query ring with latency too, just without a per-phase breakdown.
+    if let Err((status, _)) = &result {
+        if let Some(reg) = GLOBAL_SERVER_METRICS.get() {
+            let m = QueryPerformanceMetrics {
+                total_time: start_time.elapsed().as_secs_f64(),
+                query_type: "other".to_string(),
+                ..QueryPerformanceMetrics::default()
+            };
+            reg.record_query(&QuerySample {
+                metrics: &m,
+                outcome: Outcome::Err(ErrorClass::from_status(status.as_u16())),
+                has_phase_breakdown: false,
+                query_text: Some(&query_string),
+                ch: metrics::current_ch_stats(),
+            });
+        }
+    }
+    result
 }
 
 /// Inner query handler logic - runs within task-local context
@@ -1393,6 +1571,8 @@ async fn query_handler_inner(
             stats: metrics.to_stats(),
         };
 
+        record_query(&metrics, &payload.query, Outcome::Ok);
+
         let mut resp = Json(response).into_response();
         if let Ok(cache_header) = axum::http::HeaderValue::try_from(cache_status) {
             resp.headers_mut()
@@ -1456,6 +1636,7 @@ async fn query_handler_inner(
                     .insert("X-Query-Cache-Status", cache_header);
             }
 
+            record_query(&metrics, &payload.query, Outcome::Ok);
             Ok(resp)
         }
         Err(e) => Err(e),

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -1,0 +1,901 @@
+//! Server observability registry.
+//!
+//! Aggregate counters, per-phase latency histograms, captured ClickHouse
+//! execution stats, and a bounded slow-query ring buffer — rendered as both
+//! Prometheus exposition text (`/metrics`) and a JSON snapshot (`/stats`).
+//!
+//! Deliberately **zero new dependencies**: hand-rolled `AtomicU64` counters and
+//! fixed-bucket histograms, mirroring the `CacheMetrics` atomics style in
+//! `query_cache.rs`. One source of truth ([`ServerMetrics`]) serves both
+//! outputs. Prometheus exposition is just `name{labels} value` lines, so no
+//! exporter crate is needed; percentiles are bucket-approximate, which is
+//! standard for an ops dashboard.
+//!
+//! Recording is a single cheap call ([`ServerMetrics::record_query`]) made once
+//! per query from both the HTTP handler and the Bolt handler. The hot path is
+//! relaxed atomic adds plus a small bucket scan; the only lock is the
+//! slow-query ring insert, which is off the counter path.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use super::handlers::QueryPerformanceMetrics;
+
+/// Runtime configuration for the registry, built from `ServerConfig` at startup.
+#[derive(Clone, Debug)]
+pub struct MetricsConfig {
+    pub enabled: bool,
+    pub slow_query_capacity: usize,
+    pub slow_query_threshold_ms: u64,
+    /// Whether to retain a truncated Cypher preview in the ring buffer.
+    pub query_preview: bool,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            slow_query_capacity: 128,
+            slow_query_threshold_ms: 0,
+            query_preview: false,
+        }
+    }
+}
+
+// ── bounded labels ───────────────────────────────────────────────────────────
+// Only ever label by these bounded sets — never by raw query text, role,
+// tenant, schema, or user (those are unbounded and would explode series count).
+
+const QUERY_TYPES: [&str; 8] = [
+    "read",
+    "ddl",
+    "update",
+    "delete",
+    "call",
+    "procedure",
+    "bolt",
+    "other",
+];
+
+fn query_type_index(t: &str) -> usize {
+    QUERY_TYPES
+        .iter()
+        .position(|&q| q == t)
+        .unwrap_or(QUERY_TYPES.len() - 1) // "other"
+}
+
+/// Coarse classification of a failed query, used as a bounded Prometheus label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ErrorClass {
+    BadRequest,
+    NotFound,
+    Capacity,
+    Exec,
+    Internal,
+}
+
+const ERROR_CLASSES: [&str; 5] = ["bad_request", "not_found", "capacity", "exec", "internal"];
+
+impl ErrorClass {
+    fn index(self) -> usize {
+        match self {
+            ErrorClass::BadRequest => 0,
+            ErrorClass::NotFound => 1,
+            ErrorClass::Capacity => 2,
+            ErrorClass::Exec => 3,
+            ErrorClass::Internal => 4,
+        }
+    }
+
+    /// Map an HTTP status code to an error class (for the outer handler arm).
+    pub fn from_status(code: u16) -> Self {
+        match code {
+            400 | 422 => ErrorClass::BadRequest,
+            404 => ErrorClass::NotFound,
+            429 | 503 => ErrorClass::Capacity,
+            500 => ErrorClass::Internal,
+            _ => ErrorClass::Exec,
+        }
+    }
+}
+
+/// Outcome of a recorded query.
+#[derive(Clone, Copy, Debug)]
+pub enum Outcome {
+    Ok,
+    Err(ErrorClass),
+}
+
+// ── ClickHouse-side execution stats ──────────────────────────────────────────
+
+/// Execution stats captured from the ClickHouse side for one query. `Phase A`
+/// fills `network_bytes` from the response cursor (always available in remote
+/// mode); `Phase B` (gated) fills the `read_*`/`elapsed` fields from the
+/// `X-ClickHouse-Summary` header.
+#[derive(Clone, Debug, Default)]
+pub struct ChExecStats {
+    pub network_bytes: u64,
+    pub read_rows: Option<u64>,
+    pub read_bytes: Option<u64>,
+    pub elapsed_ns: Option<u64>,
+}
+
+tokio::task_local! {
+    /// Per-query slot the executor writes ClickHouse stats into and the
+    /// recording point reads. Scoped by the query handlers via
+    /// [`with_ch_stats`]; absent in embedded/Databricks modes.
+    static CH_STATS_SLOT: std::cell::RefCell<ChExecStats>;
+}
+
+/// Run `f` with a fresh ClickHouse-stats slot in scope. `record_ch_*` calls
+/// from `remote.rs` during `f` land in the slot, and [`current_ch_stats`] reads
+/// it at the recording point (which runs inside the same scope). No-op effect
+/// in embedded/Databricks modes where nothing writes the slot.
+pub async fn with_ch_stats_scope<F, T>(f: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CH_STATS_SLOT
+        .scope(std::cell::RefCell::new(ChExecStats::default()), f)
+        .await
+}
+
+/// Read the ClickHouse stats accumulated for the current query, or `None` when
+/// not inside a [`with_ch_stats_scope`] (e.g. embedded/Databricks, or a code
+/// path that doesn't wrap execution).
+pub fn current_ch_stats() -> Option<ChExecStats> {
+    CH_STATS_SLOT.try_with(|s| s.borrow().clone()).ok()
+}
+
+/// Record bytes transferred for the current query (Phase A). No-op outside a
+/// [`with_ch_stats_scope`] scope.
+pub fn record_ch_network_bytes(bytes: u64) {
+    let _ = CH_STATS_SLOT.try_with(|s| s.borrow_mut().network_bytes += bytes);
+}
+
+/// Record the parsed `X-ClickHouse-Summary` figures for the current query
+/// (Phase B). No-op outside a [`with_ch_stats`] scope.
+pub fn record_ch_summary(read_rows: u64, read_bytes: u64, elapsed_ns: u64) {
+    let _ = CH_STATS_SLOT.try_with(|s| {
+        let mut st = s.borrow_mut();
+        st.read_rows = Some(read_rows);
+        st.read_bytes = Some(read_bytes);
+        st.elapsed_ns = Some(elapsed_ns);
+    });
+}
+
+// ── latency histogram ────────────────────────────────────────────────────────
+
+/// Fixed upper bounds in seconds; an implicit `+Inf` bucket follows.
+const BUCKET_BOUNDS: [f64; 12] = [
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+const N_BUCKETS: usize = BUCKET_BOUNDS.len() + 1; // + +Inf
+
+/// A cumulative latency histogram over [`BUCKET_BOUNDS`].
+struct LatencyHistogram {
+    /// Per-bucket counts (NOT cumulative); index `BUCKET_BOUNDS.len()` is +Inf.
+    buckets: [AtomicU64; N_BUCKETS],
+    sum_micros: AtomicU64,
+    count: AtomicU64,
+}
+
+impl LatencyHistogram {
+    fn new() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            sum_micros: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    fn observe(&self, secs: f64) {
+        let idx = BUCKET_BOUNDS
+            .iter()
+            .position(|&b| secs <= b)
+            .unwrap_or(N_BUCKETS - 1);
+        self.buckets[idx].fetch_add(1, Ordering::Relaxed);
+        self.sum_micros
+            .fetch_add((secs * 1_000_000.0) as u64, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> HistogramSnapshot {
+        let counts: [u64; N_BUCKETS] =
+            std::array::from_fn(|i| self.buckets[i].load(Ordering::Relaxed));
+        HistogramSnapshot {
+            counts,
+            sum_micros: self.sum_micros.load(Ordering::Relaxed),
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct HistogramSnapshot {
+    counts: [u64; N_BUCKETS],
+    sum_micros: u64,
+    count: u64,
+}
+
+impl HistogramSnapshot {
+    /// Bucket-approximate quantile in milliseconds: the upper bound of the
+    /// bucket where the cumulative count first crosses `q`.
+    fn percentile_ms(&self, q: f64) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        let target = (q * self.count as f64).ceil() as u64;
+        let mut cumulative = 0u64;
+        for (i, &c) in self.counts.iter().enumerate() {
+            cumulative += c;
+            if cumulative >= target {
+                // +Inf bucket → report the last finite bound as the floor.
+                let bound = BUCKET_BOUNDS.get(i).copied().unwrap_or(f64::INFINITY);
+                return if bound.is_finite() {
+                    bound * 1000.0
+                } else {
+                    BUCKET_BOUNDS[BUCKET_BOUNDS.len() - 1] * 1000.0
+                };
+            }
+        }
+        BUCKET_BOUNDS[BUCKET_BOUNDS.len() - 1] * 1000.0
+    }
+
+    fn mean_ms(&self) -> f64 {
+        if self.count == 0 {
+            0.0
+        } else {
+            (self.sum_micros as f64 / self.count as f64) / 1000.0
+        }
+    }
+}
+
+/// The six query phases tracked as histograms. `total` and `exec` are recorded
+/// for every query; the rest are HTTP-only (the Bolt path lacks per-phase
+/// timers).
+const PHASES: [&str; 6] = ["total", "parse", "plan", "render", "sqlgen", "exec"];
+
+// ── slow-query ring buffer ───────────────────────────────────────────────────
+
+/// One entry in the slow-query ring. `query_preview` is JSON-only (never a
+/// Prometheus label) and present only when `query_preview` config is on.
+#[derive(Clone, Debug, Serialize)]
+pub struct SlowQueryRecord {
+    pub timestamp_ms: u64,
+    pub query_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_preview: Option<String>,
+    pub total_ms: f64,
+    pub exec_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_rows: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ch_read_rows: Option<u64>,
+    pub outcome: &'static str,
+}
+
+struct SlowQueryRing {
+    buf: VecDeque<SlowQueryRecord>,
+    cap: usize,
+}
+
+impl SlowQueryRing {
+    fn new(cap: usize) -> Self {
+        Self {
+            buf: VecDeque::with_capacity(cap.min(1024)),
+            cap: cap.max(1),
+        }
+    }
+
+    fn push(&mut self, rec: SlowQueryRecord) {
+        if self.buf.len() >= self.cap {
+            self.buf.pop_front();
+        }
+        self.buf.push_back(rec);
+    }
+
+    /// Most recent `n`, newest first.
+    fn recent(&self, n: usize) -> Vec<SlowQueryRecord> {
+        self.buf.iter().rev().take(n).cloned().collect()
+    }
+
+    /// Top `n` by `total_ms`, slowest first.
+    fn slowest(&self, n: usize) -> Vec<SlowQueryRecord> {
+        let mut v: Vec<SlowQueryRecord> = self.buf.iter().cloned().collect();
+        v.sort_by(|a, b| {
+            b.total_ms
+                .partial_cmp(&a.total_ms)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        v.truncate(n);
+        v
+    }
+}
+
+// ── the registry ─────────────────────────────────────────────────────────────
+
+/// A single query observation handed to [`ServerMetrics::record_query`].
+pub struct QuerySample<'a> {
+    pub metrics: &'a QueryPerformanceMetrics,
+    pub outcome: Outcome,
+    /// HTTP samples carry full per-phase timings; Bolt samples carry only
+    /// `total`/`exec`, so the other phase histograms are skipped for them.
+    pub has_phase_breakdown: bool,
+    /// Raw Cypher, used only for the (config-gated, truncated) ring preview.
+    pub query_text: Option<&'a str>,
+    pub ch: Option<ChExecStats>,
+}
+
+/// RAII guard that increments the in-flight gauge on creation and decrements on
+/// drop — robust against the query handler's many early returns and panics.
+pub struct InFlightGuard<'a>(&'a AtomicI64);
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Aggregate server metrics registry. Held behind a global `OnceCell`.
+pub struct ServerMetrics {
+    start_time: Instant,
+    cfg: MetricsConfig,
+
+    queries_total: AtomicU64,
+    queries_failed: AtomicU64,
+    result_rows_total: AtomicU64,
+    in_flight: AtomicI64,
+    by_type: [AtomicU64; QUERY_TYPES.len()],
+    errors_by_class: [AtomicU64; ERROR_CLASSES.len()],
+
+    histograms: [LatencyHistogram; PHASES.len()],
+
+    ch_network_bytes: AtomicU64,
+    ch_read_rows: AtomicU64,
+    ch_read_bytes: AtomicU64,
+
+    slow_queries: Mutex<SlowQueryRing>,
+}
+
+impl ServerMetrics {
+    pub fn new(cfg: MetricsConfig) -> Self {
+        let cap = cfg.slow_query_capacity;
+        Self {
+            start_time: Instant::now(),
+            cfg,
+            queries_total: AtomicU64::new(0),
+            queries_failed: AtomicU64::new(0),
+            result_rows_total: AtomicU64::new(0),
+            in_flight: AtomicI64::new(0),
+            by_type: std::array::from_fn(|_| AtomicU64::new(0)),
+            errors_by_class: std::array::from_fn(|_| AtomicU64::new(0)),
+            histograms: std::array::from_fn(|_| LatencyHistogram::new()),
+            ch_network_bytes: AtomicU64::new(0),
+            ch_read_rows: AtomicU64::new(0),
+            ch_read_bytes: AtomicU64::new(0),
+            slow_queries: Mutex::new(SlowQueryRing::new(cap)),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.cfg.enabled
+    }
+
+    /// Increment in-flight; the returned guard decrements on drop.
+    pub fn in_flight_guard(&self) -> InFlightGuard<'_> {
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
+        InFlightGuard(&self.in_flight)
+    }
+
+    /// Record a single error by class without phase timings — for early-return
+    /// paths (e.g. capacity reject, parse failure) that never built a full
+    /// `QueryPerformanceMetrics`.
+    pub fn record_error(&self, class: ErrorClass) {
+        if !self.cfg.enabled {
+            return;
+        }
+        self.queries_total.fetch_add(1, Ordering::Relaxed);
+        self.queries_failed.fetch_add(1, Ordering::Relaxed);
+        self.errors_by_class[class.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a completed query (the single recording entry point).
+    pub fn record_query(&self, sample: &QuerySample) {
+        if !self.cfg.enabled {
+            return;
+        }
+        let m = sample.metrics;
+        self.queries_total.fetch_add(1, Ordering::Relaxed);
+        self.by_type[query_type_index(&m.query_type)].fetch_add(1, Ordering::Relaxed);
+        if let Some(rows) = m.result_rows {
+            self.result_rows_total
+                .fetch_add(rows as u64, Ordering::Relaxed);
+        }
+        if let Outcome::Err(class) = sample.outcome {
+            self.queries_failed.fetch_add(1, Ordering::Relaxed);
+            self.errors_by_class[class.index()].fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Histograms: total + exec always; the rest only for HTTP samples.
+        self.histograms[0].observe(m.total_time);
+        self.histograms[5].observe(m.execution_time);
+        if sample.has_phase_breakdown {
+            self.histograms[1].observe(m.parse_time);
+            self.histograms[2].observe(m.planning_time);
+            self.histograms[3].observe(m.render_time);
+            self.histograms[4].observe(m.sql_generation_time);
+        }
+
+        if let Some(ch) = &sample.ch {
+            self.ch_network_bytes
+                .fetch_add(ch.network_bytes, Ordering::Relaxed);
+            if let Some(r) = ch.read_rows {
+                self.ch_read_rows.fetch_add(r, Ordering::Relaxed);
+            }
+            if let Some(b) = ch.read_bytes {
+                self.ch_read_bytes.fetch_add(b, Ordering::Relaxed);
+            }
+        }
+
+        // Slow-query ring (off the counter hot path).
+        let total_ms = m.total_time * 1000.0;
+        if total_ms >= self.cfg.slow_query_threshold_ms as f64 {
+            let rec = SlowQueryRecord {
+                timestamp_ms: now_ms(),
+                query_type: m.query_type.clone(),
+                query_preview: if self.cfg.query_preview {
+                    sample
+                        .query_text
+                        .map(|q| q.chars().take(120).collect::<String>())
+                } else {
+                    None
+                },
+                total_ms,
+                exec_ms: m.execution_time * 1000.0,
+                result_rows: m.result_rows,
+                ch_read_rows: sample.ch.as_ref().and_then(|c| c.read_rows),
+                outcome: match sample.outcome {
+                    Outcome::Ok => "ok",
+                    Outcome::Err(c) => ERROR_CLASSES[c.index()],
+                },
+            };
+            if let Ok(mut ring) = self.slow_queries.lock() {
+                ring.push(rec);
+            }
+        }
+    }
+
+    pub fn recent_queries(&self, n: usize) -> Vec<SlowQueryRecord> {
+        self.slow_queries
+            .lock()
+            .map(|r| r.recent(n))
+            .unwrap_or_default()
+    }
+
+    pub fn slowest_queries(&self, n: usize) -> Vec<SlowQueryRecord> {
+        self.slow_queries
+            .lock()
+            .map(|r| r.slowest(n))
+            .unwrap_or_default()
+    }
+
+    pub fn uptime_secs(&self) -> u64 {
+        self.start_time.elapsed().as_secs()
+    }
+
+    pub fn in_flight(&self) -> i64 {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// JSON snapshot for `/stats` (counters, latency percentiles, CH stats).
+    /// Cache and pool stats are attached by the handler from their own sources.
+    pub fn snapshot(&self) -> StatsSnapshot {
+        let phases = std::array::from_fn::<PhaseLatency, { PHASES.len() }, _>(|i| {
+            let s = self.histograms[i].snapshot();
+            PhaseLatency {
+                phase: PHASES[i],
+                count: s.count,
+                mean_ms: s.mean_ms(),
+                p50_ms: s.percentile_ms(0.50),
+                p95_ms: s.percentile_ms(0.95),
+                p99_ms: s.percentile_ms(0.99),
+            }
+        });
+        let by_type = QUERY_TYPES
+            .iter()
+            .enumerate()
+            .map(|(i, &t)| (t.to_string(), self.by_type[i].load(Ordering::Relaxed)))
+            .collect();
+        let errors_by_class = ERROR_CLASSES
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| {
+                (
+                    c.to_string(),
+                    self.errors_by_class[i].load(Ordering::Relaxed),
+                )
+            })
+            .collect();
+        StatsSnapshot {
+            uptime_secs: self.uptime_secs(),
+            queries_total: self.queries_total.load(Ordering::Relaxed),
+            queries_failed: self.queries_failed.load(Ordering::Relaxed),
+            in_flight: self.in_flight(),
+            result_rows_total: self.result_rows_total.load(Ordering::Relaxed),
+            by_type,
+            errors_by_class,
+            latency: phases.to_vec(),
+            clickhouse: ChStatsSnapshot {
+                network_bytes: self.ch_network_bytes.load(Ordering::Relaxed),
+                read_rows: self.ch_read_rows.load(Ordering::Relaxed),
+                read_bytes: self.ch_read_bytes.load(Ordering::Relaxed),
+            },
+        }
+    }
+
+    /// Render the registry's metrics in Prometheus exposition format. Cache and
+    /// pool gauges are appended by the handler.
+    pub fn render_prometheus(&self, out: &mut String) {
+        use std::fmt::Write;
+
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_queries_total Total queries recorded."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_queries_total counter");
+        let _ = writeln!(
+            out,
+            "clickgraph_queries_total {}",
+            self.queries_total.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_queries_failed_total Failed queries."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_queries_failed_total counter");
+        let _ = writeln!(
+            out,
+            "clickgraph_queries_failed_total {}",
+            self.queries_failed.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_queries_by_type_total Queries by type."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_queries_by_type_total counter");
+        for (i, &t) in QUERY_TYPES.iter().enumerate() {
+            let _ = writeln!(
+                out,
+                "clickgraph_queries_by_type_total{{type=\"{t}\"}} {}",
+                self.by_type[i].load(Ordering::Relaxed)
+            );
+        }
+
+        let _ = writeln!(out, "# HELP clickgraph_query_errors_total Errors by class.");
+        let _ = writeln!(out, "# TYPE clickgraph_query_errors_total counter");
+        for (i, &c) in ERROR_CLASSES.iter().enumerate() {
+            let _ = writeln!(
+                out,
+                "clickgraph_query_errors_total{{class=\"{c}\"}} {}",
+                self.errors_by_class[i].load(Ordering::Relaxed)
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_in_flight_queries Queries currently executing."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_in_flight_queries gauge");
+        let _ = writeln!(out, "clickgraph_in_flight_queries {}", self.in_flight());
+
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_result_rows_total Result rows returned."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_result_rows_total counter");
+        let _ = writeln!(
+            out,
+            "clickgraph_result_rows_total {}",
+            self.result_rows_total.load(Ordering::Relaxed)
+        );
+
+        // Per-phase latency histograms.
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_query_duration_seconds Query phase latency."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_query_duration_seconds histogram");
+        for (i, &phase) in PHASES.iter().enumerate() {
+            let s = self.histograms[i].snapshot();
+            let mut cumulative = 0u64;
+            for (b, &bound) in BUCKET_BOUNDS.iter().enumerate() {
+                cumulative += s.counts[b];
+                let _ = writeln!(
+                    out,
+                    "clickgraph_query_duration_seconds_bucket{{phase=\"{phase}\",le=\"{bound}\"}} {cumulative}"
+                );
+            }
+            cumulative += s.counts[N_BUCKETS - 1];
+            let _ = writeln!(
+                out,
+                "clickgraph_query_duration_seconds_bucket{{phase=\"{phase}\",le=\"+Inf\"}} {cumulative}"
+            );
+            let _ = writeln!(
+                out,
+                "clickgraph_query_duration_seconds_sum{{phase=\"{phase}\"}} {}",
+                s.sum_micros as f64 / 1_000_000.0
+            );
+            let _ = writeln!(
+                out,
+                "clickgraph_query_duration_seconds_count{{phase=\"{phase}\"}} {}",
+                s.count
+            );
+        }
+
+        // ClickHouse-side counters.
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_clickhouse_network_bytes_total Bytes transferred from ClickHouse."
+        );
+        let _ = writeln!(
+            out,
+            "# TYPE clickgraph_clickhouse_network_bytes_total counter"
+        );
+        let _ = writeln!(
+            out,
+            "clickgraph_clickhouse_network_bytes_total {}",
+            self.ch_network_bytes.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_clickhouse_read_rows_total Rows read by ClickHouse (summary)."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_clickhouse_read_rows_total counter");
+        let _ = writeln!(
+            out,
+            "clickgraph_clickhouse_read_rows_total {}",
+            self.ch_read_rows.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(
+            out,
+            "# HELP clickgraph_clickhouse_read_bytes_total Bytes read by ClickHouse (summary)."
+        );
+        let _ = writeln!(out, "# TYPE clickgraph_clickhouse_read_bytes_total counter");
+        let _ = writeln!(
+            out,
+            "clickgraph_clickhouse_read_bytes_total {}",
+            self.ch_read_bytes.load(Ordering::Relaxed)
+        );
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+// ── JSON snapshot types (`/stats`) ───────────────────────────────────────────
+
+#[derive(Serialize, Clone)]
+pub struct PhaseLatency {
+    pub phase: &'static str,
+    pub count: u64,
+    pub mean_ms: f64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+}
+
+#[derive(Serialize)]
+pub struct ChStatsSnapshot {
+    pub network_bytes: u64,
+    pub read_rows: u64,
+    pub read_bytes: u64,
+}
+
+#[derive(Serialize)]
+pub struct StatsSnapshot {
+    pub uptime_secs: u64,
+    pub queries_total: u64,
+    pub queries_failed: u64,
+    pub in_flight: i64,
+    pub result_rows_total: u64,
+    pub by_type: std::collections::BTreeMap<String, u64>,
+    pub errors_by_class: std::collections::BTreeMap<String, u64>,
+    pub latency: Vec<PhaseLatency>,
+    pub clickhouse: ChStatsSnapshot,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn http_metrics(query_type: &str, total: f64, rows: usize) -> QueryPerformanceMetrics {
+        QueryPerformanceMetrics {
+            total_time: total,
+            parse_time: total * 0.1,
+            planning_time: total * 0.2,
+            render_time: total * 0.05,
+            sql_generation_time: total * 0.05,
+            execution_time: total * 0.6,
+            query_type: query_type.to_string(),
+            sql_queries_count: 1,
+            result_rows: Some(rows),
+        }
+    }
+
+    fn sample<'a>(m: &'a QueryPerformanceMetrics, outcome: Outcome) -> QuerySample<'a> {
+        QuerySample {
+            metrics: m,
+            outcome,
+            has_phase_breakdown: true,
+            query_text: None,
+            ch: None,
+        }
+    }
+
+    #[test]
+    fn counters_and_by_type() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        let m = http_metrics("read", 0.01, 5);
+        sm.record_query(&sample(&m, Outcome::Ok));
+        sm.record_query(&sample(&m, Outcome::Ok));
+        let mw = http_metrics("update", 0.02, 0);
+        sm.record_query(&sample(&mw, Outcome::Err(ErrorClass::Exec)));
+
+        let snap = sm.snapshot();
+        assert_eq!(snap.queries_total, 3);
+        assert_eq!(snap.queries_failed, 1);
+        assert_eq!(snap.result_rows_total, 10);
+        assert_eq!(snap.by_type["read"], 2);
+        assert_eq!(snap.by_type["update"], 1);
+        assert_eq!(snap.errors_by_class["exec"], 1);
+    }
+
+    #[test]
+    fn record_error_no_phase() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        sm.record_error(ErrorClass::Capacity);
+        let snap = sm.snapshot();
+        assert_eq!(snap.queries_total, 1);
+        assert_eq!(snap.queries_failed, 1);
+        assert_eq!(snap.errors_by_class["capacity"], 1);
+        // No latency observed.
+        assert_eq!(snap.latency[0].count, 0);
+    }
+
+    #[test]
+    fn disabled_records_nothing() {
+        let cfg = MetricsConfig {
+            enabled: false,
+            ..MetricsConfig::default()
+        };
+        let sm = ServerMetrics::new(cfg);
+        let m = http_metrics("read", 0.01, 5);
+        sm.record_query(&sample(&m, Outcome::Ok));
+        sm.record_error(ErrorClass::Exec);
+        assert_eq!(sm.snapshot().queries_total, 0);
+    }
+
+    #[test]
+    fn in_flight_guard_balances() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        assert_eq!(sm.in_flight(), 0);
+        {
+            let _g1 = sm.in_flight_guard();
+            let _g2 = sm.in_flight_guard();
+            assert_eq!(sm.in_flight(), 2);
+        }
+        assert_eq!(sm.in_flight(), 0);
+    }
+
+    #[test]
+    fn in_flight_guard_drops_on_panic() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = sm.in_flight_guard();
+            assert_eq!(sm.in_flight(), 1);
+            panic!("boom");
+        }));
+        assert_eq!(sm.in_flight(), 0);
+    }
+
+    #[test]
+    fn histogram_percentiles_in_range() {
+        let h = LatencyHistogram::new();
+        // 99 fast (~5ms) + 1 slow (~3s).
+        for _ in 0..99 {
+            h.observe(0.005);
+        }
+        h.observe(3.0);
+        let s = h.snapshot();
+        assert_eq!(s.count, 100);
+        // p50 should land in an early (<=25ms) bucket.
+        assert!(
+            s.percentile_ms(0.50) <= 25.0,
+            "p50={}",
+            s.percentile_ms(0.50)
+        );
+        // p99/p100 should reflect the slow outlier (>1s bucket).
+        assert!(s.percentile_ms(0.99) >= 5.0);
+    }
+
+    #[test]
+    fn bolt_sample_skips_phase_histograms() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        let m = QueryPerformanceMetrics {
+            total_time: 0.02,
+            execution_time: 0.02,
+            query_type: "bolt".to_string(),
+            ..QueryPerformanceMetrics::default()
+        };
+        sm.record_query(&QuerySample {
+            metrics: &m,
+            outcome: Outcome::Ok,
+            has_phase_breakdown: false,
+            query_text: None,
+            ch: None,
+        });
+        let snap = sm.snapshot();
+        assert_eq!(snap.latency[0].count, 1); // total observed
+        assert_eq!(snap.latency[5].count, 1); // exec observed
+        assert_eq!(snap.latency[1].count, 0); // parse NOT observed
+    }
+
+    #[test]
+    fn ring_buffer_evicts_and_sorts() {
+        let cfg = MetricsConfig {
+            slow_query_capacity: 3,
+            ..MetricsConfig::default()
+        };
+        let sm = ServerMetrics::new(cfg);
+        for (i, t) in [0.01, 0.05, 0.02, 0.10, 0.03].iter().enumerate() {
+            let m = http_metrics("read", *t, i);
+            sm.record_query(&sample(&m, Outcome::Ok));
+        }
+        // cap=3 → only the last 3 retained.
+        let recent = sm.recent_queries(10);
+        assert_eq!(recent.len(), 3);
+        // recent is newest-first: last pushed was 0.03 (30ms).
+        assert!((recent[0].total_ms - 30.0).abs() < 0.01);
+        // slowest of the retained {0.02,0.10,0.03} is 0.10 (100ms).
+        let slowest = sm.slowest_queries(1);
+        assert!((slowest[0].total_ms - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn prometheus_render_shape() {
+        let sm = ServerMetrics::new(MetricsConfig::default());
+        let m = http_metrics("read", 0.01, 5);
+        sm.record_query(&sample(&m, Outcome::Ok));
+        let mut out = String::new();
+        sm.render_prometheus(&mut out);
+        assert!(out.contains("clickgraph_queries_total 1"));
+        assert!(out.contains("clickgraph_queries_by_type_total{type=\"read\"} 1"));
+        assert!(
+            out.contains("clickgraph_query_duration_seconds_bucket{phase=\"total\",le=\"+Inf\"} 1")
+        );
+        assert!(out.contains("clickgraph_query_duration_seconds_count{phase=\"total\"} 1"));
+        // Every non-comment, non-empty line must be `name value` or
+        // `name{labels} value`.
+        for line in out.lines() {
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let value = line.rsplit(' ').next().unwrap();
+            assert!(
+                value.parse::<f64>().is_ok(),
+                "non-numeric metric value in line: {line}"
+            );
+        }
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -27,6 +27,7 @@ use crate::config::ServerConfig;
 use crate::executor::{remote::RemoteClickHouseExecutor, QueryExecutor};
 use crate::graph_catalog::graph_schema::GraphSchema;
 use bolt_protocol::{BoltConfig, BoltServer};
+use connection_pool::RoleConnectionPool;
 
 pub mod bolt_protocol;
 mod clickhouse_client;
@@ -34,6 +35,7 @@ pub mod connection_pool;
 pub mod graph_catalog;
 pub mod graph_output;
 pub mod handlers;
+pub mod metrics;
 pub mod models;
 mod parameter_substitution;
 mod query_cache;
@@ -50,6 +52,9 @@ pub struct AppState {
     /// Semaphore limiting concurrent query processing.
     /// `None` when max_concurrent_queries = 0 (unlimited).
     pub query_semaphore: Option<Arc<Semaphore>>,
+    /// Remote ClickHouse connection pool, exposed so `/stats` and `/metrics`
+    /// can report pool stats. `None` in embedded / Databricks modes.
+    pub pool: Option<Arc<RoleConnectionPool>>,
 }
 
 // ==================================================================================
@@ -77,6 +82,10 @@ pub static GLOBAL_SCHEMA_CONFIGS: OnceCell<
 
 // Query cache for SQL templates
 pub static GLOBAL_QUERY_CACHE: OnceCell<query_cache::QueryCache> = OnceCell::const_new();
+
+// Observability registry (aggregate counters, latency histograms, slow-query
+// ring). Initialized once in `run_server` before the listener binds.
+pub static GLOBAL_SERVER_METRICS: OnceCell<Arc<metrics::ServerMetrics>> = OnceCell::const_new();
 
 pub async fn run() {
     dotenv().ok();
@@ -149,6 +158,7 @@ pub async fn run_with_config(config: ServerConfig) {
             clickhouse_client: None,
             query_semaphore: make_query_semaphore(&config),
             config: config.clone(),
+            pool: None,
         };
 
         // Initialize query cache
@@ -231,6 +241,7 @@ pub async fn run_with_config(config: ServerConfig) {
             clickhouse_client: None,
             query_semaphore: make_query_semaphore(&config),
             config: config.clone(),
+            pool: None,
         };
 
         let cache_config = query_cache::QueryCacheConfig::from_env();
@@ -279,6 +290,7 @@ pub async fn run_with_config(config: ServerConfig) {
             clickhouse_client: client_opt.clone(),
             query_semaphore: query_semaphore.clone(),
             config: config.clone(),
+            pool: Some(connection_pool.clone()),
         }
     } else {
         // For YAML-only mode, we need a placeholder client
@@ -295,6 +307,7 @@ pub async fn run_with_config(config: ServerConfig) {
             clickhouse_client: None,
             query_semaphore,
             config: config.clone(),
+            pool: Some(connection_pool.clone()),
         }
     };
 
@@ -340,11 +353,11 @@ fn make_query_semaphore(config: &ServerConfig) -> Option<Arc<Semaphore>> {
     }
 }
 
-/// Bind and serve HTTP (and optionally Bolt) using the given `app_state`.
-async fn run_server(app_state: AppState, config: ServerConfig) {
-    let http_bind_address = format!("{}:{}", config.http_host, config.http_port);
-    log::info!("Starting HTTP server on {}", http_bind_address);
-
+/// Build the fully-layered HTTP router for the given state and config.
+///
+/// Extracted from `run_server` so it can be exercised directly in tests via
+/// `tower::ServiceExt::oneshot` without binding a real listener.
+pub fn build_router(app_state: AppState, config: &ServerConfig) -> Router {
     let mut app = Router::new()
         .route("/health", get(health_check))
         .route("/query", post(query_handler))
@@ -355,7 +368,11 @@ async fn run_server(app_state: AppState, config: ServerConfig) {
         .route("/schemas/introspect", post(introspect_handler))
         .route("/schemas/discover-prompt", post(discover_prompt_handler))
         .route("/schemas/draft", post(draft_handler))
-        .with_state(Arc::new(app_state.clone()))
+        // Observability / stats / performance monitoring
+        .route("/metrics", get(handlers::metrics_handler))
+        .route("/stats", get(handlers::stats_handler))
+        .route("/stats/queries", get(handlers::stats_queries_handler))
+        .with_state(Arc::new(app_state))
         // Body size limit (default 1 MB, configurable via CLICKGRAPH_MAX_REQUEST_BODY_BYTES)
         .layer(DefaultBodyLimit::max(config.max_request_body_bytes))
         // Catch panics in handlers — return 500 instead of dropping the connection
@@ -367,6 +384,28 @@ async fn run_server(app_state: AppState, config: ServerConfig) {
             StatusCode::REQUEST_TIMEOUT,
             Duration::from_secs(config.query_timeout_secs),
         ));
+    }
+    app
+}
+
+/// Bind and serve HTTP (and optionally Bolt) using the given `app_state`.
+async fn run_server(app_state: AppState, config: ServerConfig) {
+    let http_bind_address = format!("{}:{}", config.http_host, config.http_port);
+    log::info!("Starting HTTP server on {}", http_bind_address);
+
+    // Initialize the observability registry once, before binding the listener
+    // (same ordering guarantee as GLOBAL_QUERY_CACHE).
+    let metrics_cfg = metrics::MetricsConfig {
+        enabled: config.metrics_enabled,
+        slow_query_capacity: config.slow_query_capacity,
+        slow_query_threshold_ms: config.slow_query_threshold_ms,
+        query_preview: config.metrics_query_preview,
+    };
+    let _ = GLOBAL_SERVER_METRICS.set(Arc::new(metrics::ServerMetrics::new(metrics_cfg)));
+
+    let app = build_router(app_state.clone(), &config);
+
+    if config.query_timeout_secs > 0 {
         log::info!("HTTP request timeout: {}s", config.query_timeout_secs);
     }
 

--- a/tests/rust/integration/metrics_endpoint_tests.rs
+++ b/tests/rust/integration/metrics_endpoint_tests.rs
@@ -1,0 +1,174 @@
+//! Integration tests for the observability endpoints (`/metrics`, `/stats`,
+//! `/stats/queries`). Drives the real router via `tower::ServiceExt::oneshot`
+//! with a stub executor — no ClickHouse or live listener required.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt; // for `oneshot`
+
+use clickgraph::config::ServerConfig;
+use clickgraph::executor::{ExecutorError, QueryExecutor};
+use clickgraph::server::metrics::{ErrorClass, MetricsConfig, Outcome, QuerySample, ServerMetrics};
+use clickgraph::server::{build_router, AppState, GLOBAL_SERVER_METRICS};
+
+/// Minimal executor — the observability endpoints never invoke it.
+struct StubExecutor;
+
+#[async_trait]
+impl QueryExecutor for StubExecutor {
+    async fn execute_json(
+        &self,
+        _sql: &str,
+        _role: Option<&str>,
+    ) -> Result<Vec<Value>, ExecutorError> {
+        Ok(vec![])
+    }
+    async fn execute_text(
+        &self,
+        _sql: &str,
+        _format: &str,
+        _role: Option<&str>,
+    ) -> Result<String, ExecutorError> {
+        Ok(String::new())
+    }
+}
+
+fn test_state() -> AppState {
+    AppState {
+        executor: Arc::new(StubExecutor),
+        clickhouse_client: None,
+        config: ServerConfig::default(),
+        query_semaphore: None,
+        pool: None,
+    }
+}
+
+/// Ensure the global registry is initialized (idempotent across the shared test
+/// binary). Returns a handle for direct recording.
+fn ensure_metrics() -> &'static Arc<ServerMetrics> {
+    let _ = GLOBAL_SERVER_METRICS.set(Arc::new(ServerMetrics::new(MetricsConfig::default())));
+    GLOBAL_SERVER_METRICS.get().expect("metrics initialized")
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8(bytes.to_vec()).expect("utf8")
+}
+
+#[tokio::test]
+async fn metrics_endpoint_serves_prometheus() {
+    let reg = ensure_metrics();
+    // Record a query so the counters are non-trivial.
+    let m = clickgraph::server::handlers::QueryPerformanceMetrics {
+        total_time: 0.012,
+        execution_time: 0.008,
+        query_type: "read".to_string(),
+        result_rows: Some(3),
+        ..clickgraph::server::handlers::QueryPerformanceMetrics::default()
+    };
+    reg.record_query(&QuerySample {
+        metrics: &m,
+        outcome: Outcome::Ok,
+        has_phase_breakdown: true,
+        query_text: Some("MATCH (n) RETURN n"),
+        ch: None,
+    });
+
+    let app = build_router(test_state(), &ServerConfig::default());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ct = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.starts_with("text/plain"), "content-type was {ct}");
+
+    let body = body_string(resp).await;
+    assert!(body.contains("clickgraph_queries_total"));
+    assert!(body.contains("clickgraph_query_duration_seconds_bucket{phase=\"total\""));
+    assert!(body.contains("clickgraph_queries_by_type_total{type=\"read\"}"));
+
+    // Every non-comment, non-blank line is a valid `name <value>` exposition.
+    for line in body.lines() {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let value = line.rsplit(' ').next().unwrap();
+        assert!(value.parse::<f64>().is_ok(), "bad metric line: {line}");
+    }
+}
+
+#[tokio::test]
+async fn stats_endpoint_serves_json() {
+    ensure_metrics();
+    let app = build_router(test_state(), &ServerConfig::default());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+    let json: Value = serde_json::from_str(&body).expect("valid JSON");
+    assert_eq!(json["service"], "clickgraph");
+    assert!(json["version"].is_string());
+    assert!(json["metrics"]["uptime_secs"].is_u64());
+    assert!(json["metrics"]["queries_total"].is_u64());
+    assert!(json["metrics"]["latency"].is_array());
+}
+
+#[tokio::test]
+async fn stats_queries_endpoint_serves_ring() {
+    let reg = ensure_metrics();
+    let m = clickgraph::server::handlers::QueryPerformanceMetrics {
+        total_time: 0.5,
+        execution_time: 0.4,
+        query_type: "read".to_string(),
+        result_rows: Some(1),
+        ..clickgraph::server::handlers::QueryPerformanceMetrics::default()
+    };
+    reg.record_query(&QuerySample {
+        metrics: &m,
+        outcome: Outcome::Err(ErrorClass::Exec),
+        has_phase_breakdown: true,
+        query_text: None,
+        ch: None,
+    });
+
+    let app = build_router(test_state(), &ServerConfig::default());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/stats/queries?recent=5&slowest=5")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json: Value = serde_json::from_str(&body_string(resp).await).expect("valid JSON");
+    assert!(json["recent"].is_array());
+    assert!(json["slowest"].is_array());
+}

--- a/tests/rust/integration/mod.rs
+++ b/tests/rust/integration/mod.rs
@@ -9,6 +9,7 @@ mod complex_feature_tests;
 mod cross_schema_pattern_tests;
 mod cte_column_aliasing_tests;
 mod ldbc_regression_tests;
+mod metrics_endpoint_tests;
 mod parameter_function_test;
 mod path_variable_tests;
 mod skip_offset_tests;


### PR DESCRIPTION
## Summary

Adds an aggregate observability / stats / performance-monitoring surface to the HTTP + Bolt server. ClickGraph already measured per-query phase timings and had `CacheMetrics`/`PoolStats`, but nothing was aggregated or exposed — there was no scrapeable monitoring endpoint.

## New endpoints
Enabled by default (`404` when `CLICKGRAPH_METRICS_ENABLED=false`):

- **`GET /metrics`** — Prometheus exposition (`text/plain; version=0.0.4`): query counters (total / by type / errors by class), in-flight gauge, per-phase latency histograms (`total`/`parse`/`plan`/`render`/`sqlgen`/`exec`), result-row + ClickHouse byte counters, plus cache and connection-pool gauges. Labels are **bounded** (never raw query text / role / tenant → no cardinality blowup).
- **`GET /stats`** — JSON snapshot: uptime, counters, p50/p95/p99 latency per phase, cache hit-rate, pool stats (`null` in embedded/Databricks), ClickHouse transfer bytes.
- **`GET /stats/queries?recent&slowest`** — bounded slow-query ring buffer (recent + slowest), **including failed queries with latency**; optional truncated query preview behind `CLICKGRAPH_METRICS_QUERY_PREVIEW`.

## Implementation
- **`src/server/metrics.rs`** (new): hand-rolled `AtomicU64` counters + fixed-bucket histograms — **zero new dependencies** (mirrors the existing `CacheMetrics` atomics style; preserves the low-RSS profile). One `ServerMetrics` source of truth renders *both* Prometheus text and the JSON snapshot. RAII in-flight guard (leak-proof across the handler's ~30 early returns); `Mutex<VecDeque>` ring off the counter hot path.
- Recording wired at the HTTP finalization sites (full phase breakdown), the outer error arm (failures with total latency), the capacity reject, and the **Bolt** `handle_run` path (coarse total/exec).
- **ClickHouse stats Phase A**: `remote.rs` records bytes received per query via a task-local. **Phase B** (true `X-ClickHouse-Summary` via a gated reqwest path) is a documented follow-up — the `clickhouse` crate drops response headers, so it needs a bypass.
- `build_router` extracted from `run_server` for testability; `AppState` gains an optional pool handle for pool stats.
- Config: `CLICKGRAPH_METRICS_ENABLED` / `SLOW_QUERY_CAPACITY` / `SLOW_QUERY_THRESHOLD_MS` / `METRICS_CH_SUMMARY` / `METRICS_QUERY_PREVIEW`.

## Testing
- 9 registry unit tests: histogram percentiles, counters by type/outcome, in-flight guard (incl. panic via `catch_unwind`), ring eviction + slowest/recent, Prometheus output shape.
- 3 integration tests driving the **real router** via `tower::ServiceExt::oneshot` with a stub executor (no ClickHouse needed).
- Full lib suite green (1388 tests); `cargo clippy --all-targets` clean.
- **Verified end-to-end** against a live server: counters move, failures classed (`bad_request`/`internal`), ring populated with successes *and* failures, Prometheus content-type correct.

Docs: new Observability section in `docs/wiki/API-Reference-HTTP.md`.

## Follow-up (separate PR)
Phase B — true `X-ClickHouse-Summary` (`read_rows`/`read_bytes`/`elapsed`) behind `CLICKGRAPH_METRICS_CH_SUMMARY` (the flag + `record_ch_summary` API already exist as drop-in points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)