### PR TITLE
fix(deltagraph): apply Databricks dialect to server-handled queries

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -236,6 +236,15 @@ pub async fn run_with_config(config: ServerConfig) {
             };
 
         let executor: Arc<dyn QueryExecutor> = Arc::new(dbc_executor);
+
+        // Target the Databricks SQL dialect for every server-handled query.
+        // Query rendering reads the dialect from the per-query `QueryContext`,
+        // which seeds from this process-wide default; without it the server
+        // would emit ClickHouse SQL even in `--databricks` mode (e.g. VLP array
+        // syntax `[]`/`Array(T)`/`arrayConcat`/`has` instead of Spark's
+        // `array()`/`ARRAY<T>`/`concat`/`array_contains`).
+        query_context::set_server_dialect(crate::sql_generator::SqlDialect::Databricks);
+
         let app_state = AppState {
             executor,
             clickhouse_client: None,

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -118,11 +118,36 @@ pub struct QueryContext {
     pub array_cte_columns: HashSet<String>,
 }
 
+/// Process-wide default SQL dialect for server-handled queries. Set once at
+/// server startup (`run_with_config`) from the `--databricks` flag. The
+/// embedded/`cg` paths set the dialect per-query (via `set_current_dialect`)
+/// and never touch this, so it stays at the ClickHouse default for them.
+static SERVER_DIALECT: std::sync::OnceLock<SqlDialect> = std::sync::OnceLock::new();
+
+/// Set the process-wide default dialect for server-handled queries. Idempotent
+/// (first write wins); call once during server init before serving requests.
+pub fn set_server_dialect(dialect: SqlDialect) {
+    let _ = SERVER_DIALECT.set(dialect);
+}
+
+/// The process-wide server dialect, or [`SqlDialect::ClickHouse`] if unset.
+fn server_dialect() -> SqlDialect {
+    SERVER_DIALECT.get().copied().unwrap_or_default()
+}
+
 impl QueryContext {
-    /// Create a new query context with schema name
+    /// Create a new query context with schema name.
+    ///
+    /// Seeds the dialect from the process-wide server default
+    /// ([`set_server_dialect`]) so every server-handled query (HTTP, Bolt,
+    /// export) targets the right SQL dialect. Without this, server queries
+    /// always rendered ClickHouse SQL even in `--databricks` mode. Callers that
+    /// need a different dialect (embedded) override it via `set_current_dialect`
+    /// inside the `with_query_context` scope.
     pub fn new(schema_name: Option<String>) -> Self {
         Self {
             schema_name,
+            dialect: server_dialect(),
             ..Default::default()
         }
     }
@@ -674,6 +699,17 @@ pub fn restore_branch_context(snapshot: BranchContextSnapshot) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn query_context_new_defaults_to_clickhouse_when_server_dialect_unset() {
+        // The embedded/`cg` paths never call `set_server_dialect`, so a fresh
+        // context must default to ClickHouse (the historical behavior). NOTE:
+        // we deliberately do NOT call `set_server_dialect` here — it writes a
+        // process-wide OnceLock that would leak into sibling tests in this
+        // binary. The Databricks path (server sets the global → `new()` reads
+        // it) is covered end-to-end by the DeltaGraph/zeta transport tests.
+        assert_eq!(QueryContext::new(None).dialect, SqlDialect::ClickHouse);
+    }
 
     #[tokio::test]
     async fn test_query_context_isolation() {


### PR DESCRIPTION
## Summary

The `--databricks` server (DeltaGraph) selected the `DatabricksSqlExecutor` but never set the SQL **dialect** for query rendering, so **every server-handled query (HTTP and Bolt) was generated as ClickHouse SQL**. Simple node/edge queries limped along (their SQL is largely dialect-neutral and the target tolerated ClickHouse identifier quoting), but anything dialect-specific broke — most visibly variable-length paths:

```
-- emitted (ClickHouse)            -- needed (Spark/Databricks)
CAST([] AS Array(String))          CAST(array() AS ARRAY<STRING>)
[a, b]                             array(a, b)
arrayConcat(...)                   concat(...)
has(arr, x)                        array_contains(arr, x)
```

…which fails to parse on a Databricks target.

## Root cause & fix

Rendering reads the dialect from the per-query `QueryContext`, built by `QueryContext::new` at every server entry point — but `new` left it at the ClickHouse default. The `cg` CLI / embedded API set it per-query (`--dialect` / `set_current_dialect`); the server had no equivalent.

Fix: a process-wide `SERVER_DIALECT` (set once in `run_with_config`'s `--databricks` branch via `set_server_dialect`) that `QueryContext::new` seeds from — covering HTTP, Bolt, and export uniformly without threading state through the three Bolt constructors that don't receive `AppState`. Embedded/`cg` never set the global, so they keep defaulting to ClickHouse and override per-query as before (behavior unchanged).

## Testing

Verified **end-to-end** against the zeta-databricks emulator with the Neo4j Browser social demo (same demo as ClickHouse): `db.labels`, `db.schema.visualization`, node/relationship queries, and the previously-failing `[:FOLLOWS*1..2]` variable-length path all render correctly via the DeltaGraph Bolt path. Added a regression unit test (default-unset → ClickHouse, no global mutation). `cargo fmt`/`clippy` (default + `databricks`)/full `cargo test` clean; adversarial review 0 defects.

Found by running the exact ClickHouse Browser demo against a DeltaGraph backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)