### PR TITLE
feat(sql-ir): dialect-aware type names + CAST syntax (Phase 1, slice 1)

### DIFF
--- a/docs/design/SQL_IR_DESIGN.md
+++ b/docs/design/SQL_IR_DESIGN.md
@@ -222,3 +222,8 @@ otherwise it rides along in Phase 1.
   (`fromUnixTimestamp64Milli`↔`timestamp_millis`).
 - **Idioms** (gap): `if`↔`CASE`, regex `match()`↔`rlike`, JSON
   `JSONExtractString(b,'f')`↔`get_json_object(b,'$.f')`.
+- **JSON row construction** (gap surfaced by the `vlp_multi_type` golden):
+  multi-type VLP builds `_properties` columns via CH-only
+  `formatRowNoNewline('JSONEachRow', ...)` — invalid on Spark, needs a
+  `to_json(struct(...))`-style equivalent. The golden locks the current
+  (Spark-incomplete) output so the fix shows as a diff.

--- a/src/graph_catalog/schema_types.rs
+++ b/src/graph_catalog/schema_types.rs
@@ -106,6 +106,31 @@ impl SchemaType {
         format!("Nullable({})", self.to_clickhouse_type())
     }
 
+    /// Spark / Databricks SQL type name. Spark has no unsigned or UUID types and
+    /// all columns are nullable, so there is no `Nullable(...)` wrapper.
+    pub fn to_spark_type(&self) -> &'static str {
+        match self {
+            SchemaType::Integer => "BIGINT",
+            SchemaType::Float => "DOUBLE",
+            SchemaType::String => "STRING",
+            SchemaType::Boolean => "BOOLEAN",
+            SchemaType::DateTime => "TIMESTAMP",
+            SchemaType::Date => "DATE",
+            SchemaType::Uuid => "STRING", // no native UUID type
+        }
+    }
+
+    /// Dialect-aware SQL type name for use inside a CAST. ClickHouse wraps in
+    /// `Nullable(T)` when `nullable`; Spark types are implicitly nullable, so the
+    /// flag is ignored there.
+    pub fn sql_type_name(&self, dialect: SqlDialect, nullable: bool) -> String {
+        match dialect {
+            SqlDialect::Databricks => self.to_spark_type().to_string(),
+            _ if nullable => self.to_nullable_clickhouse_type(),
+            _ => self.to_clickhouse_type().to_string(),
+        }
+    }
+
     /// Convert a string value to a SQL literal with correct type
     ///
     /// This is used to generate performant SQL predicates from elementId values.
