### PR TITLE
test(sql-ir): golden SQL snapshot harness, both dialects (refactor Phase 0)

### DIFF
--- a/docs/design/SQL_IR_DESIGN.md
+++ b/docs/design/SQL_IR_DESIGN.md
@@ -1,0 +1,221 @@
+# Dialect-neutral SQL rendering — design
+
+Status: **proposal for review** (no code yet). Author: DeltaGraph dialect work.
+Companion to `docs/design/DELTAGRAPH_PLAN.md`.
+
+## TL;DR
+
+We do **not** need to build a new IR. `RenderPlan` + `RenderExpr` already *are*
+a ~75% dialect-neutral relational/expression IR. The problem is that the
+**pretty-printing** of that IR is ClickHouse-baked and **duplicated across four
+render paths** that drift apart — which is the recurring root cause of the
+Spark dialect bugs (arrayConcat, CONTAINS, tuple, FINAL all had multiple sites).
+
+The evolution is therefore:
+1. Promote `FunctionMapper` into a fuller **`Dialect`** trait that owns *every*
+   divergence point (operators, type spellings, CAST syntax, literals, quoting,
+   the handful of structural rewrites), and
+2. Route **one** printer through it, **collapsing the four render paths into one**.
+
+Each step keeps ClickHouse output **byte-identical** and ships as its own
+reviewed PR. The structural gaps (types/CAST, intervals, `arraySlice`,
+`arrayJoin`, `List`, tuple-equality) stop being scattered `if dialect ==`
+branches and become `Dialect` methods.
+
+---
+
+## 1. Current state (grounded)
+
+### What already exists and is neutral (~75%)
+- **`RenderPlan`** (`src/render_plan/mod.rs:104`): `ctes`, `select`, `from`,
+  `joins`, `array_join`, `filters`, `group_by`, `having`, `order_by`, `skip`,
+  `limit`, `union`. Structurally dialect-neutral.
+- **`RenderExpr`** (`src/render_plan/render_expr.rs:691`): 17+ structural
+  variants — `Literal`, `Column`, `PropertyAccessExp`, `ScalarFnCall`,
+  `AggregateFnCall`, `OperatorApplicationExp`, `Case`, `List`, `InSubquery`,
+  `ExistsSubquery`, `ReduceExpr`, `MapLiteral`, `ArraySubscript`,
+  `ArraySlicing`, `CteEntityRef`, … Expressions are *structured*, not strings.
+- **`FunctionMapper`** (`src/sql_generator/function_mapper/`): already abstracts
+  ~30 names + a few structural ops (`min_if`, `array_literal`, `quote_alias`,
+  the array casts) per dialect, read from the task-local dialect.
+- **Function registry** `name_for(dialect)` + `databricks_name` (~20 entries).
+- **`SqlEmitter`** boundary (`src/sql_generator/mod.rs:95`) + `emitter_for`.
+
+### What's ClickHouse-specific (~25%) — the actual work
+- **Four render paths** that each turn expressions into SQL and drift:
+  - **A. `RenderExpr::to_sql()`** (`to_sql_query.rs:4354`) — canonical, all 17
+    variants, dialect-aware via FunctionMapper/registry. ~1,300 lines.
+  - **B. `render_expr_to_sql_string()`** (`plan_builder_helpers.rs:692`) —
+    JOIN dependency sort; 12 variants; **no dialect awareness**; `"TRUE"` fallback.
+  - **C. `render_expr_to_sql_string()`** (`cte_extraction.rs:1020`) — VLP CTE
+    building; 12 variants; identifier quoting; partial dialect awareness.
+  - **D. `LogicalExpr::to_sql()`** (`to_sql.rs:119`) — EXISTS/pattern-count
+    generation from the *logical* plan; returns `Result`; predates `RenderExpr`.
+- **`RenderExpr::Raw(String)`** and `CteContent::RawSql(String)` escape hatches
+  (~5–10% of expressions) — opaque CH strings the printer can't reason about.
+- **CH-baked leaves** still inline in path A and elsewhere: operator symbols,
+  type names (`Int64`, `Array(...)`, `Nullable(...)`), `CAST(x,'T')` syntax,
+  interval functions, JSON idioms.
+
+### The divergence surface the printer must own (full checklist)
+From the inventory (see appendix): function names (FunctionMapper + registry),
+**type-name spellings + CAST syntax**, tuple/struct construction *and* equality,
+JSONPath arg shaping, array-literal syntax, identifier/alias quoting,
+structural rewrites (`array_count`→`size(filter(...))`, `min_if`→`CASE`,
+`arrayJoin`→`LATERAL VIEW explode`, BFS-undirected CTE shape, `position` arg
+order), keyword support (`FINAL`, `SETTINGS`, `SAMPLE`), temporal epoch-millis
+wrapping, and `if`/`CASE` + regex `match()` idioms.
+
+---
+
+## 2. The design
+
+### 2.1 The `Dialect` trait (one printer config)
+Grow `FunctionMapper` into a `Dialect` trait that is the **single source of
+truth** for everything that differs. It is *config + small structural helpers*,
+not a visitor — a single printer walks the IR and calls into it.
+
+```
+pub(crate) trait Dialect: Send + Sync {
+    // ---- naming (mostly exists as FunctionMapper) ----
+    fn function_name(&self, canonical: &str) -> Cow<str>;   // registry-backed
+    fn operator_symbol(&self, op: Operator) -> &str;        // =, AND, ||/concat, ...
+    fn aggregate_name(&self, canonical: &str) -> Cow<str>;
+
+    // ---- literals & identifiers ----
+    fn quote_ident(&self, name: &str) -> String;            // `x` vs "x"
+    fn quote_alias(&self, name: &str) -> String;            // exists
+    fn array_literal(&self, elems: &[String]) -> String;    // [..] vs array(..)  (exists)
+    fn string_literal(&self, s: &str) -> String;
+    fn bool_literal(&self, b: bool) -> &str;
+
+    // ---- types & casts (NEW — closes the biggest gap) ----
+    fn type_name(&self, t: SqlType) -> String;              // Int64 vs BIGINT, Array<T>, Struct<..>
+    fn cast(&self, expr: &str, t: SqlType) -> String;       // CAST(x,'T') vs CAST(x AS T)
+    fn nullable(&self, t: SqlType) -> SqlType;              // CH Nullable(T) vs Spark (identity)
+
+    // ---- structural rewrites (the handful that aren't name swaps) ----
+    fn contains(&self, haystack: &str, needle: &str) -> String;      // exists (position arg order)
+    fn tuple(&self, fields: &[String]) -> String;                    // tuple(..) vs struct(..)
+    fn min_if(&self, val: &str, cond: &str) -> String;               // exists
+    fn array_count(&self, var: &str, pred: &str, arr: &str) -> String; // arrayCount vs size(filter)
+    fn array_explode(&self, arr: &str) -> Generator;                 // arrayJoin vs LATERAL VIEW
+    fn interval(&self, unit: TimeUnit, n: &str) -> String;           // toIntervalDay vs INTERVAL
+    fn json_extract_string(&self, blob: &str, path: &str) -> String; // JSONExtractString vs get_json_object($.x)
+
+    // ---- capabilities ----
+    fn supports_final(&self) -> bool;                       // exists
+    fn supports_settings(&self) -> bool;
+}
+```
+
+Two impls: `ClickHouseDialect`, `DatabricksDialect`. `for_dialect(SqlDialect)`
+selects one (mirrors `function_mapper::for_dialect`). `SqlType` is a small,
+dialect-neutral type enum derived from the existing `SchemaType` (closes the
+"no `to_spark_type()`" gap — types become a printer concern, not hardcoded CH).
+
+### 2.2 One printer
+A single `print_expr(&RenderExpr, &dyn Dialect) -> String` and
+`print_plan(&RenderPlan, &dyn Dialect) -> String`. Path A's logic becomes this
+printer with every CH-literal swapped for a `dialect.*` call. Paths B/C/D are
+**deleted** and their callers call the one printer (see migration).
+
+The `SqlEmitter` impls collapse to `print_plan(plan, for_dialect(self.dialect))`.
+The task-local dialect lookup stays as the default, so callers don't all need
+threading changes on day one.
+
+### 2.3 Hard cases
+- **Recursive CTEs (VLP)** — already structured in `Cte` with rich metadata
+  (`vlp_*`, `columns`). The CTE *body* is a `RenderPlan` (or `RawSql`). Printing
+  it is the same `print_plan`; the only dialect-divergent bits inside are
+  already enumerated (array funcs, casts, cycle check `has`→`array_contains`,
+  undirected branch shape). The undirected 2-child-limit rewrite stays a
+  `Dialect`-gated structural choice. **No new IR needed** — VLP is the proof
+  that `RenderPlan` is expressive enough.
+- **`Raw`/`RawSql` escape hatches** — shrink, don't eliminate on day one. Each
+  is a place where structured rendering was skipped; migrate opportunistically
+  to real `RenderExpr`/`RenderPlan` so the printer (and Spark) can see them.
+  Track the remaining count as a debt metric.
+- **`PatternCount` / `ExistsSubquery`** carry pre-rendered SQL today; they get
+  printed structurally once Path D (LogicalExpr) is unified.
+
+---
+
+## 3. Migration plan (incremental, CH byte-stable, each a reviewed PR)
+
+The invariant for every phase: **ClickHouse output is byte-identical** (guarded
+by the existing ~1,600 tests + a golden-SQL snapshot set we add in Phase 0).
+
+- **Phase 0 — safety net.** Add golden-SQL snapshot tests over a representative
+  query corpus (single + composite ID, VLP, OPTIONAL MATCH, aggregates, WITH,
+  UNION) for **both** dialects. This is the regression harness for everything
+  below. *(Small, high value, do first.)*
+
+- **Phase 1 — grow `Dialect`, migrate Path A leaf-by-leaf.** Add the trait
+  (superset of FunctionMapper), give it CH + Databricks impls, and replace the
+  CH-literal leaves in `RenderExpr::to_sql()` with `dialect.*` calls **one
+  variant at a time**. CH impl returns exactly today's spellings → byte-stable.
+  This also lands the **type/CAST** work (`type_name`/`cast`/`nullable`) and the
+  remaining leaf gaps (`arraySlice`, intervals, `match`) as `Dialect` methods
+  rather than scattered branches.
+
+- **Phase 2 — collapse the four paths.** Point Path B (JOIN dep-sort) and Path
+  C (CTE extraction) at the one printer; delete their partial copies. Unify Path
+  D by rendering `LogicalExpr` through the same `Dialect` (or converting to
+  `RenderExpr` first). This is the highest-leverage step — it's what stops the
+  drift that caused the recent bugs — but also the **highest-risk**, so it comes
+  after the golden harness and after Path A is fully `Dialect`-routed.
+
+- **Phase 3 — structural idioms.** `arrayJoin`→`LATERAL VIEW explode` (needs a
+  FROM-clause `Generator` concept), `if`→`CASE` where required, cross-identifier
+  composite equality → per-column `AND`. These are now localized `Dialect`
+  decisions.
+
+- **Phase 4 — shrink `Raw`.** Convert the highest-traffic `RenderExpr::Raw` /
+  `CteContent::RawSql` sites to structured forms; leave a documented, shrinking
+  tail.
+
+Phases 0–1 are mostly mechanical and low-risk; 2 is the architectural payoff; 3–4
+are cleanup. We can stop after any phase with a coherent, better-off codebase.
+
+## 4. Risks & mitigations
+- **Silent CH regressions** → golden snapshots (Phase 0) + the existing suite;
+  every phase asserts byte-identical CH.
+- **Path-collapse behavioral drift** (Paths B/C/D have subtle differences, e.g.
+  Path C quotes identifiers, Path B falls back to `"TRUE"`) → migrate one caller
+  at a time, diff output, keep the quirks that are load-bearing as `Dialect`
+  behaviors.
+- **Scope creep** → the trait is additive; we never block on "perfect IR." The
+  `Raw` tail is allowed to persist.
+
+## 5. Non-goals
+- A third dialect (Postgres/DuckDB) — the design *enables* it but we don't build
+  it. The `Dialect` trait is the seam where it would slot in.
+- Replacing the planner/optimizer — only the RenderPlan→SQL step changes.
+- A standalone SQL-AST crate / `sqlparser` adoption — `RenderExpr` is the AST.
+
+## 6. Relationship to the remaining leaf gaps
+The not-yet-done leaf fixes (`arraySlice`, type/CAST, intervals) are folded into
+**Phase 1** as `Dialect` methods, so we don't patch them twice. If you want one
+more standalone leaf PR before starting Phase 0, `arraySlice` is the candidate;
+otherwise it rides along in Phase 1.
+
+---
+
+## Appendix — divergence inventory (checklist the `Dialect` trait must cover)
+(See the two investigation outputs for file:line detail.)
+- **Name swaps** (~30 FunctionMapper + ~20 registry): `groupArray↔collect_list`,
+  `arrayElement↔element_at`, `countIf↔count_if`, `has↔array_contains`,
+  `arrayConcat↔concat`, casts (`toInt64↔bigint`, …), `tuple↔struct`,
+  `anyLast↔any_value`, date parts, …
+- **Structural**: `min_if`→CASE, `array_count`→`size(filter)`,
+  `arrayJoin`→`LATERAL VIEW explode`, `position` arg order, undirected-BFS CTE,
+  array-literal `[..]`↔`array(..)`, empty-array casts, `quote_alias`.
+- **Types/CAST** (gap): `Int64↔BIGINT`, `Float64↔DOUBLE`, `String↔STRING`,
+  `UInt8↔TINYINT`, `DateTime64(3)↔TIMESTAMP`, `Date32↔DATE`, `UUID↔STRING`,
+  `Array(T)↔ARRAY<T>`, `Nullable(T)`→(strip), `CAST(x,'T')↔CAST(x AS T)`.
+- **Keywords/temporal**: `FINAL` (CH only), `SETTINGS`/`SAMPLE` (CH only),
+  `toIntervalX`↔`INTERVAL`, epoch-millis wrapping
+  (`fromUnixTimestamp64Milli`↔`timestamp_millis`).
+- **Idioms** (gap): `if`↔`CASE`, regex `match()`↔`rlike`, JSON
+  `JSONExtractString(b,'f')`↔`get_json_object(b,'$.f')`.

