### PR TITLE
feat(sql-ir): dialect-aware array slicing (arraySlice -> slice) (Phase 1, slice 2)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1242,22 +1242,24 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             // but to_sql() doesn't support it. For now, array slicing shouldn't have
             // complex alias references that need mapping.
             let array_sql = render_expr_to_sql_string(array, alias_mapping);
+            let mapper = crate::sql_generator::function_mapper::current_function_mapper();
             match (from, to) {
                 (Some(from_expr), Some(to_expr)) => {
                     let from_sql = render_expr_to_sql_string(from_expr, alias_mapping);
                     let to_sql = render_expr_to_sql_string(to_expr, alias_mapping);
-                    format!(
-                        "arraySlice({}, {} + 1, {} - {} + 1)",
-                        array_sql, from_sql, to_sql, from_sql
+                    mapper.array_slice(
+                        &array_sql,
+                        &format!("{} + 1", from_sql),
+                        Some(&format!("{} - {} + 1", to_sql, from_sql)),
                     )
                 }
                 (Some(from_expr), None) => {
                     let from_sql = render_expr_to_sql_string(from_expr, alias_mapping);
-                    format!("arraySlice({}, {} + 1)", array_sql, from_sql)
+                    mapper.array_slice(&array_sql, &format!("{} + 1", from_sql), None)
                 }
                 (None, Some(to_expr)) => {
                     let to_sql = render_expr_to_sql_string(to_expr, alias_mapping);
-                    format!("arraySlice({}, 1, {} + 1)", array_sql, to_sql)
+                    mapper.array_slice(&array_sql, "1", Some(&format!("{} + 1", to_sql)))
                 }
                 (None, None) => array_sql,
             }

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -373,7 +373,12 @@ lazy_static::lazy_static! {
                 }
                 let list = args[0].clone();
                 if matches!(get_current_dialect(), SqlDialect::Databricks) {
-                    vec![list.clone(), "2".to_string(), format!("size({}) - 1", list)]
+                    // Floor at 0: slice errors on negative length (empty list).
+                    vec![
+                        list.clone(),
+                        "2".to_string(),
+                        format!("greatest(size({}) - 1, 0)", list),
+                    ]
                 } else {
                     vec![list, "2".to_string()]
                 }

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -359,16 +359,23 @@ lazy_static::lazy_static! {
             }),
         });
 
