### PR TITLE
fix(deltagraph): map Cypher split() to Spark split() (dialect-aware args)

### DIFF
--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -394,6 +394,45 @@ async fn pattern_comprehension_collect_list_per_dialect() {
     );
 }
 
+/// Cypher `split(str, delim)` must map per dialect: CH `splitByChar(delim, str)`
+/// (name + args swapped), Spark `split(str, delim)` (name change, Cypher arg
+/// order). The arg swap is ClickHouse-only.
+#[tokio::test]
+async fn split_function_per_dialect() {
+    let cypher = "MATCH (a:User) RETURN split(a.name, ' ') AS parts";
+
+    let ch = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::ClickHouse,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        ch.contains("splitByChar(' ', "),
+        "CH should emit `splitByChar(delim, str)`; got:\n{ch}"
+    );
+
+    let dbx = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        !dbx.contains("splitByChar"),
+        "Databricks SQL leaked CH `splitByChar`; got:\n{dbx}"
+    );
+    // Spark `split(str, delim)` keeps Cypher arg order (str first).
+    assert!(
+        dbx.contains("split(") && dbx.contains(", ' ')"),
+        "Databricks should emit `split(str, delim)` in Cypher arg order; got:\n{dbx}"
+    );
+}
+
 /// Aggregation path — exercises `build_outer_aggregate_select` and the
 /// `extract_outer_aggregation_info` rewrite where ColumnAlias references
 /// in GROUP BY / aggregate args get quoted via `quote_alias`. The plain

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -231,14 +231,20 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
-        // split(str, delimiter) -> splitByChar(delimiter, str) [ARGS SWAPPED!]
+        // Cypher split(str, delim):
+        //   CH    -> splitByChar(delim, str)   [name + args swapped]
+        //   Spark -> split(str, delim)         [name change only, Cypher arg order]
+        // The swap is ClickHouse-only, so the arg_transform reads the active
+        // dialect. (Spark `split` is regex-based; for the literal single-char
+        // delimiters Cypher `split` is used with this is equivalent.)
         m.insert("split", FunctionMapping {
             neo4j_name: "split",
             clickhouse_name: "splitByChar",
-            databricks_name: None,
+            databricks_name: Some("split"),
             arg_transform: Some(|args| {
-                if args.len() >= 2 {
-                    // Swap: split(str, delim) -> splitByChar(delim, str)
+                let dialect = crate::server::query_context::get_current_dialect();
+                if dialect == crate::sql_generator::SqlDialect::ClickHouse && args.len() >= 2 {
+                    // CH splitByChar(delim, str): swap from Cypher split(str, delim).
                     vec![args[1].clone(), args[0].clone()]
                 } else {
                     args.to_vec()

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -235,8 +235,9 @@ lazy_static::lazy_static! {
         //   CH    -> splitByChar(delim, str)   [name + args swapped]
         //   Spark -> split(str, delim)         [name change only, Cypher arg order]
         // The swap is ClickHouse-only, so the arg_transform reads the active
-        // dialect. (Spark `split` is regex-based; for the literal single-char
-        // delimiters Cypher `split` is used with this is equivalent.)
+        // dialect. (Spark `split` treats arg 2 as a regex, whereas Cypher/CH
+        // split is literal; equivalent for the single-char, non-regex-meta
+        // delimiters Cypher `split` is typically used with.)
         m.insert("split", FunctionMapping {
             neo4j_name: "split",
             clickhouse_name: "splitByChar",


### PR DESCRIPTION
## Problem
Cypher `split(str, delim)` was mapped only to ClickHouse `splitByChar(delim, str)` (name **and** args swapped), with `databricks_name: None`. On Databricks this leaked `splitByChar` (unknown function on Spark); and even with a name change the swapped arg order is wrong for Spark's `split(str, pattern)`. The translation-parity sweep flagged 2 queries.

## Fix
- `databricks_name: Some("split")`.
- Make the arg swap **ClickHouse-only**: the `arg_transform` closure reads the active dialect (`get_current_dialect()`) and only swaps for ClickHouse, so Spark gets `split(str, delim)` in Cypher order. Keeps the fix localized to the registry entry — no consumer-site changes.

## Verification
- **Live on real Databricks**: `split(u.name, ' ')` → `["Alice","Johnson"]`, identical to ClickHouse.
- Per-dialect regression test (CH `splitByChar(delim, str)` / Spark `split(str, delim)`); existing `test_arg_transformations` still passes (default dialect = ClickHouse).
- `cargo fmt`, `clippy --features databricks`, both lib suites (1451 / 1508).

Note: Spark `split` is regex-based vs CH's literal `splitByChar`; equivalent for the literal single-char delimiters Cypher `split()` is used with here (a follow-up could regex-escape for special-char delimiters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)