### PR TITLE
fix(deltagraph): dialect-aware list aggregate in pattern comprehensions

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -17683,10 +17683,13 @@ pub(super) fn build_pattern_comprehension_sql(
     let agg_fn = match agg_type {
         AggregationType::Count => "COUNT(*)".to_string(),
         AggregationType::GroupArray => {
+            // Dialect-aware list aggregate: CH `groupArray`, Spark `collect_list`.
+            let collect =
+                crate::sql_generator::function_mapper::current_function_mapper().collect_list();
             if target_join_info.is_some() {
-                "groupArray(target_prop)".to_string()
+                format!("{collect}(target_prop)")
             } else {
-                "groupArray(1)".to_string()
+                format!("{collect}(1)")
             }
         }
         AggregationType::Sum => "SUM(1)".to_string(),

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -352,6 +352,48 @@ async fn vlp_under_databricks_dialect_emits_spark_spellings() {
     );
 }
 
+/// Pattern comprehension `[(a)-[:R]->(x) | x.p]` lowers to a UNION-ALL branch
+/// aggregated with a list aggregate. That aggregate must be dialect-aware:
+/// CH `groupArray`, Spark `collect_list` (Spark has no `groupArray`).
+#[tokio::test]
+async fn pattern_comprehension_collect_list_per_dialect() {
+    let cypher = "MATCH (a:User) RETURN a.id, [(a)-[:FOLLOWS]->(x:User) | x.id] AS following";
+
+    let ch = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::ClickHouse,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        ch.contains("groupArray"),
+        "CH pattern comprehension should use `groupArray`; got:\n{ch}"
+    );
+    assert!(
+        !ch.contains("collect_list"),
+        "CH SQL leaked Spark `collect_list`; got:\n{ch}"
+    );
+
+    let dbx = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        dbx.contains("collect_list"),
+        "Databricks pattern comprehension should use `collect_list`; got:\n{dbx}"
+    );
+    assert!(
+        !dbx.contains("groupArray"),
+        "Databricks SQL leaked CH `groupArray`; got:\n{dbx}"
+    );
+}
+
 /// Aggregation path — exercises `build_outer_aggregate_select` and the
 /// `extract_outer_aggregation_info` rewrite where ColumnAlias references
 /// in GROUP BY / aggregate args get quoted via `quote_alias`. The plain


### PR DESCRIPTION
## Problem
Pattern comprehensions `[(a)-[:R]->(x) | x.p]` lower to a UNION-ALL branch aggregated with a list aggregate, hardcoded to ClickHouse's `groupArray(...)` in `plan_builder_utils.rs`. Spark/Databricks has no `groupArray`, so pattern-comprehension queries (the translation-parity sweep found **5**) failed on Databricks. (Regular `collect()` already works — it routes through the dialect-aware registry; only this pattern-comprehension site was hardcoded.)

## Fix
Route the list aggregate through the existing `FunctionMapper::collect_list()` (ClickHouse `groupArray` / Spark `collect_list`).

## Verification
- **Live on real Databricks**: `MATCH (u:User) RETURN [(u)-[:FOLLOWS]->(f) | f.name]` now executes and is content-equivalent to ClickHouse (the multiset matches; aggregate element order is unspecified for an unordered list aggregate on both engines).
- Per-dialect regression test via the spike-test harness (CH `groupArray` / Databricks `collect_list`, each direction guarded).
- `cargo fmt`, `clippy --features databricks`, full lib suite both configs (1450 / 1507).

CH output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)