### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

`cargo audit` CI started failing on **RUSTSEC-2026-0185** (high, CVSS 7.5) in `quinn-proto 0.11.14`, pulled transitively via `reqwest 0.12.24 → quinn 0.11.9`. The advisory's solution is `>=0.11.15`.

`cargo update -p quinn-proto --precise 0.11.15` bumps only that lockfile entry (a patch release, no API change). This unblocks the `cargo audit` gate for all open PRs.

## Validation
- `cargo build` green.
- Lockfile diff is a single `quinn-proto` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)