### PR TITLE
fix(deltagraph): Spark array-count IN-subquery + type-aware size() (LDBC Q10)

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2804,6 +2804,50 @@ mod tests {
         );
     }
 
+    /// `emit_array_count_in_subquery` defaults to ClickHouse's native
+    /// `arrayCount(x -> <lhs> IN (subq), arr)` outside a task-local scope.
+    #[test]
+    fn emit_array_count_in_subquery_defaults_to_clickhouse() {
+        let sql = emit_array_count_in_subquery("x", "SELECT id FROM t", "vp.path_nodes");
+        assert_eq!(
+            sql,
+            "arrayCount(x -> x IN (SELECT id FROM t), vp.path_nodes)"
+        );
+    }
+
+    /// Databricks/Spark forbids subqueries inside HOF lambdas, so the IN-subquery
+    /// array count explodes the array in a scalar subquery and tests membership in
+    /// a plain WHERE — duplicate-preserving, matching `arrayCount` semantics.
+    #[tokio::test]
+    async fn emit_array_count_in_subquery_databricks_uses_explode_scalar() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        // Simple non-correlated membership (LDBC Q10 shape).
+        let sql = with_query_context(ctx.clone(), async {
+            emit_array_count_in_subquery("x", "SELECT id FROM t", "p.posts")
+        })
+        .await;
+        assert_eq!(
+            sql,
+            "(SELECT count(*) FROM (SELECT explode(p.posts) AS x) WHERE x IN (SELECT id FROM t))"
+        );
+
+        // Correlated tuple membership (the tuple-fallback path).
+        let tuple = with_query_context(ctx, async {
+            emit_array_count_in_subquery("(x, friend.pid)", "SELECT id, gid FROM t", "p.posts")
+        })
+        .await;
+        assert_eq!(
+            tuple,
+            "(SELECT count(*) FROM (SELECT explode(p.posts) AS x) WHERE (x, friend.pid) IN (SELECT id, gid FROM t))"
+        );
+    }
+
     /// Regression test: build_cte_column_map must use real column names from expressions,
     /// not CTE alias names like p1_a_user_id. When the FROM is a base table (e.g., social.users),
     /// correlated subqueries must reference `a.user_id`, not `a.p1_a_user_id`.
@@ -16399,7 +16443,7 @@ fn generate_list_comp_array_count(
         where_str
     );
 