--- a/docs/design/SQL_IR_DESIGN.md
+++ b/docs/design/SQL_IR_DESIGN.md
@@ -43,7 +43,7 @@ branches and become `Dialect` methods.
 
 ### What's ClickHouse-specific (~25%) — the actual work
 - **Four render paths** that each turn expressions into SQL and drift:
-  - **A. `RenderExpr::to_sql()`** (`to_sql_query.rs:4354`) — canonical, all 17
+  - **A. `RenderExpr::to_sql()`** (`src/sql_generator/emitters/clickhouse/to_sql_query.rs`) — canonical, all 17
     variants, dialect-aware via FunctionMapper/registry. ~1,300 lines.
   - **B. `render_expr_to_sql_string()`** (`plan_builder_helpers.rs:692`) —
     JOIN dependency sort; 12 variants; **no dialect awareness**; `"TRUE"` fallback.
@@ -214,6 +214,9 @@ otherwise it rides along in Phase 1.
 - **Types/CAST** (gap): `Int64↔BIGINT`, `Float64↔DOUBLE`, `String↔STRING`,
   `UInt8↔TINYINT`, `DateTime64(3)↔TIMESTAMP`, `Date32↔DATE`, `UUID↔STRING`,
   `Array(T)↔ARRAY<T>`, `Nullable(T)`→(strip), `CAST(x,'T')↔CAST(x AS T)`.
