### PR TITLE
fix(deltagraph): dialect-aware VLP cycle check (has → array_contains)

### DIFF
--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1686,11 +1686,17 @@ impl DenormalizedCteStrategy {
         );
 
         // Build WHERE clause for recursion
+        let cycle_mapper = crate::sql_generator::function_mapper::current_function_mapper();
         let mut where_conditions = vec![
             format!("vp.hop_count < {}", context.spec.max_hops.unwrap_or(10)),
-            // ⚠️ ClickHouse limitation: NOT IN with array doesn't work in recursive CTEs
-            // Use NOT has(array, element) instead for cycle detection
-            format!("NOT has(vp.path_nodes, next.{})", self.to_col), // Cycle prevention
+            // ⚠️ ClickHouse limitation: NOT IN with array doesn't work in recursive CTEs.
+            // Use NOT <array_contains>(array, element) for cycle detection. The membership
+            // function is dialect-specific: CH `has`, Spark `array_contains`.
+            format!(
+                "NOT {}(vp.path_nodes, next.{})",
+                cycle_mapper.array_contains(),
+                self.to_col
+            ), // Cycle prevention
         ];
 
         // Add additional filters if present
@@ -3196,6 +3202,118 @@ mod tests {
         assert!(generation_result.sql.contains(" AS (\n")); // CTE structure with newline
         assert!(generation_result.sql.contains("users_bench"));
         assert!(generation_result.sql.contains("user_follows_bench"));
+    }
+
+    /// Build the denormalized pattern context used by the cycle-check tests.
+    fn denormalized_flights_pattern_ctx() -> PatternSchemaContext {
+        PatternSchemaContext {
+            left_node_alias: "f1".to_string(),
+            right_node_alias: "f2".to_string(),
+            rel_alias: "flights".to_string(),
+            left_node: NodeAccessStrategy::EmbeddedInEdge {
+                edge_alias: "flights".to_string(),
+                properties: HashMap::new(),
+                is_from_node: true,
+            },
+            right_node: NodeAccessStrategy::EmbeddedInEdge {
+                edge_alias: "flights".to_string(),
+                properties: HashMap::new(),
+                is_from_node: false,
+            },
+            edge: EdgeAccessStrategy::SeparateTable {
+                table: "flights".to_string(),
+                from_id: "Origin".to_string(),
+                to_id: "Dest".to_string(),
+                properties: HashMap::new(),
+            },
+            join_strategy: JoinStrategy::SingleTableScan {
+                table: "flights".to_string(),
+            },
+            coupled_context: None,
+            rel_types: vec!["FLIES_TO".to_string()],
+            left_is_polymorphic: false,
+            right_is_polymorphic: false,
+            constraints: None,
+        }
+    }
+
+    fn denormalized_cycle_check_sql() -> (DenormalizedCteStrategy, CteGenerationContext) {
+        let pattern_ctx = denormalized_flights_pattern_ctx();
+        let schema = Arc::new(GraphSchema::build(
+            1,
+            "test".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        ));
+        let strategy = DenormalizedCteStrategy::new(&pattern_ctx, schema).unwrap();
+        let context = CteGenerationContext::new()
+            .with_spec(VariableLengthSpec {
+                min_hops: Some(1),
+                max_hops: Some(3),
+            })
+            .with_start_cypher_alias("f1".to_string())
+            .with_end_cypher_alias("f2".to_string());
+        (strategy, context)
+    }
+
+    fn empty_filters() -> CategorizedFilters {
+        CategorizedFilters {
+            start_node_filters: None,
+            end_node_filters: None,
+            relationship_filters: None,
+            path_function_filters: None,
+            start_sql: None,
+            end_sql: None,
+            relationship_sql: None,
+        }
+    }
+
+    /// Regression: the recursive VLP cycle check must be dialect-aware. Under
+    /// ClickHouse (default) it uses `has`; under Databricks it must use Spark's
+    /// `array_contains` (Spark has no `has`). Covers the DenormalizedCteStrategy
+    /// recursive builder — the path the server/cg VLP queries route through.
+    #[test]
+    fn test_denormalized_cte_cycle_check_clickhouse_default() {
+        let (strategy, context) = denormalized_cycle_check_sql();
+        let sql = strategy
+            .generate_sql(&context, &[], &empty_filters())
+            .unwrap()
+            .sql;
+        assert!(
+            sql.contains("NOT has(vp.path_nodes"),
+            "CH cycle check should use `has`; got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("array_contains"),
+            "CH SQL leaked Spark `array_contains`; got:\n{sql}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_denormalized_cte_cycle_check_databricks_dialect() {
+        use crate::server::query_context::{with_query_context, QueryContext};
+        use crate::sql_generator::SqlDialect;
+
+        let (strategy, context) = denormalized_cycle_check_sql();
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async {
+            strategy
+                .generate_sql(&context, &[], &empty_filters())
+                .unwrap()
+                .sql
+        })
+        .await;
+        assert!(
+            sql.contains("array_contains(vp.path_nodes"),
+            "Databricks cycle check should use `array_contains`; got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("has(vp.path_nodes"),
+            "Databricks SQL leaked ClickHouse `has(...)` cycle check; got:\n{sql}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
The recursive variable-length-path (VLP) cycle check in `DenormalizedCteStrategy::generate_recursive_case_sql` hardcoded ClickHouse's `NOT has(vp.path_nodes, next.<col>)`. Spark/Databricks has no `has` function, so **every VLP / shortestPath query failed to execute on Databricks** (`UNRESOLVED_ROUTINE`). The translation-parity sweep flagged this as the highest-impact DeltaGraph gap — **23 queries** across pattern-matrix, denormalized-edge, VLP-crossfunctional, and schema-variation tests.

## Fix
Route the array-membership function through the existing `FunctionMapper` (`array_contains()` → ClickHouse `has`, Spark `array_contains`), mirroring the `arr_append` helper that already does this for `array_concat`/`array_literal`. One-line change; the mapper method was already implemented and unit-tested per dialect.

## Verification
- Added CH + Databricks regression tests on the `DenormalizedCteStrategy` recursive builder (the path server/cg VLP queries route through — distinct from `VariableLengthCteGenerator`, which was already mapper-routed).
- **Live on real Databricks**: `(a:User)-[:FOLLOWS*1..2]->(b:User)` now executes and returns results at parity with ClickHouse (previously errored). No residual `has(` in any VLP variant (`*2`, `*1..3`, `shortestPath`).
- `cargo fmt`, `clippy --features databricks`, full lib suite both configs (1449 default / 1506 databricks).

Part of the dual-dialect latent-bug sweep. CH output is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)