### PR TITLE
fix(deltagraph): dialect-aware interval/timestamp arithmetic for Spark

### DIFF
--- a/scripts/dbx_run.py
+++ b/scripts/dbx_run.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Minimal Databricks Statement Execution API runner (submit + poll).
+
+Reads DATABRICKS_HOST / _WAREHOUSE_ID / _TOKEN / _CATALOG from the env
+(source ~/.dbx.env first). Usage:
+    dbx_run.py "SELECT 1"                # run one statement
+    dbx_run.py --file seed.sql          # run every ;-separated statement
+    dbx_run.py --schema ldbc "SELECT *" # set default schema
+"""
+import json, os, sys, time, urllib.request, urllib.error, argparse
+
+HOST = os.environ["DATABRICKS_HOST"]
+WAREHOUSE = os.environ["DATABRICKS_WAREHOUSE_ID"]
+TOKEN = os.environ["DATABRICKS_TOKEN"]
+CATALOG = os.environ.get("DATABRICKS_CATALOG")
+BASE = f"https://{HOST}/api/2.0/sql/statements"
+
+
+def _req(url, method="GET", body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(url, data=data, method=method)
+    r.add_header("Authorization", f"Bearer {TOKEN}")
+    r.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(r, timeout=60) as resp:
+        return json.load(resp)
+
+
+def run(sql, schema=None):
+    body = {
+        "warehouse_id": WAREHOUSE,
+        "statement": sql,
+        "wait_timeout": "50s",
+        "on_wait_timeout": "CONTINUE",
+    }
+    if CATALOG:
+        body["catalog"] = CATALOG
+    if schema:
+        body["schema"] = schema
+    d = _req(BASE, "POST", body)
+    sid = d.get("statement_id")
+    while d.get("status", {}).get("state") in ("PENDING", "RUNNING"):
+        time.sleep(2)
+        d = _req(f"{BASE}/{sid}")
+    state = d.get("status", {}).get("state")
+    if state != "SUCCEEDED":
+        err = d.get("status", {}).get("error", {})
+        return state, None, err.get("message", json.dumps(err))
+    res = d.get("result", {})
+    return state, res.get("data_array", []), None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sql", nargs="?")
+    ap.add_argument("--file")
+    ap.add_argument("--schema")
+    a = ap.parse_args()
+    if a.file:
+        raw = open(a.file).read()
+        # strip `--` line comments FIRST (they may contain ';'), then split
+        no_comments = "\n".join(
+            ln.split("--", 1)[0] for ln in raw.splitlines()
+        )
+        stmts = [s.strip() for s in no_comments.split(";") if s.strip()]
+        ok = 0
+        for i, s in enumerate(stmts, 1):
+            preview = " ".join(s.split())[:70]
+            state, _, err = run(s, a.schema)
+            if state == "SUCCEEDED":
+                ok += 1
+                print(f"[{i}/{len(stmts)}] OK   {preview}")
+            else:
+                print(f"[{i}/{len(stmts)}] FAIL {state}: {err}\n     stmt: {preview}")
+                sys.exit(1)
+        print(f"\nSeeded {ok}/{len(stmts)} statements.")
+    else:
+        state, rows, err = run(a.sql, a.schema)
+        if state != "SUCCEEDED":
+            print(f"{state}: {err}")
+            sys.exit(1)
+        for row in rows:
+            print("\t".join("" if v is None else str(v) for v in row))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -39,11 +39,14 @@ fn wrap_epoch_millis_arg(args: &[String]) -> Vec<String> {
     if already_datetime {
         args.to_vec()
     } else {
-        let wrapped = match dialect {
-            SqlDialect::Databricks => format!("timestamp_millis({})", arg),
-            _ => format!("fromUnixTimestamp64Milli({})", arg),
-        };
-        vec![wrapped]
+        // Reuse the single source of truth for the epoch-millis -> timestamp wrap
+        // (CH `fromUnixTimestamp64Milli`, Spark `timestamp_millis`) so it can't
+        // drift from `render_interval_arithmetic`. (The `already_datetime`
+        // detection above is still a local copy — a deferred follow-up.)
+        vec![
+            crate::sql_generator::function_mapper::current_function_mapper()
+                .epoch_millis_to_timestamp(arg),
+        ]
     }
 }
 

--- a/src/sql_generator/emitters/clickhouse/function_translator.rs
+++ b/src/sql_generator/emitters/clickhouse/function_translator.rs
@@ -376,6 +376,65 @@ pub fn translate_scalar_function(
 ///   duration({days: 5}) -> toIntervalDay(5)
 ///   duration({days: 5, hours: 2}) -> (toIntervalDay(5) + toIntervalHour(2))
 ///   duration({months: 1, days: 15}) -> (toIntervalMonth(1) + toIntervalDay(15))
+/// Map a single Neo4j duration unit + already-rendered value expression to the
+/// active dialect's interval constructor. Returns `None` for an unrecognized
+/// unit so each caller keeps its own unknown-unit policy (error vs skip).
+///
+/// ClickHouse uses `toInterval*(n)`; sub-second units fold into
+/// `toIntervalSecond(n / scale)` since CH lacks ms/us/ns intervals. Databricks
+/// uses `make_dt_interval(days, hours, mins, secs)` / `make_ym_interval(years,
+/// months)` — both accept fractional/expression args, so sub-second precision
+/// maps onto the fractional `secs` field. NOTE: Spark rejects adding a
+/// year-month interval to a day-time interval, so a `duration({months: m,
+/// days: d})` that mixes the two families produces SQL that errors at execution
+/// on Databricks; single-family and single-unit durations are the validated,
+/// supported cases.
+pub(crate) fn interval_expr_for_unit(
+    unit_lower: &str,
+    value_sql: &str,
+    dialect: crate::sql_generator::SqlDialect,
+) -> Option<String> {
+    use crate::sql_generator::SqlDialect;
+    Some(match dialect {
+        SqlDialect::Databricks => match unit_lower {
+            "years" | "year" => format!("make_ym_interval({}, 0)", value_sql),
+            "months" | "month" => format!("make_ym_interval(0, {})", value_sql),
+            "weeks" | "week" => format!("make_dt_interval(7 * ({}), 0, 0, 0)", value_sql),
+            "days" | "day" => format!("make_dt_interval({}, 0, 0, 0)", value_sql),
+            "hours" | "hour" => format!("make_dt_interval(0, {}, 0, 0)", value_sql),
+            "minutes" | "minute" => format!("make_dt_interval(0, 0, {}, 0)", value_sql),
+            "seconds" | "second" => format!("make_dt_interval(0, 0, 0, {})", value_sql),
+            "milliseconds" | "millisecond" => {
+                format!("make_dt_interval(0, 0, 0, {} / 1000.0)", value_sql)
+            }
+            "microseconds" | "microsecond" => {
+                format!("make_dt_interval(0, 0, 0, {} / 1000000.0)", value_sql)
+            }
+            "nanoseconds" | "nanosecond" => {
+                format!("make_dt_interval(0, 0, 0, {} / 1000000000.0)", value_sql)
+            }
+            _ => return None,
+        },
+        _ => match unit_lower {
+            "years" | "year" => format!("toIntervalYear({})", value_sql),
+            "months" | "month" => format!("toIntervalMonth({})", value_sql),
+            "weeks" | "week" => format!("toIntervalWeek({})", value_sql),
+            "days" | "day" => format!("toIntervalDay({})", value_sql),
+            "hours" | "hour" => format!("toIntervalHour({})", value_sql),
+            "minutes" | "minute" => format!("toIntervalMinute({})", value_sql),
+            "seconds" | "second" => format!("toIntervalSecond({})", value_sql),
+            "milliseconds" | "millisecond" => format!("toIntervalSecond({} / 1000.0)", value_sql),
+            "microseconds" | "microsecond" => {
+                format!("toIntervalSecond({} / 1000000.0)", value_sql)
+            }
+            "nanoseconds" | "nanosecond" => {
+                format!("toIntervalSecond({} / 1000000000.0)", value_sql)
+            }
+            _ => return None,
+        },
+    })
+}
+
 fn translate_duration_function(
     fn_call: &ScalarFnCall,
 ) -> Result<String, ClickhouseQueryGeneratorError> {
@@ -396,41 +455,20 @@ fn translate_duration_function(
                 ));
             }
 
-            // Map Neo4j duration units to ClickHouse interval functions
+            // Map Neo4j duration units to the active dialect's interval
+            // constructors (ClickHouse `toInterval*`, Databricks `make_*_interval`).
+            let dialect = crate::server::query_context::get_current_dialect();
             let interval_parts: Result<Vec<String>, _> = entries
                 .iter()
                 .map(|(key, value)| {
                     let value_sql = value.to_sql()?;
                     let key_lower = key.to_lowercase();
-
-                    // Map Neo4j time unit to ClickHouse interval function
-                    let interval_fn = match key_lower.as_str() {
-                        "years" | "year" => "toIntervalYear",
-                        "months" | "month" => "toIntervalMonth",
-                        "weeks" | "week" => "toIntervalWeek",
-                        "days" | "day" => "toIntervalDay",
-                        "hours" | "hour" => "toIntervalHour",
-                        "minutes" | "minute" => "toIntervalMinute",
-                        "seconds" | "second" => "toIntervalSecond",
-                        // For sub-second precision, convert to seconds (ClickHouse doesn't have ms/us/ns intervals)
-                        "milliseconds" | "millisecond" => {
-                            return Ok(format!("toIntervalSecond({} / 1000.0)", value_sql));
-                        }
-                        "microseconds" | "microsecond" => {
-                            return Ok(format!("toIntervalSecond({} / 1000000.0)", value_sql));
-                        }
-                        "nanoseconds" | "nanosecond" => {
-                            return Ok(format!("toIntervalSecond({} / 1000000000.0)", value_sql));
-                        }
-                        _ => {
-                            return Err(ClickhouseQueryGeneratorError::SchemaError(format!(
-                                "Unknown duration unit '{}'. Supported: years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds",
-                                key
-                            )));
-                        }
-                    };
-
-                    Ok(format!("{}({})", interval_fn, value_sql))
+                    interval_expr_for_unit(&key_lower, &value_sql, dialect).ok_or_else(|| {
+                        ClickhouseQueryGeneratorError::SchemaError(format!(
+                            "Unknown duration unit '{}'. Supported: years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds",
+                            key
+                        ))
+                    })
                 })
                 .collect();
 
@@ -514,6 +552,56 @@ pub fn get_supported_functions() -> Vec<&'static str> {
 mod tests {
     use super::*;
     use crate::query_planner::logical_expr::{Literal, LogicalExpr};
+
+    #[test]
+    fn interval_expr_for_unit_clickhouse_spellings() {
+        use crate::sql_generator::SqlDialect::ClickHouse;
+        assert_eq!(
+            interval_expr_for_unit("days", "5", ClickHouse).unwrap(),
+            "toIntervalDay(5)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("month", "1", ClickHouse).unwrap(),
+            "toIntervalMonth(1)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("milliseconds", "1500", ClickHouse).unwrap(),
+            "toIntervalSecond(1500 / 1000.0)"
+        );
+        assert!(interval_expr_for_unit("fortnights", "1", ClickHouse).is_none());
+    }
+
+    #[test]
+    fn interval_expr_for_unit_databricks_spellings() {
+        use crate::sql_generator::SqlDialect::Databricks;
+        // day-time family -> make_dt_interval(days, hours, mins, secs)
+        assert_eq!(
+            interval_expr_for_unit("days", "5", Databricks).unwrap(),
+            "make_dt_interval(5, 0, 0, 0)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("hours", "2", Databricks).unwrap(),
+            "make_dt_interval(0, 2, 0, 0)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("weeks", "2", Databricks).unwrap(),
+            "make_dt_interval(7 * (2), 0, 0, 0)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("milliseconds", "1500", Databricks).unwrap(),
+            "make_dt_interval(0, 0, 0, 1500 / 1000.0)"
+        );
+        // year-month family -> make_ym_interval(years, months)
+        assert_eq!(
+            interval_expr_for_unit("year", "3", Databricks).unwrap(),
+            "make_ym_interval(3, 0)"
+        );
+        assert_eq!(
+            interval_expr_for_unit("months", "1", Databricks).unwrap(),
+            "make_ym_interval(0, 1)"
+        );
+        assert!(interval_expr_for_unit("fortnights", "1", Databricks).is_none());
+    }
 
     #[test]
     fn test_translate_simple_function() {

--- a/src/sql_generator/emitters/clickhouse/function_translator.rs
+++ b/src/sql_generator/emitters/clickhouse/function_translator.rs
@@ -363,19 +363,6 @@ pub fn translate_scalar_function(
     }
 }
 
-/// Translate Neo4j duration({...}) function to ClickHouse interval expressions
-///
-/// Neo4j duration supports the following units (all plural and singular forms):
-/// - years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds
-///
-/// ClickHouse interval functions:
-/// - toIntervalYear(n), toIntervalMonth(n), toIntervalWeek(n), toIntervalDay(n)
-/// - toIntervalHour(n), toIntervalMinute(n), toIntervalSecond(n)
-///
-/// Examples:
-///   duration({days: 5}) -> toIntervalDay(5)
-///   duration({days: 5, hours: 2}) -> (toIntervalDay(5) + toIntervalHour(2))
-///   duration({months: 1, days: 15}) -> (toIntervalMonth(1) + toIntervalDay(15))
 /// Map a single Neo4j duration unit + already-rendered value expression to the
 /// active dialect's interval constructor. Returns `None` for an unrecognized
 /// unit so each caller keeps its own unknown-unit policy (error vs skip).
@@ -384,11 +371,18 @@ pub fn translate_scalar_function(
 /// `toIntervalSecond(n / scale)` since CH lacks ms/us/ns intervals. Databricks
 /// uses `make_dt_interval(days, hours, mins, secs)` / `make_ym_interval(years,
 /// months)` — both accept fractional/expression args, so sub-second precision
-/// maps onto the fractional `secs` field. NOTE: Spark rejects adding a
-/// year-month interval to a day-time interval, so a `duration({months: m,
-/// days: d})` that mixes the two families produces SQL that errors at execution
-/// on Databricks; single-family and single-unit durations are the validated,
-/// supported cases.
+/// maps onto the fractional `secs` field.
+///
+/// Limitations (both shared with the consuming `render_interval_arithmetic`):
+/// - Spark rejects adding a year-month interval to a day-time interval, so a
+///   `duration({months: m, days: d})` that mixes the two families produces SQL
+///   that errors at execution on Databricks. Single-family and single-unit
+///   durations are the validated, supported cases.
+/// - Only single-level interval arithmetic is supported: `x + duration(..)`.
+///   Nested forms like `x + duration(..) + duration(..)` are mis-handled on
+///   both dialects because the consumer detects the interval operand by
+///   substring (`toInterval` / `make_*_interval`) and the inner result string
+///   still contains that marker. Pre-existing for ClickHouse; not addressed here.
 pub(crate) fn interval_expr_for_unit(
     unit_lower: &str,
     value_sql: &str,
@@ -435,6 +429,17 @@ pub(crate) fn interval_expr_for_unit(
     })
 }
 
+/// Translate a Neo4j `duration({...})` map into the active dialect's combined
+/// interval expression, delegating the per-unit spelling to
+/// [`interval_expr_for_unit`].
+///
+/// Neo4j duration supports (plural and singular): years, months, weeks, days,
+/// hours, minutes, seconds, milliseconds, microseconds, nanoseconds.
+///
+/// Examples (ClickHouse):
+///   duration({days: 5}) -> toIntervalDay(5)
+///   duration({days: 5, hours: 2}) -> (toIntervalDay(5) + toIntervalHour(2))
+///   duration({months: 1, days: 15}) -> (toIntervalMonth(1) + toIntervalDay(15))
 fn translate_duration_function(
     fn_call: &ScalarFnCall,
 ) -> Result<String, ClickhouseQueryGeneratorError> {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -400,8 +400,13 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
 
     let dialect = get_current_dialect();
     // An operand is the interval term when it is a dialect interval constructor.
+    // Databricks markers are anchored on the call `(` so a column whose name
+    // merely contains the token isn't mistaken for an interval. (The CH `(`-less
+    // `toInterval` check is kept verbatim to preserve byte-identical CH output.)
     let is_interval = |r: &str| match dialect {
-        SqlDialect::Databricks => r.contains("make_dt_interval") || r.contains("make_ym_interval"),
+        SqlDialect::Databricks => {
+            r.contains("make_dt_interval(") || r.contains("make_ym_interval(")
+        }
         _ => r.contains("toInterval"),
     };
 
@@ -410,11 +415,14 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
         && rendered.iter().any(|r| is_interval(r))
     {
         // An operand that is already a timestamp expression must not be re-wrapped.
+        // Databricks function markers are anchored on the call `(`; `current_timestamp`
+        // is intentionally bare (Spark allows it as a keyword without parens). The CH
+        // arm is kept verbatim to preserve byte-identical CH output.
         let already_timestamp = |r: &str| match dialect {
             SqlDialect::Databricks => {
-                r.contains("timestamp_millis")
-                    || r.contains("to_timestamp")
-                    || r.contains("from_unixtime")
+                r.contains("timestamp_millis(")
+                    || r.contains("to_timestamp(")
+                    || r.contains("from_unixtime(")
                     || r.contains("current_timestamp")
             }
             _ => {
@@ -4667,9 +4675,12 @@ impl RenderExpr {
                                 })
                                 .collect();
 
+                            // If every unit was unknown, `interval_parts` is empty —
+                            // fall through to normal function handling rather than
+                            // emitting an invalid `()`.
                             if interval_parts.len() == 1 {
                                 return interval_parts[0].clone();
-                            } else {
+                            } else if !interval_parts.is_empty() {
                                 return format!("({})", interval_parts.join(" + "));
                             }
                         }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -352,9 +352,8 @@ fn try_rewrite_in_cte_subquery(
 // `to_sql_without_table_alias`, and `impl ToSql for OperatorApplication`),
 // which is why dialect leaf-fixes previously needed editing in three places.
 // Extracted verbatim so each path calls one source of truth; output is
-// byte-identical. (The interval case still emits ClickHouse-only
-// `toInterval*`/`fromUnixTimestamp64Milli` — making it dialect-aware is a
-// separate leaf slice, now a single-site change.)
+// byte-identical. The interval case is now dialect-aware (see
+// `render_interval_arithmetic` + the `FunctionMapper` epoch/timestamp methods).
 // ---------------------------------------------------------------------------
 
 /// `list1 + list2` -> dialect array concat. Operands flatten via `to_sql()`
@@ -388,27 +387,52 @@ fn render_string_addition(op: &OperatorApplication) -> Option<String> {
     None
 }
 
-/// Interval arithmetic on epoch-millis: wrap non-interval operands with
-/// `fromUnixTimestamp64Milli` and convert the result back via
-/// `toUnixTimestamp64Milli`. `rendered` is the path's pre-rendered operands.
+/// Interval arithmetic on epoch-millis: wrap non-interval operands as a
+/// timestamp, do the `+`/`-`, and convert the result back to epoch-millis.
+/// Dialect-aware via the function mapper — ClickHouse:
+/// `toUnixTimestamp64Milli(fromUnixTimestamp64Milli(x) + toIntervalDay(n))`;
+/// Databricks: `unix_millis(timestamp_millis(x) + make_dt_interval(n,0,0,0))`.
+/// `rendered` is the path's pre-rendered operands; one of them is the interval
+/// (produced by the `duration()` translation).
 fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> Option<String> {
+    use crate::server::query_context::get_current_dialect;
+    use crate::sql_generator::SqlDialect;
+
+    let dialect = get_current_dialect();
+    // An operand is the interval term when it is a dialect interval constructor.
+    let is_interval = |r: &str| match dialect {
+        SqlDialect::Databricks => r.contains("make_dt_interval") || r.contains("make_ym_interval"),
+        _ => r.contains("toInterval"),
+    };
+
     if (op.operator == Operator::Addition || op.operator == Operator::Subtraction)
         && rendered.len() == 2
-        && rendered.iter().any(|r| r.contains("toInterval"))
+        && rendered.iter().any(|r| is_interval(r))
     {
-        let wrapped: Vec<String> = rendered
-            .iter()
-            .map(|r| {
-                if r.contains("toInterval")
-                    || r.contains("fromUnixTimestamp64Milli")
+        // An operand that is already a timestamp expression must not be re-wrapped.
+        let already_timestamp = |r: &str| match dialect {
+            SqlDialect::Databricks => {
+                r.contains("timestamp_millis")
+                    || r.contains("to_timestamp")
+                    || r.contains("from_unixtime")
+                    || r.contains("current_timestamp")
+            }
+            _ => {
+                r.contains("fromUnixTimestamp64Milli")
                     || r.contains("parseDateTime64BestEffort")
                     || r.contains("toDateTime")
                     || r.contains("now64")
                     || r.contains("now()")
-                {
+            }
+        };
+        let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+        let wrapped: Vec<String> = rendered
+            .iter()
+            .map(|r| {
+                if is_interval(r) || already_timestamp(r) {
                     r.clone()
                 } else {
-                    format!("fromUnixTimestamp64Milli({})", r)
+                    mapper.epoch_millis_to_timestamp(r)
                 }
             })
             .collect();
@@ -417,10 +441,10 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
         } else {
             "-"
         };
-        return Some(format!(
-            "toUnixTimestamp64Milli({} {} {})",
-            &wrapped[0], sql_op, &wrapped[1]
-        ));
+        return Some(
+            mapper
+                .timestamp_to_epoch_millis(&format!("{} {} {}", &wrapped[0], sql_op, &wrapped[1])),
+        );
     }
     None
 }
@@ -4622,55 +4646,24 @@ impl RenderExpr {
                 if fn_name_lower == "duration" && fn_call.args.len() == 1 {
                     if let RenderExpr::MapLiteral(entries) = &fn_call.args[0] {
                         if !entries.is_empty() {
-                            // Convert duration({days: 5, hours: 2}) -> (toIntervalDay(5) + toIntervalHour(2))
+                            // Convert duration({days: 5, hours: 2}) into the active
+                            // dialect's interval constructors (ClickHouse
+                            // `toIntervalDay(5) + toIntervalHour(2)`, Databricks
+                            // `make_dt_interval(...)`). Shares the unit mapping with
+                            // the `LogicalExpr` path via `interval_expr_for_unit`.
+                            let dialect = crate::server::query_context::get_current_dialect();
                             let interval_parts: Vec<String> = entries
                                 .iter()
                                 .filter_map(|(key, value)| {
                                     let value_sql = value.to_sql();
                                     let key_lower = key.to_lowercase();
-
-                                    // Map Neo4j time unit to ClickHouse interval function
-                                    let result = match key_lower.as_str() {
-                                        "years" | "year" => {
-                                            format!("toIntervalYear({})", value_sql)
-                                        }
-                                        "months" | "month" => {
-                                            format!("toIntervalMonth({})", value_sql)
-                                        }
-                                        "weeks" | "week" => {
-                                            format!("toIntervalWeek({})", value_sql)
-                                        }
-                                        "days" | "day" => format!("toIntervalDay({})", value_sql),
-                                        "hours" | "hour" => {
-                                            format!("toIntervalHour({})", value_sql)
-                                        }
-                                        "minutes" | "minute" => {
-                                            format!("toIntervalMinute({})", value_sql)
-                                        }
-                                        "seconds" | "second" => {
-                                            format!("toIntervalSecond({})", value_sql)
-                                        }
-                                        "milliseconds" | "millisecond" => {
-                                            format!("toIntervalSecond({} / 1000.0)", value_sql)
-                                        }
-                                        "microseconds" | "microsecond" => {
-                                            format!("toIntervalSecond({} / 1000000.0)", value_sql)
-                                        }
-                                        "nanoseconds" | "nanosecond" => {
-                                            format!(
-                                                "toIntervalSecond({} / 1000000000.0)",
-                                                value_sql
-                                            )
-                                        }
-                                        _ => {
-                                            log::debug!(
-                                                "Unknown duration unit '{}', using as-is",
-                                                key
-                                            );
-                                            return None;
-                                        }
-                                    };
-                                    Some(result)
+                                    let mapped = super::function_translator::interval_expr_for_unit(
+                                        &key_lower, &value_sql, dialect,
+                                    );
+                                    if mapped.is_none() {
+                                        log::debug!("Unknown duration unit '{}', using as-is", key);
+                                    }
+                                    mapped
                                 })
                                 .collect();
 

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -101,6 +101,14 @@ impl FunctionMapper for ClickhouseFunctionMapper {
             None => format!("arraySlice({}, {})", arr, offset),
         }
     }
+
+    fn epoch_millis_to_timestamp(&self, expr: &str) -> String {
+        format!("fromUnixTimestamp64Milli({})", expr)
+    }
+
+    fn timestamp_to_epoch_millis(&self, expr: &str) -> String {
+        format!("toUnixTimestamp64Milli({})", expr)
+    }
 }
 
 #[cfg(test)]
@@ -130,6 +138,19 @@ mod tests {
         let m = ClickhouseFunctionMapper;
         assert_eq!(m.array_slice("a", "2", Some("3")), "arraySlice(a, 2, 3)");
         assert_eq!(m.array_slice("a", "2", None), "arraySlice(a, 2)");
+    }
+
+    #[test]
+    fn epoch_millis_timestamp_roundtrip_uses_clickhouse_functions() {
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(
+            m.epoch_millis_to_timestamp("x"),
+            "fromUnixTimestamp64Milli(x)"
+        );
+        assert_eq!(
+            m.timestamp_to_epoch_millis("x"),
+            "toUnixTimestamp64Milli(x)"
+        );
     }
 
     #[test]

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -186,6 +186,16 @@ impl FunctionMapper for DatabricksFunctionMapper {
             ),
         }
     }
+
+    fn epoch_millis_to_timestamp(&self, expr: &str) -> String {
+        // Spark TIMESTAMP from epoch milliseconds. Verified on Databricks SQL:
+        // unix_millis(timestamp_millis(x)) round-trips exactly under UTC.
+        format!("timestamp_millis({})", expr)
+    }
+
+    fn timestamp_to_epoch_millis(&self, expr: &str) -> String {
+        format!("unix_millis({})", expr)
+    }
 }
 
 #[cfg(test)]
@@ -214,6 +224,8 @@ mod tests {
         assert_eq!(m.cast_string(), "string");
         assert_eq!(m.array_concat(), "concat");
         assert_eq!(m.array_contains(), "array_contains");
+        assert_eq!(m.epoch_millis_to_timestamp("x"), "timestamp_millis(x)");
+        assert_eq!(m.timestamp_to_epoch_millis("x"), "unix_millis(x)");
         assert_eq!(
             m.empty_string_array_cast(),
             "CAST(array() AS ARRAY<STRING>)"

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -152,6 +152,17 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// REQUIRES a length, so the `None` case computes `size(arr) - offset + 1`.
     /// `offset`/`length` are pre-rendered SQL fragments.
     fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String;
+
+    /// Convert an epoch-millis `BIGINT` expression to a timestamp value, so
+    /// interval arithmetic can run on it. CH: `fromUnixTimestamp64Milli(expr)`
+    /// (-> DateTime64). Spark: `timestamp_millis(expr)` (-> TIMESTAMP). The
+    /// inverse of [`timestamp_to_epoch_millis`](Self::timestamp_to_epoch_millis).
+    fn epoch_millis_to_timestamp(&self, expr: &str) -> String;
+
+    /// Convert a timestamp expression back to an epoch-millis `BIGINT`, so the
+    /// result of interval arithmetic matches the stored column type. CH:
+    /// `toUnixTimestamp64Milli(expr)`. Spark: `unix_millis(expr)`.
+    fn timestamp_to_epoch_millis(&self, expr: &str) -> String;
 }
 
 /// Returns the function mapper for the active SQL dialect, read from the

--- a/tests/rust/integration/golden/sql_ir/interval_add_days__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_add_days__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toUnixTimestamp64Milli(fromUnixTimestamp64Milli(u.registration_date) + toIntervalDay(7)) AS "d"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/interval_add_days__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_add_days__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      unix_millis(timestamp_millis(u.registration_date) + make_dt_interval(7, 0, 0, 0)) AS `d`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/interval_multi_same_family__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_multi_same_family__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toUnixTimestamp64Milli(fromUnixTimestamp64Milli(u.registration_date) + (toIntervalDay(5) + toIntervalHour(2))) AS "d"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/interval_multi_same_family__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_multi_same_family__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      unix_millis(timestamp_millis(u.registration_date) + (make_dt_interval(5, 0, 0, 0) + make_dt_interval(0, 2, 0, 0))) AS `d`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/interval_sub_month__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_sub_month__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toUnixTimestamp64Milli(fromUnixTimestamp64Milli(u.registration_date) - toIntervalMonth(1)) AS "d"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/interval_sub_month__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/interval_sub_month__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      unix_millis(timestamp_millis(u.registration_date) - make_ym_interval(0, 1)) AS `d`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -110,6 +110,24 @@ const CORPUS: &[(&str, &str)] = &[
     ),
     // tail() -> CH arraySlice(list, 2) / Spark slice(list, 2, greatest(size-1, 0))
     ("list_tail", "MATCH (u:User) RETURN tail([10, 20, 30]) AS t"),
+    // Interval arithmetic on an epoch-millis column -> CH
+    // `toUnixTimestamp64Milli(fromUnixTimestamp64Milli(x) + toIntervalDay(n))`
+    // vs Spark `unix_millis(timestamp_millis(x) + make_dt_interval(n,0,0,0))`.
+    // Day-time, year-month, and same-family multi-unit are the validated cases
+    // (verified live on Databricks SQL). Mixing year-month with day-time in one
+    // duration() is unsupported on Spark and intentionally not in the corpus.
+    (
+        "interval_add_days",
+        "MATCH (u:User) RETURN u.registration_date + duration({days: 7}) AS d",
+    ),
+    (
+        "interval_sub_month",
+        "MATCH (u:User) RETURN u.registration_date - duration({months: 1}) AS d",
+    ),
+    (
+        "interval_multi_same_family",
+        "MATCH (u:User) RETURN u.registration_date + duration({days: 5, hours: 2}) AS d",
+    ),
     // Heterogeneous end type (User|Post) routes through multi_type_vlp_joins,
     // locking the generator output for both dialects (incl. dialect-aware
     // array/string casts: CH `toString(..)`/`['x']` vs Spark `string(..)`/


### PR DESCRIPTION
## Summary
Cypher duration arithmetic (`x + duration({days: 3})`) emitted ClickHouse-only
`toUnixTimestamp64Milli(fromUnixTimestamp64Milli(x) + toIntervalDay(3))` — none of
which exist on Databricks/Spark, so any temporal arithmetic failed with
`UNRESOLVED_ROUTINE` on a SQL Warehouse. This makes the three coupled render sites
dialect-aware.

## Changes
- `FunctionMapper::epoch_millis_to_timestamp` / `timestamp_to_epoch_millis` — CH
  `from/toUnixTimestamp64Milli`, Spark `timestamp_millis`/`unix_millis`.
- `interval_expr_for_unit` — single source of truth for the duration-unit →
  interval mapping, shared by the `LogicalExpr` and `RenderExpr` duration paths
  (previously a duplicated 10-arm match). CH `toInterval*`; Spark
  `make_dt_interval(d,h,m,s)` / `make_ym_interval(y,m)` (both accept
  expression/fractional args, so ms/us/ns fold into fractional seconds).
- `render_interval_arithmetic` — detects the dialect interval term and wraps via
  the mapper instead of hard-coded CH names; detection markers anchored on `(`.

## Validation
- **ClickHouse output byte-identical** (golden net + existing duration tests).
- **Every Spark form validated live against a Databricks SQL Warehouse** on the
  seeded LDBC mini dataset (epoch-millis `creationDate`): +days, −month, +hours,
  +weeks, multi-unit same-family, and fractional milliseconds — all exact.
- New unit + golden coverage for both dialects.

## Known limitation
Spark rejects adding a year-month interval to a day-time interval, so
`duration({months: m, days: d})` mixing the two families errors at execution on
Databricks. Single-unit and same-family multi-unit are supported and documented.

## Review
Reviewed on-branch (isolated worktree); 4 MINOR findings, all addressed in the
second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)