+- **Clauses** (gaps surfaced by Phase 0 goldens): pagination — CH
+  `LIMIT {skip}, {n}` vs Spark `LIMIT {n} OFFSET {skip}`; `IN` list — Spark needs
+  `IN (a, b)`, not the array-literal swap's `IN array(a, b)`.
 - **Keywords/temporal**: `FINAL` (CH only), `SETTINGS`/`SAMPLE` (CH only),
   `toIntervalX`↔`INTERVAL`, epoch-millis wrapping
   (`fromUnixTimestamp64Milli`↔`timestamp_millis`).

--- a/tests/rust/integration/golden/sql_ir/aggregate_count__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/aggregate_count__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      count(u.user_id) AS "count(u)"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/aggregate_count__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/aggregate_count__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      count(u.user_id) AS `count(u)`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/aggregate_group_collect__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/aggregate_group_collect__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.country AS "u.country", 
+      groupArray(u.full_name) AS "names"
+FROM social.users_bench AS u
+GROUP BY u.country

--- a/tests/rust/integration/golden/sql_ir/aggregate_group_collect__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/aggregate_group_collect__databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.country AS `u.country`, 
+      collect_list(u.full_name) AS `names`
+FROM social.users_bench AS u
+GROUP BY u.country

--- a/tests/rust/integration/golden/sql_ir/case_expr__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/case_expr__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      CASE WHEN u.is_active = true THEN 'active' ELSE 'inactive' END AS "status"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/case_expr__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/case_expr__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      CASE WHEN u.is_active = true THEN 'active' ELSE 'inactive' END AS `status`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/cross_node_hop__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/cross_node_hop__clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS "u.name", 
+      p.post_title AS "p.title"
+FROM social.users_bench AS u
+INNER JOIN social.authored_bench AS t0 ON t0.user_id = u.user_id
+INNER JOIN social.posts_bench AS p ON p.post_id = t0.post_id

