### PR TITLE
fix(deltagraph): wire Databricks schema introspection into HTTP handlers

### DIFF
--- a/clickgraph-client/README.md
+++ b/clickgraph-client/README.md
@@ -136,21 +136,17 @@ ClickGraph into automation or to translate/execute without standing up a server.
 
 ## DeltaGraph (Databricks) compatibility
 
-This REPL targets a **ClickHouse-backed** ClickGraph server. Against a
-[DeltaGraph](../docs/wiki/Databricks-Deployment.md) server (the `deltagraph`
-binary, Databricks backend) support is currently **partial**:
+The REPL works against a [DeltaGraph](../docs/wiki/Databricks-Deployment.md)
+server (the `deltagraph` binary, Databricks backend) as well as a ClickHouse
+one. Cypher queries render as tables client-side (the Databricks API has no
+server-side pretty format), and `:introspect`/`:discover` drive Databricks'
+`SHOW TABLES` / `DESCRIBE TABLE EXTENDED` instead of ClickHouse `system.*`.
 
-| Command | DeltaGraph |
-|---------|-----------|
-| `:schemas`, `:design`, `:load` | ✅ works |
-| *(Cypher query)*, `:introspect`, `:discover` | ❌ not yet — server-side gaps |
-
-Queries fail because the Databricks executor doesn't yet implement text output
-formats (the REPL requests `PrettyCompact`), and introspection/discovery require
-ClickHouse `system.*` tables that don't exist on Databricks. Until those
-server-side paths land, use **Neo4j Browser** or the **`cg --dialect databricks`**
-CLI to query a DeltaGraph warehouse; you can still author schemas here with
-`:design` + `:load`.
+One difference: Databricks namespaces are `catalog.schema`, so introspection
+needs a catalog. Start the server with `DATABRICKS_CATALOG` set (or the schema
+YAML `catalog:` field); then `:introspect <schema>` / `:discover <schema>` treat
+their argument as the Spark schema within that catalog. Without a catalog those
+commands return a 400 explaining the requirement.
 
 ## See also
 

--- a/docs/wiki/Databricks-Deployment.md
+++ b/docs/wiki/Databricks-Deployment.md
@@ -69,11 +69,12 @@ The detailed, maintained DeltaGraph docs live under `docs/deltagraph/`:
 
 Connect with **Neo4j Browser**, **NeoDash**, **graph-notebook**, or any Bolt v5
 driver — these work unchanged. The `cg` CLI works too via `--dialect databricks`
