### PR TITLE
fix(deltagraph): dialect-aware array literals in pattern-union path branches (Spark)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4158,22 +4158,28 @@ pub fn extract_ctes_with_context(
                             .collect::<Vec<_>>()
                             .join("");
 
+                        // Dialect-aware array literals: ClickHouse `['x']`/`[expr]`
+                        // vs Spark/Databricks `array('x')`/`array(expr)`. A bare
+                        // `[...]` is a parse error on Databricks.
+                        let fm = crate::sql_generator::function_mapper::current_function_mapper();
+                        let path_relationships_lit =
+                            fm.array_literal(&format!("'{base_rel_type}'"));
+                        let rel_properties_lit = fm.array_literal(&rel_properties_json);
+
                         let branch_sql = format!(
                             "SELECT \
                                 '{from_label}' AS start_type, \
                                 {start_id_expr} as start_id, \
                                 {end_id_expr} as end_id, \
                                 '{to_label}' AS end_type, \
-                                ['{}'] as path_relationships, \
-                                [{}] as rel_properties, \
+                                {path_relationships_lit} as path_relationships, \
+                                {rel_properties_lit} as rel_properties, \
                                 {} as start_properties, \
                                 {} as end_properties{direct_rel_cols} \
                             FROM {rel_table} \
                             INNER JOIN {from_join_expr} ON {from_join_cond} \
                             INNER JOIN {to_join_expr} ON {to_join_cond}{where_clause} \
                             LIMIT 1000",
-                            base_rel_type,
-                            rel_properties_json,
                             start_properties_json,
                             end_properties_json,
                             from_label = combo.from_label,


### PR DESCRIPTION
## Summary

Pattern-union path branches (`MATCH p=()-[]->() RETURN p`) emitted **ClickHouse** array literals for `path_relationships`/`rel_properties` — `['AUTHORED']`, `[to_json(...)]` — which Spark/Databricks rejects:

```
[PARSE_SYNTAX_ERROR] Syntax error at or near '[' (line 2, pos 132)
```

Databricks needs `array('AUTHORED')` / `array(to_json(...))`. Route both through `current_function_mapper().array_literal()` (CH `[..]`, Databricks `array(..)`). ClickHouse output byte-identical (golden snapshots pass).

## Testing

Validated on **real Spark** (`deltaio/delta-docker:4.1.0`) against the seeded social demo — the exact DeltaGraph-generated SQL for all demo queries now runs:

| query | real Spark |
|---|---|
| `MATCH (u:User) RETURN u` | ✅ |
| `MATCH (a)-[r:FOLLOWS]->(b) RETURN a,r,b` | ✅ |
| `MATCH (n) RETURN n` | ✅ |
| `MATCH p=()-[]->() RETURN p` | ✅ (was PARSE_SYNTAX_ERROR) |
| `[:FOLLOWS*1..2]` VLP | ✅ |

`cargo fmt`/`clippy --features databricks`/full `cargo test` clean; golden unchanged.

Found via real-Spark validation of the Neo4j Browser demo (the zeta emulator's resolver errors, tracked in genezhang/zeta#2166, had masked this real dialect bug — both are confirmed emulator-only for the queries themselves; this array-literal bug is a genuine ClickGraph fix that also affects real Databricks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)