--- a/tests/rust/integration/golden/sql_ir/cross_node_hop__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/cross_node_hop__databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS `u.name`, 
+      p.post_title AS `p.title`
+FROM social.users_bench AS u
+INNER JOIN social.authored_bench AS t0 ON t0.user_id = u.user_id
+INNER JOIN social.posts_bench AS p ON p.post_id = t0.post_id

--- a/tests/rust/integration/golden/sql_ir/distinct__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/distinct__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT 
+      u.country AS "u.country"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/distinct__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/distinct__databricks.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT 
+      u.country AS `u.country`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/group_two_keys__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/group_two_keys__clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.country AS "u.country", 
+      u.city AS "u.city", 
+      count(u.user_id) AS "n"
+FROM social.users_bench AS u
+GROUP BY u.country, u.city

--- a/tests/rust/integration/golden/sql_ir/group_two_keys__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/group_two_keys__databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.country AS `u.country`, 
+      u.city AS `u.city`, 
+      count(u.user_id) AS `n`
+FROM social.users_bench AS u
+GROUP BY u.country, u.city

--- a/tests/rust/integration/golden/sql_ir/optional_match__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/optional_match__clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS "u.name", 
+      p.post_title AS "p.title"
+FROM social.users_bench AS u
+LEFT JOIN social.authored_bench AS t0 ON t0.user_id = u.user_id
+LEFT JOIN social.posts_bench AS p ON p.post_id = t0.post_id

--- a/tests/rust/integration/golden/sql_ir/optional_match__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/optional_match__databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS `u.name`, 
+      p.post_title AS `p.title`
+FROM social.users_bench AS u
+LEFT JOIN social.authored_bench AS t0 ON t0.user_id = u.user_id
+LEFT JOIN social.posts_bench AS p ON p.post_id = t0.post_id

--- a/tests/rust/integration/golden/sql_ir/order_skip_limit__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/order_skip_limit__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+ORDER BY u.full_name DESC
+LIMIT 5, 10

--- a/tests/rust/integration/golden/sql_ir/order_skip_limit__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/order_skip_limit__databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u
+ORDER BY u.full_name DESC
+LIMIT 5, 10

