### PR TITLE
docs: clickgraph-client README + Databricks deployment wiki page

### DIFF
--- a/clickgraph-client/README.md
+++ b/clickgraph-client/README.md
@@ -1,0 +1,159 @@
+# clickgraph-client
+
+An interactive REPL for querying a running **ClickGraph server** over its HTTP
+API. Type Cypher and see results; use `:`-prefixed meta-commands to introspect a
+ClickHouse database and build a graph schema (manually or LLM-assisted).
+
+This is the **human-facing** client. For scripting and agent use, reach for the
+[`cg` CLI](../clickgraph-tool/) (`clickgraph-tool`) instead — see
+[When to use which](#when-to-use-which) below.
+
+## Install / run
+
+The client talks to a ClickGraph server, so start one first (see the repo
+[Quick Start](../docs/wiki/Quick-Start-Guide.md)). Then:
+
+```bash
+# From the workspace root
+cargo run -p clickgraph-client
+
+# Point at a non-default server
+cargo run -p clickgraph-client -- --url http://my-host:7475
+
+# Or run the built binary
+cargo build --release -p clickgraph-client
+./target/release/clickgraph-client --url http://localhost:7475
+```
+
+### CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-u`, `--url <URL>` | `http://localhost:7475` | Base URL of the ClickGraph HTTP server |
+| `--version` | — | Print version |
+| `--help` | — | Print help |
+
+On start you'll get a prompt:
+
+```
+Connected to ClickGraph server at http://localhost:7475.
+Type :help for commands.
+
+clickgraph-client :)
+```
+
+Anything that doesn't start with `:` is sent to the server's `/query` endpoint
+as a Cypher query and rendered with ClickHouse's `PrettyCompact` formatter.
+`Ctrl-C` / `Ctrl-D` exits. Line history (arrow keys) is provided by `rustyline`.
+
+## REPL commands
+
+| Command | Alias | Argument | What it does |
+|---------|-------|----------|--------------|
+| *(any text)* | — | — | Run as a Cypher query against `/query` |
+| `:help` | `:h` | — | Show the command list |
+| `:schemas` | `:s` | — | List schemas currently loaded on the server (`GET /schemas`) |
+| `:introspect <db>` | `:i` | database | Show tables, columns, primary keys, and node/edge suggestions (`POST /schemas/introspect`) |
+| `:discover <db>` | `:disc` | database | **LLM-powered** schema generation — emits a ready-to-load YAML (`POST /schemas/discover-prompt` + your LLM) |
+| `:design <db>` | `:d` | database | Interactive step-by-step wizard to declare nodes, edges, and FK-edges, then generate YAML (`POST /schemas/draft`) |
+| `:load <file>` | — | file path | Load a schema YAML file into the server (`POST /schemas/load`) |
+
+### `:introspect` — see what's in a database
+
+Lists each table with row counts and primary keys, then prints heuristic
+suggestions (node candidates, edge candidates, FK-edge candidates). No LLM
+required. Good first step before `:design` or `:discover`.
+
+```
+clickgraph-client :) :introspect mydb
+```
+
+### `:discover` — LLM-generated schema
+
+Fetches table metadata from the server, sends it to an LLM, and prints a
+complete graph-schema YAML. After generation you can **[s]ave**, **[l]oad**,
+**[b]oth**, or **[n]** review only. Requires an API key (see
+[LLM configuration](#llm-configuration)); if none is set, it falls back to
+`:introspect`. Large databases are batched across multiple prompts automatically
+and the partial YAMLs are merged.
+
+```
+clickgraph-client :) :discover mydb
+```
+
+### `:design` — interactive wizard
+
+Walks you through five steps — introspect → nodes → edges → FK-edges → generate.
+At each step it shows suggestions and accepts comma-separated input. Edges use
+the form:
+
+```
+<table>:<TYPE>:<from_node>:<to_node>:<from_id>:<to_id>
+# e.g. user_follows:FOLLOWS:User:User:follower_id:followed_id
+```
+
+The wizard prints YAML you can then load with `:load`.
+
+### `:load` — load a schema file
+
+```
+clickgraph-client :) :load ./schemas/my_graph.yaml
+```
+
+The schema name defaults to the file stem (`my_graph.yaml` → `my_graph`).
+
+## LLM configuration
+
+`:discover` reads its provider/key from the environment (same variables as the
+core schema-discovery feature):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ANTHROPIC_API_KEY` | — | Enables Anthropic (Claude) mode — the default provider |
+| `OPENAI_API_KEY` | — | Used when `CLICKGRAPH_LLM_PROVIDER=openai` (falls back to `ANTHROPIC_API_KEY`) |
+| `CLICKGRAPH_LLM_PROVIDER` | `anthropic` | `anthropic` or `openai` (OpenAI-compatible: OpenAI, Ollama, vLLM, LiteLLM, Together, Groq, …) |
+| `CLICKGRAPH_LLM_MODEL` | `claude-sonnet-4-20250514` (Anthropic) / `gpt-4o` (OpenAI) | Override the model |
+| `CLICKGRAPH_LLM_API_URL` | provider default | Override the API endpoint (point at a local/proxy server) |
+| `CLICKGRAPH_LLM_MAX_TOKENS` | `8192` | Max output tokens per request |
+
+If no key is found, `:discover` prints guidance and degrades to `:introspect`.
+
+## When to use which
+
+ClickGraph ships two command-line front-ends — pick by audience:
+
+| | **clickgraph-client** (this crate) | **`cg` CLI** ([`clickgraph-tool`](../clickgraph-tool/)) |
+|---|---|---|
+| Audience | Humans, interactive | Agents, scripts, CI |
+| Interface | Persistent REPL | One-shot subcommands |
+| Needs a running server? | **Yes** (talks HTTP) | No (translates/executes locally) |
+| Schema work | `:introspect` / `:discover` / `:design` / `:load` | `schema show` / `schema discover` |
+| Cypher | Executes via server `/query` | `sql` (translate), `validate`, `query`, `nl` (NL→Cypher) |
+| Output | Pretty tables | Machine-friendly |
+
+Use **clickgraph-client** to explore a live server by hand. Use **`cg`** to wire
+ClickGraph into automation or to translate/execute without standing up a server.
+
+## DeltaGraph (Databricks) compatibility
+
+This REPL targets a **ClickHouse-backed** ClickGraph server. Against a
+[DeltaGraph](../docs/wiki/Databricks-Deployment.md) server (the `deltagraph`
+binary, Databricks backend) support is currently **partial**:
+
+| Command | DeltaGraph |
+|---------|-----------|
+| `:schemas`, `:design`, `:load` | ✅ works |
+| *(Cypher query)*, `:introspect`, `:discover` | ❌ not yet — server-side gaps |
+
+Queries fail because the Databricks executor doesn't yet implement text output
+formats (the REPL requests `PrettyCompact`), and introspection/discovery require
+ClickHouse `system.*` tables that don't exist on Databricks. Until those
+server-side paths land, use **Neo4j Browser** or the **`cg --dialect databricks`**
+CLI to query a DeltaGraph warehouse; you can still author schemas here with
+`:design` + `:load`.
+
+## See also
+
+- [HTTP API Reference](../docs/wiki/API-Reference-HTTP.md) — the endpoints this client calls
+- [Schema Discovery](../docs/wiki/Schema-Discovery.md) — server-side and `cg` discovery
+- [`cg` CLI guide](../clickgraph-tool/AGENTS.md) — the scripting/agent counterpart

--- a/docs/wiki/Databricks-Deployment.md
+++ b/docs/wiki/Databricks-Deployment.md
@@ -1,0 +1,82 @@
+# Databricks Deployment (DeltaGraph)
+
+**DeltaGraph** is ClickGraph's Databricks backend. It turns a Databricks SQL
+Warehouse into a Cypher-queryable graph database: you send the same Cypher you'd
+send to Neo4j, and the server translates it to **Spark SQL** and executes it
+against your warehouse over the Statement Execution API. Neo4j Browser, NeoDash,
+graph-notebook, and any Bolt v5 client connect unchanged.
+
+It's the same engine as ClickGraph (shared parser, planner, Bolt/HTTP servers) —
+only the SQL dialect and executor differ. Build it with the `databricks` feature
+as the `deltagraph` binary.
+
+> ⚠️ **Status:** DeltaGraph is an **early-adopter / beta** path in `v0.6.7-dev`.
+> Read queries, variable-length paths, aggregations, OAuth M2M, and
+> external-link result chunks work; writes (`CREATE`/`SET`/`DELETE`/`MERGE`) are
+> GA scope (v0.7.x). See [GA readiness](../deltagraph/GA_READINESS.md).
+
+## Quick reference
+
+```bash
+# Build (the databricks feature pulls in the Spark-SQL executor)
+cargo build --release --features databricks --bin deltagraph
+
+# Configure (token is env-only, never a CLI flag)
+export DATABRICKS_HOST=dbc-abc123-def4.cloud.databricks.com
+export DATABRICKS_WAREHOUSE_ID=...
+export DATABRICKS_TOKEN=...
+export GRAPH_CONFIG_PATH=./schemas/my_graph.yaml
+
+# Run — same HTTP (7475) + Bolt (7687) surface as clickgraph
+./target/release/deltagraph
+```
+
+Inspect the generated Spark SQL without executing:
+
+```bash
+curl -s -X POST http://localhost:7475/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"MATCH (u:User) RETURN u.name LIMIT 5","sql_only":true}' | jq -r .sql
+```
+
+## Full guides
+
+The detailed, maintained DeltaGraph docs live under `docs/deltagraph/`:
+
+- **[DeltaGraph Quickstart](../deltagraph/QUICKSTART.md)** — build, env vars,
+  catalog precedence, Neo4j Browser setup, sample queries, troubleshooting, and
+  pointing the `cg` CLI at the same warehouse.
+- **[GA Readiness](../deltagraph/GA_READINESS.md)** — what's complete vs. the
+  gating items for general availability.
+- **[Local Testing Results](../deltagraph/LOCAL_TESTING_RESULTS.md)** —
+  validation against the Spark/Delta docker environment.
+- **[Zeta Fidelity](../deltagraph/ZETA_FIDELITY.md)** — fidelity of the
+  zeta-databricks emulator vs. real Spark/Delta.
+
+## Env vars at a glance
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DATABRICKS_HOST` | yes | Workspace hostname, no scheme |
+| `DATABRICKS_WAREHOUSE_ID` | yes | Target SQL Warehouse ID |
+| `DATABRICKS_TOKEN` | yes (PAT auth) | Personal access token — **env-only** |
+| `DATABRICKS_CATALOG` | no | Default Unity Catalog for unqualified names |
+| `DATABRICKS_SCHEMA` | no | Default schema within the catalog |
+| `CG_DATABRICKS_CLIENT_ID` / `CG_DATABRICKS_CLIENT_SECRET` | no | OAuth M2M service-principal auth (alternative to PAT) |
+| `GRAPH_CONFIG_PATH` | yes | Path to the graph-schema YAML |
+
+## Clients
+
+Connect with **Neo4j Browser**, **NeoDash**, **graph-notebook**, or any Bolt v5
+driver — these work unchanged. The `cg` CLI works too via `--dialect databricks`
+(see Quickstart). The interactive **`clickgraph-client` REPL** is only partially
+supported against DeltaGraph today: schema authoring (`:design`/`:load`) works,
+but Cypher queries and `:introspect`/`:discover` do not yet (the Databricks
+executor lacks text output formats, and introspection relies on ClickHouse
+`system.*` tables). Use Neo4j Browser or `cg` to query in the meantime.
+
+## See also
+
+- [HTTP API Reference](API-Reference-HTTP.md) — the endpoints the server exposes
+- [Schema Basics](Schema-Basics.md) — authoring the graph-schema YAML
+- [`cg` CLI](../../clickgraph-tool/AGENTS.md) — `--dialect databricks` for ad-hoc queries

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -96,6 +96,7 @@ curl -X POST http://localhost:8080/query \
 ### Production Deployment
 - **[Docker Deployment](Docker-Deployment.md)** - Production Docker setup
 - **[Kubernetes Deployment](Kubernetes-Deployment.md)** - Helm charts and K8s manifests
+- **[Databricks Deployment (DeltaGraph)](Databricks-Deployment.md)** - Run Cypher against a Databricks SQL Warehouse (Spark SQL backend)
 - **[Embedded Mode](Embedded-Mode.md)** - Serverless / edge deployments without ClickHouse
 - **[Production Best Practices](Production-Best-Practices.md)** - Security, performance, monitoring
 - **[Performance Tuning](Performance-Query-Optimization.md)** - Query and schema optimization


### PR DESCRIPTION
## What

Fills two documentation gaps surfaced by a coverage audit:

1. **`clickgraph-client/README.md`** (was MISSING) — the interactive REPL crate had no dedicated docs. Documents:
   - CLI flags (`--url`, default `http://localhost:7475`)
   - All six `:` commands (`:help`, `:schemas`, `:introspect`, `:discover`, `:design`, `:load`) with aliases and the endpoints each calls
   - LLM env-var config for `:discover` (`ANTHROPIC_API_KEY`, `CLICKGRAPH_LLM_*`, etc.)
   - A "REPL vs `cg` CLI" guidance table
   - A **DeltaGraph compatibility** section: only `:design`/`:load` work today; querying + introspection need server-side support (tracked separately).

2. **`docs/wiki/Databricks-Deployment.md`** (was hidden) — DeltaGraph docs existed only under `docs/deltagraph/` and weren't reachable from the wiki. New concise entry point (build/run quick-ref, env-var table, client notes) linking into the detailed QUICKSTART/GA_READINESS guides, plus a link from `Home.md` under Production Deployment.

## Notes
- Docs-only; no code changes.
- `docs/wiki/Databricks-Deployment.md` was `git add -f`'d (the `docs/` tree is gitignored; existing wiki pages are tracked the same way).
- The server-side DeltaGraph client-support fixes (Databricks text output format + `information_schema` introspection) are intentionally **out of scope** here and will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)