### PR TITLE
fix(deltagraph): parenthesize per-branch LIMIT in pattern-union UNION (Spark)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4192,7 +4192,24 @@ pub fn extract_ctes_with_context(
                     .collect();
 
                 let union_branches = union_branches?;
-                let union_sql = union_branches.join("\nUNION ALL\n");
+                // Each branch carries a `LIMIT 1000` safety cap. Spark/Databricks
+                // forbids a bare per-branch LIMIT in a set operation
+                // (`SELECT … LIMIT n UNION ALL …` → parse error "Expected ), found
+                // UNION"); the branch must be parenthesized. ClickHouse accepts
+                // the bare form, so only wrap for Databricks to keep CH output
+                // byte-identical.
+                let union_sql = if matches!(
+                    crate::server::query_context::get_current_dialect(),
+                    crate::sql_generator::SqlDialect::Databricks
+                ) {
+                    union_branches
+                        .iter()
+                        .map(|b| format!("({b})"))
+                        .collect::<Vec<_>>()
+                        .join("\nUNION ALL\n")
+                } else {
+                    union_branches.join("\nUNION ALL\n")
+                };
 
                 // Create CTE name based on relationship alias
                 let cte_name = format!("pattern_union_{}", graph_rel.alias);


### PR DESCRIPTION
## Summary

Pattern-union path queries (`MATCH p=()-[]->() RETURN p` over multiple relationship types) build a `UNION ALL` of branches, each with a `LIMIT 1000` safety cap. Spark/Databricks rejects a bare per-branch LIMIT in a set operation (`SELECT … LIMIT n UNION ALL …` → `Expected ), found UNION`); each LIMIT-bearing branch must be parenthesized. ClickHouse accepts the bare form.

Wrap each branch in parens when the dialect is Databricks; ClickHouse output stays byte-identical (golden snapshots pass).

## Testing
- Verified the parenthesized form parses on the Databricks target (bare form did not).
- Golden snapshots unchanged; `cargo fmt`/`clippy --features databricks`/full `cargo test` clean.

Found running the Neo4j Browser demo's path query against a DeltaGraph backend. (Note: the same query then surfaces a separate zeta-emulator resolver limitation — qualified column refs — tracked in genezhang/zeta#2166; real Databricks is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)