### PR TITLE
feat(passthrough): dbx. native-function pass-through for Databricks/Spark

### DIFF
--- a/docs/wiki/ClickHouse-Functions.md
+++ b/docs/wiki/ClickHouse-Functions.md
@@ -2,6 +2,8 @@
 
 ClickGraph provides direct access to **any ClickHouse function** using the `ch.` and `chagg.` prefixes. This enables ClickHouse's powerful analytics capabilities directly from Cypher queries.
 
+> **Backend-specific.** The `ch.`/`chagg.` prefixes work only against the **ClickHouse** backend. On the Databricks/Spark backend (DeltaGraph) use the `dbx.` prefix instead — see **[Databricks Function Pass-Through](Databricks-Functions.md)**. A `ch.` call sent to a Databricks server is rejected at translation time (and vice-versa) rather than producing wrong SQL.
+
 ## Quick Reference
 
 | Prefix | Use Case | GROUP BY |

--- a/docs/wiki/ClickHouse-Functions.md
+++ b/docs/wiki/ClickHouse-Functions.md
@@ -2,7 +2,7 @@
 
 ClickGraph provides direct access to **any ClickHouse function** using the `ch.` and `chagg.` prefixes. This enables ClickHouse's powerful analytics capabilities directly from Cypher queries.
 
-> **Backend-specific.** The `ch.`/`chagg.` prefixes work only against the **ClickHouse** backend. On the Databricks/Spark backend (DeltaGraph) use the `dbx.` prefix instead — see **[Databricks Function Pass-Through](Databricks-Functions.md)**. A `ch.` call sent to a Databricks server is rejected at translation time (and vice-versa) rather than producing wrong SQL.
+> **Backend-specific.** The `ch.`/`chagg.` prefixes work only against the **ClickHouse** backend. On the Databricks/Spark backend (DeltaGraph) use the `dbx.` prefix instead — see **[Databricks Function Pass-Through](Databricks-Functions.md)**. A `ch.` call sent to a Databricks server always fails (and vice-versa) — the prefix is never silently stripped into a valid call on the other backend — surfacing as either a translation-time error or a database error on the unknown function.
 
 ## Quick Reference
 

--- a/docs/wiki/Cypher-Functions.md
+++ b/docs/wiki/Cypher-Functions.md
@@ -981,6 +981,8 @@ LIMIT 5
 
 ClickGraph provides direct access to **any ClickHouse function** using the `ch.` and `chagg.` prefixes.
 
+> Running against **Databricks/Spark** (DeltaGraph)? Use the `dbx.` prefix instead — see [Databricks Function Pass-Through](Databricks-Functions.md). `ch.`/`chagg.` are ClickHouse-only.
+
 ### Quick Reference
 
 | Prefix | Use Case | GROUP BY |

--- a/docs/wiki/Databricks-Deployment.md
+++ b/docs/wiki/Databricks-Deployment.md
@@ -78,6 +78,7 @@ it.
 
 ## See also
 
+- [Databricks Function Pass-Through](Databricks-Functions.md) — reach native Spark/Databricks functions from Cypher with the `dbx.` prefix
 - [HTTP API Reference](API-Reference-HTTP.md) — the endpoints the server exposes
 - [Schema Basics](Schema-Basics.md) — authoring the graph-schema YAML
 - [`cg` CLI](../../clickgraph-tool/AGENTS.md) — `--dialect databricks` for ad-hoc queries

