### PR TITLE
test(zeta-integration): VLP runs on Zeta end-to-end; track ZETA_FIDELITY

### DIFF
--- a/docs/deltagraph/ZETA_FIDELITY.md
+++ b/docs/deltagraph/ZETA_FIDELITY.md
@@ -1,0 +1,114 @@
+# DeltaGraph ↔ zeta-databricks: dialect fidelity boundary
+
+`zeta-databricks` (`zeta/crates/zeta-databricks-rest/`) is an axum server that
+implements the Databricks **Statement Execution API** (submit / poll / cancel,
+warehouse CRUD, catalog/schema discovery) on top of the Zeta SQL engine, so
+DeltaGraph can run end-to-end "as if" against a Databricks SQL Warehouse with
+no live workspace. It is the local stand-in for the *transport + executor*
+layer that the Spark/Delta docker container cannot exercise.
+
+This doc records **what zeta-databricks can validate vs. what it cannot**, so we
+don't mistake "zeta-databricks tests pass" for "Spark dialect validated." The
+two local environments are complementary, not interchangeable.
+
+Method: static analysis of the Zeta parser/planner/executor plus the actual
+Spark-dialect SQL emitted by `cg --dialect databricks sql` for the high-risk
+query shapes (flat join, aggregation, OPTIONAL MATCH, undirected VLP recursive
+CTE). Not yet confirmed by executing the VLP SQL against a running Zeta — the
+two gaps below are code-level absences, definitive enough to act on.
+
+## Three environments, three jobs
+
+| Concern | Spark/Delta docker | zeta-databricks REST | Live Databricks |
+|---|---|---|---|
+| Spark SQL dialect — flat / agg / string / OPTIONAL MATCH | ✅ | ✅ | ✅ |
+| Spark SQL dialect — **VLP / BFS** (`array_contains`, array `concat`, array CAST, lateral aliases / ORDER BY) | ✅ | ✅ (closed, see below) | ✅ |
+| Statement Execution REST transport, poll loop, executor wiring | ❌ | ✅ | ✅ |
+| Warehouse lifecycle, schema/catalog discovery | ❌ | ✅ (start/stop endpoints) | ✅ |
+| EXTERNAL_LINKS, OAuth M2M, real cold-start/auto-stop/429, perf | ❌ | ❌ | ✅ |
+
+## What zeta-databricks DOES validate (Spark dialect features Zeta accepts)
+
+Zeta is deliberately Spark-compatible, not just Postgres:
+
+- **Backtick-quoted identifiers** — `zeta/crates/zeta-parser/src/backtick_identifiers.rs`
+  rewrites Spark backticks (`` `friendId` ``) because sqlparser's
+  PostgreSqlDialect rejects them. DeltaGraph quotes every alias in backticks.
+- **`UNION DISTINCT`** — supported (`zeta-substrait` translate + `pg_regress_union` tests).
+- **`WITH RECURSIVE`** — CTE `recursive` flag + `RecursiveCte` logical plan.
+- **`collect_list()` / `collect_set()`** — mapped as Spark NULL-skipping aggregates
+  (`zeta-planner/src/planner.rs:4001`).
+- **`ARRAY<T>` angle-bracket casts** — `zeta-parser/src/datatype.rs` handles the
+  `AngleBracket` form (`CAST(array() AS ARRAY<STRING>)`).
+- **`array(...)` literal constructor** — `zeta-parser/src/convert.rs`.
+- **`||` array concatenation** — `zeta-planner/src/plan.rs:1217`.
+
+Combined with #1932 (alias preservation through OLAP routing, `schema`-field
+scoping, path-param routes), this means the **flat-join, aggregation, OPTIONAL
+MATCH, and string-function query families translate AND execute end-to-end
+through the real REST path** on zeta-databricks. That is the half the docker
+container cannot cover.
+
+## What zeta-databricks does NOT validate — two concrete Zeta gaps
+
+DeltaGraph's variable-length-path (VLP) and BFS shortestPath SQL depends on two
+array primitives Zeta does not implement:
+
+1. **`array_contains(path_nodes, end_node.id)`** — cycle detection in the
+   recursive step. **Absent from Zeta entirely** (`grep -rin array_contains`
+   over `zeta/` returns nothing).
+2. **`concat(path_nodes, array(end_node.id))`** — path extension. Zeta's
+   `CONCAT` (`zeta-server/src/lib.rs:64774`) is **string-only**: it stringifies
+   every argument and returns `Value::String`, so it does not array-concat the
+   way Spark's `concat` does. (Zeta does array-concat via `||`, but DeltaGraph
+   emits the `concat(...)` function form.)
+
+Original impact (historical): undirected/directed VLP (`*1..n`) and BFS
+shortestPath did not run on zeta-databricks. **This has since been closed** —
+see "VLP on Zeta — CLOSED" below; the four required Zeta features were added and
+VLP (including `ORDER BY`) now runs end-to-end through the REST path.
+
+## VLP on Zeta — CLOSED
+
+Four Zeta features were added so DeltaGraph's full variable-length-path SQL
+(including `ORDER BY`) executes end-to-end through the zeta-databricks REST path:
+
+- **`array_contains(arr, x)`** scalar builtin — eval in
+  `zeta/crates/zeta-server/src/lib.rs` (modeled on `ARRAY_POSITION`), return
+  type `Boolean` in `zeta/crates/zeta-planner/src/resolve.rs`. Spark NULL
+  semantics (NULL array → NULL; NULL search value → NULL; unprovable absence
+  via a NULL element → NULL).
+- **Array-overloaded `concat(...)`** — same eval file: when any operand is an
+  array it array-concatenates (NULL operand → NULL, element type follows the
+  first array); otherwise unchanged string concat. Return type is array-aware
+  in `resolve.rs`, so a recursive-CTE column `concat(path_nodes, array(x))`
+  unifies with its array anchor instead of degrading to Text.
+- **`CAST(... AS ARRAY<T>)` at execution** — `cast_value` in
+  `zeta-server/src/lib.rs` now retypes arrays element-wise (the VLP
+  `path_relationships` accumulator emits `CAST(array() AS ARRAY<STRING>)`).
+- **Spark lateral column aliases** — the planner (`zeta-planner/src/planner.rs`)
+  inlines references to an earlier projection alias in the same SELECT list
+  (`SELECT x AS id, id AS __order_col_0`), which DeltaGraph's `ORDER BY`
+  desugaring relies on. A real FROM column wins over a same-named alias (Spark
+  precedence). Affects all ORDER BY-on-expression queries, not just VLP.
+
+Covered by `zeta/crates/zeta-server/tests/array_contains_concat.rs` (12 tests,
+incl. a VLP-shaped recursive CTE with `CAST(array() AS ARRAY<STRING>)`) and
+`lateral_column_alias.rs` (4 tests, incl. precedence + the DeltaGraph ORDER BY
+shape). Validated end-to-end by the cross-stack transport gate
+(`tests/zeta_integration/`): `MATCH (p)-[:KNOWS*1..2]-(f) … RETURN DISTINCT
+f.id AS id ORDER BY id` runs cg → executor → REST → Zeta and returns the
+correct ordered rows. (The unrelated pre-existing `Int32/Int64` failures in
+`pg_regress_lateral_column_alias` / `_quoted_alias` reproduce on clean `main`
+and are not touched by this change.)
+
+## Bottom line
+
+- **Transport, executor, lifecycle, discovery, flat/agg/string AND VLP/BFS
+  (incl. ORDER BY)** → validated on **zeta-databricks** end-to-end
+  (`tests/zeta_integration/`, CI-friendly, no warehouse, no docker).
+- **Spark-runtime parity at scale** (Photon, exact engine semantics on large
+  data) → still best confirmed on the **Spark/Delta docker** sweep; Zeta is a
+  different engine that now accepts the same dialect.
+- **EXTERNAL_LINKS, OAuth M2M, real cold-start/auto-stop/429, performance** →
+  irreducibly **live Databricks**.

