### PR TITLE
fix(deltagraph): implement execute_text for Databricks (Pretty/CSV output)

### DIFF
--- a/src/executor/databricks_sql.rs
+++ b/src/executor/databricks_sql.rs
@@ -19,11 +19,11 @@
 //!   Databricks. EXTERNAL_LINKS downloads presigned chunk URLs (JSON
 //!   arrays-of-arrays) and follows `next_chunk_index`, so it has no size
 //!   ceiling; use it for any result that can exceed the inline cap.
-//! - `execute_text` rejects `Pretty`/`CSV`-style formats. Adding
-//!   format conversion is straightforward but isn't needed yet —
-//!   the only consumer that calls `execute_text` is the ClickHouse
-//!   passthrough endpoint, which a Databricks deployment wouldn't
-//!   expose.
+//! - `execute_text` renders `Pretty`/`PrettyCompact`/`CSV`/`CSVWithNames`
+//!   client-side (the Databricks API has no server-side tabular renderer),
+//!   via [`super::text_format`]. These are the formats the HTTP `/query`
+//!   endpoint routes through `execute_text` — e.g. what the interactive
+//!   `clickgraph-client` REPL requests. Other formats error out up front.
 //!
 //! ## Statement Execution API reference
 //!
@@ -500,15 +500,16 @@ impl DatabricksSqlExecutor {
             .await?;
         decode_statement_response(resp).await
     }
-}
 
