### PR TITLE
fix(planner): map Cypher properties inside UNWIND expressions to DB columns (#400)

### DIFF
--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -361,7 +361,15 @@ impl JoinBuilder for LogicalPlan {
         match self {
             LogicalPlan::Unwind(u) => {
                 // Convert LogicalExpr to RenderExpr for this UNWIND
-                let render_expr = RenderExpr::try_from(u.expression.clone())?;
+                let mut render_expr = RenderExpr::try_from(u.expression.clone())?;
+                // Apply schema property mapping so Cypher property references inside the
+                // UNWIND expression (e.g. `split(u.name, ' ')`) resolve to their DB columns
+                // (`u.full_name`). Without this, the raw Cypher property leaks into the
+                // ARRAY JOIN / LATERAL VIEW and fails to resolve. (issue #400)
+                crate::render_plan::plan_builder_helpers::apply_property_mapping_to_expr(
+                    &mut render_expr,
+                    &u.input,
+                );
                 array_joins.push(ArrayJoin {
                     expression: render_expr,
                     alias: u.alias.clone(),

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -363,9 +363,9 @@ impl JoinBuilder for LogicalPlan {
                 // Convert LogicalExpr to RenderExpr for this UNWIND
                 let mut render_expr = RenderExpr::try_from(u.expression.clone())?;
                 // Apply schema property mapping so Cypher property references inside the
-                // UNWIND expression (e.g. `split(u.name, ' ')`) resolve to their DB columns
-                // (`u.full_name`). Without this, the raw Cypher property leaks into the
-                // ARRAY JOIN / LATERAL VIEW and fails to resolve. (issue #400)
+                // UNWIND expression (e.g. `split(u.name, ' ')`) resolve to their mapped DB
+                // column. Without this, the raw Cypher property leaks into the ARRAY JOIN /
+                // LATERAL VIEW and fails to resolve. (issue #400)
                 crate::render_plan::plan_builder_helpers::apply_property_mapping_to_expr(
                     &mut render_expr,
                     &u.input,

--- a/src/render_plan/tests/where_clause_filter_tests.rs
+++ b/src/render_plan/tests/where_clause_filter_tests.rs
@@ -776,3 +776,47 @@ mod vlp_chained_pattern_filters {
         );
     }
 }
+
+/// Regression tests for issue #400: property references inside an UNWIND
+/// expression after a MATCH must be schema-mapped to their DB column, exactly
+/// like SELECT/WHERE. The schema maps Cypher `full_name` -> DB column `name`.
+#[cfg(test)]
+mod unwind_property_mapping {
+    use super::*;
+
+    #[test]
+    fn test_unwind_function_arg_property_is_mapped() {
+        // `split(u.full_name, ' ')` inside UNWIND: the Cypher property `full_name`
+        // must resolve to the DB column `name`, not leak through as `u.full_name`.
+        let cypher = "MATCH (u:User) UNWIND split(u.full_name, ' ') AS part RETURN part";
+        let sql = cypher_to_sql(cypher);
+
+        println!("UNWIND function-arg property mapping SQL:\n{}", sql);
+
+        assert!(
+            sql.contains("u.name"),
+            "UNWIND expression should map `full_name` -> DB column `name`. Got: {}",
+            sql
+        );
+        assert!(
+            !sql.contains("u.full_name"),
+            "UNWIND expression leaked unmapped Cypher property `u.full_name`. Got: {}",
+            sql
+        );
+    }
+
+    #[test]
+    fn test_unwind_literal_is_unaffected() {
+        // A literal UNWIND has no property to map and must be unchanged.
+        let cypher = "UNWIND [1, 2, 3] AS x RETURN x";
+        let sql = cypher_to_sql(cypher);
+
+        println!("UNWIND literal SQL:\n{}", sql);
+
+        assert!(
+            sql.contains("[1, 2, 3]"),
+            "Literal UNWIND should pass the array through unchanged. Got: {}",
+            sql
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #400. A property reference **inside an UNWIND expression** after a MATCH was emitted with the raw Cypher property name instead of the schema-mapped DB column, producing SQL with an unresolved identifier. Fails identically on ClickHouse and Databricks (dialect-independent).

```
MATCH (u:User) WHERE u.user_id=1 UNWIND split(u.name,' ') AS part RETURN part
```
Before (CH): `ARRAY JOIN splitByChar(' ', u.name)` → `Identifier 'u.name' cannot be resolved`
After (CH):  `ARRAY JOIN splitByChar(' ', u.full_name)` ✓
After (DBX): `LATERAL VIEW explode(split(u.full_name, ' '))` ✓

## Root cause
`extract_array_join` (join_builder.rs) converted the UNWIND `LogicalExpr` to a `RenderExpr` but never ran the property-mapping rewrite that SELECT/WHERE/GROUP BY all apply. The fix routes the converted expression through `apply_property_mapping_to_expr`, which recurses into function args. Literal UNWINDs (no property to map) are unaffected.

## Tests
- New regression tests in `where_clause_filter_tests.rs` (schema maps Cypher `full_name` → DB column `name`): function-arg property is mapped; literal UNWIND passes through unchanged.
- Verified the function-arg test **fails without the fix**.
- Full lib suite green (1455 passed); fmt + clippy clean.
- Manually verified on both `--dialect clickhouse` and `--dialect databricks` via `cg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)