-    let result = emit_array_count_call("x", &format!("x IN ({})", inner_select), &list_col);
+    let result = emit_array_count_in_subquery("x", &inner_select, &list_col);
 
     log::info!(
         "🔧 array-count expression: {}",
@@ -16423,6 +16467,31 @@ fn emit_array_count_call(lambda_var: &str, predicate: &str, array: &str) -> Stri
         }
         _ => format!(
             "{}({lambda_var} -> {predicate}, {array})",
+            current_function_mapper().array_count()
+        ),
+    }
+}
+
+/// Count array elements whose membership is tested by an `IN (subquery)`
+/// predicate (the list-comprehension-with-pattern idiom, e.g. LDBC Q10's
+/// `size([p IN posts WHERE (p)-[:HAS_TAG]->()<-[:HAS_INTEREST]-(person)])`).
+///
+/// ClickHouse keeps the native `arrayCount(x -> <lhs> IN (subq), arr)` — CH
+/// allows subqueries inside lambdas. Spark/Databricks forbids ANY subquery
+/// inside a higher-order-function lambda (`UNSUPPORTED_SUBQUERY_EXPRESSION_
+/// CATEGORY.HIGHER_ORDER_FUNCTION`), so neither `size(filter(arr, x -> x IN
+/// (subq)))` nor an `array_contains` over a CTE-bound set works. Instead explode
+/// the array in a scalar subquery and move the membership test to a plain WHERE:
+/// `(SELECT count(*) FROM (SELECT explode(arr) AS x) WHERE <lhs> IN (subq))`.
+/// This is duplicate-preserving — matching `arrayCount` semantics exactly (unlike
+/// `array_intersect`, which would dedupe) — and supports a correlated tuple `lhs`.
+fn emit_array_count_in_subquery(membership_lhs: &str, inner_select: &str, array: &str) -> String {
+    match crate::server::query_context::get_current_dialect() {
+        crate::sql_generator::SqlDialect::Databricks => format!(
+            "(SELECT count(*) FROM (SELECT explode({array}) AS x) WHERE {membership_lhs} IN ({inner_select}))"
+        ),
+        _ => format!(
+            "{}(x -> {membership_lhs} IN ({inner_select}), {array})",
             current_function_mapper().array_count()
         ),
     }
@@ -16470,11 +16539,7 @@ fn generate_list_comp_array_count_tuple_fallback(
         where_str
     );
 
-    let result = emit_array_count_call(
-        "x",
-        &format!("{} IN ({})", lambda_tuple, inner_select),
-        list_col,
-    );
+    let result = emit_array_count_in_subquery(&lambda_tuple, &inner_select, list_col);
 
     log::info!(
         "🔧 array-count tuple fallback: {}",

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -108,6 +108,14 @@ pub struct QueryContext {
     /// column for a given table alias when the variable registry is not populated
     /// (simple queries without WITH clauses).
     pub alias_label_map: HashMap<String, String>,
+
+    /// Names of CTE output columns that hold an array/collection value (produced
+    /// by a `collect`/`groupArray` aggregate or a list literal). Set once during
+    /// render_plan_to_sql(). Lets the Databricks `size()` render dispatch pick
+    /// Spark `size` (collection) vs `length` (string) when the argument is a
+    /// carried-forward collection column whose type the variable registry does
+    /// not track (e.g. `WITH collect(post) AS posts`).
+    pub array_cte_columns: HashSet<String>,
 }
 
 impl QueryContext {
@@ -449,6 +457,28 @@ pub fn set_current_variable_registry(
     let _ = QUERY_CONTEXT.try_with(|ctx| {
         ctx.borrow_mut().current_variable_registry = Some(registry);
     });
+}
+
+/// Record the set of CTE columns that hold array/collection values.
+pub fn set_array_cte_columns(columns: std::collections::HashSet<String>) {
+    let _ = QUERY_CONTEXT.try_with(|ctx| {
+        ctx.borrow_mut().array_cte_columns = columns;
+    });
+}
+
+/// True if `column` is a known array/collection-valued CTE column.
+pub fn is_array_cte_column(column: &str) -> bool {
+    QUERY_CONTEXT
+        .try_with(|ctx| ctx.borrow().array_cte_columns.contains(column))
+        .unwrap_or(false)
+}
+
+/// Snapshot the current array-CTE-column set (for save/restore around re-entrant
+/// `render_plan_to_sql` calls so a nested sub-plan doesn't clobber the parent's).
+pub fn get_array_cte_columns() -> std::collections::HashSet<String> {
+    QUERY_CONTEXT
+        .try_with(|ctx| ctx.borrow().array_cte_columns.clone())
+        .unwrap_or_default()
 }
 
 /// Get the current variable registry (for property resolution during SQL rendering)

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -221,6 +221,12 @@ lazy_static::lazy_static! {
         m.insert("size", FunctionMapping {
             neo4j_name: "size",
             clickhouse_name: "length",
+            // CH `length` is overloaded for arrays AND strings, but Spark splits
+            // them: `length` is string/binary-only (rejects arrays) and `size`
+            // is collection-only (rejects strings). The static name therefore
+            // can't be right for both — `length` is the string-safe default and
+            // the ScalarFnCall render site upgrades it to Spark `size` when the
+            // argument is a detected collection (see `databricks_size_name`).
             databricks_name: None,
             arg_transform: None,
         });

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -797,6 +797,101 @@ fn substitute_alias_refs_in_expr(expr: &mut RenderExpr, alias_map: &HashMap<Stri
     }
 }
 
+/// Resolve Cypher `size(arg)` to a Spark/Databricks function name, or `None`
+/// when no dialect-specific override applies (caller falls back to the registry
+/// default, `length`).
+///
+/// CH `length` is overloaded for strings and arrays; Spark is not — `size` is
+/// collection-only and `length` string-only. The static registry name can't be
+/// right for both, and the argument's type is not always inferable from the
+/// Cypher text (a bare `posts` and a bare `name` both render as a column ref).
+/// So the default stays the string-safe `length` and this returns `Some("size")`
+/// only when the argument is a *detected* collection: an inline list literal, a
+/// `collect`/`groupArray` aggregate, or a variable the registry typed as a
+/// collection (e.g. `WITH collect(post) AS posts`). Schemas that need `size()`
+/// over a non-obvious collection should declare the column's array type so the
+/// registry resolves it. Returns `None` outside Databricks (CH unchanged).
+fn databricks_size_name(
+    arg: Option<&RenderExpr>,
+    dialect: crate::sql_generator::SqlDialect,
+) -> Option<&'static str> {
+    use crate::sql_generator::SqlDialect;
+    if dialect != SqlDialect::Databricks {
+        return None;
+    }
+    arg.filter(|a| render_arg_is_collection(a)).map(|_| "size")
+}
+
+/// True when a `size()` argument is recognizably a collection (vs a string).
+fn render_arg_is_collection(arg: &RenderExpr) -> bool {
+    fn name_is_collection(name: &str) -> bool {
+        // Variable registry (collection-typed vars) OR the array-CTE-column set
+        // collected from the plan (carried-forward collect()/groupArray columns
+        // the registry types only as scalars).
+        crate::server::query_context::get_current_variable_registry()
+            .and_then(|r| r.lookup(name).map(|v| v.is_collection()))
+            .unwrap_or(false)
+            || crate::server::query_context::is_array_cte_column(name)
+    }
+    match arg {
+        RenderExpr::List(_) => true,
+        RenderExpr::AggregateFnCall(a) => is_collection_aggregate(&a.name),
+        RenderExpr::TableAlias(ta) => name_is_collection(&ta.0),
+        RenderExpr::Column(c) => name_is_collection(c.raw()),
+        // A carried-forward CTE column keeps its producing variable's name as the
+        // column (e.g. `posts`); match on that. The table alias is intentionally
+        // not consulted — property access on a collection isn't valid Cypher, so
+        // checking it would only widen the false-positive surface.
+        RenderExpr::PropertyAccessExp(pa) => name_is_collection(pa.column.raw()),
+        _ => false,
+    }
+}
+
+/// True for aggregates that produce an array value.
+fn is_collection_aggregate(name: &str) -> bool {
+    matches!(
+        name.to_lowercase().as_str(),
+        "collect" | "collect_list" | "collect_set" | "grouparray" | "array_agg"
+    )
+}
+
+/// Collect the names of CTE output columns that hold an array/collection value:
+/// a SELECT item whose source expression is a collection aggregate
+/// (`collect`/`groupArray`/…) or a list literal. Walks every structured CTE and
+/// UNION branch. Name-keyed (carried-forward columns keep the producing alias),
+/// which is unambiguous within a single query plan.
+fn collect_array_cte_columns(plan: &RenderPlan) -> HashSet<String> {
+    fn expr_is_collection(expr: &RenderExpr) -> bool {
+        match expr {
+            RenderExpr::List(_) => true,
+            RenderExpr::AggregateFnCall(a) => is_collection_aggregate(&a.name),
+            _ => false,
+        }
+    }
+    fn walk(plan: &RenderPlan, out: &mut HashSet<String>) {
+        for item in &plan.select.items {
+            if let Some(ca) = &item.col_alias {
+                if expr_is_collection(&item.expression) {
+                    out.insert(ca.0.clone());
+                }
+            }
+        }
+        if let Some(union) = plan.union.0.as_ref() {
+            for branch in &union.input {
+                walk(branch, out);
+            }
+        }
+        for cte in &plan.ctes.0 {
+            if let CteContent::Structured(cte_plan) = &cte.content {
+                walk(cte_plan, out);
+            }
+        }
+    }
+    let mut out = HashSet::new();
+    walk(plan, &mut out);
+    out
+}
+
 /// Render the SKIP/LIMIT clause, dialect-aware (no trailing newline; empty when
 /// neither is set). ClickHouse uses the MySQL-style `LIMIT offset, count` and
 /// requires a count when offsetting (so SKIP-only emits a huge upper bound);
@@ -3686,6 +3781,20 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
     // stale whole-node `person`). ClickHouse path is untouched (gated).
     inline_where_alias_refs_for_spark(&mut plan);
 
+    // Record which CTE columns are array/collection-valued so the Databricks
+    // `size()` render can pick Spark `size` vs `length` (see databricks_size_name).
+    // `render_plan_to_sql` is re-entrant (scalar-subquery RenderExprs render their
+    // own sub-plan), so save the parent's set and restore it on every exit — a
+    // nested sub-plan must not clobber the outer scope's array columns.
+    struct ArrayColsGuard(HashSet<String>);
+    impl Drop for ArrayColsGuard {
+        fn drop(&mut self) {
+            crate::server::query_context::set_array_cte_columns(std::mem::take(&mut self.0));
+        }
+    }
+    let _array_cols_guard = ArrayColsGuard(crate::server::query_context::get_array_cte_columns());
+    crate::server::query_context::set_array_cte_columns(collect_array_cte_columns(&plan));
+
     let mut sql = String::new();
 
     // If there's a Union, wrap it in a subquery for correct ClickHouse behavior.
@@ -5048,12 +5157,19 @@ impl RenderExpr {
                             args_sql
                         };
 
+                        let dialect = crate::server::query_context::get_current_dialect();
+                        // Cypher `size()` is dialect-/type-sensitive on Spark: emit
+                        // `size` for a collection argument, else the string-safe
+                        // `length` default. ClickHouse keeps overloaded `length`.
+                        let fn_name = if fn_name_lower == "size" {
+                            databricks_size_name(fn_call.args.first(), dialect)
+                                .unwrap_or_else(|| mapping.name_for(dialect))
+                        } else {
+                            mapping.name_for(dialect)
+                        };
+
                         // Return dialect-appropriate function with transformed args
-                        format!(
-                            "{}({})",
-                            mapping.name_for(crate::server::query_context::get_current_dialect()),
-                            transformed_args.join(", ")
-                        )
+                        format!("{}({})", fn_name, transformed_args.join(", "))
                     }
                     None => {
                         // No mapping found - use original function name (passthrough)
@@ -6455,6 +6571,62 @@ mod tests {
             .unwrap()
             .to_sql();
         assert!(branch_sql.contains("friend.birthday"), "got: {branch_sql}");
+    }
+
+    /// `databricks_size_name`: outside Databricks → None (registry default
+    /// `length`); under Databricks a list-literal arg → Spark `size`.
+    #[test]
+    fn databricks_size_name_dispatches_by_dialect_and_arg() {
+        use crate::sql_generator::SqlDialect;
+        let list = RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(1))]);
+        assert_eq!(
+            databricks_size_name(Some(&list), SqlDialect::ClickHouse),
+            None
+        );
+        assert_eq!(
+            databricks_size_name(Some(&list), SqlDialect::Databricks),
+            Some("size")
+        );
+        // A bare string-ish arg (no collection signal) → None → falls back to length.
+        let lit = RenderExpr::Literal(Literal::String("abc".to_string()));
+        assert_eq!(
+            databricks_size_name(Some(&lit), SqlDialect::Databricks),
+            None
+        );
+    }
+
+    /// `collect_array_cte_columns` records SELECT aliases whose source is a
+    /// collection aggregate or list literal, across CTEs — so a carried-forward
+    /// `collect()` column (registry-typed as scalar) is still detectable.
+    #[test]
+    fn collect_array_cte_columns_finds_collection_columns() {
+        let mut cte_plan = empty_plan();
+        cte_plan.select = SelectItems {
+            items: vec![
+                SelectItem {
+                    expression: RenderExpr::AggregateFnCall(AggregateFnCall {
+                        name: "collect".to_string(),
+                        args: vec![friend_birthday()],
+                    }),
+                    col_alias: Some(ColumnAlias("posts".to_string())),
+                },
+                SelectItem {
+                    expression: friend_birthday(),
+                    col_alias: Some(ColumnAlias("bday".to_string())),
+                },
+            ],
+            distinct: false,
+        };
+        let mut plan = empty_plan();
+        plan.ctes = CteItems(vec![Cte::new(
+            "with_posts_cte".to_string(),
+            CteContent::Structured(Box::new(cte_plan)),
+            false,
+        )]);
+
+        let cols = collect_array_cte_columns(&plan);
+        assert!(cols.contains("posts"), "got: {cols:?}");
+        assert!(!cols.contains("bday"), "got: {cols:?}");
     }
 
     /// Test: collect(x) + collect(y) → arrayConcat(groupArray(x), groupArray(y))


