### PR TITLE
fix(spark): render tuple as struct on Databricks (generic via registry)

### DIFF
--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -103,8 +103,12 @@ impl Identifier {
                     .collect::<Vec<_>>()
                     .join(", ");
                 // ClickHouse: bare tuple literal `(a, b)`. Spark has no row-value
-                // constructor with that syntax, so use `struct(a, b)` — its
-                // equality compares element-wise the same way.
+                // constructor with that syntax, so use `struct(a, b)`. Spark struct
+                // equality matches when both sides have the same field names — the
+                // common case here (same `Identifier`, two aliases). Equality
+                // between two *different* composite identifiers (different column
+                // names) would need per-column AND (see `to_sql_equality`); that
+                // cross-identifier composite join on Spark is a known follow-up.
                 match crate::server::query_context::get_current_dialect() {
                     crate::sql_generator::SqlDialect::Databricks => format!("struct({})", fields),
                     _ => format!("({})", fields),

--- a/src/graph_catalog/config.rs
+++ b/src/graph_catalog/config.rs
@@ -102,7 +102,13 @@ impl Identifier {
                     .map(|c| format!("{}.{}", alias, c))
                     .collect::<Vec<_>>()
                     .join(", ");
-                format!("({})", fields)
+                // ClickHouse: bare tuple literal `(a, b)`. Spark has no row-value
+                // constructor with that syntax, so use `struct(a, b)` — its
+                // equality compares element-wise the same way.
+                match crate::server::query_context::get_current_dialect() {
+                    crate::sql_generator::SqlDialect::Databricks => format!("struct({})", fields),
+                    _ => format!("({})", fields),
+                }
             }
         }
     }
