### PR TITLE
fix(spark): correct CONTAINS arg order + toString cast for Databricks

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1129,7 +1129,13 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 }
                 Operator::StartsWith => format!("startsWith({}, {})", operands[0], operands[1]),
                 Operator::EndsWith => format!("endsWith({}, {})", operands[0], operands[1]),
-                Operator::Contains => format!("(position({}, {}) > 0)", operands[0], operands[1]),
+                Operator::Contains => {
+                    // Dialect-aware: Spark's position(substr, str) reverses CH's arg order.
+                    crate::clickhouse_query_generator::contains_predicate(
+                        &operands[0],
+                        &operands[1],
+                    )
+                }
                 Operator::IsNull => format!("{} IS NULL", operands[0]),
                 Operator::IsNotNull => format!("{} IS NOT NULL", operands[0]),
                 Operator::Distinct => format!("{} IS DISTINCT FROM {}", operands[0], operands[1]),

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -16913,7 +16913,10 @@ fn render_logical_expr_to_sql(
                 return match op.operator {
                     Op::StartsWith => format!("startsWith({}, {})", left, right),
                     Op::EndsWith => format!("endsWith({}, {})", left, right),
-                    Op::Contains => format!("position({}, {}) > 0", left, right),
+                    Op::Contains => {
+                        // Dialect-aware: Spark's position(substr, str) reverses CH's arg order.
+                        crate::clickhouse_query_generator::contains_predicate(&left, &right)
+                    }
                     Op::RegexMatch => format!("match({}, {})", left, right),
                     _ => unreachable!(),
                 };

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -54,3 +54,20 @@ pub fn quote_identifier(name: &str) -> String {
 pub fn qualified_column(table_alias: &str, column_name: &str) -> String {
     format!("{}.{}", table_alias, quote_identifier(column_name))
 }
+
+/// Emit a substring-containment predicate for Cypher `haystack CONTAINS needle`,
+/// dialect-aware.
+///
+/// ClickHouse `position(haystack, needle)` and Spark/Databricks
+/// `position(substr, str)` take their two arguments in OPPOSITE order, so the
+/// operands are swapped when rendering for Databricks. Both return a 1-based
+/// index (0 = not found), so the `> 0` test is identical.
+pub fn contains_predicate(haystack: &str, needle: &str) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        // Spark: position(substr, str) — substring first.
+        SqlDialect::Databricks => format!("(position({}, {}) > 0)", needle, haystack),
+        // ClickHouse: position(haystack, needle) — haystack first.
+        _ => format!("(position({}, {}) > 0)", haystack, needle),
+    }
+}

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -936,8 +936,15 @@ lazy_static::lazy_static! {
             databricks_name: None,
             arg_transform: Some(|args| {
                 // contains(str, search) -> position(str, search) > 0
-                // Caller needs to handle the > 0 comparison
-                args.to_vec()
+                // (caller adds the > 0). Spark's position(substr, str) reverses
+                // the arg order, so swap the two operands on Databricks.
+                use crate::server::query_context::get_current_dialect;
+                use crate::sql_generator::SqlDialect;
+                if args.len() == 2 && matches!(get_current_dialect(), SqlDialect::Databricks) {
+                    vec![args[1].clone(), args[0].clone()]
+                } else {
+                    args.to_vec()
+                }
             }),
         });
 

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -928,8 +928,7 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
-        // contains(str, search) -> position(str, search) > 0 or like
-        // ClickHouse has positionCaseInsensitive too
+        // contains(str, search) -> position(str, search) > 0 (caller adds the > 0)
         m.insert("contains", FunctionMapping {
             neo4j_name: "contains",
             clickhouse_name: "position",

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -22,7 +22,7 @@ mod view_scan;
 #[cfg(test)]
 mod where_clause_tests;
 
-pub use common::{qualified_column, quote_identifier};
+pub use common::{contains_predicate, qualified_column, quote_identifier};
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{
     get_supported_functions, is_ch_aggregate_function, is_function_supported,

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -321,11 +321,10 @@ impl ToSql for LogicalExpr {
                         ))
                     }
                     Operator::Contains => {
-                        // ClickHouse: position(haystack, needle) > 0 or like(haystack, '%needle%')
-                        // Using position() for efficiency
-                        Ok(format!(
-                            "(position({}, {}) > 0)",
-                            operands_sql[0], operands_sql[1]
+                        // position(haystack, needle) > 0 — dialect-aware (Spark reverses args).
+                        Ok(super::common::contains_predicate(
+                            &operands_sql[0],
+                            &operands_sql[1],
                         ))
                     }
                     Operator::Not => Ok(format!("NOT ({})", operands_sql[0])),

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5113,7 +5113,7 @@ impl RenderExpr {
                     return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::Contains && rendered.len() == 2 {
-                    return format!("(position({}, {}) > 0)", &rendered[0], &rendered[1]);
+                    return super::common::contains_predicate(&rendered[0], &rendered[1]);
                 }
 
                 // Special handling for Addition with list/array operands - use arrayConcat()
@@ -5534,7 +5534,7 @@ impl RenderExpr {
                     return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::Contains && rendered.len() == 2 {
-                    return format!("(position({}, {}) > 0)", &rendered[0], &rendered[1]);
+                    return super::common::contains_predicate(&rendered[0], &rendered[1]);
                 }
 
                 // Special handling for Addition with list/array operands - use arrayConcat()
@@ -5764,7 +5764,7 @@ impl ToSql for OperatorApplication {
             return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
         }
         if self.operator == Operator::Contains && rendered.len() == 2 {
-            return format!("(position({}, {}) > 0)", &rendered[0], &rendered[1]);
+            return super::common::contains_predicate(&rendered[0], &rendered[1]);
         }
 
         // Special handling for Addition with list/array operands - use arrayConcat()
@@ -5986,6 +5986,36 @@ mod tests {
                 && make_op().to_sql().contains("arrayConcat("),
             "CH baseline should still emit arrayConcat"
         );
+    }
+
+    /// CONTAINS renders `position(haystack, needle) > 0` on ClickHouse but must
+    /// REVERSE the args on Databricks, since Spark's `position(substr, str)` takes
+    /// the substring first.
+    #[tokio::test]
+    async fn test_contains_reverses_position_args_on_databricks() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let make_expr = || {
+            RenderExpr::OperatorApplicationExp(OperatorApplication {
+                operator: Operator::Contains,
+                operands: vec![
+                    RenderExpr::Literal(Literal::String("hay".to_string())),
+                    RenderExpr::Literal(Literal::String("need".to_string())),
+                ],
+            })
+        };
+
+        // ClickHouse (default): haystack first.
+        assert_eq!(make_expr().to_sql(), "(position('hay', 'need') > 0)");
+
+        // Databricks: substring (needle) first.
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async { make_expr().to_sql() }).await;
+        assert_eq!(sql, "(position('need', 'hay') > 0)");
     }
 
     /// Test: numeric + numeric (no list) → stays as addition, not arrayConcat

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -2393,8 +2393,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 let concat_parts: Vec<String> = cols
                     .iter()
                     .map(|c| {
+                        // toString -> Spark `string` cast alias via the FunctionMapper.
                         format!(
-                            "toString({}.{})",
+                            "{}({}.{})",
+                            crate::sql_generator::function_mapper::current_function_mapper()
+                                .cast_string(),
                             &self.relationship_alias,
                             crate::clickhouse_query_generator::quote_identifier(c)
                         )


### PR DESCRIPTION
## Summary
Two Spark scalar-function divergences in the shared renderer:

1. **CONTAINS arg order** — ClickHouse `position(haystack, needle)` vs Spark `position(substr, str)` take their two args in **opposite** order, so `x CONTAINS y` silently matched the wrong way on Databricks. New dialect-aware `contains_predicate()` helper swaps operands for Spark; **all six** emission sites routed through it (to_sql.rs, three to_sql_query.rs arms, cte_extraction.rs, plan_builder_utils.rs), plus the Cypher `contains()` function mapping reverses its args via arg_transform.
2. **toString** — Spark has no `toString`; route the VLP composite-key cast through the existing FunctionMapper `cast_string()` (→ Spark `string`).

`startsWith`/`endsWith` take the same arg order on both dialects and were correctly left untouched.

## Tests
CONTAINS emit-diff: ClickHouse keeps `(position('hay','need') > 0)`; Databricks swaps to `(position('need','hay') > 0)`.

## Review
Subagent-reviewed: the multi-site sweep was confirmed complete, arg-order correct in both operator and function-call paths, no ClickHouse semantic regression. Remaining notes were non-blocking (one site gains harmless wrapping parens; test covers the shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)