### PR DESCRIPTION
## Summary

Closes two Databricks/Spark dialect gaps surfaced by LDBC interactive Q10:

1. **HOF subquery rejection** — Spark forbids any subquery inside higher-order-function lambdas (`UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.HIGHER_ORDER_FUNCTION`). Patterns like `size(filter(posts, x -> x IN (subquery)))` now render as an explode-scalar-subquery on Databricks (`(SELECT count(*) FROM (SELECT explode(arr) AS x) WHERE x IN (subquery))`), verified duplicate-preserving on a live warehouse for both simple and tuple-correlated forms. ClickHouse keeps native `arrayCount`.

2. **`size()` vs `length()` on collections** — Spark's `length` is string/binary-only and `size`/`cardinality` are collection-only (`DATATYPE_MISMATCH` otherwise), whereas ClickHouse overloads `length` for both. `size()` now dispatches type-aware on Databricks: emits `size` only for detected collections (list literal, `collect()` aggregate, registry collection var, or array-typed CTE column), defaulting to `length` for strings. ClickHouse output unchanged.

## Implementation

- `to_sql_query.rs`: `databricks_size_name`, `render_arg_is_collection`, `is_collection_aggregate`, `collect_array_cte_columns`; `size` dispatch at the `ScalarFnCall` render site. Array-CTE-column detection uses a task-local set guarded by an RAII `ArrayColsGuard` that snapshots/restores across re-entrant `render_plan_to_sql` (correct LIFO nesting).
- `plan_builder_utils.rs`: `emit_array_count_in_subquery` reroutes both IN-subquery call sites; non-subquery predicate path keeps `emit_array_count_call`.
- `query_context.rs`: `array_cte_columns` field + accessors.
- `function_registry.rs`: `size` keeps `databricks_name: None` (string-safe default; render site upgrades to `size` for collections).

## Testing

- 4 new unit tests; full Rust suite green (0 failures).
- Golden CH snapshots byte-identical (`sql_golden_snapshots`).
- `cargo fmt --all`, `cargo clippy --all-targets` clean.
- LDBC parity sweep: Q10 reaches MATCH on Databricks with 0 Databricks-specific dialect errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)