@@ -2599,6 +2605,29 @@ fn resolve_fulltext_indexes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_to_sql_tuple_composite_is_dialect_aware() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let id = Identifier::Composite(vec!["c1".to_string(), "c2".to_string()]);
+
+        // ClickHouse (default scope): bare tuple literal.
+        assert_eq!(id.to_sql_tuple("a"), "(a.c1, a.c2)");
+
+        // Databricks: struct(...) (Spark has no bare row constructor).
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let dbx = with_query_context(ctx, async { id.to_sql_tuple("a") }).await;
+        assert_eq!(dbx, "struct(a.c1, a.c2)");
+
+        // Single ID is unchanged on both dialects.
+        let single = Identifier::Single("id".to_string());
+        assert_eq!(single.to_sql_tuple("a"), "a.id");
+    }
 
     #[test]
     fn test_relationship_definition_edge_id_parsing() {

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1148,7 +1148,9 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 .iter()
                 .map(|arg| render_expr_to_sql_string(arg, alias_mapping))
                 .collect();
-            format!("{}({})", func.name, args.join(", "))
+            // Map dialect-divergent names (e.g. tuple -> Spark struct) via the registry.
+            let name = crate::clickhouse_query_generator::dialect_function_name(&func.name);
+            format!("{}({})", name, args.join(", "))
         }
         RenderExpr::AggregateFnCall(agg) => {
             let args: Vec<String> = agg

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -759,7 +759,9 @@ pub(crate) fn render_expr_to_sql_string(
                 .iter()
                 .map(|arg| render_expr_to_sql_string(arg, alias_mapping))
                 .collect();
-            format!("{}({})", func.name, args.join(", "))
+            // Map dialect-divergent names (e.g. tuple -> Spark struct) via the registry.
+            let name = crate::clickhouse_query_generator::dialect_function_name(&func.name);
+            format!("{}({})", name, args.join(", "))
         }
         RenderExpr::AggregateFnCall(agg) => {
             let args: Vec<String> = agg

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -82,9 +82,49 @@ pub fn contains_predicate(haystack: &str, needle: &str) -> String {
 pub fn dialect_function_name(name: &str) -> String {
     use super::function_registry::get_function_mapping;
     match get_function_mapping(&name.to_lowercase()) {
-        Some(mapping) => mapping
+        // Only remap pure name-swaps. A registry entry with an `arg_transform`
+        // (e.g. `left`/`right` -> `substring(s, 1, n)`) also rewrites its
+        // arguments; this shim renders args itself and cannot apply that
+        // transform, so name-mapping such an entry would emit a wrong call.
+        // Leave those raw — they are handled correctly by the canonical
+        // `RenderExpr::to_sql` / `translate_scalar_function` paths.
+        Some(mapping) if mapping.arg_transform.is_none() => mapping
             .name_for(crate::server::query_context::get_current_dialect())
             .to_string(),
-        None => name.to_string(),
+        _ => name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod dialect_function_name_tests {
+    use super::dialect_function_name;
+    use crate::server::query_context::{with_query_context, QueryContext};
+    use crate::sql_generator::SqlDialect;
+
+    #[tokio::test]
+    async fn maps_pure_name_swaps_only() {
+        // tuple is a pure name-swap -> mapped per dialect.
+        assert_eq!(dialect_function_name("tuple"), "tuple"); // default = ClickHouse
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let dbx_tuple = with_query_context(ctx, async { dialect_function_name("tuple") }).await;
+        assert_eq!(dbx_tuple, "struct");
+
+        // left/right have an arg_transform (-> substring with rewritten args), so
+        // this shim must NOT name-map them — it would emit substring() without the
+        // transform. They stay raw on both dialects.
+        assert_eq!(dialect_function_name("left"), "left");
+        assert_eq!(dialect_function_name("right"), "right");
+        let ctx2 = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let dbx_left = with_query_context(ctx2, async { dialect_function_name("left") }).await;
+        assert_eq!(dbx_left, "left");
+
+        // Unknown functions fall through unchanged.
+        assert_eq!(dialect_function_name("some_native_fn"), "some_native_fn");
     }
 }

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -71,3 +71,20 @@ pub fn contains_predicate(haystack: &str, needle: &str) -> String {
         _ => format!("(position({}, {}) > 0)", haystack, needle),
     }
 }
+
+/// Resolve a SQL function name to its active-dialect spelling via the function
+/// registry, falling back to `name` unchanged when it has no registry entry.
+///
+/// Lets the duplicate generic `ScalarFnCall` renderers (in `render_plan`) map
+/// dialect-divergent names (e.g. `tuple` -> Spark `struct`) without each one
+/// re-implementing the lookup. The canonical `RenderExpr::to_sql` arm already
+/// routes through the registry directly; this is the shared shim for the others.
+pub fn dialect_function_name(name: &str) -> String {
+    use super::function_registry::get_function_mapping;
+    match get_function_mapping(&name.to_lowercase()) {
+        Some(mapping) => mapping
+            .name_for(crate::server::query_context::get_current_dialect())
+            .to_string(),
+        None => name.to_string(),
+    }
+}

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -928,6 +928,14 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
+        // tuple(a, b, ...) -> CH `tuple`, Spark `struct` (element-wise equality).
+        m.insert("tuple", FunctionMapping {
+            neo4j_name: "tuple",
+            clickhouse_name: "tuple",
+            databricks_name: Some("struct"),
+            arg_transform: None,
+        });
+
         // contains(str, search) -> position(str, search) > 0 (caller adds the > 0)
         m.insert("contains", FunctionMapping {
             neo4j_name: "contains",

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -22,7 +22,7 @@ mod view_scan;
 #[cfg(test)]
 mod where_clause_tests;
 
-pub use common::{contains_predicate, qualified_column, quote_identifier};
+pub use common::{contains_predicate, dialect_function_name, qualified_column, quote_identifier};
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{
     get_supported_functions, is_ch_aggregate_function, is_function_supported,

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -6018,6 +6018,35 @@ mod tests {
         assert_eq!(sql, "(position('need', 'hay') > 0)");
     }
 
+    /// A `tuple(...)` ScalarFnCall renders as CH `tuple(...)` but Spark `struct(...)`.
+    #[tokio::test]
+    async fn test_tuple_renders_as_struct_on_databricks() {
+        use crate::render_plan::render_expr::ScalarFnCall;
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let make_expr = || {
+            RenderExpr::ScalarFnCall(ScalarFnCall {
+                name: "tuple".to_string(),
+                args: vec![
+                    RenderExpr::Literal(Literal::Integer(1)),
+                    RenderExpr::Literal(Literal::Integer(2)),
+                ],
+            })
+        };
+
+        // ClickHouse (default).
+        assert_eq!(make_expr().to_sql(), "tuple(1, 2)");
+
+        // Databricks.
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async { make_expr().to_sql() }).await;
+        assert_eq!(sql, "struct(1, 2)");
+    }
+
     /// Test: numeric + numeric (no list) → stays as addition, not arrayConcat
     #[test]
     fn test_addition_without_lists_unchanged() {

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -850,12 +850,19 @@ impl<'a> VariableLengthCteGenerator<'a> {
                     .iter()
                     .map(|col| format!("{}.{}", self.relationship_alias, col))
                     .collect();
-                format!("tuple({})", tuple_elements.join(", "))
+                format!(
+                    "{}({})",
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .tuple_constructor(),
+                    tuple_elements.join(", ")
+                )
             }
             None => {
                 // Default: use (from_id, to_id) as edge identity
                 format!(
-                    "tuple({}.{}, {}.{})",
+                    "{}({}.{}, {}.{})",
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .tuple_constructor(),
                     self.relationship_alias,
                     self.relationship_from_column,
                     self.relationship_alias,
@@ -878,11 +885,18 @@ impl<'a> VariableLengthCteGenerator<'a> {
                     .iter()
                     .map(|col| format!("{}.{}", rel_alias, col))
                     .collect();
-                format!("tuple({})", tuple_elements.join(", "))
+                format!(
+                    "{}({})",
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .tuple_constructor(),
+                    tuple_elements.join(", ")
+                )
             }
             None => {
                 format!(
-                    "tuple({}.{}, {}.{})",
+                    "{}({}.{}, {}.{})",
+                    crate::sql_generator::function_mapper::current_function_mapper()
+                        .tuple_constructor(),
                     rel_alias,
                     self.relationship_from_column,
                     rel_alias,


### PR DESCRIPTION
## Summary
ClickHouse tuples are invalid on Spark, which uses `struct(...)`. Two representations existed, both fixed:
1. `ScalarFnCall{name:"tuple"}` → registry entry `tuple` (clickhouse_name=`tuple`, databricks_name=`struct`), so every registry-aware render path maps it.
2. composite node-id `to_sql_tuple()` → CH keeps `(a,b)`; Databricks emits `struct(a,b)`.

## Generic mechanism
A shared `dialect_function_name()` shim routes the two duplicate generic `ScalarFnCall` renderers (cte_extraction, plan_builder_helpers) through the registry. **It maps every pure name-swap** (registry entry with no `arg_transform`) — not just `tuple` — which also brings those secondary renderers in line with the canonical `RenderExpr::to_sql` arm (e.g. `size→length`, `toUpper→upper` no longer leak raw on either dialect). It deliberately leaves `arg_transform` entries (`left`/`right`→`substring(...)`, etc.) **raw**, since this shim can't apply the arg rewrite — mapping the name alone would be wrong. ClickHouse output for previously-working queries is unchanged.

## Tests
- `tuple` ScalarFnCall → CH `tuple`, Spark `struct`.
- `to_sql_tuple` composite → CH `(a,b)`, Spark `struct(a,b)`; single ID unchanged.
- `dialect_function_name` shim: `tuple` maps, `left`/`right` stay raw, unknown passthrough.

## Review (two passes)
First pass caught a MAJOR (shim dropped `arg_transform` → `left`/`right` wrong on CH) — fixed with the `arg_transform.is_none()` guard. Second pass confirmed solid, no CH regression.

## Known follow-ups (pre-existing, out of scope)
- Cross-identifier composite equality on Spark (different column names) needs per-column `AND` (`to_sql_equality`) rather than `struct(...)` equality, which is field-name sensitive. Same-identifier joins (the common case) are correct.
- The two generic renderers render `RenderExpr::List` as bare `(a,b)` and don't apply `arg_transform` for name-divergent functions — they're a second, less-complete codepath than canonical `to_sql`. Tracked for the broader renderer/IR work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)