### PR TITLE
fix(deltagraph): DISTINCT + ORDER BY resolves via alias on Databricks

### DIFF
--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -476,6 +476,44 @@ async fn unwind_literal_per_dialect() {
     );
 }
 
+/// `RETURN DISTINCT expr ORDER BY expr`: Spark resolves ORDER BY against the
+/// DISTINCT output, so the sort term must reference the projection's backtick
+/// alias, not the underlying `table.col`. ClickHouse keeps `table.col`.
+#[tokio::test]
+async fn distinct_order_by_per_dialect() {
+    let cypher = "MATCH (a:User) RETURN DISTINCT a.name ORDER BY a.name";
+
+    let ch = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::ClickHouse,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        ch.contains("ORDER BY a.name"),
+        "CH DISTINCT should order by `table.col`; got:\n{ch}"
+    );
+
+    let dbx = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        dbx.contains("ORDER BY `a.name`"),
+        "Databricks DISTINCT should order by the backtick alias; got:\n{dbx}"
+    );
+    assert!(
+        !dbx.contains("ORDER BY a.name "),
+        "Databricks DISTINCT leaked raw `table.col` in ORDER BY; got:\n{dbx}"
+    );
+}
+
 /// Aggregation path — exercises `build_outer_aggregate_select` and the
 /// `extract_outer_aggregation_info` rewrite where ColumnAlias references
 /// in GROUP BY / aggregate args get quoted via `quote_alias`. The plain

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4238,7 +4238,23 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
         sql.push('\n');
     }
 
-    sql.push_str(&plan.order_by.to_sql());
+    // Databricks `SELECT DISTINCT` resolves ORDER BY against the aliased
+    // DISTINCT output, not the source relation — so a sort term matching a
+    // projection must reference its alias, not `table.col` (ClickHouse is
+    // lenient here and resolves against the FROM relation).
+    let distinct_spark_order = plan.select.distinct
+        && matches!(
+            crate::server::query_context::get_current_dialect(),
+            crate::sql_generator::SqlDialect::Databricks
+        );
+    if distinct_spark_order {
+        sql.push_str(&render_order_by_with_select_aliases(
+            &plan.order_by,
+            &plan.select,
+        ));
+    } else {
+        sql.push_str(&plan.order_by.to_sql());
+    }
     sql.push_str(&plan.union.to_sql());
 
     sql.push_str(&limit_offset_clause(plan.skip.0, plan.limit.0));
@@ -4486,6 +4502,36 @@ impl ToSql for GroupByExpressions {
         sql.push('\n');
         sql
     }
+}
+
+/// Render ORDER BY for a Databricks `SELECT DISTINCT`. Spark resolves ORDER BY
+/// terms against the (aliased) DISTINCT output, so a term that matches a SELECT
+/// projection is rendered as that projection's alias (backtick-quoted) rather
+/// than the underlying `table.col`, which is no longer in scope after DISTINCT.
+/// Terms with no matching projection fall back to the raw expression.
+fn render_order_by_with_select_aliases(order_by: &OrderByItems, select: &SelectItems) -> String {
+    if order_by.0.is_empty() {
+        return String::new();
+    }
+    let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+    let mut sql = String::from("ORDER BY ");
+    for (i, item) in order_by.0.iter().enumerate() {
+        let term = select
+            .items
+            .iter()
+            .find(|s| s.expression == item.expression)
+            .and_then(|s| s.col_alias.as_ref())
+            .map(|a| mapper.quote_alias(&a.0))
+            .unwrap_or_else(|| item.expression.to_sql());
+        sql.push_str(&term);
+        sql.push(' ');
+        sql.push_str(&item.order.to_sql());
+        if i + 1 < order_by.0.len() {
+            sql.push_str(", ");
+        }
+    }
+    sql.push('\n');
+    sql
 }
 
 impl ToSql for OrderByItems {


### PR DESCRIPTION
## Problem
`RETURN DISTINCT expr ORDER BY expr` emitted:
```sql
SELECT DISTINCT u.country AS `u.country` FROM ... ORDER BY u.country
```
Spark resolves `ORDER BY` against the **DISTINCT output** (whose only column is the alias `u.country`), so the raw `table.col` sort term is unresolvable → `UNRESOLVED_COLUMN`. ClickHouse is lenient and resolves it against the FROM relation, so it only fails on Databricks. Found by the real-Databricks core-feature parity run.

## Fix
For **Databricks + DISTINCT**, render each ORDER BY term that matches a SELECT projection as that projection's backtick-quoted alias (via `FunctionMapper::quote_alias`); terms with no matching projection fall back to the raw expression. ClickHouse and all non-DISTINCT paths are untouched (guarded by `plan.select.distinct && dialect == Databricks`).

## Verification
- **Live on real Databricks**: `RETURN DISTINCT u.country ORDER BY u.country` executes and matches ClickHouse; a multi-key `country ASC, city DESC` DISTINCT variant orders correctly.
- CH output byte-for-byte unchanged (`ORDER BY u.country`).
- Per-dialect regression test; `cargo fmt`, `clippy --features databricks`, both lib suites (1453 / 1510).

This is the 5th and final fix from the DeltaGraph latent-bug sweep (after #394 VLP `array_contains`, #395 `collect_list`, #396 `split`, #397 UNWIND `explode`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)