--- a/docs/wiki/Databricks-Functions.md
+++ b/docs/wiki/Databricks-Functions.md
@@ -1,0 +1,98 @@
+# Databricks / Spark Function Pass-Through
+
+When ClickGraph runs against a **Databricks SQL Warehouse** (the DeltaGraph
+backend, Spark SQL dialect), the `dbx.` prefix gives Cypher queries direct
+access to **any native Databricks / Spark SQL function** that has no Cypher
+built-in.
+
+> This is the Databricks counterpart to ClickHouse's
+> [`ch.`/`chagg.` pass-through](ClickHouse-Functions.md). The two are
+> **backend-specific and mutually exclusive**: `dbx.` works only on the
+> Databricks backend, `ch.`/`chagg.` only on ClickHouse. Using the wrong
+> prefix for the active backend is rejected at translation time with a
+> message pointing at the right one — it never silently produces wrong SQL.
+
+## Quick reference
+
+| Prefix | Use case | GROUP BY |
+|--------|----------|----------|
+| `dbx.` | **Any** scalar *or* aggregate Spark/Databricks function | Auto for aggregates |
+
+```cypher
+-- Scalar function
+MATCH (u:User) RETURN dbx.get_json_object(u.metadata, '$.tier') AS tier
+
+-- Aggregate (GROUP BY added automatically)
+MATCH (u:User) RETURN u.country, dbx.percentile_approx(u.score, 0.95) AS p95
+
+-- Aggregate that collects into an array
+MATCH (u:User) RETURN u.country, dbx.collect_list(u.id) AS ids
+```
+
+The bare function name (prefix stripped) is emitted directly into the
+generated Spark SQL: `dbx.percentile_approx(u.score, 0.95)` →
+`percentile_approx(score, 0.95)`. Arguments still go through ClickGraph's
+normal property mapping and parameter substitution.
+
+## One prefix, not two — why there's no `dbxagg.`
+
+ClickHouse has **two** prefixes (`ch.` for scalars / known aggregates,
+`chagg.` to force aggregate treatment) for a historical reason: the
+pass-through shipped before an aggregate registry existed, so users had to
+declare a function's type themselves.
+
+Databricks ships with a registry of Spark's built-in aggregate functions
+from day one, so ClickGraph **infers** scalar-vs-aggregate itself — a single
+`dbx.` prefix is enough. Spark's aggregate surface is bounded and
+enumerable (unlike ClickHouse's open-ended combinator space), so the
+registry can be effectively complete.
+
+- `dbx.<aggregate>` → recognized as an aggregate, GROUP BY added.
+- `dbx.<anything else>` → treated as a scalar.
+
+### If an aggregate isn't recognized
+
+If you call a Spark aggregate (or a user-defined UDAF) that isn't yet in
+ClickGraph's registry, it will be treated as a *scalar* and GROUP BY won't
+be generated — producing a Spark error. The fix is to **add the function to
+the registry** (`SPARK_AGGREGATE_FUNCTIONS` in
+`src/sql_generator/passthrough/databricks.rs`), not to learn a second
+prefix. Please open an issue or PR if you hit a missing one.
+
+## Recognized aggregate functions
+
+The registry tracks Spark / Databricks SQL built-in aggregates, including:
+
+| Category | Functions |
+|----------|-----------|
+| **Basic** | `count`, `count_if`, `sum`, `avg`, `mean`, `min`, `max`, `min_by`, `max_by`, `first`, `last`, `any_value`, `mode`, `product` |
+| **Collection** | `collect_list`, `collect_set`, `array_agg` |
+| **Cardinality / sketch** | `approx_count_distinct`, `count_min_sketch`, `hll_sketch_agg`, `hll_union_agg` |
+| **Percentiles** | `median`, `percentile`, `percentile_approx`, `approx_percentile`, `histogram_numeric` |
+| **Statistics** | `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`, `skewness`, `kurtosis`, `corr`, `covar_samp`, `covar_pop` |
+| **Regression** | `regr_avgx`, `regr_avgy`, `regr_count`, `regr_intercept`, `regr_r2`, `regr_slope`, `regr_sxx`, `regr_sxy`, `regr_syy` |
+| **Boolean / bitwise** | `any`, `some`, `every`, `bool_and`, `bool_or`, `bit_and`, `bit_or`, `bit_xor`, `bitmap_construct_agg`, `bitmap_or_agg` |
+| **Grouping** | `grouping`, `grouping_id` |
+| **`try_*` variants** | `try_avg`, `try_sum` |
+
+Everything else under `dbx.` is treated as a scalar function — e.g.
+`dbx.get_json_object`, `dbx.element_at`, `dbx.array_contains`, `dbx.upper`,
+`dbx.regexp_extract`, `dbx.from_unixtime`, …
+
+See the
+[Databricks SQL built-in functions reference](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-functions-builtin)
+for the full catalog.
+
+## Notes
+
+- **Argument shapes are passed through verbatim.** ClickGraph does not
+  rewrite a native function's argument conventions — you write them as Spark
+  expects (e.g. JSONPath `'$.field'` for `dbx.get_json_object`).
+- **Cypher built-ins are still translated** the normal way; only use `dbx.`
+  for functions ClickGraph doesn't already map.
+
+## See also
+
+- [ClickHouse Function Pass-Through](ClickHouse-Functions.md) — the `ch.` / `chagg.` equivalent
+- [Databricks Deployment (DeltaGraph)](Databricks-Deployment.md)
+- [Cypher Functions](Cypher-Functions.md)

--- a/docs/wiki/Databricks-Functions.md
+++ b/docs/wiki/Databricks-Functions.md
@@ -9,8 +9,11 @@ built-in.
 > [`ch.`/`chagg.` pass-through](ClickHouse-Functions.md). The two are
 > **backend-specific and mutually exclusive**: `dbx.` works only on the
 > Databricks backend, `ch.`/`chagg.` only on ClickHouse. Using the wrong
-> prefix for the active backend is rejected at translation time with a
-> message pointing at the right one — it never silently produces wrong SQL.
+> prefix for the active backend always **fails** — the prefix is never
+> silently stripped into a valid function on the other backend. Depending
+> on the code path it surfaces either as a translation-time error (with a
+> message naming the correct prefix) or as a database error on the unknown
+> prefixed function name.
 
 ## Quick reference
 
@@ -65,11 +68,11 @@ The registry tracks Spark / Databricks SQL built-in aggregates, including:
 
 | Category | Functions |
 |----------|-----------|
-| **Basic** | `count`, `count_if`, `sum`, `avg`, `mean`, `min`, `max`, `min_by`, `max_by`, `first`, `last`, `any_value`, `mode`, `product` |
+| **Basic** | `count`, `count_if`, `sum`, `avg`, `mean`, `min`, `max`, `min_by`, `max_by`, `first`, `first_value`, `last`, `last_value`, `any_value`, `mode` |
 | **Collection** | `collect_list`, `collect_set`, `array_agg` |
 | **Cardinality / sketch** | `approx_count_distinct`, `count_min_sketch`, `hll_sketch_agg`, `hll_union_agg` |
 | **Percentiles** | `median`, `percentile`, `percentile_approx`, `approx_percentile`, `histogram_numeric` |
-| **Statistics** | `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`, `skewness`, `kurtosis`, `corr`, `covar_samp`, `covar_pop` |
+| **Statistics** | `std`, `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`, `skewness`, `kurtosis`, `corr`, `covar_samp`, `covar_pop` |
 | **Regression** | `regr_avgx`, `regr_avgy`, `regr_count`, `regr_intercept`, `regr_r2`, `regr_slope`, `regr_sxx`, `regr_sxy`, `regr_syy` |
 | **Boolean / bitwise** | `any`, `some`, `every`, `bool_and`, `bool_or`, `bit_and`, `bit_or`, `bit_xor`, `bitmap_construct_agg`, `bitmap_or_agg` |
 | **Grouping** | `grouping`, `grouping_id` |

--- a/src/query_planner/logical_expr/ast_conversion.rs
+++ b/src/query_planner/logical_expr/ast_conversion.rs
@@ -11,9 +11,6 @@
 use std::sync::Arc;
 
 use crate::{
-    clickhouse_query_generator::{
-        is_ch_passthrough_aggregate, CH_AGG_PREFIX, CH_PASSTHROUGH_PREFIX,
-    },
     open_cypher_parser,
     query_planner::logical_plan::{Filter, GraphNode, GraphRel, LogicalPlan},
 };
@@ -158,12 +155,16 @@ impl<'a> TryFrom<open_cypher_parser::ast::FunctionCall<'a>> for LogicalExpr {
         // Check if it's a standard aggregate function
         let is_standard_agg = agg_fns.contains(&name_lower.as_str());
 
-        // Check if it's a ch./chagg. prefixed ClickHouse aggregate function
-        // chagg. prefix is ALWAYS an aggregate (explicit declaration)
-        // ch. prefix checks against the aggregate registry
-        let is_ch_agg = value.name.starts_with(CH_AGG_PREFIX)
-            || (value.name.starts_with(CH_PASSTHROUGH_PREFIX)
-                && is_ch_passthrough_aggregate(&value.name));
+        // Check if it's a native pass-through aggregate (any backend's prefix).
+        // Dialect-agnostic on purpose: the planner runs before the dialect is
+        // pinned, so we classify by recognizing every backend's prefixes —
+        // `ch.`/`chagg.` (ClickHouse, registry + explicit) and `dbx.`
+        // (Databricks, registry). Wrong-backend prefixes are rejected later, at
+        // emit time. See `sql_generator::passthrough`.
+        let is_passthrough_agg = matches!(
+            crate::sql_generator::passthrough::classify_passthrough(&value.name),
+            Some(crate::sql_generator::passthrough::PassthroughKind::Aggregate)
+        );
 
         let args = value
             .args
@@ -171,7 +172,7 @@ impl<'a> TryFrom<open_cypher_parser::ast::FunctionCall<'a>> for LogicalExpr {
             .map(LogicalExpr::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
-        if is_standard_agg || is_ch_agg {
+        if is_standard_agg || is_passthrough_agg {
             Ok(LogicalExpr::AggregateFnCall(AggregateFnCall {
                 name: value.name,
                 args,

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -840,6 +840,90 @@ async fn shortestpath_bfs_under_clickhouse_keeps_three_branch_undirected() {
     );
 }
 
+// ===========================================================================
+// Native-function pass-through, end to end (sql_generator::passthrough).
+//
+// `dbx.` reaches Spark/Databricks native functions; the registry decides
+// scalar vs aggregate (single prefix, no `dbxagg.`). `ch.`/`chagg.` stay
+// ClickHouse-only. These exercise the full Cypher → SQL path under each
+// dialect; the prefix-matching / cross-backend-rejection logic itself is
+// unit-tested in `sql_generator::passthrough`.
+// ===========================================================================
+
+/// `dbx.<scalar>` under the Databricks dialect emits the bare Spark name.
+#[tokio::test]
+async fn dbx_scalar_passthrough_under_databricks() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN dbx.upper(u.name) AS n")
+    })
+    .await;
+    assert!(
+        sql.contains("upper(") && !sql.contains("dbx."),
+        "expected bare `upper(` with the `dbx.` prefix stripped; got:\n{sql}"
+    );
+}
+
+/// `dbx.<aggregate>` is recognised as an aggregate via the Spark registry
+/// (no `dbxagg.` needed) and emitted bare.
+#[tokio::test]
+async fn dbx_aggregate_passthrough_under_databricks() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN dbx.collect_list(u.id) AS ids")
+    })
+    .await;
+    assert!(
+        sql.contains("collect_list(") && !sql.contains("dbx."),
+        "expected bare `collect_list(` (registry-detected aggregate); got:\n{sql}"
+    );
+}
+
+/// `dbx.percentile_approx(...)` — multi-arg aggregate, prefix stripped.
+#[tokio::test]
+async fn dbx_percentile_approx_under_databricks() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN dbx.percentile_approx(u.id, 0.95) AS p")
+    })
+    .await;
+    assert!(
+        sql.contains("percentile_approx("),
+        "expected bare `percentile_approx(`; got:\n{sql}"
+    );
+}
+
+/// Regression: `ch.`/`chagg.` pass-through still works under the ClickHouse
+/// dialect, scalar and aggregate, with the prefix stripped.
+#[tokio::test]
+async fn ch_passthrough_still_works_under_clickhouse() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::ClickHouse,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN ch.cityHash64(u.id) AS h, ch.uniq(u.id) AS c")
+    })
+    .await;
+    assert!(
+        sql.contains("cityHash64(") && sql.contains("uniq("),
+        "expected bare CH `cityHash64(` (scalar) and `uniq(` (aggregate); got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("ch."),
+        "CH prefix should be stripped from emitted SQL; got:\n{sql}"
+    );
+}
+
 /// `is_integer_literal` is the guard that keeps the Databricks anchor
 /// cast from wrapping non-numeric IDs. Direct unit test — covers the
 /// shape via the cypher_to_sql path elsewhere but locks the predicate

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -924,6 +924,65 @@ async fn ch_passthrough_still_works_under_clickhouse() {
     );
 }
 
