### PR TITLE
fix(spark): never emit FINAL on Databricks (dialect-gated render)

### DIFF
--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -1101,32 +1101,12 @@ fn determine_use_final(
     config_use_final: Option<bool>,
     engine: &Option<TableEngine>,
 ) -> Option<bool> {
-    let engine_supports_final = engine.as_ref().map(|e| e.supports_final()).unwrap_or(false);
-
-    if let Some(explicit) = config_use_final {
-        // Ignore an explicit `use_final: true` only when the engine is KNOWN and
-        // demonstrably cannot do FINAL — notably a Databricks/Delta/Spark source,
-        // where FINAL is invalid SQL and meaningless (no ReplacingMergeTree-style
-        // merge to finalize). When the engine is undetected (None) we respect the
-        // user's explicit choice: on ClickHouse they may know it is a FINAL-capable
-        // engine that detection missed.
-        if explicit {
-            if let Some(e) = engine {
-                if !e.supports_final() {
-                    log::warn!(
-                        "Ignoring `use_final: true`: engine {:?} does not support FINAL; \
-                         forcing use_final=false",
-                        e
-                    );
-                    return Some(false);
-                }
-            }
-        }
-        return Some(explicit);
+    // If config has explicit value, use it
+    if config_use_final.is_some() {
+        return config_use_final;
     }
-
-    // No explicit value — auto-detect from the engine.
-    Some(engine_supports_final)
+    // Otherwise, auto-detect from engine
+    Some(engine.as_ref().map(|e| e.supports_final()).unwrap_or(false))
 }
 
 /// Parse node_id types from YAML configuration
@@ -2619,36 +2599,6 @@ fn resolve_fulltext_indexes(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_determine_use_final_honors_engine_support() {
-        let replacing = Some(TableEngine::ReplacingMergeTree {
-            version_column: None,
-        });
-        let plain = Some(TableEngine::MergeTree);
-
-        // No explicit value -> auto-detect from engine.
-        assert_eq!(determine_use_final(None, &replacing), Some(true));
-        assert_eq!(determine_use_final(None, &plain), Some(false));
-        assert_eq!(determine_use_final(None, &None), Some(false));
-
-        // Explicit true honored when the engine supports FINAL.
-        assert_eq!(determine_use_final(Some(true), &replacing), Some(true));
-        // Explicit true on a KNOWN engine without FINAL (e.g. a Databricks/Delta
-        // source, which surfaces as a non-MergeTree engine) is ignored.
-        assert_eq!(determine_use_final(Some(true), &plain), Some(false));
-        assert_eq!(
-            determine_use_final(Some(true), &Some(TableEngine::Other("delta".to_string()))),
-            Some(false)
-        );
-        // Explicit true with an UNDETECTED engine (None) is respected — on
-        // ClickHouse the user may know it's a FINAL-capable engine detection missed.
-        assert_eq!(determine_use_final(Some(true), &None), Some(true));
-
-        // Explicit false is always respected.
-        assert_eq!(determine_use_final(Some(false), &replacing), Some(false));
-        assert_eq!(determine_use_final(Some(false), &plain), Some(false));
-    }
 
     #[test]
     fn test_relationship_definition_edge_id_parsing() {

--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -1101,12 +1101,32 @@ fn determine_use_final(
     config_use_final: Option<bool>,
     engine: &Option<TableEngine>,
 ) -> Option<bool> {
-    // If config has explicit value, use it
-    if config_use_final.is_some() {
-        return config_use_final;
+    let engine_supports_final = engine.as_ref().map(|e| e.supports_final()).unwrap_or(false);
+
+    if let Some(explicit) = config_use_final {
+        // Ignore an explicit `use_final: true` only when the engine is KNOWN and
+        // demonstrably cannot do FINAL — notably a Databricks/Delta/Spark source,
+        // where FINAL is invalid SQL and meaningless (no ReplacingMergeTree-style
+        // merge to finalize). When the engine is undetected (None) we respect the
+        // user's explicit choice: on ClickHouse they may know it is a FINAL-capable
+        // engine that detection missed.
+        if explicit {
+            if let Some(e) = engine {
+                if !e.supports_final() {
+                    log::warn!(
+                        "Ignoring `use_final: true`: engine {:?} does not support FINAL; \
+                         forcing use_final=false",
+                        e
+                    );
+                    return Some(false);
+                }
+            }
+        }
+        return Some(explicit);
     }
-    // Otherwise, auto-detect from engine
-    Some(engine.as_ref().map(|e| e.supports_final()).unwrap_or(false))
+
+    // No explicit value — auto-detect from the engine.
+    Some(engine_supports_final)
 }
 
 /// Parse node_id types from YAML configuration
@@ -2599,6 +2619,36 @@ fn resolve_fulltext_indexes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_determine_use_final_honors_engine_support() {
+        let replacing = Some(TableEngine::ReplacingMergeTree {
+            version_column: None,
+        });
+        let plain = Some(TableEngine::MergeTree);
+
+        // No explicit value -> auto-detect from engine.
+        assert_eq!(determine_use_final(None, &replacing), Some(true));
+        assert_eq!(determine_use_final(None, &plain), Some(false));
+        assert_eq!(determine_use_final(None, &None), Some(false));
+
+        // Explicit true honored when the engine supports FINAL.
+        assert_eq!(determine_use_final(Some(true), &replacing), Some(true));
+        // Explicit true on a KNOWN engine without FINAL (e.g. a Databricks/Delta
+        // source, which surfaces as a non-MergeTree engine) is ignored.
+        assert_eq!(determine_use_final(Some(true), &plain), Some(false));
+        assert_eq!(
+            determine_use_final(Some(true), &Some(TableEngine::Other("delta".to_string()))),
+            Some(false)
+        );
+        // Explicit true with an UNDETECTED engine (None) is respected — on
+        // ClickHouse the user may know it's a FINAL-capable engine detection missed.
+        assert_eq!(determine_use_final(Some(true), &None), Some(true));
+
+        // Explicit false is always respected.
+        assert_eq!(determine_use_final(Some(false), &replacing), Some(false));
+        assert_eq!(determine_use_final(Some(false), &plain), Some(false));
+    }
 
     #[test]
     fn test_relationship_definition_edge_id_parsing() {

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -445,8 +445,15 @@ impl ToSql for LogicalPlan {
     fn to_sql(&self) -> Result<String, ClickhouseQueryGeneratorError> {
         match self {
             LogicalPlan::ViewScan(scan) => {
-                // Add FINAL keyword if enabled
-                let final_keyword = if scan.use_final { " FINAL" } else { "" };
+                // Add FINAL keyword if enabled. FINAL is ClickHouse-only — never emit it
+                // on other dialects (e.g. Databricks/Spark) where it is invalid SQL.
+                let final_keyword = if scan.use_final
+                    && crate::server::query_context::get_current_dialect().supports_final_keyword()
+                {
+                    " FINAL"
+                } else {
+                    ""
+                };
                 let mut sql = format!("SELECT * FROM {}{}", scan.source_table, final_keyword);
 
                 // Add WHERE clause if view_filter is present
@@ -473,5 +480,52 @@ impl ToSql for LogicalPlan {
             }
             _ => Err(ClickhouseQueryGeneratorError::UnsupportedDDLQuery),
         }
+    }
+}
+
+#[cfg(test)]
+mod final_dialect_tests {
+    use super::ToSql;
+    use crate::query_planner::logical_plan::{LogicalPlan, ViewScan};
+    use crate::server::query_context::{with_query_context, QueryContext};
+    use crate::sql_generator::SqlDialect;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn view_scan_with_final() -> LogicalPlan {
+        let mut scan = ViewScan::new(
+            "users".to_string(),
+            None,
+            HashMap::new(),
+            "id".to_string(),
+            vec![],
+            vec![],
+        );
+        scan.use_final = true;
+        LogicalPlan::ViewScan(Arc::new(scan))
+    }
+
+    /// FINAL is ClickHouse-only: emitted under ClickHouse, omitted under Databricks
+    /// even when the schema requests it (use_final = true).
+    #[tokio::test]
+    async fn final_emitted_only_on_clickhouse() {
+        // Default scope -> ClickHouse -> FINAL present.
+        let ch_sql = view_scan_with_final().to_sql().unwrap();
+        assert!(
+            ch_sql.contains(" FINAL"),
+            "ClickHouse should emit FINAL; got: {ch_sql}"
+        );
+
+        // Databricks dialect -> no FINAL (invalid Spark SQL).
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let dbx_sql =
+            with_query_context(ctx, async { view_scan_with_final().to_sql().unwrap() }).await;
+        assert!(
+            !dbx_sql.contains("FINAL"),
+            "Databricks must not emit FINAL; got: {dbx_sql}"
+        );
     }
 }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3806,8 +3806,12 @@ impl ToSql for FromTableItem {
             sql.push_str(" AS ");
             sql.push_str(&alias);
 
-            // Add FINAL keyword AFTER alias if needed (ClickHouse syntax: FROM table AS alias FINAL)
-            if view_ref.use_final {
+            // Add FINAL keyword AFTER alias if needed (ClickHouse syntax: FROM table AS alias FINAL).
+            // FINAL is ClickHouse-only — never emit it on other dialects (e.g. Databricks/Spark),
+            // where it is invalid SQL, regardless of the schema's use_final.
+            if view_ref.use_final
+                && crate::server::query_context::get_current_dialect().supports_final_keyword()
+            {
                 sql.push_str(" FINAL");
             }
 

--- a/src/sql_generator/emitters/clickhouse/view_scan.rs
+++ b/src/sql_generator/emitters/clickhouse/view_scan.rs
@@ -44,8 +44,11 @@ pub fn build_view_scan(scan: &ViewScan, _plan: &LogicalPlan) -> String {
         scan.source_table.clone()
     };
 
-    // Add FINAL keyword if enabled for this table
-    if scan.use_final {
+    // Add FINAL keyword if enabled for this table. FINAL is ClickHouse-only —
+    // never emit it on other dialects (e.g. Databricks/Spark) where it is invalid SQL.
+    if scan.use_final
+        && crate::server::query_context::get_current_dialect().supports_final_keyword()
+    {
         sql.push_str(&format!("SELECT * FROM {} FINAL", table_ref));
     } else {
         sql.push_str(&format!("SELECT * FROM {}", table_ref));

--- a/src/sql_generator/mod.rs
+++ b/src/sql_generator/mod.rs
@@ -76,6 +76,15 @@ impl SqlDialect {
     pub fn is_supported(&self) -> bool {
         matches!(self, SqlDialect::ClickHouse)
     }
+
+    /// Whether this dialect supports the `FINAL` table modifier. `FINAL` is a
+    /// ClickHouse MergeTree-family read-time dedup hint; it is invalid SQL on
+    /// other backends (notably Databricks/Spark, which has no such storage
+    /// engine), so the renderer must not emit it there regardless of a schema's
+    /// `use_final` setting.
+    pub fn supports_final_keyword(&self) -> bool {
+        matches!(self, SqlDialect::ClickHouse)
+    }
 }
 
 /// Renders a `RenderPlan` into SQL text for a target dialect.


### PR DESCRIPTION
## Summary
`FINAL` is a ClickHouse MergeTree-family read-time dedup hint — invalid SQL on Databricks/Spark. Gate FINAL emission on dialect at the render leaves so it's emitted only for ClickHouse.

Adds `SqlDialect::supports_final_keyword()` (ClickHouse only) and guards all three FINAL emission sites (`to_sql.rs`, `to_sql_query.rs`, `view_scan.rs`) with `get_current_dialect().supports_final_keyword()`.

## Why render-layer, not config-layer
An earlier attempt forced `use_final` off at the config resolver. Review caught two problems: (1) `Replicated*`/`Shared*` MergeTree engines classify as `TableEngine::Other` (supports_final()==false), so it would have **dropped FINAL and returned duplicate rows on ClickHouse**; (2) Databricks schemas load with `engine=None` (no ClickHouse client), so the engine check never fired. The dialect — available at render time — is the correct signal. ClickHouse behavior (including the explicit `use_final` override for replicated engines) is **completely unchanged**.

## Tests
Direct emit test: FINAL present under ClickHouse, absent under Databricks (with `use_final = true`).

## Review
Two passes. First found the config-layer BLOCKER; pivoted to render-layer. Second confirmed config.rs reverted byte-for-byte, the three leaves are the complete FINAL surface, and no ClickHouse regression. Remaining notes (single-leaf test, inert dead-code guard) are non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)