@@ -282,6 +307,45 @@ pub fn map_clickhouse_type(ch_type: &str) -> SchemaType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sql_type_name_dialect_aware() {
+        // ClickHouse: existing spellings; Nullable wrapper when requested.
+        assert_eq!(
+            SchemaType::Integer.sql_type_name(SqlDialect::ClickHouse, false),
+            "Int64"
+        );
+        assert_eq!(
+            SchemaType::Integer.sql_type_name(SqlDialect::ClickHouse, true),
+            "Nullable(Int64)"
+        );
+        assert_eq!(
+            SchemaType::Boolean.sql_type_name(SqlDialect::ClickHouse, false),
+            "UInt8"
+        );
+
+        // Databricks: Spark spellings, nullable flag ignored (implicitly nullable).
+        assert_eq!(
+            SchemaType::Integer.sql_type_name(SqlDialect::Databricks, true),
+            "BIGINT"
+        );
+        assert_eq!(
+            SchemaType::String.sql_type_name(SqlDialect::Databricks, false),
+            "STRING"
+        );
+        assert_eq!(
+            SchemaType::Boolean.sql_type_name(SqlDialect::Databricks, false),
+            "BOOLEAN"
+        );
+        assert_eq!(
+            SchemaType::DateTime.sql_type_name(SqlDialect::Databricks, false),
+            "TIMESTAMP"
+        );
+        assert_eq!(
+            SchemaType::Uuid.sql_type_name(SqlDialect::Databricks, false),
+            "STRING"
+        );
+    }
 
     #[test]
     fn test_from_str_basic() {

--- a/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
+++ b/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
@@ -268,8 +268,8 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         let start_id_needs_string = self.needs_string_conversion_for_end_id() || any_composite;
 
         // Dialect-aware CAST: CH `CAST(x, 'T')` (Nullable-wrapped) vs Spark
-        // `CAST(x AS T)` with Spark type names. type-name + syntax are owned by
-        // SchemaType::sql_type_name / FunctionMapper::cast_as.
+        // `CAST(x AS T)` with Spark type names. Type-name and syntax are owned
+        // by SchemaType::sql_type_name and FunctionMapper::cast_as.
         let dialect = crate::server::query_context::get_current_dialect();
         let mapper = crate::sql_generator::function_mapper::current_function_mapper();
 

--- a/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
+++ b/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
@@ -267,36 +267,37 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         // (when end_id is String due to heterogeneous types or composite IDs)
         let start_id_needs_string = self.needs_string_conversion_for_end_id() || any_composite;
 
+        // Dialect-aware CAST: CH `CAST(x, 'T')` (Nullable-wrapped) vs Spark
+        // `CAST(x AS T)` with Spark type names. type-name + syntax are owned by
+        // SchemaType::sql_type_name / FunctionMapper::cast_as.
+        let dialect = crate::server::query_context::get_current_dialect();
+        let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+
         let start_id_sql = if start_id_needs_string {
-            "CAST('', 'String')".to_string()
+            mapper.cast_as("''", &SchemaType::String.sql_type_name(dialect, false))
         } else {
-            // Use Nullable(T) when default_value is NULL so ClickHouse accepts the CAST
+            // Nullable when default_value is NULL so the CAST is accepted.
             let default = start_id_type.default_value();
-            let ch_type = if default == "NULL" {
-                start_id_type.to_nullable_clickhouse_type()
-            } else {
-                start_id_type.to_clickhouse_type().to_string()
-            };
-            format!("CAST({}, '{}')", default, ch_type)
+            mapper.cast_as(
+                default,
+                &start_id_type.sql_type_name(dialect, default == "NULL"),
+            )
         };
 
         // End ID needs String if heterogeneous types OR composite IDs
         let end_id_needs_string = self.needs_string_conversion_for_end_id() || any_composite;
 
         let end_id_sql = if end_id_needs_string {
-            "CAST('', 'String')".to_string()
+            mapper.cast_as("''", &SchemaType::String.sql_type_name(dialect, false))
         } else {
             let default = end_id_type.default_value();
-            let ch_type = if default == "NULL" {
-                end_id_type.to_nullable_clickhouse_type()
-            } else {
-                end_id_type.to_clickhouse_type().to_string()
-            };
-            format!("CAST({}, '{}')", default, ch_type)
+            mapper.cast_as(
+                default,
+                &end_id_type.sql_type_name(dialect, default == "NULL"),
+            )
         };
 
-        let empty_str_arr = crate::sql_generator::function_mapper::current_function_mapper()
-            .empty_string_array_cast();
+        let empty_str_arr = mapper.empty_string_array_cast();
         format!(
             "SELECT '' AS end_type, {end_id_sql} AS end_id, {start_id_sql} AS start_id, '' AS start_type, \
              '{{}}' AS end_properties, '{{}}' AS start_properties, \

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -89,6 +89,11 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         // and naive wrapping would produce malformed SQL.
         format!("\"{}\"", name.replace('"', "\"\""))
     }
+
+    fn cast_as(&self, expr: &str, type_name: &str) -> String {
+        // ClickHouse function-call CAST with a quoted type string.
+        format!("CAST({}, '{}')", expr, type_name)
+    }
 }
 
 #[cfg(test)]
@@ -101,6 +106,16 @@ mod tests {
         let m = ClickhouseFunctionMapper;
         assert_eq!(m.quote_alias("b.id"), "\"b.id\"");
         assert_eq!(m.quote_alias("x\"y"), "\"x\"\"y\"");
+    }
+
+    #[test]
+    fn cast_as_uses_clickhouse_function_call_form() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.cast_as("''", "String"), "CAST('', 'String')");
+        assert_eq!(
+            m.cast_as("NULL", "Nullable(Int64)"),
+            "CAST(NULL, 'Nullable(Int64)')"
+        );
     }
 
     #[test]

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -165,6 +165,11 @@ impl FunctionMapper for DatabricksFunctionMapper {
         // so this stays consistent with that.
         format!("`{}`", name.replace('`', "``"))
     }
+
+    fn cast_as(&self, expr: &str, type_name: &str) -> String {
+        // Spark/ANSI CAST(expr AS TYPE) with an unquoted type keyword.
+        format!("CAST({} AS {})", expr, type_name)
+    }
 }
 
 #[cfg(test)]