--- a/tests/rust/integration/golden/sql_ir/project_multi__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/project_multi__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.user_id AS "u.user_id", 
+      u.full_name AS "u.name", 
+      u.country AS "u.country"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/project_multi__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/project_multi__databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.user_id AS `u.user_id`, 
+      u.full_name AS `u.name`, 
+      u.country AS `u.country`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/simple_match__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/simple_match__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/simple_match__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/simple_match__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/single_hop__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/single_hop__clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS "u.name", 
+      f.full_name AS "f.name"
+FROM social.users_bench AS u
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = u.user_id
+INNER JOIN social.users_bench AS f ON f.user_id = t0.followed_id

--- a/tests/rust/integration/golden/sql_ir/single_hop__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/single_hop__databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.full_name AS `u.name`, 
+      f.full_name AS `f.name`
+FROM social.users_bench AS u
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = u.user_id
+INNER JOIN social.users_bench AS f ON f.user_id = t0.followed_id

--- a/tests/rust/integration/golden/sql_ir/string_fns__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/string_fns__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      upper(u.full_name) AS "up", 
+      lower(u.country) AS "lo"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/string_fns__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/string_fns__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      upper(u.full_name) AS `up`, 
+      lower(u.country) AS `lo`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/union__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/union__clickhouse.sql
@@ -1,0 +1,10 @@
+WITH __multi_label_union AS (
+SELECT 'Post' as _label, toString(post_id) as _id, formatRowNoNewline('JSONEachRow', posts_bench.author_id AS author_id, posts_bench.post_content AS content, posts_bench.post_date AS date, posts_bench.post_id AS post_id, posts_bench.post_title AS title) as _properties FROM social.posts_bench
+UNION ALL
+SELECT 'User' as _label, toString(user_id) as _id, formatRowNoNewline('JSONEachRow', users_bench.city AS city, users_bench.country AS country, users_bench.email_address AS email, users_bench.is_active AS is_active, users_bench.full_name AS name, users_bench.registration_date AS registration_date, users_bench.user_id AS user_id) as _properties FROM social.users_bench
+)
+SELECT 
+      n._label AS "n_label", 
+      n._id AS "n_id", 
+      n._properties AS "n_properties"
+FROM __multi_label_union AS n

--- a/tests/rust/integration/golden/sql_ir/union__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/union__databricks.sql
@@ -1,0 +1,10 @@
+WITH __multi_label_union AS (
+SELECT 'Post' as _label, string(post_id) as _id, formatRowNoNewline('JSONEachRow', posts_bench.author_id AS author_id, posts_bench.post_content AS content, posts_bench.post_date AS date, posts_bench.post_id AS post_id, posts_bench.post_title AS title) as _properties FROM social.posts_bench
+UNION ALL
+SELECT 'User' as _label, string(user_id) as _id, formatRowNoNewline('JSONEachRow', users_bench.city AS city, users_bench.country AS country, users_bench.email_address AS email, users_bench.is_active AS is_active, users_bench.full_name AS name, users_bench.registration_date AS registration_date, users_bench.user_id AS user_id) as _properties FROM social.users_bench
+)
+SELECT 
+      n._label AS `n_label`, 
+      n._id AS `n_id`, 
+      n._properties AS `n_properties`
+FROM __multi_label_union AS n

--- a/tests/rust/integration/golden/sql_ir/vlp_recursive__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/vlp_recursive__clickhouse.sql
@@ -1,0 +1,26 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes
+    FROM vlp_a_b vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_nodes, end_node.user_id)
+)
+SELECT 
+      t.end_id AS "b.user_id"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/vlp_recursive__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/vlp_recursive__databricks.sql
@@ -1,0 +1,26 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes
+    FROM vlp_a_b vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_nodes, end_node.user_id)
+)
+SELECT 
+      t.end_id AS `b.user_id`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/where_and__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/where_and__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+WHERE (u.country = 'US' AND u.is_active = true)

--- a/tests/rust/integration/golden/sql_ir/where_and__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/where_and__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u
+WHERE (u.country = 'US' AND u.is_active = true)

--- a/tests/rust/integration/golden/sql_ir/where_comparison__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/where_comparison__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+WHERE u.country = 'US'

--- a/tests/rust/integration/golden/sql_ir/where_comparison__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/where_comparison__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u
+WHERE u.country = 'US'

--- a/tests/rust/integration/golden/sql_ir/where_contains__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/where_contains__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS "u.user_id"
+FROM social.users_bench AS u
+WHERE (position(u.full_name, 'a') > 0)

--- a/tests/rust/integration/golden/sql_ir/where_contains__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/where_contains__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS `u.user_id`
+FROM social.users_bench AS u
+WHERE (position('a', u.full_name) > 0)

--- a/tests/rust/integration/golden/sql_ir/where_in_list__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/where_in_list__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+WHERE u.country IN ['US', 'UK']

--- a/tests/rust/integration/golden/sql_ir/where_in_list__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/where_in_list__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u
+WHERE u.country IN array('US', 'UK')

