### PR TITLE
feat(metrics): Phase B — capture true X-ClickHouse-Summary (read_rows/read_bytes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,10 @@ chdb-rust = { version = "1.3.1", optional = true }
 # Compiled only when the `databricks` feature is enabled. `rustls-tls` chosen
 # over native-tls to avoid OpenSSL version coupling on Linux distros and to
 # match what the underlying clickhouse crate already pulls in via reqwest.
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+# Non-optional: used by the Databricks executor (databricks feature) AND the
+# remote executor's metrics summary path (reads X-ClickHouse-Summary, gated at
+# runtime by CLICKGRAPH_METRICS_CH_SUMMARY).
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
@@ -75,7 +78,9 @@ jemalloc = ["tikv-jemallocator"]
 embedded = ["chdb-rust"]
 # DeltaGraph Phase 2: Databricks SQL Warehouse executor.
 # Off by default — only enable when building DeltaGraph distribution.
-databricks = ["reqwest"]
+# (reqwest is now a non-optional dependency, so this feature is a marker for
+# the Databricks-only code paths gated via #[cfg(feature = "databricks")].)
+databricks = []
 
 [dev-dependencies]
 clickhouse = { version = "0.13.2", features = ["test-util"] }

--- a/src/executor/remote.rs
+++ b/src/executor/remote.rs
@@ -4,11 +4,15 @@
 //! the `QueryExecutor` trait, preserving all existing behaviour (role-based
 //! pools, cluster round-robin, etc.).
 //!
-//! It also records observability stats (Phase A): the bytes received from
-//! ClickHouse for each query are pushed into the per-query metrics slot (a
-//! no-op outside a metrics scope). The richer `X-ClickHouse-Summary`
-//! (read_rows/read_bytes) is not exposed by the `clickhouse` crate and is a
-//! gated follow-up.
+//! It also records observability stats:
+//! - **Phase A (always on):** bytes received from ClickHouse per query are
+//!   pushed into the per-query metrics slot (a no-op outside a metrics scope).
+//! - **Phase B (opt-in, `CLICKGRAPH_METRICS_CH_SUMMARY=1`):** the JSON read
+//!   path is executed via a direct HTTP request so the `X-ClickHouse-Summary`
+//!   response header (read_rows / read_bytes / elapsed) — which the `clickhouse`
+//!   crate drops — can be captured. The request uses the SAME settings as the
+//!   crate client (`RoleConnectionPool::http_endpoint` →
+//!   `ConnectionConfig::standard_options`) so results are identical.
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -17,7 +21,7 @@ use std::sync::Arc;
 
 use super::{ExecutorError, QueryExecutor};
 use crate::server::connection_pool::RoleConnectionPool;
-use crate::server::metrics::record_ch_network_bytes;
+use crate::server::metrics::{record_ch_network_bytes, record_ch_summary};
 
 /// SQL executor that delegates to a remote ClickHouse server via HTTP.
 ///
@@ -25,12 +29,111 @@ use crate::server::metrics::record_ch_network_bytes;
 /// backend-agnostic [`QueryExecutor`] trait.
 pub struct RemoteClickHouseExecutor {
     pool: Arc<RoleConnectionPool>,
+    /// When true, the JSON read path runs via direct HTTP to capture the
+    /// ClickHouse summary header (Phase B). From `CLICKGRAPH_METRICS_CH_SUMMARY`.
+    ch_summary: bool,
+    /// Reusable HTTP client for the Phase B summary path (shares a connection
+    /// pool). Only used when `ch_summary` is set.
+    http: reqwest::Client,
 }
 
 impl RemoteClickHouseExecutor {
     pub fn new(pool: Arc<RoleConnectionPool>) -> Self {
-        Self { pool }
+        Self::with_ch_summary(pool, false)
     }
+
+    pub fn with_ch_summary(pool: Arc<RoleConnectionPool>, ch_summary: bool) -> Self {
+        Self {
+            pool,
+            ch_summary,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Phase B: execute a SELECT via direct HTTP and capture
+    /// `X-ClickHouse-Summary` (read_rows / read_bytes / elapsed). Returns the
+    /// same `Vec<Value>` (JSONEachRow) shape as the crate path.
+    async fn execute_json_via_http(
+        &self,
+        sql: &str,
+        role: Option<&str>,
+    ) -> Result<Vec<Value>, ExecutorError> {
+        let ep = self.pool.http_endpoint(role);
+
+        // Compose the URL exactly as the crate would: database + standard
+        // options as query params, plus JSONEachRow output and
+        // wait_end_of_query=1 (the latter makes ClickHouse buffer server-side so
+        // the summary is a complete response header rather than a trailer).
+        let mut url = reqwest::Url::parse(&ep.url)
+            .map_err(|e| ExecutorError::Io(format!("invalid ClickHouse URL: {e}")))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("database", &ep.database);
+            for (name, value) in &ep.options {
+                q.append_pair(name, value);
+            }
+            q.append_pair("default_format", "JSONEachRow");
+            q.append_pair("wait_end_of_query", "1");
+        }
+
+        let resp = self
+            .http
+            .post(url)
+            .header("X-ClickHouse-User", &ep.user)
+            .header("X-ClickHouse-Key", &ep.password)
+            .body(sql.to_string())
+            .send()
+            .await
+            .map_err(|e| ExecutorError::Io(format!("request failed: {e}")))?;
+
+        let status = resp.status();
+        // Capture the summary header before consuming the body.
+        if let Some(summary) = resp
+            .headers()
+            .get("x-clickhouse-summary")
+            .and_then(|v| v.to_str().ok())
+        {
+            record_summary_header(summary);
+        }
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| ExecutorError::Io(format!("reading response body: {e}")))?;
+        if !status.is_success() {
+            let text = String::from_utf8_lossy(&body);
+            log::error!("ClickHouse query failed. SQL was:\n{sql}\nError: {text}");
+            return Err(ExecutorError::QueryFailed(text.to_string()));
+        }
+        record_ch_network_bytes(body.len() as u64);
+
+        let mut rows = Vec::new();
+        for line in body.split(|&b| b == b'\n') {
+            if line.iter().all(u8::is_ascii_whitespace) {
+                continue;
+            }
+            let value: Value = serde_json::from_slice(line).map_err(|e| {
+                log::error!("Failed to parse JSON from ClickHouse response: {e}");
+                ExecutorError::Parse(e.to_string())
+            })?;
+            rows.push(value);
+        }
+        Ok(rows)
+    }
+}
+
+/// Parse the `X-ClickHouse-Summary` JSON (fields are quoted decimal strings) and
+/// record read_rows / read_bytes / elapsed_ns into the per-query metrics slot.
+fn record_summary_header(header: &str) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(header) else {
+        return;
+    };
+    let num = |k: &str| -> u64 {
+        v.get(k)
+            .and_then(|x| x.as_str())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0)
+    };
+    record_ch_summary(num("read_rows"), num("read_bytes"), num("elapsed_ns"));
 }
 
 /// Drain a `fetch_bytes` cursor into one buffer and record the bytes received.
