### PR TITLE
fix(schemas): repair broken ecommerce example schemas

### DIFF
--- a/schemas/examples/ecommerce_benchmark.yaml
+++ b/schemas/examples/ecommerce_benchmark.yaml
@@ -7,7 +7,7 @@ graph_schema:
       database: brahmand
       table: customers
       node_id: customer_id
-      property-mappings:
+      property_mappings:
         customer_id: customer_id  # this is default and can be omitted, backwards compatibility
         email: email
         first_name: first_name
@@ -37,7 +37,10 @@ graph_schema:
 
   edges:
     - type: PURCHASED
+      database: brahmand
       table: orders
+      from_node: Customer
+      to_node: Product
       from_id: customer_id
       to_id: product_id
       property_mappings:

--- a/schemas/examples/ecommerce_graph_demo.yaml
+++ b/schemas/examples/ecommerce_graph_demo.yaml
@@ -23,7 +23,6 @@ graph_schema:
         database: ecommerce
         table: products
         node_id: product_id
-        label: Product
         property_mappings:
           name: name
           category: category
@@ -39,9 +38,10 @@ graph_schema:
       - type: PURCHASED
         database: ecommerce
         table: orders
+        from_node: Customer
+        to_node: Product
         from_id: customer_id
         to_id: "product_id"
-        type_name: "PURCHASED"
         property_mappings:
           order_id: "order_id"
           quantity: "quantity"


### PR DESCRIPTION
## Problem
Both shipped e-commerce example schemas failed to load (found while validating the graph-notebook demo):
- **ecommerce_graph_demo.yaml**: duplicate `label: Product` key inside the Product node (`duplicate field label`); the PURCHASED edge was missing `from_node`/`to_node` and carried a redundant `type_name`.
- **ecommerce_benchmark.yaml**: `property-mappings` (hyphen) typo on the Customer node, so the required `property_mappings` field was absent (`missing field property_mappings`); the PURCHASED edge was missing `database`/`from_node`/`to_node`.

## Fix
Correct the keys and complete the PURCHASED edge (`from_node: Customer`, `to_node: Product`, and `database:` for the benchmark).

## Verification
Both schemas now load and translate the `(:Customer)-[:PURCHASED]->(:Product)` pattern — including a premium-customer aggregation — on **both** ClickHouse and Databricks dialects via `cg sql`/`validate`. No code change; no test references these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)