-#[async_trait]
-impl QueryExecutor for DatabricksSqlExecutor {
-    async fn execute_json(
-        &self,
-        sql: &str,
-        _role: Option<&str>,
-    ) -> Result<Vec<Value>, ExecutorError> {
+    /// Submit a statement, poll to a terminal state, and return the
+    /// SUCCEEDED response together with its result rows as positional
+    /// arrays-of-values (column names live in the response manifest).
+    ///
+    /// Shared by `execute_json` (which keys each row by column name) and
+    /// `execute_text` (which renders the rows as a text table). Both
+    /// INLINE (`data_array`) and EXTERNAL_LINKS (downloaded chunks) results
+    /// resolve to the same positional shape here.
+    async fn run(&self, sql: &str) -> Result<(StatementResponse, Vec<Vec<Value>>), ExecutorError> {
         // Observability: time the whole statement and count polls so a slow
         // query is traceable. The Databricks `statement_id` is logged so an
         // oncall can pivot from a ClickGraph log line to the warehouse's
@@ -522,9 +523,9 @@ impl QueryExecutor for DatabricksSqlExecutor {
             self.config.disposition.as_api_str(),
         );
 
-        // Poll until the statement reaches a terminal state. The
-        // initial submit may already return SUCCEEDED if the query
-        // finished within `wait_timeout`; otherwise we poll.
+        // Poll until the statement reaches a terminal state. The initial
+        // submit may already return SUCCEEDED if the query finished within
+        // `wait_timeout`; otherwise we poll.
         let mut polls: u32 = 0;
         while !response.status.state.is_terminal() {
             tokio::time::sleep(Duration::from_millis(500)).await;
@@ -556,17 +557,21 @@ impl QueryExecutor for DatabricksSqlExecutor {
         }
 
         // EXTERNAL_LINKS results carry presigned chunk URLs instead of an
-        // inline `data_array`; fetch and concatenate them, then key by the
-        // manifest columns exactly as the inline path does.
-        let rows = if let Some(links) = response
+        // inline `data_array`; fetch and concatenate them. INLINE results
+        // read straight from the body. A missing `data_array` is valid for
+        // empty result sets (DDL or a SELECT with zero rows) → empty Vec.
+        let data: Vec<Vec<Value>> = if let Some(links) = response
             .result
             .as_ref()
             .and_then(|r| r.external_links.as_ref())
         {
-            let data = self.fetch_external_links(&statement_id, links).await?;
-            rows_from_data(&response, &data)?
+            self.fetch_external_links(&statement_id, links).await?
         } else {
-            rows_from_response(&response)?
+            response
+                .result
+                .as_ref()
+                .and_then(|r| r.data_array.clone())
+                .unwrap_or_default()
         };
 
         log::info!(
@@ -574,23 +579,40 @@ impl QueryExecutor for DatabricksSqlExecutor {
             "statement_id={statement_id} state=SUCCEEDED polls={polls} \
              duration_ms={} rows={}",
             started.elapsed().as_millis(),
-            rows.len(),
+            data.len(),
         );
-        Ok(rows)
+        Ok((response, data))
+    }
+}
+
+#[async_trait]
+impl QueryExecutor for DatabricksSqlExecutor {
+    async fn execute_json(
+        &self,
+        sql: &str,
+        _role: Option<&str>,
+    ) -> Result<Vec<Value>, ExecutorError> {
+        let (response, data) = self.run(sql).await?;
+        rows_from_data(&response, &data)
     }
 
     async fn execute_text(
         &self,
-        _sql: &str,
+        sql: &str,
         format: &str,
         _role: Option<&str>,
     ) -> Result<String, ExecutorError> {
-        // No-op for now — the Databricks API doesn't speak ClickHouse
-        // output formats. If a future consumer needs CSV/Pretty
-        // output, the right shape is to fetch JSON via `execute_json`
-        // and post-format here. Returning an explicit error keeps
-        // accidental callers from silently emitting bad output.
-        Err(ExecutorError::UnsupportedFormat(format.to_string()))
+        // The Databricks API has no server-side pretty/tabular renderer
+        // (unlike ClickHouse's `Pretty`/`CSV` output formats), so fetch the
+        // structured rows and format them client-side. Only the formats the
+        // HTTP `/query` endpoint routes here are supported; reject anything
+        // else up front so we don't spend a warehouse query we can't emit.
+        if !super::text_format::is_supported(format) {
+            return Err(ExecutorError::UnsupportedFormat(format.to_string()));
+        }
+        let (response, data) = self.run(sql).await?;
+        let columns = columns_of(&response);
+        super::text_format::format_rows(&columns, &data, format)
     }
 }
 
@@ -785,8 +807,10 @@ async fn decode_statement_response(
 
 /// Convert a SUCCEEDED `StatementResponse` into JSONEachRow-style
 /// objects: one `serde_json::Value::Object` per row, keyed by column
-/// name. Pulled out as a free function so unit tests can feed
-/// hand-built responses without an HTTP round trip.
+/// name. Test-only convenience that bundles inline `data_array` extraction
+/// with `rows_from_data` — production resolves rows (inline or external)
+/// in `run()` and calls `rows_from_data` directly.
+#[cfg(test)]
 fn rows_from_response(resp: &StatementResponse) -> Result<Vec<Value>, ExecutorError> {
     let data = match resp.result.as_ref().and_then(|r| r.data_array.as_ref()) {
         Some(rows) => rows.as_slice(),
@@ -797,6 +821,15 @@ fn rows_from_response(resp: &StatementResponse) -> Result<Vec<Value>, ExecutorEr
     rows_from_data(resp, data)
 }
 
+/// Manifest column names, in order. Empty when the response carried no
+/// manifest (e.g. a DDL statement) — `execute_text` renders that as no table.
+fn columns_of(resp: &StatementResponse) -> Vec<String> {
+    resp.manifest
+        .as_ref()
+        .map(|m| m.schema.columns.iter().map(|c| c.name.clone()).collect())
+        .unwrap_or_default()
+}
+
 /// Key an already-collected set of row arrays by the response's manifest
 /// column names. Shared by the INLINE path (`data_array`) and the
 /// EXTERNAL_LINKS path (downloaded chunks).
@@ -804,6 +837,11 @@ fn rows_from_data(
     resp: &StatementResponse,
     data: &[Vec<Value>],
 ) -> Result<Vec<Value>, ExecutorError> {
+    // Empty result sets (DDL or a zero-row SELECT) need no manifest — and
+    // some may not carry one. Short-circuit before requiring it.
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
     let manifest = resp
         .manifest
         .as_ref()
@@ -1159,20 +1197,71 @@ mod wiremock_tests {
     }
 
     #[tokio::test]
-    async fn execute_text_rejects_format() {
-        // Doesn't hit the wire — `execute_text` errors out before any
-        // HTTP call. Test it here so the rejection path is exercised
-        // in the same module that documents the policy.
+    async fn execute_text_rejects_unsupported_format() {
+        // An unsupported format is rejected BEFORE any HTTP call — no mock is
+        // registered, so a wire hit would fail the test. (The four supported
+        // formats are Pretty/PrettyCompact/CSV/CSVWithNames.)
         let server = MockServer::start().await;
         let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
         let err = exec
-            .execute_text("SELECT 1", "Pretty", None)
+            .execute_text("SELECT 1", "JSONEachRow", None)
             .await
             .expect_err("should reject");
         assert!(
-            matches!(err, ExecutorError::UnsupportedFormat(ref f) if f == "Pretty"),
-            "expected UnsupportedFormat(\"Pretty\"), got {err:?}"
+            matches!(err, ExecutorError::UnsupportedFormat(ref f) if f == "JSONEachRow"),
+            "expected UnsupportedFormat(\"JSONEachRow\"), got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn execute_text_renders_pretty_table() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-text-1",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": manifest_with_columns(&["id", "name"]),
+                "result": { "data_array": [[1, "alice"], [2, "bob"]] }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let text = exec
+            .execute_text("SELECT id, name FROM users", "PrettyCompact", None)
+            .await
+            .expect("execute_text");
+        let lines: Vec<&str> = text.lines().collect();
+        // top, header, separator, 2 data rows, bottom
+        assert_eq!(lines.len(), 6, "got:\n{text}");
+        assert!(lines[1].contains("id") && lines[1].contains("name"));
+        assert!(lines[3].contains("alice"));
+        assert!(lines[4].contains("bob"));
+    }
+
+    #[tokio::test]
+    async fn execute_text_renders_csv_with_names() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": "stmt-text-2",
+                "status": { "state": "SUCCEEDED" },
+                "manifest": manifest_with_columns(&["id", "name"]),
+                "result": { "data_array": [[1, "alice"]] }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let exec = DatabricksSqlExecutor::new(cfg_for(&server)).expect("client builds");
+        let text = exec
+            .execute_text("SELECT id, name FROM users", "CSVWithNames", None)
+            .await
+            .expect("execute_text");
+        assert_eq!(text, "id,name\n1,alice\n");
     }
 
     fn external_links_cfg(server: &MockServer) -> DatabricksConfig {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -23,6 +23,8 @@ pub mod source_resolver;
 
 #[cfg(feature = "databricks")]
 pub mod databricks_sql;
+#[cfg(feature = "databricks")]
+mod text_format;
 
 /// Backend-agnostic SQL execution interface.
 ///

--- a/src/executor/text_format.rs
+++ b/src/executor/text_format.rs
@@ -1,0 +1,212 @@
+//! Render Databricks query results as ClickHouse-style text output.
+//!
+//! The Databricks Statement Execution API only returns structured data
+//! (JSON arrays-of-arrays plus a column manifest) — it has no server-side
+//! tabular/pretty renderer like ClickHouse's `PrettyCompact`. So when a
+//! caller asks the `DatabricksSqlExecutor` for a text format, we format the
+//! rows here, client-side.
+//!
+//! The only caller is the HTTP `/query` endpoint, which routes
+//! `Pretty`/`PrettyCompact`/`CSV`/`CSVWithNames` through `execute_text`
+//! (see `server::handlers::execute_cte_queries`) — notably what the
+//! interactive `clickgraph-client` REPL requests. Those four formats are
+//! the entire supported set; anything else is an explicit
+//! `UnsupportedFormat` error rather than silently wrong output.
+//!
+//! Cells are left-aligned (ClickHouse right-aligns numerics; we keep it
+//! simple) and `NULL` renders as an empty cell.
+
+use serde_json::Value;
+
+use super::ExecutorError;
+
+/// Whether `format` can be rendered here. Lets callers fail fast (before
+/// running a warehouse query) on a format they can't emit.
+pub(crate) fn is_supported(format: &str) -> bool {
+    matches!(format, "CSV" | "CSVWithNames" | "Pretty" | "PrettyCompact")
+}
+
+/// Render `rows` (positional arrays, column names in `columns`) as `format`.
+pub(crate) fn format_rows(
+    columns: &[String],
+    rows: &[Vec<Value>],
+    format: &str,
+) -> Result<String, ExecutorError> {
+    match format {
+        "CSV" => Ok(csv(columns, rows, false)),
+        "CSVWithNames" => Ok(csv(columns, rows, true)),
+        "Pretty" | "PrettyCompact" => Ok(pretty(columns, rows)),
+        other => Err(ExecutorError::UnsupportedFormat(other.to_string())),
+    }
+}
+
+/// Render one JSON value as a plain cell string. Strings are unquoted;
+/// arrays/objects fall back to compact JSON; `NULL` is empty.
+fn cell(v: &Value) -> String {
+    match v {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        // Arrays / objects: compact JSON (e.g. collect() results).
+        other => other.to_string(),
+    }
+}
+
+fn csv(columns: &[String], rows: &[Vec<Value>], with_names: bool) -> String {
+    let mut out = String::new();
+    if with_names {
+        out.push_str(
+            &columns
+                .iter()
+                .map(|c| csv_escape(c))
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        out.push('\n');
+    }
+    for row in rows {
+        let line = row
+            .iter()
+            .map(|v| csv_escape(&cell(v)))
+            .collect::<Vec<_>>()
+            .join(",");
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Quote per RFC 4180 when the field contains a delimiter, quote, or newline.
+fn csv_escape(s: &str) -> String {
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+/// Box-drawn table in ClickHouse `PrettyCompact` style.
+fn pretty(columns: &[String], rows: &[Vec<Value>]) -> String {
+    if columns.is_empty() {
+        // No manifest columns (e.g. a DDL statement) — nothing to tabulate.
+        return String::new();
+    }
+    let n = columns.len();
+
+    // Pre-render every cell so width math and emission agree on the text.
+    let cells: Vec<Vec<String>> = rows.iter().map(|r| r.iter().map(cell).collect()).collect();
+
+    let mut widths: Vec<usize> = columns.iter().map(|c| c.chars().count()).collect();
+    for row in &cells {
+        for (i, c) in row.iter().enumerate() {
+            if i < n {
+                widths[i] = widths[i].max(c.chars().count());
+            }
+        }
+    }
+
+    // A horizontal rule: left/mid/right corners with `─` runs padded to
+    // width+2 (one space of padding either side of each cell).
+    let bar = |left: &str, mid: &str, right: &str| -> String {
+        let mut s = String::from(left);
+        for (i, w) in widths.iter().enumerate() {
+            s.push_str(&"─".repeat(w + 2));
+            s.push_str(if i + 1 < n { mid } else { right });
+        }
+        s.push('\n');
+        s
+    };
+
+    let emit_row = |out: &mut String, vals: &[String]| {
+        out.push('│');
+        for (i, w) in widths.iter().enumerate() {
+            let c = vals.get(i).map(String::as_str).unwrap_or("");
+            let pad = w.saturating_sub(c.chars().count());
+            out.push(' ');
+            out.push_str(c);
+            out.push_str(&" ".repeat(pad));
+            out.push(' ');
+            out.push('│');
+        }
+        out.push('\n');
+    };
+
+    let mut out = String::new();
+    out.push_str(&bar("┌", "┬", "┐"));
+    emit_row(&mut out, columns);
+    out.push_str(&bar("├", "┼", "┤"));
+    for row in &cells {
+        emit_row(&mut out, row);
+    }
+    out.push_str(&bar("└", "┴", "┘"));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cols() -> Vec<String> {
+        vec!["name".to_string(), "age".to_string()]
+    }
+
+    fn rows() -> Vec<Vec<Value>> {
+        vec![
+            vec![json!("Alice"), json!(30)],
+            vec![json!("Bob"), json!(25)],
+        ]
+    }
+
+    #[test]
+    fn csv_no_header() {
+        let out = format_rows(&cols(), &rows(), "CSV").unwrap();
+        assert_eq!(out, "Alice,30\nBob,25\n");
+    }
+
+    #[test]
+    fn csv_with_names_has_header() {
+        let out = format_rows(&cols(), &rows(), "CSVWithNames").unwrap();
+        assert_eq!(out, "name,age\nAlice,30\nBob,25\n");
+    }
+
+    #[test]
+    fn csv_escapes_commas_quotes_newlines() {
+        let r = vec![vec![json!("Smith, Jr"), json!("a\"b")]];
+        let out = format_rows(&cols(), &r, "CSV").unwrap();
+        assert_eq!(out, "\"Smith, Jr\",\"a\"\"b\"\n");
+    }
+
+    #[test]
+    fn csv_null_is_empty_field() {
+        let r = vec![vec![json!("Alice"), Value::Null]];
+        let out = format_rows(&cols(), &r, "CSV").unwrap();
+        assert_eq!(out, "Alice,\n");
+    }
+
+    #[test]
+    fn pretty_aligns_and_boxes() {
+        // col0 width = max("name"=4, "Alice"=5) = 5; col1 = max("age"=3, 2) = 3.
+        let out = format_rows(&cols(), &rows(), "PrettyCompact").unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 6); // top, header, separator, 2 rows, bottom
+        assert_eq!(lines[1], "│ name  │ age │");
+        assert_eq!(lines[3], "│ Alice │ 30  │");
+        assert_eq!(lines[4], "│ Bob   │ 25  │");
+        assert!(lines[0].starts_with('┌') && lines[0].ends_with('┐'));
+        assert!(lines[5].starts_with('└') && lines[5].ends_with('┘'));
+    }
+
+    #[test]
+    fn pretty_empty_columns_is_empty_string() {
+        let out = format_rows(&[], &[], "Pretty").unwrap();
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn unsupported_format_errors() {
+        let err = format_rows(&cols(), &rows(), "JSONEachRow").unwrap_err();
+        assert!(matches!(err, ExecutorError::UnsupportedFormat(f) if f == "JSONEachRow"));
+    }
+}


### PR DESCRIPTION
## Problem

`DatabricksSqlExecutor::execute_text()` rejected **all** output formats, so the HTTP `/query` endpoint returned **HTTP 500** whenever a caller requested `Pretty` / `PrettyCompact` / `CSV` / `CSVWithNames`. Those are exactly the formats the interactive **`clickgraph-client` REPL** requests, so querying a DeltaGraph (Databricks-backed) server via the REPL — or `curl` with a text format — was impossible. This was the #1 client/DeltaGraph compatibility gap.

## Why client-side formatting

The Databricks Statement Execution API has **no server-side tabular/pretty renderer** (it returns `JSON_ARRAY` / Arrow / CSV *data*, not formatted text like ClickHouse's `PrettyCompact`). So the table layout has to happen in our code.

## Changes

- **New `src/executor/text_format.rs`** — small, reusable renderer: manifest columns + positional rows → `CSV` / `CSVWithNames` / `Pretty` / `PrettyCompact`. RFC-4180 CSV escaping; box-drawn `Pretty` table. Any other format is an explicit `UnsupportedFormat` error.
- **Refactor `DatabricksSqlExecutor`** — extract submit/poll/resolve into a shared `run()` used by both `execute_json` and `execute_text` (no duplicated polling logic), exposing the manifest columns so `execute_text` renders a header even for empty result sets. `execute_text` **fails fast** on an unsupported format before spending a warehouse query.
- **`rows_from_data()`** short-circuits on empty data, preserving the previous zero-row / DDL behaviour now that `run()` resolves rows for both inline and external-link paths.

## Tests

- 7 `text_format` unit tests (CSV header/escaping/null, Pretty alignment, empty columns, unsupported format)
- 2 new wiremock `execute_text` tests (Pretty table render, CSVWithNames)
- Updated the stale `execute_text_rejects_format` test to use a genuinely-unsupported format
- Full suite green: **1391 lib + 59 executor tests**, clippy clean (`--features databricks`), `deltagraph` binary builds.

## Scope

This unblocks **querying** the REPL/`curl` against DeltaGraph. **Introspection** (`:introspect` / `:discover`) — wiring the existing `databricks_probe.rs` into the handlers — is a separate follow-up PR (PR B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)