--- a/tests/rust/integration/golden/sql_ir/whole_entity__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/whole_entity__clickhouse.sql
@@ -1,0 +1,9 @@
+SELECT 
+      u.city AS "u.city", 
+      u.country AS "u.country", 
+      u.email_address AS "u.email", 
+      u.is_active AS "u.is_active", 
+      u.full_name AS "u.name", 
+      u.registration_date AS "u.registration_date", 
+      u.user_id AS "u.user_id"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/whole_entity__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/whole_entity__databricks.sql
@@ -1,0 +1,9 @@
+SELECT 
+      u.city AS `u.city`, 
+      u.country AS `u.country`, 
+      u.email_address AS `u.email`, 
+      u.is_active AS `u.is_active`, 
+      u.full_name AS `u.name`, 
+      u.registration_date AS `u.registration_date`, 
+      u.user_id AS `u.user_id`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/with_having__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/with_having__clickhouse.sql
@@ -1,0 +1,11 @@
+WITH with_c_n_cte_0 AS (SELECT 
+      u.country AS "c", 
+      count(u.user_id) AS "n"
+FROM social.users_bench AS u
+GROUP BY u.country
+HAVING n > 5
+)
+SELECT 
+      c_n.c AS "c", 
+      c_n.n AS "n"
+FROM with_c_n_cte_0 AS c_n

--- a/tests/rust/integration/golden/sql_ir/with_having__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/with_having__databricks.sql
@@ -1,0 +1,11 @@
+WITH with_c_n_cte_0 AS (SELECT 
+      u.country AS `c`, 
+      count(u.user_id) AS `n`
+FROM social.users_bench AS u
+GROUP BY u.country
+HAVING n > 5
+)
+SELECT 
+      c_n.c AS `c`, 
+      c_n.n AS `n`
+FROM with_c_n_cte_0 AS c_n

--- a/tests/rust/integration/mod.rs
+++ b/tests/rust/integration/mod.rs
@@ -15,4 +15,5 @@ mod metrics_endpoint_tests;
 mod parameter_function_test;
 mod path_variable_tests;
 mod skip_offset_tests;
+mod sql_golden_tests;
 mod with_where_having_tests;

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -82,6 +82,26 @@ const CORPUS: &[(&str, &str)] = &[
         "vlp_recursive",
         "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.user_id",
     ),
