### PR TITLE
fix(deltagraph): UNWIND uses LATERAL VIEW explode on Databricks

### DIFF
--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -433,6 +433,49 @@ async fn split_function_per_dialect() {
     );
 }
 
+/// UNWIND of a literal list lowers to array expansion. The base relation and
+/// expansion syntax are dialect-specific: CH `FROM system.one` + `ARRAY JOIN`,
+/// Spark `FROM (SELECT 1) AS _unwind` + `LATERAL VIEW explode` (Spark has
+/// neither `system.one` nor `ARRAY JOIN`).
+#[tokio::test]
+async fn unwind_literal_per_dialect() {
+    let cypher = "UNWIND [1, 2, 3, 4] AS x RETURN x, x * x AS sq ORDER BY x";
+
+    let ch = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::ClickHouse,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        ch.contains("FROM system.one") && ch.contains("ARRAY JOIN"),
+        "CH UNWIND should use system.one + ARRAY JOIN; got:\n{ch}"
+    );
+
+    let dbx = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        dbx.contains("LATERAL VIEW explode("),
+        "Databricks UNWIND should use LATERAL VIEW explode; got:\n{dbx}"
+    );
+    assert!(
+        dbx.contains("FROM (SELECT 1)"),
+        "Databricks UNWIND-only needs a one-row subquery base; got:\n{dbx}"
+    );
+    assert!(
+        !dbx.contains("system.one") && !dbx.contains("ARRAY JOIN"),
+        "Databricks SQL leaked CH `system.one`/`ARRAY JOIN`; got:\n{dbx}"
+    );
+}
+
 /// Aggregation path — exercises `build_outer_aggregate_select` and the
 /// `extract_outer_aggregation_info` rewrite where ColumnAlias references
 /// in GROUP BY / aggregate args get quoted via `quote_alias`. The plain

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4207,12 +4207,20 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
     sql.push_str(&plan.ctes.to_sql());
     sql.push_str(&plan.select.to_sql_with_unwind_aliases(&unwind_aliases));
 
-    // Add FROM clause - use system.one for UNWIND-only queries (no actual table)
+    // Add FROM clause - UNWIND-only queries (no actual table) need a one-row
+    // base relation for the array-expansion to hang off. Dialect-specific:
+    //   CH:    `system.one` (single-row virtual table) + `ARRAY JOIN`
+    //   Spark: `(SELECT 1)` subquery (aliased) + `LATERAL VIEW explode`
     let from_sql = plan.from.to_sql();
     if from_sql.is_empty() && !plan.array_join.0.is_empty() {
-        // ARRAY JOIN requires a FROM clause in ClickHouse
-        // system.one is a virtual table with one row, perfect for UNWIND-only queries
-        sql.push_str("FROM system.one\n");
+        match crate::server::query_context::get_current_dialect() {
+            crate::sql_generator::SqlDialect::Databricks => {
+                sql.push_str("FROM (SELECT 1) AS _unwind\n");
+            }
+            _ => {
+                sql.push_str("FROM system.one\n");
+            }
+        }
     } else {
         sql.push_str(&from_sql);
     }
@@ -4437,13 +4445,26 @@ impl ToSql for ArrayJoinItem {
             return "".into();
         }
 
+        let databricks = matches!(
+            crate::server::query_context::get_current_dialect(),
+            crate::sql_generator::SqlDialect::Databricks
+        );
         let mut sql = String::new();
         for array_join in &self.0 {
-            sql.push_str(&format!(
-                "ARRAY JOIN {} AS {}\n",
-                array_join.expression.to_sql(),
-                array_join.alias
-            ));
+            if databricks {
+                // Spark has no ARRAY JOIN; UNWIND maps to LATERAL VIEW explode.
+                sql.push_str(&format!(
+                    "LATERAL VIEW explode({}) AS {}\n",
+                    array_join.expression.to_sql(),
+                    array_join.alias
+                ));
+            } else {
+                sql.push_str(&format!(
+                    "ARRAY JOIN {} AS {}\n",
+                    array_join.expression.to_sql(),
+                    array_join.alias
+                ));
+            }
         }
         sql
     }


### PR DESCRIPTION
## Problem
UNWIND lowered to ClickHouse-only SQL — `FROM system.one` (CH single-row virtual table) + `ARRAY JOIN expr AS alias`. Spark has **neither** `system.one` nor `ARRAY JOIN`, so any UNWIND failed on Databricks (`system.one` undefined / `ARRAY JOIN` not Spark syntax). Found by the real-Databricks core-feature parity run.

## Fix
Both emission sites in `to_sql_query.rs` are now dialect-aware (via the task-local dialect):

| | base relation | expansion |
|---|---|---|
| ClickHouse | `FROM system.one` | `ARRAY JOIN expr AS alias` |
| Databricks | `FROM (SELECT 1) AS _unwind` | `LATERAL VIEW explode(expr) AS alias` |

The single `ArrayJoinItem::to_sql()` emitter covers UNWIND-only, UNWIND-after-MATCH, and multi-UNWIND cartesian.

## Verification
- **Live on real Databricks**: `UNWIND [1,2,3,4] AS x RETURN x, x*x` → 1,4,9,16; two-UNWIND cartesian `[1,2]×[10,20]` → 4 rows; all identical to ClickHouse.
- CH output unchanged (`system.one` + `ARRAY JOIN`).
- Per-dialect regression test; `cargo fmt`, `clippy --features databricks`, both lib suites (1452 / 1509).

Note: a separate, pre-existing, **dialect-independent** bug exists where a property reference inside an UNWIND expression after MATCH (e.g. `UNWIND split(u.name,' ')`) isn't mapped to its DB column — it fails identically on ClickHouse and Databricks and is out of scope here (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)