@@ -206,6 +211,9 @@ mod tests {
         // Embedded backticks must be doubled, not left raw — otherwise
         // an alias like `` x`y `` would prematurely close the quote.
         assert_eq!(m.quote_alias("x`y"), "`x``y`");
+        // ANSI CAST syntax with unquoted type keyword.
+        assert_eq!(m.cast_as("''", "STRING"), "CAST('' AS STRING)");
+        assert_eq!(m.cast_as("NULL", "BIGINT"), "CAST(NULL AS BIGINT)");
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -139,6 +139,13 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// concern — it already uses backticks for both dialects since
     /// both accept them for plain column refs.
     fn quote_alias(&self, name: &str) -> String;
+
+    /// Build a CAST expression. The two dialects diverge on both syntax and the
+    /// type-name spelling: ClickHouse uses the function-call form with a quoted
+    /// type string, `CAST(expr, 'Int64')`; Spark/ANSI uses `CAST(expr AS BIGINT)`.
+    /// `type_name` must already be the dialect-appropriate spelling (see
+    /// `SchemaType::sql_type_name`).
+    fn cast_as(&self, expr: &str, type_name: &str) -> String;
 }
 
 /// Returns the function mapper for the active SQL dialect, read from the

--- a/tests/rust/integration/golden/sql_ir/vlp_multi_type__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/vlp_multi_type__clickhouse.sql
@@ -1,0 +1,24 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Post' AS end_type, p2.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, toString(r1.user_id) AS r_from_id, toString(r1.post_id) AS r_to_id, formatRowNoNewline('JSONEachRow', p2.author_id AS author_id, p2.post_content AS content, p2.post_date AS date, p2.post_id AS post_id, p2.post_title AS title) AS end_properties, p2.author_id AS end_author_id, p2.post_content AS end_content, p2.post_date AS end_date, p2.post_id AS end_post_id, p2.post_title AS end_title, formatRowNoNewline('JSONEachRow', a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 1 AS hop_count, ['AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.authored_date)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id)] AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.authored_bench r1 ON a_1.user_id = r1.user_id
+INNER JOIN social.posts_bench p2 ON r1.post_id = p2.post_id
+UNION ALL
+SELECT 'Post' AS end_type, p3.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', p3.author_id AS author_id, p3.post_content AS content, p3.post_date AS date, p3.post_id AS post_id, p3.post_title AS title) AS end_properties, p3.author_id AS end_author_id, p3.post_content AS end_content, p3.post_date AS end_date, p3.post_id AS end_post_id, p3.post_title AS end_title, formatRowNoNewline('JSONEachRow', a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.follow_date), formatRowNoNewline('JSONEachRow', r2.authored_date)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id)] AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.user_follows_bench r1 ON a_1.user_id = r1.follower_id
+INNER JOIN social.users_bench u2 ON r1.followed_id = u2.user_id
+INNER JOIN social.authored_bench r2 ON u2.user_id = r2.user_id
+INNER JOIN social.posts_bench p3 ON r2.post_id = p3.post_id
+)
+SELECT 
+      t.end_properties AS "b.properties", 
+      t.end_id AS "b.id", 
+      t.end_type AS "b.__label__"
+FROM vlp_multi_type_a_b AS t
+UNION ALL 
+SELECT 
+      t.end_properties AS "b.properties", 
+      t.end_id AS "b.id", 
+      t.end_type AS "b.__label__"
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/vlp_multi_type__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/vlp_multi_type__databricks.sql
@@ -1,0 +1,24 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Post' AS end_type, p2.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, string(r1.user_id) AS r_from_id, string(r1.post_id) AS r_to_id, formatRowNoNewline('JSONEachRow', p2.author_id AS author_id, p2.post_content AS content, p2.post_date AS date, p2.post_id AS post_id, p2.post_title AS title) AS end_properties, p2.author_id AS end_author_id, p2.post_content AS end_content, p2.post_date AS end_date, p2.post_id AS end_post_id, p2.post_title AS end_title, formatRowNoNewline('JSONEachRow', a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 1 AS hop_count, array('AUTHORED') AS path_relationships, array(formatRowNoNewline('JSONEachRow', r1.authored_date)) AS rel_properties, array(string(a_1.user_id), string(p2.post_id)) AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.authored_bench r1 ON a_1.user_id = r1.user_id
+INNER JOIN social.posts_bench p2 ON r1.post_id = p2.post_id
+UNION ALL
+SELECT 'Post' AS end_type, p3.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', p3.author_id AS author_id, p3.post_content AS content, p3.post_date AS date, p3.post_id AS post_id, p3.post_title AS title) AS end_properties, p3.author_id AS end_author_id, p3.post_content AS end_content, p3.post_date AS end_date, p3.post_id AS end_post_id, p3.post_title AS end_title, formatRowNoNewline('JSONEachRow', a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'AUTHORED') AS path_relationships, array(formatRowNoNewline('JSONEachRow', r1.follow_date), formatRowNoNewline('JSONEachRow', r2.authored_date)) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id)) AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.user_follows_bench r1 ON a_1.user_id = r1.follower_id
+INNER JOIN social.users_bench u2 ON r1.followed_id = u2.user_id
+INNER JOIN social.authored_bench r2 ON u2.user_id = r2.user_id
+INNER JOIN social.posts_bench p3 ON r2.post_id = p3.post_id
+)
+SELECT 
+      t.end_properties AS `b.properties`, 
+      t.end_id AS `b.id`, 
+      t.end_type AS `b.__label__`
+FROM vlp_multi_type_a_b AS t
+UNION ALL 
+SELECT 
+      t.end_properties AS `b.properties`, 
+      t.end_id AS `b.id`, 
+      t.end_type AS `b.__label__`
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -83,6 +83,12 @@ const CORPUS: &[(&str, &str)] = &[
         "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.user_id",
     ),
     ("whole_entity", "MATCH (u:User) RETURN u"),