@@ -62,6 +165,10 @@ impl QueryExecutor for RemoteClickHouseExecutor {
         sql: &str,
         role: Option<&str>,
     ) -> Result<Vec<Value>, ExecutorError> {
+        // Phase B: capture the ClickHouse summary via a direct HTTP request.
+        if self.ch_summary {
+            return self.execute_json_via_http(sql, role).await;
+        }
         let client = self.pool.get_client(role).await;
         let cursor = client.query(sql).fetch_bytes("JSONEachRow").map_err(|e| {
             log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
@@ -103,5 +210,51 @@ impl QueryExecutor for RemoteClickHouseExecutor {
             text.pop();
         }
         Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::metrics::{current_ch_stats, with_ch_stats_scope};
+
+    #[tokio::test]
+    async fn summary_header_parsed_and_recorded() {
+        let stats = with_ch_stats_scope(async {
+            record_summary_header(
+                r#"{"read_rows":"123","read_bytes":"4096","written_rows":"0","elapsed_ns":"777"}"#,
+            );
+            current_ch_stats()
+        })
+        .await
+        .expect("in scope");
+        assert_eq!(stats.read_rows, Some(123));
+        assert_eq!(stats.read_bytes, Some(4096));
+        assert_eq!(stats.elapsed_ns, Some(777));
+    }
+
+    #[tokio::test]
+    async fn malformed_summary_header_is_ignored() {
+        let stats = with_ch_stats_scope(async {
+            record_summary_header("not json");
+            current_ch_stats()
+        })
+        .await
+        .expect("in scope");
+        // No panic; nothing recorded.
+        assert_eq!(stats.read_rows, None);
+    }
+
+    #[tokio::test]
+    async fn missing_fields_default_to_zero() {
+        let stats = with_ch_stats_scope(async {
+            record_summary_header(r#"{"read_rows":"5"}"#);
+            current_ch_stats()
+        })
+        .await
+        .expect("in scope");
+        assert_eq!(stats.read_rows, Some(5));
+        assert_eq!(stats.read_bytes, Some(0));
+        assert_eq!(stats.elapsed_ns, Some(0));
     }
 }

--- a/src/server/connection_pool.rs
+++ b/src/server/connection_pool.rs
@@ -160,6 +160,21 @@ impl RoleConnectionPool {
             cluster_name: self.base_config.cluster_name.clone(),
         }
     }
+
+    /// Raw HTTP endpoint parts for the metrics summary path (`remote.rs`), which
+    /// bypasses the `clickhouse` crate to read `X-ClickHouse-Summary`. Selects a
+    /// node via the same round-robin as `get_client` and carries the identical
+    /// settings (`standard_options`) + role so results match the crate path.
+    pub fn http_endpoint(&self, role: Option<&str>) -> ChHttpEndpoint {
+        let idx = self.round_robin.fetch_add(1, Ordering::Relaxed) % self.base_config.urls.len();
+        ChHttpEndpoint {
+            url: self.base_config.urls[idx].clone(),
+            user: self.base_config.user.clone(),
+            password: self.base_config.password.clone(),
+            database: self.base_config.database.clone(),
+            options: ConnectionConfig::standard_options(self.base_config.max_cte_depth, role),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -168,6 +183,19 @@ pub struct PoolStats {
     pub roles: Vec<String>,
     pub node_count: usize,
     pub cluster_name: Option<String>,
+}
+
+/// Connection details for a direct ClickHouse HTTP request (the metrics
+/// summary path). Auth goes in `X-ClickHouse-User` / `-Key` headers; `database`,
+/// `options`, and any role go in the URL query string — matching how the
+/// `clickhouse` crate composes its request.
+#[derive(Debug, Clone)]
+pub struct ChHttpEndpoint {
+    pub url: String,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+    pub options: Vec<(String, String)>,
 }
 
 impl ConnectionConfig {
@@ -263,33 +291,50 @@ impl ConnectionConfig {
         }
     }
 
+    /// The ClickHouse settings every query runs with. Single source of truth so
+    /// the `clickhouse`-crate client and the metrics reqwest path (which reads
+    /// `X-ClickHouse-Summary`) apply identical settings — any drift would make
+    /// the two execution paths return different results.
+    fn standard_options(max_cte_depth: u32, role: Option<&str>) -> Vec<(String, String)> {
+        let mut opts = vec![
+            ("join_use_nulls".to_string(), "1".to_string()),
+            ("allow_experimental_json_type".to_string(), "1".to_string()),
+            (
+                "input_format_binary_read_json_as_string".to_string(),
+                "1".to_string(),
+            ),
+            (
+                "output_format_binary_write_json_as_string".to_string(),
+                "1".to_string(),
+            ),
+            (
+                "max_recursive_cte_evaluation_depth".to_string(),
+                max_cte_depth.to_string(),
+            ),
+            // VLP queries with polymorphic schemas generate large SQL via UNION
+            // ALL expansion; the 256KB default is too small for multi-type VLP.
+            ("max_query_size".to_string(), "10485760".to_string()), // 10MB
+            // Large VLP SQL also creates large ASTs; default 50000 is too small.
+            ("max_ast_elements".to_string(), "1000000".to_string()), // 1M
+        ];
+        if let Some(role_name) = role {
+            opts.push(("role".to_string(), role_name.to_string()));
+        }
+        opts
+    }
+
     fn create_client_for_url(&self, url: &str, role: Option<&str>) -> Client {
         let mut client = Client::default()
             .with_url(url)
             .with_user(&self.user)
             .with_password(&self.password)
-            .with_database(&self.database)
-            .with_option("join_use_nulls", "1")
-            .with_option("allow_experimental_json_type", "1")
-            .with_option("input_format_binary_read_json_as_string", "1")
-            .with_option("output_format_binary_write_json_as_string", "1")
-            .with_option(
-                "max_recursive_cte_evaluation_depth",
-                self.max_cte_depth.to_string(),
-            )
-            // VLP queries with polymorphic schemas generate large SQL due to UNION ALL expansion.
-            // The default 262144 bytes (256KB) is too small for multi-type VLP queries.
-            .with_option("max_query_size", "10485760") // 10MB query size limit
-            // Large VLP SQL also creates large ASTs; default 50000 is too small.
-            .with_option("max_ast_elements", "1000000"); // 1M AST elements
-
-        // Set role for this connection pool via ClickHouse option
-        // This adds the role parameter to all HTTP requests from this client
-        if let Some(role_name) = role {
-            log::debug!("Creating connection pool with role: {}", role_name);
-            client = client.with_option("role", role_name);
+            .with_database(&self.database);
+        for (name, value) in Self::standard_options(self.max_cte_depth, role) {
+            client = client.with_option(name, value);
         }
-
+        if role.is_some() {
+            log::debug!("Creating connection pool with role: {:?}", role);
+        }
         client
     }
 }

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -158,7 +158,7 @@ pub fn record_ch_network_bytes(bytes: u64) {
 }
 
 /// Record the parsed `X-ClickHouse-Summary` figures for the current query
-/// (Phase B). No-op outside a [`with_ch_stats`] scope.
+/// (Phase B). No-op outside a [`with_ch_stats_scope`] scope.
 pub fn record_ch_summary(read_rows: u64, read_bytes: u64, elapsed_ns: u64) {
     let _ = CH_STATS_SLOT.try_with(|s| {
         let mut st = s.borrow_mut();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -283,8 +283,10 @@ pub async fn run_with_config(config: ServerConfig) {
 
     let query_semaphore = make_query_semaphore(&config);
     let app_state = if client_opt.is_some() {
-        let executor: Arc<dyn QueryExecutor> =
-            Arc::new(RemoteClickHouseExecutor::new(connection_pool.clone()));
+        let executor: Arc<dyn QueryExecutor> = Arc::new(RemoteClickHouseExecutor::with_ch_summary(
+            connection_pool.clone(),
+            config.metrics_ch_summary,
+        ));
         AppState {
             executor,
             clickhouse_client: client_opt.clone(),
@@ -300,8 +302,10 @@ pub async fn run_with_config(config: ServerConfig) {
             "  Note: Some query functionality may be limited without ClickHouse connection."
         );
 
-        let executor: Arc<dyn QueryExecutor> =
-            Arc::new(RemoteClickHouseExecutor::new(connection_pool.clone()));
+        let executor: Arc<dyn QueryExecutor> = Arc::new(RemoteClickHouseExecutor::with_ch_summary(
+            connection_pool.clone(),
+            config.metrics_ch_summary,
+        ));
         AppState {
             executor,
             clickhouse_client: None,


### PR DESCRIPTION
## Summary

Completes the observability work's Phase B: capture ClickHouse's real execution summary (`read_rows` / `read_bytes` / `elapsed`), opt-in via `CLICKGRAPH_METRICS_CH_SUMMARY=true`.

**Why a bypass:** the `clickhouse` crate drops all HTTP response headers (verified true through the latest 0.15), so `X-ClickHouse-Summary` isn't reachable through it. When the flag is set, the JSON read path runs via a direct `reqwest` request that reads the header.

## Scope (narrow + gated)
- Only **`execute_json`** (the default `/query` JSON response path) takes the HTTP path. `execute_text` (Pretty/CSV/export) stays on the crate path — no summary there.
- Default off → unchanged behavior (crate path; Phase A network-bytes still recorded).

## Correctness
The reqwest request uses the **same settings** as the crate client. `create_client_for_url` and the new `RoleConnectionPool::http_endpoint` both source from one `ConnectionConfig::standard_options` (single source of truth) — so the two execution paths can't drift. Auth via `X-ClickHouse-User`/`-Key` headers; database + options + role as query params; `wait_end_of_query=1` so the summary is a complete response header.

## Verification
End-to-end against a live ClickHouse (mini LDBC):
- `MATCH (p:Person) RETURN p.id ORDER BY id` → correct `{id:1..5}` **and** `/stats` `clickhouse.read_rows = 5`, `read_bytes = 40`; `/metrics` `clickgraph_clickhouse_read_rows_total 5`.
- Filtered query returns correct rows via the reqwest path too.
- 3 unit tests for `X-ClickHouse-Summary` parsing (well-formed / malformed / missing fields). Full lib suite green (1391); clippy clean on default **and** `databricks` feature sets.

## Dependency change
`reqwest` is promoted to a **non-optional** dependency — it's now used by the always-compiled remote executor, not just the `databricks` feature (which becomes a marker feature). rustls-tls overlaps the existing TLS stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)