### PR TITLE
fix(spark): route arrayConcat through FunctionMapper (concat on Databricks)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -217,7 +217,12 @@ impl ToSql for LogicalExpr {
                                 .into_iter()
                                 .flatten()
                                 .collect();
-                            Ok(format!("arrayConcat({})", flattened.join(", ")))
+                            Ok(format!(
+                                "{}({})",
+                                crate::sql_generator::function_mapper::current_function_mapper()
+                                    .array_concat(),
+                                flattened.join(", ")
+                            ))
                         }
                         // Use concat() for string concatenation, + for numeric
                         // Flatten nested + operations for cases like: a + ' - ' + b

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5120,7 +5120,12 @@ impl RenderExpr {
                         .iter()
                         .flat_map(flatten_list_addition_operands)
                         .collect();
-                    return format!("arrayConcat({})", flattened.join(", "));
+                    return format!(
+                        "{}({})",
+                        crate::sql_generator::function_mapper::current_function_mapper()
+                            .array_concat(),
+                        flattened.join(", ")
+                    );
                 }
 
                 // Special handling for Addition with string operands - use concat()
@@ -5535,7 +5540,12 @@ impl RenderExpr {
                         .iter()
                         .flat_map(flatten_list_addition_operands)
                         .collect();
-                    return format!("arrayConcat({})", flattened.join(", "));
+                    return format!(
+                        "{}({})",
+                        crate::sql_generator::function_mapper::current_function_mapper()
+                            .array_concat(),
+                        flattened.join(", ")
+                    );
                 }
 
                 // Special handling for interval arithmetic with epoch-millis values
@@ -5920,6 +5930,40 @@ mod tests {
         });
         let sql = expr.to_sql();
         assert_eq!(sql, "arrayConcat([42], [1])");
+    }
+
+    /// Under the Databricks dialect, list concatenation emits Spark's
+    /// `concat(...)` (array-overloaded), not ClickHouse's `arrayConcat(...)`.
+    #[tokio::test]
+    async fn test_list_concat_uses_concat_under_databricks() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let make_expr = || {
+            RenderExpr::OperatorApplicationExp(OperatorApplication {
+                operator: Operator::Addition,
+                operands: vec![
+                    RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(1))]),
+                    RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(2))]),
+                ],
+            })
+        };
+
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async { make_expr().to_sql() }).await;
+        assert!(
+            sql.contains("concat(") && !sql.contains("arrayConcat("),
+            "expected Spark `concat(`, not `arrayConcat(`; got: {sql}"
+        );
+
+        // CH baseline (default scope) keeps arrayConcat.
+        assert!(
+            make_expr().to_sql().contains("arrayConcat("),
+            "CH baseline should still emit arrayConcat"
+        );
     }
 
     /// Test: numeric + numeric (no list) → stays as addition, not arrayConcat

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5770,7 +5770,11 @@ impl ToSql for OperatorApplication {
                 .iter()
                 .flat_map(flatten_list_addition_operands)
                 .collect();
-            return format!("arrayConcat({})", flattened.join(", "));
+            return format!(
+                "{}({})",
+                crate::sql_generator::function_mapper::current_function_mapper().array_concat(),
+                flattened.join(", ")
+            );
         }
 
         // Special handling for Addition with string operands - use concat()
@@ -5949,19 +5953,33 @@ mod tests {
             })
         };
 
+        // Bare OperatorApplication::to_sql is a separate render arm (reached via
+        // JOIN ON predicates) — cover it too.
+        let make_op = || OperatorApplication {
+            operator: Operator::Addition,
+            operands: vec![
+                RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(1))]),
+                RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(2))]),
+            ],
+        };
+
         let ctx = QueryContext {
             dialect: SqlDialect::Databricks,
             ..QueryContext::default()
         };
-        let sql = with_query_context(ctx, async { make_expr().to_sql() }).await;
-        assert!(
-            sql.contains("concat(") && !sql.contains("arrayConcat("),
-            "expected Spark `concat(`, not `arrayConcat(`; got: {sql}"
-        );
+        let (sql, op_sql) =
+            with_query_context(ctx, async { (make_expr().to_sql(), make_op().to_sql()) }).await;
+        for s in [&sql, &op_sql] {
+            assert!(
+                s.contains("concat(") && !s.contains("arrayConcat("),
+                "expected Spark `concat(`, not `arrayConcat(`; got: {s}"
+            );
+        }
 
-        // CH baseline (default scope) keeps arrayConcat.
+        // CH baseline (default scope) keeps arrayConcat on both arms.
         assert!(
-            make_expr().to_sql().contains("arrayConcat("),
+            make_expr().to_sql().contains("arrayConcat(")
+                && make_op().to_sql().contains("arrayConcat("),
             "CH baseline should still emit arrayConcat"
         );
     }


### PR DESCRIPTION
## Summary
Cypher list concatenation (`list1 + list2`) hard-coded ClickHouse's `arrayConcat(...)` at all four render arms, bypassing the `FunctionMapper` → invalid Spark SQL on the Databricks backend. Route every arm through `current_function_mapper().array_concat()` so ClickHouse keeps `arrayConcat` and Databricks emits `concat` (array-overloaded, same arg order/semantics).

Sites: `to_sql.rs` (LogicalExpr) + three `to_sql_query.rs` arms (`RenderExpr::to_sql`, `to_sql_without_table_alias`, and bare `OperatorApplication::to_sql` reached via JOIN ON predicates).

## Tests
Databricks emit-diff test asserting `concat(` (not `arrayConcat(`) for both the `RenderExpr` and bare `OperatorApplication` arms, with CH baselines guarding no regression.

## Review
Subagent-reviewed: first pass found a missed third arm (different indentation) + thin coverage; both fixed here. Composition with `collect`→`collect_list` and `[x]`→`array(x)` verified; no string-concat ambiguity (guarded by `is_list_expr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)