+/// A foreign-backend prefix on the rendering path (which returns `String`,
+/// not `Result`) is emitted **verbatim** so the query fails loudly at the
+/// database on an unknown function — never silently stripped into a
+/// valid-looking call. `ch.uniq` (aggregate) under Databricks.
+#[tokio::test]
+async fn foreign_aggregate_prefix_emitted_verbatim_under_databricks() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN ch.uniq(u.id) AS c")
+    })
+    .await;
+    // The invalid prefixed name survives into the SQL (DB will reject it);
+    // it is NOT silently stripped to a bare `uniq(`.
+    assert!(
+        sql.contains("ch.uniq("),
+        "expected the foreign `ch.uniq(` to be emitted verbatim (loud failure); got:\n{sql}"
+    );
+}
+
+/// Foreign scalar prefix `dbx.upper` under ClickHouse — emitted verbatim.
+#[tokio::test]
+async fn foreign_scalar_prefix_emitted_verbatim_under_clickhouse() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::ClickHouse,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN dbx.upper(u.name) AS n")
+    })
+    .await;
+    assert!(
+        sql.contains("dbx.upper("),
+        "expected the foreign `dbx.upper(` to be emitted verbatim; got:\n{sql}"
+    );
+}
+
+/// Nested foreign pass-through as an argument must NOT be silently dropped.
+/// `dbx.upper(ch.lower(u.name))` under Databricks: the outer `dbx.` strips
+/// to `upper(...)`, the inner foreign `ch.lower` is emitted verbatim as the
+/// argument — so the argument list is intact (no `upper()` with a lost arg).
+#[tokio::test]
+async fn nested_foreign_passthrough_arg_is_not_dropped() {
+    let ctx = QueryContext {
+        dialect: SqlDialect::Databricks,
+        ..QueryContext::default()
+    };
+    let sql = with_query_context(ctx, async {
+        cypher_to_sql("MATCH (u:User) RETURN dbx.upper(ch.lower(u.name)) AS n")
+    })
+    .await;
+    assert!(
+        sql.contains("upper(ch.lower("),
+        "expected nested arg preserved as `upper(ch.lower(`, not dropped; got:\n{sql}"
+    );
+}
+
 /// `is_integer_literal` is the guard that keeps the Databricks anchor
 /// cast from wrapping non-numeric IDs. Direct unit test — covers the
 /// shape via the cypher_to_sql path elsewhere but locks the predicate

--- a/src/sql_generator/emitters/clickhouse/function_translator.rs
+++ b/src/sql_generator/emitters/clickhouse/function_translator.rs
@@ -285,9 +285,37 @@ pub fn translate_scalar_function(
 ) -> Result<String, ClickhouseQueryGeneratorError> {
     let fn_name = &fn_call.name;
 
-    // Check for ClickHouse pass-through prefixes (chagg. or ch.)
-    if fn_name.starts_with(CH_AGG_PREFIX) || fn_name.starts_with(CH_PASSTHROUGH_PREFIX) {
-        return translate_ch_passthrough(fn_call);
+    // Native-function pass-through, keyed by the active dialect (`ch.`/`chagg.`
+    // for ClickHouse, `dbx.` for Databricks). A prefix belonging to a *different*
+    // backend is rejected here rather than leaking into the generated SQL.
+    if let Some(bare) = crate::sql_generator::passthrough::strip_passthrough(
+        fn_name,
+        crate::server::query_context::get_current_dialect(),
+    )
+    .map_err(|e| ClickhouseQueryGeneratorError::SchemaError(e.to_string()))?
+    {
+        let args_sql: Vec<String> = fn_call
+            .args
+            .iter()
+            .map(|e| e.to_sql())
+            .collect::<Result<_, _>>()
+            .map_err(|e| {
+                ClickhouseQueryGeneratorError::schema_error_with_context(
+                    format!("Failed to convert arguments to SQL: {}", e),
+                    format!(
+                        "in {} pass-through function with {} arguments",
+                        fn_call.name,
+                        fn_call.args.len()
+                    ),
+                )
+            })?;
+        log::debug!(
+            "native pass-through: {}(..) -> {}({})",
+            fn_call.name,
+            bare,
+            args_sql.join(", ")
+        );
+        return Ok(format!("{}({})", bare, args_sql.join(", ")));
     }
 
     let fn_name_lower = fn_name.to_lowercase();
@@ -360,77 +388,6 @@ pub fn translate_scalar_function(
             Ok(format!("{}({})", fn_call.name, args_sql.join(", ")))
         }
     }
-}
-
-/// Translate a ClickHouse pass-through function (ch. prefix)
-///
-/// The ch. prefix allows direct access to any ClickHouse function without
-/// requiring a Neo4j mapping. Uses dot notation for Neo4j ecosystem compatibility
-/// (consistent with apoc.*, gds.* patterns). Arguments still undergo property
-/// mapping and parameter substitution.
-///
-/// # Examples
-/// ```cypher
-/// // Scalar functions
-/// RETURN ch.cityHash64(u.email) AS hash
-/// RETURN ch.JSONExtractString(u.metadata, 'field') AS field
-///
-/// // URL functions
-/// RETURN ch.domain(u.url) AS domain
-///
-/// // IP functions
-/// RETURN ch.IPv4NumToString(u.ip) AS ip_str
-///
-/// // Geo functions
-/// RETURN ch.greatCircleDistance(lat1, lon1, lat2, lon2) AS distance
-/// ```
-fn translate_ch_passthrough(
-    fn_call: &ScalarFnCall,
-) -> Result<String, ClickhouseQueryGeneratorError> {
-    // Strip the ch. or chagg. prefix to get the raw ClickHouse function name
-    let ch_fn_name = get_ch_function_name(&fn_call.name).ok_or_else(|| {
-        ClickhouseQueryGeneratorError::schema_error_with_context(
-            "Expected ch. or chagg. prefix in function name",
-            format!("function name provided: {}", fn_call.name),
-        )
-    })?;
-
-    if ch_fn_name.is_empty() {
-        return Err(ClickhouseQueryGeneratorError::schema_error_with_context(
-            "ch./chagg. prefix requires a function name (e.g., ch.cityHash64, chagg.myAgg)",
-            format!("in ClickHouse pass-through function: {}", fn_call.name),
-        ));
-    }
-
-    // Convert arguments to SQL (this preserves property mapping)
-    let args_sql: Result<Vec<String>, _> = fn_call.args.iter().map(|e| e.to_sql()).collect();
-
-    let args_sql = args_sql.map_err(|e| {
-        ClickhouseQueryGeneratorError::schema_error_with_context(
-            format!("Failed to convert arguments to SQL: {}", e),
-            format!(
-                "in {} function with {} arguments",
-                fn_call.name,
-                fn_call.args.len()
-            ),
-        )
-    })?;
-
-    log::debug!(
-        "ClickHouse pass-through: {}({}) -> {}({})",
-        fn_call.name,
-        fn_call
-            .args
-            .iter()
-            .map(|a| format!("{:?}", a))
-            .collect::<Vec<_>>()
-            .join(", "),
-        ch_fn_name,
-        args_sql.join(", ")
-    );
-
-    // Generate ClickHouse function call directly
-    Ok(format!("{}({})", ch_fn_name, args_sql.join(", ")))
 }
 
 /// Translate Neo4j duration({...}) function to ClickHouse interval expressions

--- a/src/sql_generator/emitters/clickhouse/function_translator.rs
+++ b/src/sql_generator/emitters/clickhouse/function_translator.rs
@@ -244,39 +244,12 @@ static CH_AGGREGATE_FUNCTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(|
     s
 });
 
-/// Check if a function name (without ch. prefix) is a known ClickHouse aggregate
+/// Check if a function name (without ch. prefix) is a known ClickHouse aggregate.
+/// Consulted by the ClickHouse [`PassthroughPolicy`] to classify `ch.` calls.
+///
+/// [`PassthroughPolicy`]: crate::sql_generator::passthrough::PassthroughPolicy
 pub fn is_ch_aggregate_function(fn_name: &str) -> bool {
     CH_AGGREGATE_FUNCTIONS.contains(fn_name.to_lowercase().as_str())
-}
-
-/// Check if a function uses the explicit chagg. prefix
-/// chagg.functionName() is ALWAYS treated as an aggregate, no registry lookup needed
-pub fn is_explicit_ch_aggregate(fn_name: &str) -> bool {
-    fn_name.starts_with(CH_AGG_PREFIX)
-}
-
-/// Check if a ch. prefixed function is an aggregate
-/// Returns true if:
-/// 1. Function starts with chagg. (explicit aggregate), OR
-/// 2. Function starts with ch. and the underlying function is in the aggregate registry
-pub fn is_ch_passthrough_aggregate(fn_name: &str) -> bool {
-    // Explicit chagg. prefix - always an aggregate
-    if fn_name.starts_with(CH_AGG_PREFIX) {
-        return true;
-    }
-    // ch. prefix - check registry
-    if let Some(ch_fn_name) = fn_name.strip_prefix(CH_PASSTHROUGH_PREFIX) {
-        return is_ch_aggregate_function(ch_fn_name);
-    }
-    false
-}
-
-/// Get the raw ClickHouse function name from a ch. or chagg. prefixed name
-/// Returns None if not a ch./chagg. prefixed function
-pub fn get_ch_function_name(fn_name: &str) -> Option<&str> {
-    fn_name
-        .strip_prefix(CH_AGG_PREFIX)
-        .or_else(|| fn_name.strip_prefix(CH_PASSTHROUGH_PREFIX))
 }
 
 /// Translate a Neo4j scalar function call to ClickHouse SQL
