### PR TITLE
fix(spark): IN constant-list emits value-list, not array() (Phase 1)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -441,6 +441,18 @@ fn render_constant_in_list(op: &OperatorApplication, rendered: &[String]) -> Opt
         return None;
     }
     if let RenderExpr::List(items) = &op.operands[1] {
+        // Empty list: Spark `IN ()` is a syntax error. `IN []` is always false,
+        // `NOT IN []` always true — emit the constant predicate directly.
+        if items.is_empty() {
+            return Some(
+                if op.operator == Operator::In {
+                    "FALSE"
+                } else {
+                    "TRUE"
+                }
+                .to_string(),
+            );
+        }
         if items
             .iter()
             .all(|i| matches!(i, RenderExpr::Literal(_) | RenderExpr::Parameter(_)))

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -425,6 +425,38 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
     None
 }
 
+/// `x IN [const, const, ...]` on Databricks/Spark, where the array-literal form
+/// (`x IN array(...)`) is invalid — Spark needs a paren value-list `x IN (a, b)`.
+/// Returns `None` on ClickHouse (its `x IN [array]` form is kept byte-stable) and
+/// for non-constant lists (those are expanded to OR/AND by the caller first).
+/// `rendered[0]` is the path-rendered LHS; list items are constants so they
+/// render identically regardless of aliasing.
+fn render_constant_in_list(op: &OperatorApplication, rendered: &[String]) -> Option<String> {
+    use crate::server::query_context::get_current_dialect;
+    use crate::sql_generator::SqlDialect;
+    if !matches!(get_current_dialect(), SqlDialect::Databricks)
+        || !matches!(op.operator, Operator::In | Operator::NotIn)
+        || rendered.len() != 2
+    {
+        return None;
+    }
+    if let RenderExpr::List(items) = &op.operands[1] {
+        if items
+            .iter()
+            .all(|i| matches!(i, RenderExpr::Literal(_) | RenderExpr::Parameter(_)))
+        {
+            let rhs: Vec<String> = items.iter().map(|i| i.to_sql()).collect();
+            let kw = if op.operator == Operator::In {
+                "IN"
+            } else {
+                "NOT IN"
+            };
+            return Some(format!("{} {} ({})", rendered[0], kw, rhs.join(", ")));
+        }
+    }
+    None
+}
+
 /// Render the SKIP/LIMIT clause, dialect-aware (no trailing newline; empty when
 /// neither is set). ClickHouse uses the MySQL-style `LIMIT offset, count` and
 /// requires a count when offsetting (so SKIP-only emits a huge upper bound);
@@ -5181,6 +5213,8 @@ impl RenderExpr {
                                     .collect();
                                 return format!("({})", clauses.join(" AND "));
                             }
+                        } else if let Some(s) = render_constant_in_list(op, &rendered) {
+                            return s;
                         }
                     }
                 }
@@ -5559,6 +5593,8 @@ impl RenderExpr {
                                     .collect();
                                 return format!("({})", clauses.join(" AND "));
                             }
+                        } else if let Some(s) = render_constant_in_list(op, &rendered) {
+                            return s;
                         }
                     }
                 }
@@ -5754,6 +5790,8 @@ impl ToSql for OperatorApplication {
                             .collect();
                         return format!("({})", clauses.join(" AND "));
                     }
+                } else if let Some(s) = render_constant_in_list(self, &rendered) {
+                    return s;
                 }
             }
         }

--- a/tests/rust/integration/golden/sql_ir/in_empty__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/in_empty__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS "u.name"
+FROM social.users_bench AS u
+WHERE u.country IN []

--- a/tests/rust/integration/golden/sql_ir/in_empty__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/in_empty__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.full_name AS `u.name`
+FROM social.users_bench AS u
+WHERE FALSE

--- a/tests/rust/integration/golden/sql_ir/where_in_list__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/where_in_list__databricks.sql
@@ -1,4 +1,4 @@
 SELECT 
       u.full_name AS `u.name`
 FROM social.users_bench AS u
-WHERE u.country IN array('US', 'UK')
+WHERE u.country IN ('US', 'UK')

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -49,6 +49,7 @@ const CORPUS: &[(&str, &str)] = &[
         "where_in_list",
         "MATCH (u:User) WHERE u.country IN ['US', 'UK'] RETURN u.name",
     ),
+    ("in_empty", "MATCH (u:User) WHERE u.country IN [] RETURN u.name"),
     (
         "order_skip_limit",
         "MATCH (u:User) RETURN u.name ORDER BY u.name DESC SKIP 5 LIMIT 10",


### PR DESCRIPTION
## Summary
`x IN ['a','b']` rendered the List via `array_literal`, giving Databricks `x IN array('a','b')` — invalid Spark (IN needs a paren value-list). New `render_constant_in_list` helper: on Databricks, all-constant `IN`/`NOT IN` lists emit `x IN ('a','b')`; ClickHouse keeps `x IN ['a','b']` (byte-stable). Wired into all three OperatorApplication render paths after the existing non-constant (OR/AND) branch.

Edge case (review): empty `x IN []` would emit Spark `x IN ()` (syntax error) → now emits `FALSE` (`NOT IN [] → TRUE`); CH keeps `IN []`.

Unchanged: IN over an array *property* → `array_contains`/`has` (correct on both); non-constant lists → OR/AND (valid Spark).

## Goldens
- `where_in_list__databricks`: `IN array('US','UK')` → `IN ('US','UK')`; CH unchanged.
- new `in_empty`: CH `IN []`, Databricks `FALSE`.

## Review
Worktree-isolated: CH byte-stable, no `array()` leak in any Spark IN path (Path C/B already render lists as paren tuples), all 3 paths wired. Found the empty-list regression (fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)