--- a/tests/zeta_integration/test_zeta_transport.py
+++ b/tests/zeta_integration/test_zeta_transport.py
@@ -117,11 +117,11 @@ def _cg_query(cg_bin: Path, cypher: str) -> list[dict]:
 
 # ── the cross-stack checks ───────────────────────────────────────────────────
 
-# Cross-stack cases that pass today: they prove the transport layer (cg →
-# DatabricksSqlExecutor → REST submit/poll → JSON decode → rows). ORDER BY is
-# avoided and rows are compared order-insensitively (see _rows_eq), because
-# Zeta lacks Spark's lateral column aliases that DeltaGraph's ORDER BY
-# desugaring relies on — one of the documented Zeta VLP gaps below.
+# Cross-stack cases proving the transport layer (cg → DatabricksSqlExecutor →
+# REST submit/poll → JSON decode → rows). The VLP case additionally exercises
+# the Zeta `array_contains` / array-`concat` / `CAST(array() AS ARRAY<T>)`
+# builtins and Spark lateral column aliases (the `ORDER BY` desugaring) — all of
+# which DeltaGraph's variable-length-path SQL needs and which now run on Zeta.
 CASES = [
     (
         "flat_knows_join",
@@ -135,23 +135,18 @@ CASES = [
         "RETURN count(f) AS friendCount",
         [{"friendCount": 2}],
     ),
+    (
+        # Undirected VLP with ORDER BY: exercises recursive CTEs +
+        # array_contains/concat (cycle detection / path extension) + the
+        # array CAST + lateral column aliases (ORDER BY desugaring).
+        # KNOWS edges anchored at 1: 1↔2, 1↔3, 2↔3, 3↔4, 4↔5 → within 2 hops
+        # (excluding self): {2,3,4}.
+        "vlp_two_hops_ordered",
+        "MATCH (p:Person {id:1})-[:KNOWS*1..2]-(f:Person) WHERE f.id <> p.id "
+        "RETURN DISTINCT f.id AS id ORDER BY id",
+        [{"id": 2}, {"id": 3}, {"id": 4}],
+    ),
 ]
-
-# Variable-length-path queries do NOT yet execute on Zeta end-to-end. The
-# `array_contains` / array-`concat` builtins added for this are necessary but
-# not sufficient: DeltaGraph's VLP SQL also needs
-#   (a) `CAST(array() AS ARRAY<T>)` at execution — Zeta errors
-#       "unsupported CAST target type: ARRAY<STRING>"; and
-#   (b) Spark lateral column aliases for the ORDER BY desugaring
-#       (`SELECT x AS id, id AS __order_col_0`) — Zeta errors
-#       "column not found: id".
-# Until those land in Zeta, VLP fidelity is validated on the Spark/Delta docker
-# container (tests/spark_smoke), not here. See docs/deltagraph/ZETA_FIDELITY.md.
-VLP_KNOWN_GAP = (
-    "vlp_two_hops",
-    "MATCH (p:Person {id:1})-[:KNOWS*1..2]-(f:Person) WHERE f.id <> p.id "
-    "RETURN DISTINCT f.id AS id",
-)
 
 
 def _sort_key(d: dict) -> str:
@@ -159,8 +154,7 @@ def _sort_key(d: dict) -> str:
 
 
 def _rows_eq(a: list[dict], b: list[dict]) -> bool:
-    """Order-insensitive row comparison (Zeta returns unordered without the
-    lateral-alias ORDER BY path)."""
+    """Order-insensitive row comparison."""
     return sorted(a, key=_sort_key) == sorted(b, key=_sort_key)
 
 
@@ -170,18 +164,6 @@ def _run_all(cg_bin: Path) -> None:
         rows = _cg_query(cg_bin, cypher)
         assert _rows_eq(rows, expected), f"[{name}] expected {expected}, got {rows}"
         print(f"[PASS] {name}: {rows}")
-    # VLP is a documented Zeta gap — confirm it still fails. An XPASS here means
-    # Zeta closed the gaps, so FAIL loudly to prompt updating ZETA_FIDELITY.md.
-    name, cypher = VLP_KNOWN_GAP
-    try:
-        rows = _cg_query(cg_bin, cypher)
-    except AssertionError:
-        print(f"[KNOWN-GAP] {name}: VLP not yet executable on Zeta (see ZETA_FIDELITY.md)")
-        return
-    raise AssertionError(
-        f"[XPASS] {name}: VLP now runs on Zeta (got {rows}) — close the gap, "
-        "drop the known-gap marker, and update ZETA_FIDELITY.md"
-    )
 
 
 # pytest entrypoints ----------------------------------------------------------
@@ -191,14 +173,6 @@ try:
     import pytest as _pytest
 except ImportError:  # pragma: no cover - standalone mode
     _pytest = None
-
-
-def _xfail_strict(reason: str):
-    """`@pytest.mark.xfail(strict=True)` when pytest is present, else a no-op
-    (the decorated test funcs aren't invoked in standalone mode)."""
-    if _pytest is not None:
-        return _pytest.mark.xfail(strict=True, reason=reason)
-    return lambda f: f
 
 
 def _require_env():
@@ -224,15 +198,12 @@ def test_zeta_transport_aggregation():
     assert _rows_eq(_cg_query(cg, CASES[1][1]), CASES[1][2])
 
 
-@_xfail_strict("VLP not executable on Zeta (array CAST + lateral alias) — see ZETA_FIDELITY.md")
-def test_zeta_transport_vlp_known_gap():
-    """VLP doesn't execute on Zeta yet (CAST-to-array + lateral-alias gaps).
-    The query IS run — it raises today → xfail. When Zeta closes the gaps it
-    succeeds → strict xfail turns that into an XPASS failure, prompting the
-    marker's removal."""
+def test_zeta_transport_vlp_ordered():
+    """VLP with ORDER BY now runs on Zeta end-to-end (recursive CTEs +
+    array_contains/concat + array CAST + lateral column aliases)."""
     cg = _require_env()
     _seed()
-    _cg_query(cg, VLP_KNOWN_GAP[1])
+    assert _rows_eq(_cg_query(cg, CASES[2][1]), CASES[2][2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The two remaining Zeta VLP execution gaps are closed in **zeta PR #1941** (CAST to `ARRAY<T>` at execution; Spark lateral column aliases for the `ORDER BY` desugaring). With those, DeltaGraph's variable-length-path SQL — **including `ORDER BY`** — now runs end-to-end through the zeta-databricks REST path.

This PR updates the clickgraph side to match:
- **`tests/zeta_integration/`**: flips the VLP known-gap into a passing case — `vlp_two_hops_ordered` (`MATCH (p)-[:KNOWS*1..2]-(f) … RETURN DISTINCT f.id AS id ORDER BY id` → `[2,3,4]`), and removes the xfail/known-gap machinery. Verified green against a live zeta-databricks server (all three transport cases pass).
- **`docs/deltagraph/ZETA_FIDELITY.md`**: marks VLP **CLOSED**, documenting the four Zeta features it required (array_contains, array concat, array CAST, lateral aliases).

## Note on the doc
`ZETA_FIDELITY.md` is **force-added** here: `.gitignore` lists both `docs/` and `*.md`, so this file (created during the earlier deltagraph work) was silently skipped by `git add -A` and had never actually been committed. The sibling deltagraph docs (`GA_READINESS.md`, etc.) are tracked the same way (force-added), so this is consistent with the repo's existing pattern. Flagging in case the broad `docs/` ignore is worth revisiting separately.

## Dependency
Requires zeta **#1941** to be deployed for the live transport gate to pass; the gate is env-gated (`CLICKGRAPH_ZETA_TESTS=1` + a reachable server) and skips cleanly otherwise, so this doesn't affect default CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)