@@ -489,11 +462,6 @@ fn translate_duration_function(
     }
 }
 
-/// Check if a function uses ClickHouse pass-through (ch. prefix)
-pub fn is_ch_passthrough(fn_name: &str) -> bool {
-    fn_name.starts_with(CH_PASSTHROUGH_PREFIX)
-}
-
 /// Check if a function is supported (has a mapping)
 pub fn is_function_supported(fn_name: &str) -> bool {
     get_function_mapping(fn_name).is_some()
@@ -688,15 +656,6 @@ mod tests {
             .contains("requires a function name"));
     }
 
-    #[test]
-    fn test_is_ch_passthrough() {
-        assert!(is_ch_passthrough("ch.cityHash64"));
-        assert!(is_ch_passthrough("ch.JSONExtract"));
-        assert!(!is_ch_passthrough("cityHash64"));
-        assert!(!is_ch_passthrough("toUpper"));
-        assert!(!is_ch_passthrough("CH.test")); // Case sensitive
-    }
-
     // ===== ClickHouse Aggregate Function Tests =====
 
     #[test]
@@ -720,52 +679,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_ch_passthrough_aggregate() {
-        // ch. prefixed aggregates
-        assert!(is_ch_passthrough_aggregate("ch.uniq"));
-        assert!(is_ch_passthrough_aggregate("ch.quantile"));
-        assert!(is_ch_passthrough_aggregate("ch.topK"));
-        assert!(is_ch_passthrough_aggregate("ch.groupArray"));
-
-        // ch. prefixed non-aggregates
-        assert!(!is_ch_passthrough_aggregate("ch.cityHash64"));
-        assert!(!is_ch_passthrough_aggregate("ch.JSONExtract"));
-
-        // Non ch. prefixed
-        assert!(!is_ch_passthrough_aggregate("uniq"));
-        assert!(!is_ch_passthrough_aggregate("count"));
-    }
-
-    #[test]
-    fn test_chagg_explicit_aggregate_prefix() {
-        // chagg. prefix is ALWAYS an aggregate, regardless of function name
-        assert!(is_ch_passthrough_aggregate("chagg.customAggregate"));
-        assert!(is_ch_passthrough_aggregate("chagg.mySpecialFunc"));
-        assert!(is_ch_passthrough_aggregate("chagg.uniq")); // Also works for known ones
-        assert!(is_ch_passthrough_aggregate("chagg.anyNewFunction"));
-
-        // chagg. prefix starts_with check
-        assert!(is_explicit_ch_aggregate("chagg.test"));
-        assert!(!is_explicit_ch_aggregate("ch.test"));
-        assert!(!is_explicit_ch_aggregate("test"));
-    }
-
-    #[test]
-    fn test_get_ch_function_name_both_prefixes() {
-        // ch. prefix
-        assert_eq!(get_ch_function_name("ch.uniq"), Some("uniq"));
-        assert_eq!(get_ch_function_name("ch.cityHash64"), Some("cityHash64"));
-
-        // chagg. prefix
-        assert_eq!(get_ch_function_name("chagg.customAgg"), Some("customAgg"));
-        assert_eq!(get_ch_function_name("chagg.uniq"), Some("uniq"));
-
-        // No prefix
-        assert_eq!(get_ch_function_name("uniq"), None);
-        assert_eq!(get_ch_function_name("count"), None);
-    }
-
-    #[test]
     fn test_chagg_translate_function() {
         // chagg.customAggregate(x) -> customAggregate(x)
         let fn_call = ScalarFnCall {
@@ -775,15 +688,6 @@ mod tests {
 
         let result = translate_scalar_function(&fn_call).unwrap();
         assert_eq!(result, "myCustomAgg('test')");
-    }
-
-    #[test]
-    fn test_get_ch_function_name() {
-        assert_eq!(get_ch_function_name("ch.uniq"), Some("uniq"));
-        assert_eq!(get_ch_function_name("ch.cityHash64"), Some("cityHash64"));
-        assert_eq!(get_ch_function_name("ch."), Some(""));
-        assert_eq!(get_ch_function_name("uniq"), None);
-        assert_eq!(get_ch_function_name("count"), None);
     }
 
     #[test]

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -25,8 +25,7 @@ mod where_clause_tests;
 pub use common::{qualified_column, quote_identifier};
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{
-    get_ch_function_name, get_supported_functions, is_ch_aggregate_function, is_ch_passthrough,
-    is_ch_passthrough_aggregate, is_explicit_ch_aggregate, is_function_supported,
+    get_supported_functions, is_ch_aggregate_function, is_function_supported,
     translate_scalar_function, CH_AGG_PREFIX, CH_PASSTHROUGH_PREFIX,
 };
 pub use json_builder::{

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -144,6 +144,18 @@ impl ToSql for LogicalExpr {
                     fn_call.args.iter().map(|e| e.to_sql()).collect();
                 let args_sql = args_sql?;
 
+                // Native-function pass-through (ch./chagg. for ClickHouse, dbx. for
+                // Databricks). This arm returns Result, so a foreign-backend prefix
+                // is surfaced as a clean translation error here.
+                if let Some(bare) = crate::sql_generator::passthrough::strip_passthrough(
+                    &fn_call.name,
+                    crate::server::query_context::get_current_dialect(),
+                )
+                .map_err(|e| ClickhouseQueryGeneratorError::SchemaError(e.to_string()))?
+                {
+                    return Ok(format!("{}({})", bare, args_sql.join(", ")));
+                }
+
                 // Use function registry to translate Neo4j -> ClickHouse function names
                 // Note: We use ClickHouse-specific aggregate names (like "anyLast") to avoid
                 // conflicts with Cypher functions (like "any" for array predicates)

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -25,7 +25,6 @@ use std::collections::HashSet;
 
 // Import function translator for Neo4j -> ClickHouse function mappings
 use super::function_registry::get_function_mapping;
-use super::function_translator::{get_ch_function_name, CH_PASSTHROUGH_PREFIX};
 
 // ============================================================================
 // RENDER CONTEXT ACCESSORS (delegating to unified query_context)
@@ -4565,6 +4564,32 @@ impl RenderExpr {
                     }
                 }
 
+                // Native-function pass-through, keyed by the active dialect
+                // (`ch.` for ClickHouse, `dbx.` for Databricks). A foreign
+                // prefix is rejected; this arm returns `String`, so the
+                // rejection degrades to an empty render (loud SQL failure) —
+                // the clear, message-bearing error path lives in
+                // `translate_scalar_function` and `strip_passthrough`.
+                match crate::sql_generator::passthrough::strip_passthrough(
+                    &fn_call.name,
+                    crate::server::query_context::get_current_dialect(),
+                ) {
+                    Ok(Some(bare)) => {
+                        let args = fn_call
+                            .args
+                            .iter()
+                            .map(|e| e.to_sql())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return format!("{}({})", bare, args);
+                    }
+                    Ok(None) => { /* not a pass-through name — normal mapping below */ }
+                    Err(e) => {
+                        log::error!("scalar pass-through rejected: {}", e);
+                        return String::new();
+                    }
+                }
+
                 // Check if we have a Neo4j -> ClickHouse mapping
                 match get_function_mapping(&fn_name_lower) {
                     Some(mapping) => {
@@ -4599,17 +4624,13 @@ impl RenderExpr {
                 }
             }
             RenderExpr::AggregateFnCall(agg) => {
-                // Check for ClickHouse pass-through prefix (ch.)
-                if agg.name.starts_with(CH_PASSTHROUGH_PREFIX) {
-                    if let Some(ch_fn_name) = get_ch_function_name(&agg.name) {
-                        if ch_fn_name.is_empty() {
-                            log::error!("ch. prefix requires a function name (e.g., ch.uniq)");
-                            // TODO: Refactor to_sql() to return Result<String, Error> so this error
-                            // can be propagated instead of returning an empty string here.
-                            // Returning an empty string is acceptable as an intermediate step
-                            // but may lead to SQL syntax errors later in query execution.
-                            return String::new(); // Return empty string for invalid function name
-                        }
+                // Native-function pass-through, keyed by the active dialect
+                // (`ch.`/`chagg.` for ClickHouse, `dbx.` for Databricks).
+                match crate::sql_generator::passthrough::strip_passthrough(
+                    &agg.name,
+                    crate::server::query_context::get_current_dialect(),
+                ) {
+                    Ok(Some(bare)) => {
                         let args = agg
                             .args
                             .iter()
@@ -4617,13 +4638,23 @@ impl RenderExpr {
                             .collect::<Vec<_>>()
                             .join(", ");
                         log::debug!(
-                            "ClickHouse aggregate pass-through: ch.{}({}) -> {}({})",
-                            ch_fn_name,
-                            args,
-                            ch_fn_name,
+                            "aggregate pass-through: {}(..) -> {}({})",
+                            agg.name,
+                            bare,
                             args
                         );
-                        return format!("{}({})", ch_fn_name, args);
+                        return format!("{}({})", bare, args);
+                    }
+                    Ok(None) => { /* not a pass-through name — fall through to the registry */ }
+                    Err(e) => {
+                        // This arm returns `String`, not `Result`, so a foreign-backend
+                        // prefix (e.g. `ch.uniq` on Databricks) can't be surfaced as a
+                        // clean translation error here — log it and emit nothing so the
+                        // downstream SQL fails loudly rather than running wrong. (Scalar
+                        // pass-through DOES return a proper error; same pre-existing
+                        // asymmetry as the empty-name case once tracked by this TODO.)
+                        log::error!("aggregate pass-through rejected: {}", e);
+                        return String::new();
                     }
                 }
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4565,11 +4565,13 @@ impl RenderExpr {
                 }
 
                 // Native-function pass-through, keyed by the active dialect
-                // (`ch.` for ClickHouse, `dbx.` for Databricks). A foreign
-                // prefix is rejected; this arm returns `String`, so the
-                // rejection degrades to an empty render (loud SQL failure) —
-                // the clear, message-bearing error path lives in
-                // `translate_scalar_function` and `strip_passthrough`.
+                // (`ch.` for ClickHouse, `dbx.` for Databricks). This arm returns
+                // `String`, not `Result`, so a foreign-backend prefix can't be
+                // surfaced as a clean error here — instead we emit the *original*
+                // prefixed name (e.g. `ch.uniq(x)`) so the query fails loudly at
+                // the database on an unknown function, never silently dropping the
+                // prefix into a valid-looking call. The message-bearing error path
+                // is `translate_scalar_function` / the `LogicalExpr` arms.
                 match crate::sql_generator::passthrough::strip_passthrough(
                     &fn_call.name,
                     crate::server::query_context::get_current_dialect(),
@@ -4586,7 +4588,13 @@ impl RenderExpr {
                     Ok(None) => { /* not a pass-through name — normal mapping below */ }
                     Err(e) => {
                         log::error!("scalar pass-through rejected: {}", e);
-                        return String::new();
+                        let args = fn_call
+                            .args
+                            .iter()
+                            .map(|e| e.to_sql())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return format!("{}({})", fn_call.name, args);
                     }
                 }
 
@@ -4649,12 +4657,18 @@ impl RenderExpr {
                     Err(e) => {
                         // This arm returns `String`, not `Result`, so a foreign-backend
                         // prefix (e.g. `ch.uniq` on Databricks) can't be surfaced as a
-                        // clean translation error here — log it and emit nothing so the
-                        // downstream SQL fails loudly rather than running wrong. (Scalar
-                        // pass-through DOES return a proper error; same pre-existing
-                        // asymmetry as the empty-name case once tracked by this TODO.)
+                        // clean translation error here — emit the *original* prefixed
+                        // name so the query fails loudly at the database on an unknown
+                        // function, never silently dropping the prefix. The
+                        // message-bearing error path is the `LogicalExpr` arms.
                         log::error!("aggregate pass-through rejected: {}", e);
-                        return String::new();
+                        let args = agg
+                            .args
+                            .iter()
+                            .map(|e| e.to_sql())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return format!("{}({})", agg.name, args);
                     }
                 }
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4568,10 +4568,11 @@ impl RenderExpr {
                 // (`ch.` for ClickHouse, `dbx.` for Databricks). This arm returns
                 // `String`, not `Result`, so a foreign-backend prefix can't be
                 // surfaced as a clean error here — instead we emit the *original*
-                // prefixed name (e.g. `ch.uniq(x)`) so the query fails loudly at
-                // the database on an unknown function, never silently dropping the
-                // prefix into a valid-looking call. The message-bearing error path
-                // is `translate_scalar_function` / the `LogicalExpr` arms.
+                // prefixed name (e.g. `ch.uniq(x)`) so the query surfaces a
+                // database error on the unknown prefixed function rather than
+                // silently dropping the prefix into a valid-looking call. The
+                // message-bearing error path is `translate_scalar_function` /
+                // the `LogicalExpr` arms.
                 match crate::sql_generator::passthrough::strip_passthrough(
                     &fn_call.name,
                     crate::server::query_context::get_current_dialect(),
@@ -4658,9 +4659,9 @@ impl RenderExpr {
                         // This arm returns `String`, not `Result`, so a foreign-backend
                         // prefix (e.g. `ch.uniq` on Databricks) can't be surfaced as a
                         // clean translation error here — emit the *original* prefixed
-                        // name so the query fails loudly at the database on an unknown
-                        // function, never silently dropping the prefix. The
-                        // message-bearing error path is the `LogicalExpr` arms.
+                        // name so the query surfaces a database error on the unknown
+                        // prefixed function rather than silently dropping the prefix.
+                        // The message-bearing error path is the `LogicalExpr` arms.
                         log::error!("aggregate pass-through rejected: {}", e);
                         let args = agg
                             .args

--- a/src/sql_generator/mod.rs
+++ b/src/sql_generator/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod clickhouse;
 pub(crate) mod databricks;
 pub(crate) mod emitters;
 pub(crate) mod function_mapper;
+pub(crate) mod passthrough;
 
 /// SQL dialect for query generation.
 ///

--- a/src/sql_generator/passthrough/clickhouse.rs
+++ b/src/sql_generator/passthrough/clickhouse.rs
@@ -1,0 +1,56 @@
+//! ClickHouse pass-through policy.
+//!
+//! Two prefixes, for historical reasons (the pass-through predates the
+//! aggregate registry — see the parent module docs):
+//! - `ch.` — scalar, or a registry-detected aggregate (`ch.uniq` →
+//!   aggregate because `uniq` is in [`CH_AGGREGATE_FUNCTIONS`]).
+//! - `chagg.` — forces aggregate treatment for *any* name, the escape
+//!   hatch for CH's unbounded combinator aggregates (`-If`, `-Array`,
+//!   `-State`, `-Merge`, parametric) that a static registry can't cover.
+//!
+//! The prefix constants, the registry, and the `is_ch_*` helpers remain
+//! defined in `function_translator` (where they're tested and used by the
+//! CH emitter); this policy delegates to them so there is a single source
+//! of truth.
+
+use super::PassthroughPolicy;
+use crate::clickhouse_query_generator::{
+    is_ch_aggregate_function, CH_AGG_PREFIX, CH_PASSTHROUGH_PREFIX,
+};
+
+pub(crate) struct ClickhousePassthrough;
+
+impl PassthroughPolicy for ClickhousePassthrough {
+    fn scalar_prefix(&self) -> &'static str {
+        CH_PASSTHROUGH_PREFIX // "ch."
+    }
+
+    fn agg_prefix(&self) -> Option<&'static str> {
+        Some(CH_AGG_PREFIX) // "chagg."
+    }
+
+    fn is_aggregate(&self, stripped: &str) -> bool {
+        is_ch_aggregate_function(stripped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes() {
+        let p = ClickhousePassthrough;
+        assert_eq!(p.scalar_prefix(), "ch.");
+        assert_eq!(p.agg_prefix(), Some("chagg."));
+    }
+
+    #[test]
+    fn registry_backed_aggregate_detection() {
+        let p = ClickhousePassthrough;
+        assert!(p.is_aggregate("uniq"));
+        assert!(p.is_aggregate("quantile"));
+        assert!(!p.is_aggregate("cityHash64"));
+        assert!(!p.is_aggregate("upper"));
+    }
+}

--- a/src/sql_generator/passthrough/databricks.rs
+++ b/src/sql_generator/passthrough/databricks.rs
@@ -1,0 +1,164 @@
+//! Databricks / Spark SQL pass-through policy.
+//!
+//! A **single** prefix, `dbx.`, for both scalar and aggregate native
+//! functions. There is no `dbxagg.` counterpart to `chagg.`: Spark's
+//! aggregate surface is bounded and enumerable, so the
+//! [`SPARK_AGGREGATE_FUNCTIONS`] registry is authoritative and the system
+//! infers scalar-vs-aggregate itself. A missing aggregate is fixed by
+//! adding it here, not by asking users to learn a second prefix.
+//!
+//! Spelling reference:
+//! <https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-functions-builtin>
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use super::PassthroughPolicy;
+
+/// Pass-through prefix for Databricks / Spark SQL native functions.
+/// Usage: `dbx.functionName(args)` → `functionName(args)`.
+pub const DBX_PASSTHROUGH_PREFIX: &str = "dbx.";
+
+/// Known Spark / Databricks SQL built-in **aggregate** functions (lowercased).
+/// Used to decide whether a `dbx.` call needs GROUP BY. Scalar functions are
+/// everything else — they are not enumerated.
+///
+/// Bounded, unlike ClickHouse's combinator-driven aggregate space, so this
+/// set can be effectively complete. UDAFs a user registers in their own
+/// warehouse won't be here; add them as they surface.
+static SPARK_AGGREGATE_FUNCTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    let mut s = HashSet::new();
+
+    // Basic
+    s.insert("count");
+    s.insert("count_if");
+    s.insert("sum");
+    s.insert("avg");
+    s.insert("mean");
+    s.insert("min");
+    s.insert("max");
+    s.insert("min_by");
+    s.insert("max_by");
+    s.insert("first");
+    s.insert("first_value");
+    s.insert("last");
+    s.insert("last_value");
+    s.insert("any_value");
+    s.insert("mode");
+    s.insert("product");
+
+    // Collection
+    s.insert("collect_list");
+    s.insert("collect_set");
+    s.insert("array_agg"); // alias of collect_list
+
+    // Distinct / sketch cardinality
+    s.insert("approx_count_distinct");
+    s.insert("count_min_sketch");
+    s.insert("hll_sketch_agg");
+    s.insert("hll_union_agg");
+
+    // Percentiles / quantiles
+    s.insert("median");
+    s.insert("percentile");
+    s.insert("percentile_approx");
+    s.insert("approx_percentile");
+    s.insert("histogram_numeric");
+
+    // Statistics
+    s.insert("stddev");
+    s.insert("std");
+    s.insert("stddev_samp");
+    s.insert("stddev_pop");
+    s.insert("variance");
+    s.insert("var_samp");
+    s.insert("var_pop");
+    s.insert("skewness");
+    s.insert("kurtosis");
+    s.insert("corr");
+    s.insert("covar_samp");
+    s.insert("covar_pop");
+
+    // Regression
+    s.insert("regr_avgx");
+    s.insert("regr_avgy");
+    s.insert("regr_count");
+    s.insert("regr_intercept");
+    s.insert("regr_r2");
+    s.insert("regr_slope");
+    s.insert("regr_sxx");
+    s.insert("regr_sxy");
+    s.insert("regr_syy");
+
+    // Boolean / bitwise
+    s.insert("any");
+    s.insert("some");
+    s.insert("every");
+    s.insert("bool_and");
+    s.insert("bool_or");
+    s.insert("bit_and");
+    s.insert("bit_or");
+    s.insert("bit_xor");
+    s.insert("bitmap_construct_agg");
+    s.insert("bitmap_or_agg");
+
+    // Grouping (used with GROUPING SETS / ROLLUP / CUBE)
+    s.insert("grouping");
+    s.insert("grouping_id");
+
+    // try_* aggregate variants
+    s.insert("try_avg");
+    s.insert("try_sum");
+
+    s
+});
+
+/// Whether `fn_name` (without the `dbx.` prefix) is a known Spark aggregate.
+pub fn is_spark_aggregate_function(fn_name: &str) -> bool {
+    SPARK_AGGREGATE_FUNCTIONS.contains(fn_name.to_lowercase().as_str())
+}
+
+pub(crate) struct DatabricksPassthrough;
+
+impl PassthroughPolicy for DatabricksPassthrough {
+    fn scalar_prefix(&self) -> &'static str {
+        DBX_PASSTHROUGH_PREFIX // "dbx."
+    }
+
+    fn agg_prefix(&self) -> Option<&'static str> {
+        None // single-prefix design — the registry is authoritative
+    }
+
+    fn is_aggregate(&self, stripped: &str) -> bool {
+        is_spark_aggregate_function(stripped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_prefix_no_agg_variant() {
+        let p = DatabricksPassthrough;
+        assert_eq!(p.scalar_prefix(), "dbx.");
+        assert_eq!(p.agg_prefix(), None);
+    }
+
+    #[test]
+    fn aggregate_detection_is_case_insensitive() {
+        assert!(is_spark_aggregate_function("percentile_approx"));
+        assert!(is_spark_aggregate_function("PERCENTILE_APPROX"));
+        assert!(is_spark_aggregate_function("collect_list"));
+        assert!(is_spark_aggregate_function("approx_count_distinct"));
+        assert!(is_spark_aggregate_function("max_by"));
+    }
+
+    #[test]
+    fn scalar_functions_are_not_aggregates() {
+        assert!(!is_spark_aggregate_function("get_json_object"));
+        assert!(!is_spark_aggregate_function("upper"));
+        assert!(!is_spark_aggregate_function("element_at"));
+        assert!(!is_spark_aggregate_function("array_contains"));
+    }
+}

--- a/src/sql_generator/passthrough/databricks.rs
+++ b/src/sql_generator/passthrough/databricks.rs
@@ -45,7 +45,6 @@ static SPARK_AGGREGATE_FUNCTIONS: LazyLock<HashSet<&'static str>> = LazyLock::ne
     s.insert("last_value");
     s.insert("any_value");
     s.insert("mode");
-    s.insert("product");
 
     // Collection
     s.insert("collect_list");

--- a/src/sql_generator/passthrough/mod.rs
+++ b/src/sql_generator/passthrough/mod.rs
@@ -1,0 +1,310 @@
+//! Native-function pass-through — dialect-keyed policy.
+//!
+//! ClickGraph lets a Cypher query reach a backend's native SQL functions
+//! that have no Cypher built-in, via a dotted prefix on the function name
+//! (dot notation chosen for Neo4j-ecosystem consistency with `apoc.*` /
+//! `gds.*`). Each dialect owns its prefixes and its notion of which
+//! functions are aggregates:
+//!
+//! | Dialect    | Scalar prefix | Aggregate prefix | Aggregate detection        |
+//! |------------|---------------|------------------|----------------------------|
+//! | ClickHouse | `ch.`         | `chagg.`         | registry, `chagg.` override |
+//! | Databricks | `dbx.`        | — (none)         | registry only               |
+//!
+//! ## One prefix vs two — why they differ
+//! The original ClickHouse pass-through shipped *before* an aggregate
+//! registry existed, so users had to declare intent: `ch.` for scalars,
+//! `chagg.` for aggregates. A registry removes that need — the system
+//! looks the type up — so Databricks ships with a single `dbx.` prefix
+//! and a [`databricks::SPARK_AGGREGATE_FUNCTIONS`] registry. ClickHouse
+//! keeps `chagg.` as an escape hatch because CH's aggregate surface is
+//! effectively unbounded (combinators: `-If`, `-Array`, `-State`,
+//! `-Merge`, parametric…) and can't be fully enumerated; Spark's is
+//! bounded, so `dbx.` alone suffices and a missing function is fixed by
+//! extending the registry, not by teaching users a second prefix.
+//!
+//! ## Two entry points, two stages
+//! - [`classify_passthrough`] runs at **plan time** (scalar vs aggregate
+//!   decides GROUP BY) and is deliberately **dialect-agnostic**: it
+//!   recognizes every dialect's prefixes so the plan is shaped correctly
+//!   regardless of which backend ultimately runs. The dialect isn't
+//!   reliably set this early.
+//! - [`strip_passthrough`] runs at **emit time**, where the active
+//!   dialect *is* set (task-local [`QueryContext`]). It strips the active
+//!   dialect's prefix and **rejects a foreign prefix** (e.g. `ch.` on the
+//!   Databricks backend) with a helpful error — closing the gap where a
+//!   `ch.` name used to leak verbatim into Spark SQL.
+//!
+//! Mirrors the sibling [`function_mapper`] module's `for_dialect` shape.
+//!
+//! [`QueryContext`]: crate::server::query_context::QueryContext
+//! [`function_mapper`]: crate::sql_generator::function_mapper
+
+pub(crate) mod clickhouse;
+pub(crate) mod databricks;
+
+use crate::sql_generator::SqlDialect;
+
+/// Whether a pass-through call is a scalar or an aggregate function — the
+/// distinction the planner needs to decide GROUP BY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassthroughKind {
+    Scalar,
+    Aggregate,
+}
+
+/// Why a pass-through name could not be resolved against the active dialect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassthroughError {
+    /// A prefix from a *different* backend was used (e.g. `ch.` while the
+    /// active backend is Databricks). Carries a ready-to-surface message.
+    WrongBackend(String),
+    /// The prefix was present but no function name followed it (e.g. `ch.`).
+    EmptyName(String),
+}
+
+impl std::fmt::Display for PassthroughError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PassthroughError::WrongBackend(m) | PassthroughError::EmptyName(m) => f.write_str(m),
+        }
+    }
+}
+
+/// Per-dialect pass-through rules. `pub(crate)` for the same reason as
+/// [`FunctionMapper`](crate::sql_generator::function_mapper::FunctionMapper):
+/// external code can't name it, so it can't implement it.
+pub(crate) trait PassthroughPolicy: Send + Sync {
+    /// Prefix for scalar (and registry-detected aggregate) pass-through.
+    fn scalar_prefix(&self) -> &'static str;
+
+    /// Prefix that *forces* aggregate treatment regardless of the
+    /// registry. `None` for dialects whose registry is authoritative.
+    fn agg_prefix(&self) -> Option<&'static str>;
+
+    /// Whether `stripped` (the bare function name, prefix removed) names a
+    /// known aggregate in this dialect.
+    fn is_aggregate(&self, stripped: &str) -> bool;
+}
+
+/// Dialects that have a pass-through policy. Kept in sync with the
+/// `match` in [`for_dialect`]; used by [`classify_passthrough`] and the
+/// foreign-prefix scan in [`strip_passthrough`].
+const POLICY_DIALECTS: &[SqlDialect] = &[SqlDialect::ClickHouse, SqlDialect::Databricks];
+
+/// Returns the pass-through policy for an explicit dialect.
+pub(crate) fn for_dialect(dialect: SqlDialect) -> &'static dyn PassthroughPolicy {
+    static CLICKHOUSE: clickhouse::ClickhousePassthrough = clickhouse::ClickhousePassthrough;
+    static DATABRICKS: databricks::DatabricksPassthrough = databricks::DatabricksPassthrough;
+    match dialect {
+        SqlDialect::ClickHouse => &CLICKHOUSE,
+        SqlDialect::Databricks => &DATABRICKS,
+        d => unimplemented!(
+            "pass-through policy for dialect {:?} is not yet implemented",
+            d
+        ),
+    }
+}
+
+/// Strip a prefix and require a non-empty remainder. Returns `None` when
+/// `name` doesn't start with `prefix` at all.
+fn strip_nonempty<'a>(name: &'a str, prefix: &str) -> Option<Result<&'a str, ()>> {
+    name.strip_prefix(prefix)
+        .map(|rest| if rest.is_empty() { Err(()) } else { Ok(rest) })
+}
+
+/// Plan-time classification: is `name` a pass-through call, and if so is it
+/// scalar or aggregate? **Dialect-agnostic on purpose** — see module docs.
+///
+/// Returns `None` for a plain (non-prefixed) function or a bare prefix with
+/// no function name (the empty-name case is reported later, at emit time).
+pub fn classify_passthrough(name: &str) -> Option<PassthroughKind> {
+    for &dialect in POLICY_DIALECTS {
+        let policy = for_dialect(dialect);
+
+        // Explicit aggregate prefix wins outright.
+        if let Some(agg_prefix) = policy.agg_prefix() {
+            if let Some(Ok(_)) = strip_nonempty(name, agg_prefix) {
+                return Some(PassthroughKind::Aggregate);
+            }
+        }
+
+        // Scalar prefix: registry decides scalar vs aggregate.
+        if let Some(Ok(rest)) = strip_nonempty(name, policy.scalar_prefix()) {
+            return Some(if policy.is_aggregate(rest) {
+                PassthroughKind::Aggregate
+            } else {
+                PassthroughKind::Scalar
+            });
+        }
+    }
+    None
+}
+
+/// Emit-time resolution against `dialect`.
+///
+/// - `Ok(Some(bare))` — a pass-through for the active dialect; `bare` is the
+///   prefix-stripped function name to emit verbatim.
+/// - `Ok(None)` — not a pass-through name at all (caller falls through to
+///   normal function mapping).
+/// - `Err(WrongBackend)` — a *foreign* dialect's prefix was used; the
+///   message names the right one for the active backend.
+/// - `Err(EmptyName)` — a prefix with no function name.
+pub fn strip_passthrough(
+    name: &str,
+    dialect: SqlDialect,
+) -> Result<Option<&str>, PassthroughError> {
+    let active = for_dialect(dialect);
+
+    if let Some(agg_prefix) = active.agg_prefix() {
+        if let Some(res) = strip_nonempty(name, agg_prefix) {
+            return res.map(Some).map_err(|()| empty_name_err(name, agg_prefix));
+        }
+    }
+    if let Some(res) = strip_nonempty(name, active.scalar_prefix()) {
+        return res
+            .map(Some)
+            .map_err(|()| empty_name_err(name, active.scalar_prefix()));
+    }
+
+    // Not the active dialect's prefix — is it another backend's? If so,
+    // reject with a pointer to the correct prefix rather than letting the
+    // foreign name leak into the generated SQL.
+    for &other in POLICY_DIALECTS {
+        if other == dialect {
+            continue;
+        }
+        let foreign = for_dialect(other);
+        let hits = name.starts_with(foreign.scalar_prefix())
+            || foreign.agg_prefix().is_some_and(|p| name.starts_with(p));
+        if hits {
+            return Err(PassthroughError::WrongBackend(format!(
+                "'{name}' uses the {} pass-through prefix, which is not available on the {} backend. \
+                 Use the '{}' prefix instead.",
+                other.as_str(),
+                dialect.as_str(),
+                active.scalar_prefix(),
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+fn empty_name_err(name: &str, prefix: &str) -> PassthroughError {
+    PassthroughError::EmptyName(format!(
+        "pass-through prefix '{prefix}' requires a function name (e.g. '{prefix}myFunc'); got '{name}'"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_clickhouse_prefixes() {
+        // ch. + registry aggregate
+        assert_eq!(
+            classify_passthrough("ch.uniq"),
+            Some(PassthroughKind::Aggregate)
+        );
+        // ch. + non-aggregate (scalar)
+        assert_eq!(
+            classify_passthrough("ch.cityHash64"),
+            Some(PassthroughKind::Scalar)
+        );
+        // chagg. forces aggregate even for unknown names
+        assert_eq!(
+            classify_passthrough("chagg.myCustomAgg"),
+            Some(PassthroughKind::Aggregate)
+        );
+    }
+
+    #[test]
+    fn classify_databricks_prefix() {
+        // dbx. + Spark registry aggregate
+        assert_eq!(
+            classify_passthrough("dbx.percentile_approx"),
+            Some(PassthroughKind::Aggregate)
+        );
+        assert_eq!(
+            classify_passthrough("dbx.collect_list"),
+            Some(PassthroughKind::Aggregate)
+        );
+        // dbx. + scalar
+        assert_eq!(
+            classify_passthrough("dbx.get_json_object"),
+            Some(PassthroughKind::Scalar)
+        );
+    }
+
+    #[test]
+    fn classify_non_passthrough_is_none() {
+        assert_eq!(classify_passthrough("count"), None);
+        assert_eq!(classify_passthrough("upper"), None);
+        // bare prefix, no function name -> not classified here (caught at emit)
+        assert_eq!(classify_passthrough("ch."), None);
+        assert_eq!(classify_passthrough("dbx."), None);
+        // dbxagg. is NOT a Databricks prefix (single-prefix design)
+        assert_eq!(classify_passthrough("dbxagg.foo"), None);
+    }
+
+    #[test]
+    fn strip_active_dialect_prefix() {
+        assert_eq!(
+            strip_passthrough("ch.cityHash64", SqlDialect::ClickHouse),
+            Ok(Some("cityHash64"))
+        );
+        assert_eq!(
+            strip_passthrough("chagg.myAgg", SqlDialect::ClickHouse),
+            Ok(Some("myAgg"))
+        );
+        assert_eq!(
+            strip_passthrough("dbx.percentile_approx", SqlDialect::Databricks),
+            Ok(Some("percentile_approx"))
+        );
+    }
+
+    #[test]
+    fn strip_plain_function_is_none() {
+        assert_eq!(strip_passthrough("count", SqlDialect::ClickHouse), Ok(None));
+        assert_eq!(strip_passthrough("upper", SqlDialect::Databricks), Ok(None));
+    }
+
+    #[test]
+    fn strip_rejects_foreign_prefix() {
+        // ch. on the Databricks backend -> rejected, points at dbx.
+        let err = strip_passthrough("ch.uniq", SqlDialect::Databricks).unwrap_err();
+        match err {
+            PassthroughError::WrongBackend(m) => {
+                assert!(m.contains("clickhouse"), "{m}");
+                assert!(m.contains("databricks"), "{m}");
+                assert!(m.contains("dbx."), "{m}");
+            }
+            other => panic!("expected WrongBackend, got {other:?}"),
+        }
+        // chagg. on Databricks too
+        assert!(matches!(
+            strip_passthrough("chagg.myAgg", SqlDialect::Databricks),
+            Err(PassthroughError::WrongBackend(_))
+        ));
+        // dbx. on the ClickHouse backend -> rejected, points at ch.
+        let err = strip_passthrough("dbx.collect_list", SqlDialect::ClickHouse).unwrap_err();
+        match err {
+            PassthroughError::WrongBackend(m) => assert!(m.contains("ch."), "{m}"),
+            other => panic!("expected WrongBackend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strip_rejects_empty_name() {
+        assert!(matches!(
+            strip_passthrough("ch.", SqlDialect::ClickHouse),
+            Err(PassthroughError::EmptyName(_))
+        ));
+        assert!(matches!(
+            strip_passthrough("dbx.", SqlDialect::Databricks),
+            Err(PassthroughError::EmptyName(_))
+        ));
+    }
+}

--- a/src/sql_generator/passthrough/mod.rs
+++ b/src/sql_generator/passthrough/mod.rs
@@ -48,14 +48,14 @@ use crate::sql_generator::SqlDialect;
 /// Whether a pass-through call is a scalar or an aggregate function — the
 /// distinction the planner needs to decide GROUP BY.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PassthroughKind {
+pub(crate) enum PassthroughKind {
     Scalar,
     Aggregate,
 }
 
 /// Why a pass-through name could not be resolved against the active dialect.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PassthroughError {
+pub(crate) enum PassthroughError {
     /// A prefix from a *different* backend was used (e.g. `ch.` while the
     /// active backend is Databricks). Carries a ready-to-surface message.
     WrongBackend(String),
@@ -92,17 +92,18 @@ pub(crate) trait PassthroughPolicy: Send + Sync {
 /// foreign-prefix scan in [`strip_passthrough`].
 const POLICY_DIALECTS: &[SqlDialect] = &[SqlDialect::ClickHouse, SqlDialect::Databricks];
 
-/// Returns the pass-through policy for an explicit dialect.
-pub(crate) fn for_dialect(dialect: SqlDialect) -> &'static dyn PassthroughPolicy {
+/// Returns the pass-through policy for an explicit dialect, or `None` for a
+/// dialect that has no policy yet. Returning `None` (rather than panicking)
+/// keeps this safe on the per-function-call hot path: dialects without a
+/// pass-through policy also have no SQL emitter, so they fail earlier at
+/// `emitter_for` — here they simply mean "no pass-through handling".
+fn for_dialect(dialect: SqlDialect) -> Option<&'static dyn PassthroughPolicy> {
     static CLICKHOUSE: clickhouse::ClickhousePassthrough = clickhouse::ClickhousePassthrough;
     static DATABRICKS: databricks::DatabricksPassthrough = databricks::DatabricksPassthrough;
     match dialect {
-        SqlDialect::ClickHouse => &CLICKHOUSE,
-        SqlDialect::Databricks => &DATABRICKS,
-        d => unimplemented!(
-            "pass-through policy for dialect {:?} is not yet implemented",
-            d
-        ),
+        SqlDialect::ClickHouse => Some(&CLICKHOUSE),
+        SqlDialect::Databricks => Some(&DATABRICKS),
+        _ => None,
     }
 }
 
@@ -118,9 +119,11 @@ fn strip_nonempty<'a>(name: &'a str, prefix: &str) -> Option<Result<&'a str, ()>
 ///
 /// Returns `None` for a plain (non-prefixed) function or a bare prefix with
 /// no function name (the empty-name case is reported later, at emit time).
-pub fn classify_passthrough(name: &str) -> Option<PassthroughKind> {
+pub(crate) fn classify_passthrough(name: &str) -> Option<PassthroughKind> {
     for &dialect in POLICY_DIALECTS {
-        let policy = for_dialect(dialect);
+        let Some(policy) = for_dialect(dialect) else {
+            continue;
+        };
 
         // Explicit aggregate prefix wins outright.
         if let Some(agg_prefix) = policy.agg_prefix() {
@@ -150,11 +153,14 @@ pub fn classify_passthrough(name: &str) -> Option<PassthroughKind> {
 /// - `Err(WrongBackend)` — a *foreign* dialect's prefix was used; the
 ///   message names the right one for the active backend.
 /// - `Err(EmptyName)` — a prefix with no function name.
-pub fn strip_passthrough(
+pub(crate) fn strip_passthrough(
     name: &str,
     dialect: SqlDialect,
 ) -> Result<Option<&str>, PassthroughError> {
-    let active = for_dialect(dialect);
+    // A dialect without a pass-through policy gets no pass-through handling.
+    let Some(active) = for_dialect(dialect) else {
+        return Ok(None);
+    };
 
     if let Some(agg_prefix) = active.agg_prefix() {
         if let Some(res) = strip_nonempty(name, agg_prefix) {
@@ -174,7 +180,9 @@ pub fn strip_passthrough(
         if other == dialect {
             continue;
         }
-        let foreign = for_dialect(other);
+        let Some(foreign) = for_dialect(other) else {
+            continue;
+        };
         let hits = name.starts_with(foreign.scalar_prefix())
             || foreign.agg_prefix().is_some_and(|p| name.starts_with(p));
         if hits {


### PR DESCRIPTION
## Summary

Adds a **dialect-keyed native-function pass-through** so Cypher queries can reach a backend's native SQL functions, dispatched by the active dialect instead of hard-coded `ch.` checks scattered across call sites (mirrors the existing `function_mapper/` pattern).

- **ClickHouse** keeps `ch.` (scalar / registry-detected aggregate) and `chagg.` (force aggregate) — semantics unchanged.
- **Databricks/Spark (new)**: a **single `dbx.` prefix**, backed by a Spark aggregate registry that infers scalar-vs-aggregate. No `dbxagg.` needed — the registry removes the reason ClickHouse has two prefixes.
- Fixes a latent bug where a prefix could leak verbatim into the wrong backend's SQL; a foreign prefix is now **rejected** (clean translation error on the `LogicalExpr` path; verbatim-emit → database error on the `String`-returning render path — never a silent valid call).

## Design

New `src/sql_generator/passthrough/` module:
- `PassthroughPolicy` trait + `for_dialect` (mirrors `function_mapper`)
- `classify_passthrough` — **plan-time, dialect-agnostic** (scalar vs aggregate for GROUP BY)
- `strip_passthrough` — **emit-time, dialect-aware** (strips active prefix, rejects foreign)

Call sites rewired: `ast_conversion.rs` (classify), `to_sql.rs` + `to_sql_query.rs` scalar/aggregate arms (strip).

## Tests
Unit (classify/strip per dialect, foreign-prefix + empty-name rejection, registries) + end-to-end emit-diff under each dialect, including verbatim foreign-prefix emit and the nested-argument no-drop case.

## Docs
Standalone `docs/wiki/Databricks-Functions.md` (the "one prefix, no `dbxagg.`" rationale + recognized aggregates) + backend notes/links in `ClickHouse-Functions.md`, `Cypher-Functions.md`, `Databricks-Deployment.md`.

## Review
Reviewed by subagent over two passes: first pass 5 real-code findings (silent nested-arg drop, dual error paths, test gap, hot-path panic, bypassed aggregate arm) all fixed; second pass 1 real-code comment (an accepted, documented `String`-vs-`Result` design trade-off) plus nits (dead-code removal, comment wording) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)