### PR TITLE
feat(sql-ir): dialect-aware LIMIT/OFFSET pagination (Phase 1)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -425,6 +425,37 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
     None
 }
 
+/// Render the SKIP/LIMIT clause, dialect-aware (no trailing newline; empty when
+/// neither is set). ClickHouse uses the MySQL-style `LIMIT offset, count` and
+/// requires a count when offsetting (so SKIP-only emits a huge upper bound);
+/// Spark/Databricks uses standard `LIMIT count OFFSET offset` and supports a
+/// bare `OFFSET`. Replaces the same logic previously copy-pasted across the
+/// union-branch, main-query, and CTE-body emission sites.
+fn limit_offset_clause(skip: Option<i64>, limit: Option<i64>) -> String {
+    use crate::server::query_context::get_current_dialect;
+    use crate::sql_generator::SqlDialect;
+    let databricks = matches!(get_current_dialect(), SqlDialect::Databricks);
+    match (skip, limit) {
+        (None, None) => String::new(),
+        (None, Some(l)) => format!("LIMIT {l}"),
+        (Some(s), Some(l)) => {
+            if databricks {
+                format!("LIMIT {l} OFFSET {s}")
+            } else {
+                format!("LIMIT {s}, {l}")
+            }
+        }
+        (Some(s), None) => {
+            if databricks {
+                format!("OFFSET {s}")
+            } else {
+                // ClickHouse requires a count with an offset; use a huge upper bound.
+                format!("LIMIT {s}, 18446744073709551615")
+            }
+        }
+    }
+}
+
 /// Build the relationship columns mapping from a RenderPlan (for collecting data)
 /// Returns the mapping of alias → (from_id_column, to_id_column)
 fn build_relationship_columns_from_plan(plan: &RenderPlan) -> HashMap<String, (String, String)> {
@@ -2850,15 +2881,10 @@ fn render_union_branch_sql(branch: &RenderPlan) -> String {
         if has_order_by {
             bsql.push_str(&branch.order_by.to_sql());
         }
-        if let Some(limit) = branch.limit.0 {
-            if let Some(skip) = branch.skip.0 {
-                bsql.push_str(&format!("LIMIT {skip}, {limit}\n"));
-            } else {
-                bsql.push_str(&format!("LIMIT {limit}\n"));
-            }
-        } else if let Some(skip) = branch.skip.0 {
-            // ClickHouse requires LIMIT when using offset; emulate SKIP-only with large upper bound
-            bsql.push_str(&format!("LIMIT {skip}, 18446744073709551615\n"));
+        let clause = limit_offset_clause(branch.skip.0, branch.limit.0);
+        if !clause.is_empty() {
+            bsql.push_str(&clause);
+            bsql.push('\n');
         }
 
         bsql
@@ -3631,16 +3657,7 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
             }
 
             // Add LIMIT/OFFSET after ORDER BY if present
-            if let Some(m) = plan.limit.0 {
-                if let Some(n) = plan.skip.0 {
-                    sql.push_str(&format!("LIMIT {n}, {m}"));
-                } else {
-                    sql.push_str(&format!("LIMIT {m}"));
-                }
-            } else if let Some(n) = plan.skip.0 {
-                // ClickHouse requires LIMIT when using offset; emulate SKIP-only with large upper bound
-                sql.push_str(&format!("LIMIT {n}, 18446744073709551615"));
-            }
+            sql.push_str(&limit_offset_clause(plan.skip.0, plan.limit.0));
         } else {
             // No ordering/limiting - bare UNION is fine
             if let Some(union) = &plan.union.0 {
@@ -3728,16 +3745,7 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
     sql.push_str(&plan.order_by.to_sql());
     sql.push_str(&plan.union.to_sql());
 
-    if let Some(m) = plan.limit.0 {
-        if let Some(n) = plan.skip.0 {
-            sql.push_str(&format!("LIMIT {n}, {m}"));
-        } else {
-            sql.push_str(&format!("LIMIT {m}"));
-        }
-    } else if let Some(n) = plan.skip.0 {
-        // ClickHouse requires LIMIT when using offset; emulate SKIP-only with large upper bound
-        sql.push_str(&format!("LIMIT {n}, 18446744073709551615"));
-    }
+    sql.push_str(&limit_offset_clause(plan.skip.0, plan.limit.0));
 
     // Note: max_recursive_cte_evaluation_depth is set as a client-level option
     // in connection_pool.rs, not as a SQL SETTINGS clause.
@@ -4207,14 +4215,10 @@ impl ToSql for Cte {
                         cte_body.push_str(&plan.order_by.to_sql());
 
                         // Handle SKIP/LIMIT - either or both may be present
-                        if plan.limit.0.is_some() || plan.skip.0.is_some() {
-                            let skip_str = if let Some(n) = plan.skip.0 {
-                                format!("{n}, ")
-                            } else {
-                                "".to_string()
-                            };
-                            let limit_val = plan.limit.0.unwrap_or(9223372036854775807i64);
-                            cte_body.push_str(&format!("LIMIT {skip_str}{limit_val}\n"));
+                        let clause = limit_offset_clause(plan.skip.0, plan.limit.0);
+                        if !clause.is_empty() {
+                            cte_body.push_str(&clause);
+                            cte_body.push('\n');
                         }
                     } else {
                         // For Union plans without modifiers, just emit the union branches directly
@@ -4245,15 +4249,10 @@ impl ToSql for Cte {
                     cte_body.push_str(&plan.order_by.to_sql());
 
                     // Add LIMIT/SKIP for non-union CTEs as well
-                    if plan.limit.0.is_some() || plan.skip.0.is_some() {
-                        let skip_str = if let Some(n) = plan.skip.0 {
-                            format!("{n}, ")
-                        } else {
-                            "".to_string()
-                        };
-                        // ClickHouse requires LIMIT if OFFSET is present
-                        let limit_val = plan.limit.0.unwrap_or(9223372036854775807i64);
-                        cte_body.push_str(&format!("LIMIT {skip_str}{limit_val}\n"));
+                    let clause = limit_offset_clause(plan.skip.0, plan.limit.0);
+                    if !clause.is_empty() {
+                        cte_body.push_str(&clause);
+                        cte_body.push('\n');
                     }
                 }
 

--- a/tests/rust/integration/golden/sql_ir/skip_only__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/skip_only__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+ORDER BY u.full_name ASC
+LIMIT 3, 18446744073709551615

--- a/tests/rust/integration/golden/sql_ir/skip_only__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/skip_only__databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       u.full_name AS `u.name`
 FROM social.users_bench AS u
-ORDER BY u.full_name DESC
-LIMIT 10 OFFSET 5
+ORDER BY u.full_name ASC
+OFFSET 3

--- a/tests/rust/integration/golden/sql_ir/with_skip_limit__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/with_skip_limit__clickhouse.sql
@@ -1,0 +1,9 @@
+WITH with_n_cte_0 AS (SELECT 
+      u.full_name AS "n"
+FROM social.users_bench AS u
+ORDER BY n ASC
+LIMIT 2, 5
+)
+SELECT 
+      n.n AS "n"
+FROM with_n_cte_0 AS n

--- a/tests/rust/integration/golden/sql_ir/with_skip_limit__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/with_skip_limit__databricks.sql
@@ -1,0 +1,9 @@
+WITH with_n_cte_0 AS (SELECT 
+      u.full_name AS `n`
+FROM social.users_bench AS u
+ORDER BY n ASC
+LIMIT 5 OFFSET 2
+)
+SELECT 
+      n.n AS `n`
+FROM with_n_cte_0 AS n

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -53,6 +53,11 @@ const CORPUS: &[(&str, &str)] = &[
         "order_skip_limit",
         "MATCH (u:User) RETURN u.name ORDER BY u.name DESC SKIP 5 LIMIT 10",
     ),
+    // SKIP without LIMIT: CH needs a huge upper bound; Spark uses bare OFFSET.
+    (
+        "skip_only",
+        "MATCH (u:User) RETURN u.name ORDER BY u.name SKIP 3",
+    ),
     ("aggregate_count", "MATCH (u:User) RETURN count(u)"),
     (
         "aggregate_group_collect",

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -58,6 +58,11 @@ const CORPUS: &[(&str, &str)] = &[
         "skip_only",
         "MATCH (u:User) RETURN u.name ORDER BY u.name SKIP 3",
     ),
+    // SKIP/LIMIT inside a WITH -> drives the CTE-body LIMIT emission path.
+    (
+        "with_skip_limit",
+        "MATCH (u:User) WITH u.name AS n ORDER BY n SKIP 2 LIMIT 5 RETURN n",
+    ),
     ("aggregate_count", "MATCH (u:User) RETURN count(u)"),
     (
         "aggregate_group_collect",


### PR DESCRIPTION
## Summary
ClickHouse uses MySQL-style `LIMIT offset, count` (and needs a count when offsetting, so SKIP-only emitted a huge upper bound) — invalid on Spark/Databricks, which uses `LIMIT count OFFSET offset` and supports bare `OFFSET`. The `skip, count` logic was copy-pasted across ~4 emission clusters.

One `limit_offset_clause(skip, limit)` helper (dialect-aware), all sites routed through it:
- skip+limit: CH `LIMIT s, l` / Spark `LIMIT l OFFSET s`
- limit only: `LIMIT l` (both)
- skip only: CH `LIMIT s, <u64max>` / Spark `OFFSET s`

ClickHouse byte-identical on every golden except the intended Databricks fix (`order_skip_limit`: `LIMIT 5, 10` → `LIMIT 10 OFFSET 5`). New `skip_only` + `with_skip_limit` goldens lock the SKIP-only and WITH+pagination branches on both dialects. (Minor: the CTE skip-only-no-limit edge now uses the u64-max sentinel like the other sites instead of i64-max — functionally identical, and unifies the constant.)

## Review
Worktree-isolated: no correctness bugs; CH byte-stability + per-site newline handling verified; Spark `OFFSET` validity confirmed (Spark 3.4+/Databricks). Remaining note: union-branch / CTE-body LIMIT paths are byte-verified by inspection (golden coverage is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)