+    ("whole_entity", "MATCH (u:User) RETURN u"),
+    (
+        "optional_match",
+        "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",
+    ),
+    (
+        "union",
+        "MATCH (u:User) RETURN u.name AS x UNION MATCH (p:Post) RETURN p.title AS x",
+    ),
+    (
+        "group_two_keys",
+        "MATCH (u:User) RETURN u.country, u.city, count(u) AS n",
+    ),
+    // NOTE: Path D coverage (EXISTS / pattern-predicate, e.g.
+    // `WHERE (u)-[:AUTHORED]->(:Post)`) is intentionally absent — that path
+    // currently hits `unimplemented!` in render_expr for anonymous pattern
+    // nodes in expression context. Add it to this corpus once it renders
+    // (it is the path Phase 2 of the IR refactor unifies). Likewise composite
+    // node-ID, denormalized, multi-label, and UNWIND/arrayJoin shapes need
+    // additional schemas / not-yet-implemented Spark structural support.
 ];
 
 fn load_schema() -> GraphSchema {
@@ -117,6 +137,13 @@ async fn render(schema: &GraphSchema, cypher: &str, dialect: SqlDialect) -> Stri
 /// ordering/concurrency: `ALIAS_COUNTER` (anonymous rel aliases `t{n}`) and
 /// `CTE_COUNTER` (`cte{n}`). Each is remapped by first appearance, so goldens
 /// are deterministic while structure (which alias joins where) is preserved.
+///
+/// CAUTION: this is text-blind — it rewrites any `t<digits>`/`cte<digits>`
+/// token, including ones inside string literals or a schema column literally
+/// named `t5`. Today the corpus contains no such token (verified), but if you
+/// add a query whose SQL contains a non-counter `t<n>`/`cte<n>`, tighten this
+/// (e.g. scope to the alias-defining position) so a real regression in that
+/// token can't be silently normalized away.
 fn normalize(sql: &str) -> String {
     fn remap(input: &str, pattern: &str, prefix: &str) -> String {
         let re = regex::Regex::new(pattern).unwrap();
@@ -148,7 +175,7 @@ fn golden_path(name: &str, dialect: &str) -> String {
 #[tokio::test]
 async fn sql_golden_snapshots() {
     let schema = load_schema();
-    let update = std::env::var("UPDATE_GOLDEN").is_ok();
+    let update = std::env::var("UPDATE_GOLDEN").as_deref() == Ok("1");
     let mut mismatches: Vec<String> = Vec::new();
 
     for (name, cypher) in CORPUS {
@@ -157,6 +184,11 @@ async fn sql_golden_snapshots() {
             (SqlDialect::Databricks, "databricks"),
         ] {
             let sql = normalize(&render(&schema, cypher, dialect).await);
+            // Guard against a vacuous pass (e.g. a future to_sql() returning "").
+            assert!(
+                sql.contains("SELECT"),
+                "{name}__{dname} produced SQL without SELECT:\n{sql}"
+            );
             let path = golden_path(name, dname);
 
             if update {

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -88,6 +88,9 @@ const CORPUS: &[(&str, &str)] = &[
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",
     ),
     (
+        // NB: the engine currently renders this via the multi-label entity-union
+        // path (a `__multi_label_union` CTE), not a projection-list UNION — the
+        // golden locks that current behavior.
         "union",
         "MATCH (u:User) RETURN u.name AS x UNION MATCH (p:Post) RETURN p.title AS x",
     ),

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -1,0 +1,187 @@
+//! Golden SQL snapshots — Phase 0 of the dialect-neutral SQL rendering refactor.
+//!
+//! These lock the *current* `RenderPlan -> SQL` output for BOTH dialects
+//! (ClickHouse + Databricks) over a representative query corpus. They are the
+//! regression net for the refactor: every later phase must keep the ClickHouse
+//! goldens **byte-identical**, and any intended Databricks change shows up as a
+//! reviewable golden diff rather than silently.
+//!
+//! Goldens live in `tests/rust/integration/golden/sql_ir/{name}__{dialect}.sql`.
+//! Regenerate after an *intended* change with:
+//!
+//! ```text
+//! UPDATE_GOLDEN=1 cargo test -p clickgraph --test integration sql_golden -- --nocapture
+//! ```
+//!
+//! No ClickHouse connection is needed — this is SQL generation only.
+
+use std::sync::Arc;
+
+use clickgraph::{
+    graph_catalog::{config::GraphSchemaConfig, graph_schema::GraphSchema},
+    open_cypher_parser::{parse_cypher_statement, strip_comments},
+    query_planner::evaluate_read_statement,
+    render_plan::{logical_plan_to_render_plan, ToSql},
+    server::query_context::{set_current_schema, with_query_context, QueryContext},
+    sql_generator::SqlDialect,
+};
+
+/// Representative corpus exercising the RenderPlan -> SQL surface. Chosen to
+/// render cleanly on BOTH dialects (no UNWIND/arrayJoin or array_count, which
+/// hit not-yet-implemented Spark structural gaps). Add cases as coverage grows.
+const CORPUS: &[(&str, &str)] = &[
+    ("simple_match", "MATCH (u:User) RETURN u.name"),
+    ("project_multi", "MATCH (u:User) RETURN u.user_id, u.name, u.country"),
+    ("distinct", "MATCH (u:User) RETURN DISTINCT u.country"),
+    (
+        "where_comparison",
+        "MATCH (u:User) WHERE u.country = 'US' RETURN u.name",
+    ),
+    (
+        "where_and",
+        "MATCH (u:User) WHERE u.country = 'US' AND u.is_active = true RETURN u.name",
+    ),
+    (
+        "where_contains",
+        "MATCH (u:User) WHERE u.name CONTAINS 'a' RETURN u.user_id",
+    ),
+    (
+        "where_in_list",
+        "MATCH (u:User) WHERE u.country IN ['US', 'UK'] RETURN u.name",
+    ),
+    (
+        "order_skip_limit",
+        "MATCH (u:User) RETURN u.name ORDER BY u.name DESC SKIP 5 LIMIT 10",
+    ),
+    ("aggregate_count", "MATCH (u:User) RETURN count(u)"),
+    (
+        "aggregate_group_collect",
+        "MATCH (u:User) RETURN u.country, collect(u.name) AS names",
+    ),
+    (
+        "string_fns",
+        "MATCH (u:User) RETURN toUpper(u.name) AS up, toLower(u.country) AS lo",
+    ),
+    (
+        "case_expr",
+        "MATCH (u:User) RETURN CASE WHEN u.is_active = true THEN 'active' ELSE 'inactive' END AS status",
+    ),
+    (
+        "single_hop",
+        "MATCH (u:User)-[:FOLLOWS]->(f:User) RETURN u.name, f.name",
+    ),
+    (
+        "cross_node_hop",
+        "MATCH (u:User)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",
+    ),
+    (
+        "with_having",
+        "MATCH (u:User) WITH u.country AS c, count(u) AS n WHERE n > 5 RETURN c, n",
+    ),
+    (
+        "vlp_recursive",
+        "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.user_id",
+    ),
+];
+
+fn load_schema() -> GraphSchema {
+    GraphSchemaConfig::from_yaml_file("benchmarks/social_network/schemas/social_benchmark.yaml")
+        .expect("load social_benchmark.yaml")
+        .to_graph_schema()
+        .expect("convert to GraphSchema")
+}
+
+async fn render(schema: &GraphSchema, cypher: &str, dialect: SqlDialect) -> String {
+    let schema = schema.clone();
+    let cypher = cypher.to_string();
+    let ctx = QueryContext {
+        dialect,
+        ..QueryContext::default()
+    };
+    with_query_context(ctx, async move {
+        set_current_schema(Arc::new(schema.clone()));
+        let cleaned = strip_comments(&cypher);
+        let (_rest, statement) =
+            parse_cypher_statement(&cleaned).unwrap_or_else(|e| panic!("parse: {e:?}"));
+        let (logical_plan, _plan_ctx) =
+            evaluate_read_statement(statement, &schema, None, None, None)
+                .unwrap_or_else(|e| panic!("plan: {e:?}"));
+        let render_plan = logical_plan_to_render_plan(logical_plan, &schema)
+            .unwrap_or_else(|e| panic!("render: {e:?}"));
+        render_plan.to_sql()
+    })
+    .await
+}
+
+/// Anonymize the two process-global counters whose values vary with test
+/// ordering/concurrency: `ALIAS_COUNTER` (anonymous rel aliases `t{n}`) and
+/// `CTE_COUNTER` (`cte{n}`). Each is remapped by first appearance, so goldens
+/// are deterministic while structure (which alias joins where) is preserved.
+fn normalize(sql: &str) -> String {
+    fn remap(input: &str, pattern: &str, prefix: &str) -> String {
+        let re = regex::Regex::new(pattern).unwrap();
+        let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut next = 0usize;
+        for m in re.find_iter(input) {
+            seen.entry(m.as_str().to_string()).or_insert_with(|| {
+                let p = format!("{prefix}{next}");
+                next += 1;
+                p
+            });
+        }
+        re.replace_all(input, |c: &regex::Captures| seen[&c[0].to_string()].clone())
+            .into_owned()
+    }
+    let s = remap(sql, r"\bt\d+\b", "t");
+    remap(&s, r"\bcte\d+\b", "cte")
+}
+
+fn golden_path(name: &str, dialect: &str) -> String {
+    format!(
+        "{}/tests/rust/integration/golden/sql_ir/{}__{}.sql",
+        env!("CARGO_MANIFEST_DIR"),
+        name,
+        dialect
+    )
+}
+
+#[tokio::test]
+async fn sql_golden_snapshots() {
+    let schema = load_schema();
+    let update = std::env::var("UPDATE_GOLDEN").is_ok();
+    let mut mismatches: Vec<String> = Vec::new();
+
+    for (name, cypher) in CORPUS {
+        for (dialect, dname) in [
+            (SqlDialect::ClickHouse, "clickhouse"),
+            (SqlDialect::Databricks, "databricks"),
+        ] {
+            let sql = normalize(&render(&schema, cypher, dialect).await);
+            let path = golden_path(name, dname);
+
+            if update {
+                if let Some(dir) = std::path::Path::new(&path).parent() {
+                    std::fs::create_dir_all(dir).expect("create golden dir");
+                }
+                std::fs::write(&path, &sql).expect("write golden");
+            } else {
+                match std::fs::read_to_string(&path) {
+                    Ok(expected) if expected == sql => {}
+                    Ok(expected) => mismatches.push(format!(
+                        "--- {name}__{dname} MISMATCH ---\nEXPECTED:\n{expected}\nACTUAL:\n{sql}\n"
+                    )),
+                    Err(_) => mismatches.push(format!(
+                        "--- {name}__{dname} MISSING golden (run UPDATE_GOLDEN=1) ---"
+                    )),
+                }
+            }
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "{} golden mismatch(es):\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary
Phase 0 of the dialect-neutral SQL rendering refactor (design: `docs/design/SQL_IR_DESIGN.md`). **Test + design-doc only — no production code.**

Adds a golden-SQL snapshot regression net: renders a 20-case Cypher corpus (projections, WHERE incl. CONTAINS/IN, ORDER/SKIP/LIMIT, aggregates + multi-key GROUP BY, joins, OPTIONAL MATCH, UNION, WITH+HAVING, CASE, string fns, whole-entity RETURN, recursive VLP) to SQL for **both** ClickHouse and Databricks, and diffs against committed goldens. Every later refactor phase must keep the ClickHouse goldens byte-identical; intended Databricks changes surface as reviewable golden diffs.

- Output is normalized for the two process-global counters (`ALIAS_COUNTER` `t{n}`, `CTE_COUNTER` `cte{n}`) which vary with test ordering/concurrency — remapped by first appearance, deterministic under the parallel runner while preserving structure.
- Ordering is genuinely deterministic (whole-entity/UNION property lists are sorted; verified across separate processes).
- Regenerate after an intended change with `UPDATE_GOLDEN=1`.

The goldens deliberately lock two **pre-existing** Databricks bugs (`LIMIT skip,n` should be `LIMIT n OFFSET skip`; `IN array(..)` should be `IN (..)`) so their eventual fixes show as diffs — recorded in the design doc's gap appendix. Path D (EXISTS/pattern-predicate) is deferred (currently `unimplemented!`; the path Phase 2 unifies).

## Review
Two passes. First raised 8 forward-looking items (normalization caveat, coverage breadth, vacuous-pass guard, UPDATE_GOLDEN gate) — all addressed. Second pass: **solid, 0 real code comments**, byte-stable and non-flaky under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)