+    // Heterogeneous end type (User|Post) routes through multi_type_vlp_joins,
+    // exercising the dialect-aware CAST/type-name path end-to-end.
+    (
+        "vlp_multi_type",
+        "MATCH (a:User)-[:FOLLOWS|AUTHORED*1..2]->(b) RETURN b",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -84,7 +84,13 @@ const CORPUS: &[(&str, &str)] = &[
     ),
     ("whole_entity", "MATCH (u:User) RETURN u"),
     // Heterogeneous end type (User|Post) routes through multi_type_vlp_joins,
-    // exercising the dialect-aware CAST/type-name path end-to-end.
+    // locking the generator output for both dialects (incl. dialect-aware
+    // array/string casts: CH `toString(..)`/`['x']` vs Spark `string(..)`/
+    // `array('x')`). NOTE: this query enumerates real paths, so it takes the
+    // concrete-branch path and does NOT reach `generate_empty_cte_sql` (the
+    // empty-placeholder CAST sites migrated in this slice) — those remain
+    // covered by the `cast_as`/`sql_type_name` unit tests; an integration
+    // golden for the no-path empty branch is a deferred follow-up.
     (
         "vlp_multi_type",
         "MATCH (a:User)-[:FOLLOWS|AUTHORED*1..2]->(b) RETURN b",


### PR DESCRIPTION
## Summary
First leaf migration of the dialect-neutral SQL rendering refactor: **type names + CAST syntax** — the biggest correctness gap for Databricks (heterogeneous-VLP UNION placeholders emitted CH `CAST(x, 'T')` / `Nullable(...)` / CH type names, all invalid on Spark).

- `SchemaType::sql_type_name(dialect, nullable)` — CH spellings unchanged (with `Nullable(T)` wrap); Spark spellings (`BIGINT`/`DOUBLE`/`STRING`/`BOOLEAN`/`TIMESTAMP`/`DATE`; no unsigned/UUID/Nullable).
- `FunctionMapper::cast_as(expr, type)` — CH function-call `CAST(x, 'T')`; Spark/ANSI `CAST(x AS T)`.
- Migrate the 4 `generate_empty_cte_sql` CAST sites in `multi_type_vlp_joins.rs`.

ClickHouse output is **byte-identical** (the new helpers reproduce the old literals exactly), guarded by the existing multi_type_vlp tests + the Phase-0 golden net. Unit tests pin both helpers on both dialects.

## Coverage note
Added a `vlp_multi_type` golden (heterogeneous end type) locking the multi_type_vlp generator + dialect array/string casts for both dialects. It takes the concrete-branch path, so it does **not** reach `generate_empty_cte_sql` — those migrated CAST sites stay covered by the helper unit tests; a no-path empty-branch golden is a deferred follow-up. The golden also surfaced a pre-existing CH-ism now locked for later: `formatRowNoNewline('JSONEachRow', ...)` (recorded in the design-doc gap appendix).

## Review
Two passes (second in an isolated worktree): byte-stable for ClickHouse, correct Spark spellings, clean helper abstractions. Remaining note (empty-CTE branch unpinned at integration level) is accurately documented as deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)