-        // tail(list) -> arraySlice(list, 2) [all but first]
+        // tail(list) = all but first. CH arraySlice(list, 2) (2-arg, rest from
+        // offset). Spark slice requires a length, so emit slice(list, 2, size(list) - 1).
         m.insert("tail", FunctionMapping {
             neo4j_name: "tail",
             clickhouse_name: "arraySlice",
-            databricks_name: None,
+            databricks_name: Some("slice"),
             arg_transform: Some(|args| {
-                if !args.is_empty() {
-                    vec![args[0].clone(), "2".to_string()]
+                use crate::server::query_context::get_current_dialect;
+                use crate::sql_generator::SqlDialect;
+                if args.is_empty() {
+                    return args.to_vec();
+                }
+                let list = args[0].clone();
+                if matches!(get_current_dialect(), SqlDialect::Databricks) {
+                    vec![list.clone(), "2".to_string(), format!("size({}) - 1", list)]
                 } else {
-                    args.to_vec()
+                    vec![list, "2".to_string()]
                 }
             }),
         });

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5370,31 +5370,33 @@ impl RenderExpr {
                 // - offset: 1-based index (Cypher uses 0-based, need to convert)
                 // - length: number of elements to extract
                 let array_sql = array.to_sql();
+                let mapper = crate::sql_generator::function_mapper::current_function_mapper();
 
                 match (from, to) {
                     (Some(from_expr), Some(to_expr)) => {
-                        // [from..to] - both bounds specified
-                        // Cypher: 0-based inclusive on both ends
-                        // ClickHouse arraySlice: 1-based offset, length parameter
-                        // Example: [2..4] means indices 2,3,4 (3 elements starting at index 2)
-                        // Convert: arraySlice(arr, from+1, to-from+1)
-                        format!(
-                            "arraySlice({}, {} + 1, {} - {} + 1)",
-                            array_sql,
-                            from_expr.to_sql(),
-                            to_expr.to_sql(),
-                            from_expr.to_sql()
+                        // [from..to] (Cypher 0-based inclusive) -> 1-based offset + length.
+                        // CH arraySlice(arr, from+1, to-from+1); Spark slice(...) (same shape).
+                        mapper.array_slice(
+                            &array_sql,
+                            &format!("{} + 1", from_expr.to_sql()),
+                            Some(&format!(
+                                "{} - {} + 1",
+                                to_expr.to_sql(),
+                                from_expr.to_sql()
+                            )),
                         )
                     }
                     (Some(from_expr), None) => {
-                        // [from..] - only lower bound, slice to end
-                        // arraySlice(arr, from+1) - omitting length takes rest of array
-                        format!("arraySlice({}, {} + 1)", array_sql, from_expr.to_sql())
+                        // [from..] - slice to end. CH 2-arg form; Spark computes the length.
+                        mapper.array_slice(&array_sql, &format!("{} + 1", from_expr.to_sql()), None)
                     }
                     (None, Some(to_expr)) => {
-                        // [..to] - only upper bound, slice from start
-                        // arraySlice(arr, 1, to+1) - from index 1, take to+1 elements
-                        format!("arraySlice({}, 1, {} + 1)", array_sql, to_expr.to_sql())
+                        // [..to] - from index 1, take to+1 elements.
+                        mapper.array_slice(
+                            &array_sql,
+                            "1",
+                            Some(&format!("{} + 1", to_expr.to_sql())),
+                        )
                     }
                     (None, None) => {
                         // [..] - no bounds, return entire array (identity operation)

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5365,17 +5365,18 @@ impl RenderExpr {
                 format!("{}[{}]", array_sql, index_sql)
             }
             RenderExpr::ArraySlicing { array, from, to } => {
-                // Array slicing in ClickHouse using arraySlice function
-                // arraySlice(array, offset, length)
-                // - offset: 1-based index (Cypher uses 0-based, need to convert)
-                // - length: number of elements to extract
+                // Array slicing -> arraySlice(arr, offset, length) (CH) / slice (Spark),
+                // both 1-based offset + element count. Cypher indices are 0-based, so
+                // offset = from + 1. NOTE: this computes `to - from + 1` (to-INCLUSIVE),
+                // which differs from Neo4j's half-open `[from..to)` semantics — a
+                // pre-existing discrepancy preserved byte-for-byte here (not introduced
+                // by the dialect refactor); tracked separately.
                 let array_sql = array.to_sql();
                 let mapper = crate::sql_generator::function_mapper::current_function_mapper();
 
                 match (from, to) {
                     (Some(from_expr), Some(to_expr)) => {
-                        // [from..to] (Cypher 0-based inclusive) -> 1-based offset + length.
-                        // CH arraySlice(arr, from+1, to-from+1); Spark slice(...) (same shape).
+                        // [from..to] -> 1-based offset + length (to-inclusive, see above).
                         mapper.array_slice(
                             &array_sql,
                             &format!("{} + 1", from_expr.to_sql()),

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -94,6 +94,13 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         // ClickHouse function-call CAST with a quoted type string.
         format!("CAST({}, '{}')", expr, type_name)
     }
+
+    fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String {
+        match length {
+            Some(l) => format!("arraySlice({}, {}, {})", arr, offset, l),
+            None => format!("arraySlice({}, {})", arr, offset),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -116,6 +123,13 @@ mod tests {
             m.cast_as("NULL", "Nullable(Int64)"),
             "CAST(NULL, 'Nullable(Int64)')"
         );
+    }
+
+    #[test]
+    fn array_slice_keeps_clickhouse_2_and_3_arg_forms() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.array_slice("a", "2", Some("3")), "arraySlice(a, 2, 3)");
+        assert_eq!(m.array_slice("a", "2", None), "arraySlice(a, 2)");
     }
 
     #[test]

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -172,13 +172,16 @@ impl FunctionMapper for DatabricksFunctionMapper {
     }
 
     fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String {
-        // Spark slice(arr, start, length) requires a length. CH's 2-arg
-        // arraySlice(arr, offset) (rest from offset) becomes
-        // slice(arr, offset, size(arr) - (offset) + 1).
+        // Spark slice(arr, start, length) requires a length, and ERRORS on a
+        // negative one — whereas CH's 2-arg arraySlice(arr, offset) silently
+        // returns empty when offset is past the end. So the computed
+        // rest-from-offset length, size(arr) - offset + 1, is floored at 0 with
+        // greatest(...) to preserve CH's empty-on-out-of-bounds behavior.
+        // (Note: `arr` is evaluated twice here; fine for column/literal arrays.)
         match length {
             Some(l) => format!("slice({}, {}, {})", arr, offset, l),
             None => format!(
-                "slice({}, {}, size({}) - ({}) + 1)",
+                "slice({}, {}, greatest(size({}) - ({}) + 1, 0))",
                 arr, offset, arr, offset
             ),
         }
@@ -231,7 +234,7 @@ mod tests {
         assert_eq!(m.array_slice("arr", "2", Some("3")), "slice(arr, 2, 3)");
         assert_eq!(
             m.array_slice("arr", "2", None),
-            "slice(arr, 2, size(arr) - (2) + 1)"
+            "slice(arr, 2, greatest(size(arr) - (2) + 1, 0))"
         );
     }
 

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -170,6 +170,19 @@ impl FunctionMapper for DatabricksFunctionMapper {
         // Spark/ANSI CAST(expr AS TYPE) with an unquoted type keyword.
         format!("CAST({} AS {})", expr, type_name)
     }
+
+    fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String {
+        // Spark slice(arr, start, length) requires a length. CH's 2-arg
+        // arraySlice(arr, offset) (rest from offset) becomes
+        // slice(arr, offset, size(arr) - (offset) + 1).
+        match length {
+            Some(l) => format!("slice({}, {}, {})", arr, offset, l),
+            None => format!(
+                "slice({}, {}, size({}) - ({}) + 1)",
+                arr, offset, arr, offset
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -214,6 +227,12 @@ mod tests {
         // ANSI CAST syntax with unquoted type keyword.
         assert_eq!(m.cast_as("''", "STRING"), "CAST('' AS STRING)");
         assert_eq!(m.cast_as("NULL", "BIGINT"), "CAST(NULL AS BIGINT)");
+        // slice requires a length; the 2-arg CH form computes one.
+        assert_eq!(m.array_slice("arr", "2", Some("3")), "slice(arr, 2, 3)");
+        assert_eq!(
+            m.array_slice("arr", "2", None),
+            "slice(arr, 2, size(arr) - (2) + 1)"
+        );
     }
 
     /// Documented structural gap: `array_count` has no clean Spark mapping.

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -146,6 +146,12 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// `type_name` must already be the dialect-appropriate spelling (see
     /// `SchemaType::sql_type_name`).
     fn cast_as(&self, expr: &str, type_name: &str) -> String;
+
+    /// Array slice from a 1-based `offset`. CH `arraySlice(arr, offset[, length])`
+    /// accepts a 2-arg "rest from offset" form; Spark `slice(arr, start, length)`
+    /// REQUIRES a length, so the `None` case computes `size(arr) - offset + 1`.
+    /// `offset`/`length` are pre-rendered SQL fragments.
+    fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String;
 }
 
 /// Returns the function mapper for the active SQL dialect, read from the

--- a/tests/rust/integration/golden/sql_ir/list_slice_bounded__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_bounded__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      arraySlice([10, 20, 30, 40], 1 + 1, 3 - 1 + 1) AS "s"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_bounded__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_bounded__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      slice(array(10, 20, 30, 40), 1 + 1, 3 - 1 + 1) AS `s`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_open__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_open__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      arraySlice([10, 20, 30, 40], 1 + 1) AS "s"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_open__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_open__databricks.sql
@@ -1,3 +1,3 @@
 SELECT 
-      slice(array(10, 20, 30, 40), 1 + 1, size(array(10, 20, 30, 40)) - (1 + 1) + 1) AS `s`
+      slice(array(10, 20, 30, 40), 1 + 1, greatest(size(array(10, 20, 30, 40)) - (1 + 1) + 1, 0)) AS `s`
 FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_open__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_open__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      slice(array(10, 20, 30, 40), 1 + 1, size(array(10, 20, 30, 40)) - (1 + 1) + 1) AS `s`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_to__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_to__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      arraySlice([10, 20, 30, 40], 1, 2 + 1) AS "s"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_slice_to__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_slice_to__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      slice(array(10, 20, 30, 40), 1, 2 + 1) AS `s`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_tail__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/list_tail__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      arraySlice([10, 20, 30], 2) AS "t"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_tail__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_tail__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      slice(array(10, 20, 30), 2, greatest(size(array(10, 20, 30)) - 1, 0)) AS `t`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -93,6 +93,12 @@ const CORPUS: &[(&str, &str)] = &[
         "list_slice_open",
         "MATCH (u:User) RETURN [10, 20, 30, 40][1..] AS s",
     ),
+    (
+        "list_slice_to",
+        "MATCH (u:User) RETURN [10, 20, 30, 40][..2] AS s",
+    ),
+    // tail() -> CH arraySlice(list, 2) / Spark slice(list, 2, greatest(size-1, 0))
+    ("list_tail", "MATCH (u:User) RETURN tail([10, 20, 30]) AS t"),
     // Heterogeneous end type (User|Post) routes through multi_type_vlp_joins,
     // locking the generator output for both dialects (incl. dialect-aware
     // array/string casts: CH `toString(..)`/`['x']` vs Spark `string(..)`/

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -83,6 +83,16 @@ const CORPUS: &[(&str, &str)] = &[
         "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) RETURN b.user_id",
     ),
     ("whole_entity", "MATCH (u:User) RETURN u"),
+    // List slicing -> arraySlice (CH) / slice (Spark). Both the 3-arg bounded
+    // form and the 2-arg open-ended form (Spark needs a computed length).
+    (
+        "list_slice_bounded",
+        "MATCH (u:User) RETURN [10, 20, 30, 40][1..3] AS s",
+    ),
+    (
+        "list_slice_open",
+        "MATCH (u:User) RETURN [10, 20, 30, 40][1..] AS s",
+    ),
     // Heterogeneous end type (User|Post) routes through multi_type_vlp_joins,
     // locking the generator output for both dialects (incl. dialect-aware
     // array/string casts: CH `toString(..)`/`['x']` vs Spark `string(..)`/


### PR DESCRIPTION
## Summary
Cypher list slicing `arr[from..to]` emitted ClickHouse `arraySlice`, including a 2-arg "rest-from-offset" form Spark's `slice(arr, start, length)` doesn't support.

- `FunctionMapper::array_slice(arr, offset, length)` — CH `arraySlice(arr, offset[, length])`; Spark `slice(arr, start, length)`, computing `greatest(size(arr) - offset + 1, 0)` for the open-ended case (floored at 0 since Spark `slice` errors on negative length, whereas CH returns empty).
- All `RenderExpr::ArraySlicing` sites migrated (`to_sql_query` + `cte_extraction`: `[from..to]`, `[from..]`, `[..to]`).
- `tail()` registry entry now dialect-aware: CH `arraySlice(list, 2)`, Spark `slice(list, 2, greatest(size(list) - 1, 0))`.

ClickHouse output is byte-identical (the new helper reproduces the old `arraySlice` literals exactly). Goldens lock all four arms on both dialects; mapper unit tests on both dialects.

Pre-existing (preserved, tracked separately): the length math is to-INCLUSIVE (`to - from + 1`), which differs from Neo4j's half-open slice semantics.

## Review
Worktree-isolated review: no blockers, CH byte-stable, Spark length math verified (no off-by-one). Review fixes: floored Spark length, added `[..to]`/`tail` goldens, corrected comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)