-(see Quickstart). The interactive **`clickgraph-client` REPL** is only partially
-supported against DeltaGraph today: schema authoring (`:design`/`:load`) works,
-but Cypher queries and `:introspect`/`:discover` do not yet (the Databricks
-executor lacks text output formats, and introspection relies on ClickHouse
-`system.*` tables). Use Neo4j Browser or `cg` to query in the meantime.
+(see Quickstart). The interactive **`clickgraph-client` REPL** also works against
+DeltaGraph: Cypher queries render as tables client-side, and
+`:introspect`/`:discover` drive Databricks' `SHOW TABLES` / `DESCRIBE TABLE
+EXTENDED`. Introspection needs a catalog — set `DATABRICKS_CATALOG` (or the YAML
+`catalog:` field) and the REPL's argument is treated as the Spark schema within
+it.
 
 ## See also
 

--- a/src/executor/databricks_sql.rs
+++ b/src/executor/databricks_sql.rs
@@ -225,6 +225,13 @@ impl DatabricksSqlExecutor {
         })
     }
 
+    /// The default Unity Catalog this executor targets, if configured
+    /// (`DATABRICKS_CATALOG` or the schema YAML `catalog:` field). Used by
+    /// schema introspection, which needs a `catalog.schema` namespace.
+    pub fn catalog(&self) -> Option<&str> {
+        self.config.catalog.as_deref()
+    }
+
     /// Resolve the bearer token for an API call. Under PAT auth this is the
     /// static token. Under OAuth M2M it returns a cached token if still valid,
     /// otherwise fetches a fresh one from the OIDC endpoint and caches it with
@@ -614,6 +621,10 @@ impl QueryExecutor for DatabricksSqlExecutor {
         let columns = columns_of(&response);
         super::text_format::format_rows(&columns, &data, format)
     }
+
+    fn as_any(&self) -> Option<&(dyn std::any::Any + 'static)> {
+        Some(self)
+    }
 }
 
 // ---------- Statement Execution API request/response shapes ----------
@@ -930,6 +941,33 @@ mod tests {
         let v = serde_json::to_value(&body).unwrap();
         assert_eq!(v["catalog"], json!("main"));
         assert_eq!(v["schema"], json!("default"));
+    }
+
+    #[test]
+    fn catalog_accessor_reflects_config() {
+        // Introspection reads the configured catalog through this accessor.
+        let exec = DatabricksSqlExecutor::new(cfg()).expect("client builds");
+        assert_eq!(exec.catalog(), None);
+
+        let mut c = cfg();
+        c.catalog = Some("main".into());
+        let exec = DatabricksSqlExecutor::new(c).expect("client builds");
+        assert_eq!(exec.catalog(), Some("main"));
+    }
+
+    #[test]
+    fn as_any_downcasts_to_concrete_executor() {
+        // The introspect handler recovers the concrete type from the trait
+        // object via this hook to drive `DatabricksProbe`.
+        let exec = DatabricksSqlExecutor::new(cfg()).expect("client builds");
+        let dynref: &dyn QueryExecutor = &exec;
+        assert!(
+            dynref
+                .as_any()
+                .and_then(|a| a.downcast_ref::<DatabricksSqlExecutor>())
+                .is_some(),
+            "DatabricksSqlExecutor should downcast from &dyn QueryExecutor"
+        );
     }
 
     #[test]

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -53,4 +53,12 @@ pub trait QueryExecutor: Send + Sync {
         format: &str,
         role: Option<&str>,
     ) -> Result<String, ExecutorError>;
+
+    /// Downcast hook for callers that need a backend's concrete capabilities
+    /// beyond this trait — currently only the Databricks executor, whose
+    /// concrete type schema introspection (`DatabricksProbe`) drives directly.
+    /// Returns `None` by default; backends opt in by overriding it.
+    fn as_any(&self) -> Option<&(dyn std::any::Any + 'static)> {
+        None
+    }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2167,6 +2167,90 @@ pub struct IntrospectRequest {
     pub database: String,
 }
 
+/// Run schema introspection against whichever backend the server uses: the
+/// Databricks probe (`SHOW TABLES` / `DESCRIBE TABLE EXTENDED`) when running in
+/// DeltaGraph mode, or the ClickHouse `system.*` path otherwise. Both return the
+/// same `IntrospectResponse`, so the introspect / discover-prompt handlers share
+/// this entry point. `database` is the namespace to introspect — a ClickHouse
+/// database, or (under Databricks) the Spark schema within `DATABRICKS_CATALOG`.
+async fn introspect_for_backend(
+    app_state: &AppState,
+    database: &str,
+) -> Result<
+    crate::graph_catalog::schema_discovery::IntrospectResponse,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    #[cfg(feature = "databricks")]
+    if app_state.config.databricks {
+        return databricks_introspect(app_state, database).await;
+    }
+
+    let ch_client = match &app_state.clickhouse_client {
+        Some(c) => c,
+        None => {
+            return Err((
+                StatusCode::NOT_IMPLEMENTED,
+                Json(
+                    serde_json::json!({ "error": "Schema introspection is not available in this mode (no ClickHouse connection)" }),
+                ),
+            ));
+        }
+    };
+
+    SchemaDiscovery::introspect(ch_client, database)
+        .await
+        .map_err(|e| {
+            log::error!("Introspect failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+        })
+}
+
+/// DeltaGraph introspection: resolve the concrete `DatabricksSqlExecutor` from
+/// the trait object, use its configured catalog plus the request's `database`
+/// (treated as the Spark schema) and drive `DatabricksProbe`.
+#[cfg(feature = "databricks")]
+async fn databricks_introspect(
+    app_state: &AppState,
+    schema: &str,
+) -> Result<
+    crate::graph_catalog::schema_discovery::IntrospectResponse,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    use crate::executor::databricks_sql::DatabricksSqlExecutor;
+    use crate::graph_catalog::databricks_probe::DatabricksProbe;
+
+    let executor = app_state
+        .executor
+        .as_any()
+        .and_then(|a| a.downcast_ref::<DatabricksSqlExecutor>())
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Databricks mode is active but the executor is not a DatabricksSqlExecutor" })),
+            )
+        })?;
+
+    let catalog = executor.catalog().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Databricks introspection requires a catalog. Set DATABRICKS_CATALOG (or the schema YAML `catalog:` field) and restart the server; the request's `database` is used as the Spark schema within that catalog." })),
+        )
+    })?;
+
+    DatabricksProbe::introspect(executor, catalog, schema)
+        .await
+        .map_err(|e| {
+            log::error!("Databricks introspect failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+        })
+}
+
 pub async fn introspect_handler(
     State(app_state): State<Arc<AppState>>,
     Json(payload): Json<IntrospectRequest>,
@@ -2186,30 +2270,8 @@ pub async fn introspect_handler(
         ));
     }
 
-    let ch_client = match &app_state.clickhouse_client {
-        Some(c) => c,
-        None => {
-            return Err((
-                StatusCode::NOT_IMPLEMENTED,
-                Json(
-                    serde_json::json!({ "error": "Schema introspection is not available in embedded mode (no ClickHouse connection)" }),
-                ),
-            ));
-        }
-    };
-
-    let response = SchemaDiscovery::introspect(ch_client, &payload.database).await;
-
-    match response {
-        Ok(resp) => Ok(Json(serde_json::to_value(resp).unwrap())),
-        Err(e) => {
-            log::error!("Introspect failed: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            ))
-        }
-    }
+    let resp = introspect_for_backend(&app_state, &payload.database).await?;
+    Ok(Json(serde_json::to_value(resp).unwrap()))
 }
 
 #[derive(Deserialize)]
@@ -2235,37 +2297,11 @@ pub async fn discover_prompt_handler(
         ));
     }
 
-    // Introspect the database
-    let ch_client = match &app_state.clickhouse_client {
-        Some(c) => c,
-        None => {
-            return Err((
-                StatusCode::NOT_IMPLEMENTED,
-                Json(
-                    serde_json::json!({ "error": "Schema discovery is not available in embedded mode (no ClickHouse connection)" }),
-                ),
-            ));
-        }
-    };
-
-    let introspect_result = SchemaDiscovery::introspect(ch_client, &payload.database).await;
-
-    match introspect_result {
-        Ok(resp) => {
-            let prompt_response = crate::graph_catalog::llm_prompt::format_discovery_prompt(
-                &resp.database,
-                &resp.tables,
-            );
-            Ok(Json(serde_json::to_value(prompt_response).unwrap()))
-        }
-        Err(e) => {
-            log::error!("Introspect failed for discover-prompt: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            ))
-        }
-    }
+    // Introspect via whichever backend is active (ClickHouse or Databricks).
+    let resp = introspect_for_backend(&app_state, &payload.database).await?;
+    let prompt_response =
+        crate::graph_catalog::llm_prompt::format_discovery_prompt(&resp.database, &resp.tables);
+    Ok(Json(serde_json::to_value(prompt_response).unwrap()))
 }
 
 #[derive(Deserialize)]

--- a/tests/rust/integration/databricks_introspect_tests.rs
+++ b/tests/rust/integration/databricks_introspect_tests.rs
@@ -1,0 +1,168 @@
+//! Integration tests for DeltaGraph schema introspection over HTTP.
+//!
+//! Drives the real router (`POST /schemas/introspect`) via
+//! `tower::ServiceExt::oneshot` with an `AppState` whose executor is a real
+//! `DatabricksSqlExecutor` pointed at a `wiremock` mock — exercising the full
+//! wiring: handler → `as_any` downcast → catalog resolution → `DatabricksProbe`
+//! → `SHOW TABLES` / `DESCRIBE TABLE EXTENDED` / `SELECT … LIMIT 3`.
+//!
+//! Gated on the `databricks` feature (where the executor/probe compile).
+
+#![cfg(feature = "databricks")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt; // for `oneshot`
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use clickgraph::config::ServerConfig;
+use clickgraph::executor::databricks_sql::{DatabricksConfig, DatabricksSqlExecutor};
+use clickgraph::executor::QueryExecutor;
+use clickgraph::server::{build_router, AppState};
+
+/// Mount the SHOW TABLES / DESCRIBE / SELECT mocks the probe walks through.
+async fn mount_catalog_mocks(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("SHOW TABLES IN"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-show",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [
+                { "name": "database" }, { "name": "tableName" }, { "name": "isTemporary" }
+            ]}},
+            "result": { "data_array": [
+                ["graphs", "users", false],
+                ["graphs", "follows", false]
+            ]}
+        })))
+        .mount(server)
+        .await;
+
+    for table in ["users", "follows"] {
+        Mock::given(method("POST"))
+            .and(path("/api/2.0/sql/statements"))
+            .and(body_string_contains(format!(
+                "DESCRIBE TABLE EXTENDED `main`.`graphs`.`{table}`"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "statement_id": format!("stmt-desc-{table}"),
+                "status": { "state": "SUCCEEDED" },
+                "manifest": { "schema": { "columns": [
+                    { "name": "col_name" }, { "name": "data_type" }, { "name": "comment" }
+                ]}},
+                "result": { "data_array": [
+                    ["id", "bigint", null],
+                    ["name", "string", null]
+                ]}
+            })))
+            .mount(server)
+            .await;
+    }
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("LIMIT 3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-sample",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [ { "name": "id" }, { "name": "name" } ]}},
+            "result": { "data_array": [[1, "alice"]] }
+        })))
+        .mount(server)
+        .await;
+}
+
+fn databricks_state(server: &MockServer, catalog: Option<&str>) -> (AppState, ServerConfig) {
+    let mut dbc = DatabricksConfig::new("ignored.cloud.databricks.com", "wh-test", "dapi-test");
+    dbc.base_url = Some(server.uri());
+    dbc.catalog = catalog.map(String::from);
+    let executor: Arc<dyn QueryExecutor> =
+        Arc::new(DatabricksSqlExecutor::new(dbc).expect("executor builds"));
+
+    let config = ServerConfig {
+        databricks: true,
+        ..ServerConfig::default()
+    };
+
+    let state = AppState {
+        executor,
+        clickhouse_client: None,
+        config: config.clone(),
+        query_semaphore: None,
+        pool: None,
+    };
+    (state, config)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).expect("json body")
+}
+
+#[tokio::test]
+async fn introspect_routes_to_databricks_probe() {
+    let server = MockServer::start().await;
+    mount_catalog_mocks(&server).await;
+
+    let (state, config) = databricks_state(&server, Some("main"));
+    let app = build_router(state, &config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/schemas/introspect")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "database": "graphs" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    // database is the catalog.schema namespace; tables come from the probe.
+    assert_eq!(body["database"], json!("main.graphs"));
+    let names: Vec<&str> = body["tables"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["follows", "users"]); // sorted by the probe
+}
+
+#[tokio::test]
+async fn introspect_without_catalog_returns_400() {
+    let server = MockServer::start().await;
+    // No mocks needed — the handler should reject before any HTTP call.
+
+    let (state, config) = databricks_state(&server, None);
+    let app = build_router(state, &config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/schemas/introspect")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "database": "graphs" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp).await;
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("catalog"),
+        "expected a catalog-required error, got {body}"
+    );
+}

--- a/tests/rust/integration/mod.rs
+++ b/tests/rust/integration/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod browser_test_schemas;
 mod complex_feature_tests;
 mod cross_schema_pattern_tests;
 mod cte_column_aliasing_tests;
+#[cfg(feature = "databricks")]
+mod databricks_introspect_tests;
 mod ldbc_regression_tests;
 mod metrics_endpoint_tests;
 mod parameter_function_test;


### PR DESCRIPTION
## Problem

`POST /schemas/introspect` and `POST /schemas/discover-prompt` required a ClickHouse client and issued ClickHouse `system.*` SQL, so they returned **501** against a DeltaGraph (Databricks) server. That broke the `clickgraph-client` REPL's `:introspect` / `:discover` commands. This is the second half of the client/DeltaGraph compatibility work (follows #358, which fixed query output).

## Key find

A complete Databricks introspection module — `graph_catalog::databricks_probe` (`SHOW TABLES IN catalog.schema` + `DESCRIBE TABLE EXTENDED`) — already existed and returns the **same `IntrospectResponse`** shape as the ClickHouse path. It just wasn't reachable from the server. So this PR is mostly wiring, not new logic.

## Changes

- **`QueryExecutor::as_any()`** downcast hook — default `None`; only `DatabricksSqlExecutor` overrides it. Lets a handler recover the concrete executor from the `Arc<dyn QueryExecutor>` trait object without threading a second handle through every `AppState` constructor.
- **`DatabricksSqlExecutor::catalog()`** — exposes the configured `DATABRICKS_CATALOG` / YAML `catalog:`, which introspection needs for the `catalog.schema` namespace.
- **`handlers.rs`** — a backend-aware `introspect_for_backend()` shared by both endpoints: Databricks mode → `DatabricksProbe` (catalog from config + the request's `database` treated as the Spark schema); otherwise the existing ClickHouse path. Missing catalog → **400** with a clear message.

### Catalog/schema mapping
Per the chosen design: catalog comes from `DATABRICKS_CATALOG` (or YAML `catalog:`); the request's `database` is the Spark schema within it.

## Tests

- Executor unit tests: `catalog()` accessor, `as_any()` downcast.
- New `tests/rust/integration/databricks_introspect_tests.rs` (gated on `databricks`): drives `POST /schemas/introspect` through the real router against `wiremock` — happy path returns `catalog.schema` + sorted tables; no-catalog returns 400.
- Full suite green: **1437 databricks lib + 284 integration**, **1391 default lib**; clippy clean on default and `--features databricks`.

## Docs
Updates `clickgraph-client/README.md` and `docs/wiki/Databricks-Deployment.md`: with #358 + this PR, the REPL is **fully supported** against DeltaGraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)