### PR TITLE
fix(planner): keep UNWIND array expansion when segment is wrapped into a CTE (#401)

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -8038,6 +8038,23 @@ pub(crate) fn build_chained_with_match_cte_plan(
                     plan_to_render.to_render_plan_with_ctx(schema, plan_ctx, body_scope_ref)?
                 };
 
+                // When a WITH segment contains an UNWIND (e.g. `UNWIND [1,2,3] AS x
+                // WITH x ...`), the CTE-body render path above can drop the array
+                // expansion, leaving the unwound variable undefined in the CTE body.
+                // Re-extract the array joins from the segment and attach them so the
+                // CTE keeps its ARRAY JOIN / LATERAL VIEW. The empty FROM falls back
+                // to the dialect's one-row base at SQL-generation time, exactly like a
+                // non-CTE UNWIND. (issue #401)
+                if rendered.array_join.0.is_empty() {
+                    let array_joins =
+                        <LogicalPlan as super::join_builder::JoinBuilder>::extract_array_join(
+                            plan_to_render,
+                        )?;
+                    if !array_joins.is_empty() {
+                        rendered.array_join = ArrayJoinItem(array_joins);
+                    }
+                }
+
                 // CRITICAL: Extract CTE schemas from nested rendering
                 // When rendering nested WITHs, the recursive call builds CTEs that we need
                 // to reference. Extract their schemas and add to our cte_schemas map.

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -476,6 +476,46 @@ async fn unwind_literal_per_dialect() {
     );
 }
 
+/// Regression for issue #401: an UNWIND-only segment wrapped into a CTE (via a
+/// following WITH) must keep both its array expansion AND its one-row base
+/// relation inside the CTE body. Previously the CTE body dropped both, leaving
+/// the unwound variable undefined (`SELECT x ... WHERE x > 1` with no FROM/JOIN).
+#[tokio::test]
+async fn unwind_in_cte_per_dialect() {
+    let cypher = "UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x";
+
+    let ch = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::ClickHouse,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    // The CTE body must contain the base relation + ARRAY JOIN, not just `SELECT x`.
+    assert!(
+        ch.contains("FROM system.one") && ch.contains("ARRAY JOIN"),
+        "CH UNWIND-in-CTE body should keep system.one + ARRAY JOIN; got:\n{ch}"
+    );
+
+    let dbx = with_query_context(
+        QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        },
+        async { cypher_to_sql(cypher) },
+    )
+    .await;
+    assert!(
+        dbx.contains("FROM (SELECT 1)") && dbx.contains("LATERAL VIEW explode("),
+        "Databricks UNWIND-in-CTE body should keep one-row base + LATERAL VIEW explode; got:\n{dbx}"
+    );
+    assert!(
+        !dbx.contains("system.one") && !dbx.contains("ARRAY JOIN"),
+        "Databricks UNWIND-in-CTE leaked CH `system.one`/`ARRAY JOIN`; got:\n{dbx}"
+    );
+}
+
 /// `RETURN DISTINCT expr ORDER BY expr`: Spark resolves ORDER BY against the
 /// DISTINCT output, so the sort term must reference the projection's backtick
 /// alias, not the underlying `table.col`. ClickHouse keeps `table.col`.

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4788,7 +4788,23 @@ impl ToSql for Cte {
                         cte_body.push_str(&plan.select.to_sql());
                     }
 
-                    cte_body.push_str(&plan.from.to_sql());
+                    // UNWIND-only CTE bodies (e.g. `UNWIND [1,2,3] AS x WITH x ...`)
+                    // have no real table; the array expansion needs a one-row base
+                    // relation, mirroring the main-query path. Dialect-specific:
+                    // CH `system.one`, Spark `(SELECT 1)`. (issue #401)
+                    let cte_from_sql = plan.from.to_sql();
+                    if cte_from_sql.is_empty() && !plan.array_join.0.is_empty() {
+                        match crate::server::query_context::get_current_dialect() {
+                            crate::sql_generator::SqlDialect::Databricks => {
+                                cte_body.push_str("FROM (SELECT 1) AS _unwind\n");
+                            }
+                            _ => {
+                                cte_body.push_str("FROM system.one\n");
+                            }
+                        }
+                    } else {
+                        cte_body.push_str(&cte_from_sql);
+                    }
                     cte_body.push_str(&plan.joins.to_sql());
                     cte_body.push_str(&plan.array_join.to_sql());
                     cte_body.push_str(&plan.filters.to_sql());


### PR DESCRIPTION
## Summary
Fixes #401. An UNWIND-only segment wrapped into a CTE (via a following WITH) lost its array expansion **and** its base relation, producing invalid SQL where the unwound variable is undefined. Dialect-independent (fails on both ClickHouse and Databricks).

```
UNWIND [1,2,3] AS x WITH x WHERE x > 1 RETURN x
```
Before — broken CTE body:
```sql
with_x_cte_0 AS (SELECT x AS "x" WHERE x > 1)   -- no FROM, no ARRAY JOIN → x undefined
```
After (CH):
```sql
with_x_cte_0 AS (SELECT x AS "x" FROM system.one ARRAY JOIN [1, 2, 3] AS x WHERE x > 1)
```
After (Databricks):
```sql
with_x_cte_0 AS (SELECT x AS `x` FROM (SELECT 1) AS _unwind LATERAL VIEW explode(array(1, 2, 3)) AS x WHERE x > 1)
```

## Root cause — two gaps
1. **`build_chained_with_match_cte_plan`** (`plan_builder_utils.rs`) renders the WITH segment via `to_render_plan_with_ctx`, whose path drops the UNWIND's `array_join`. Fix: re-extract array joins from the segment (`extract_array_join` already handles `Unwind`) and attach them to the CTE body.
2. **CTE-body SQL emitter** (`Cte::to_sql`, standard single-query branch in `to_sql_query.rs`) lacked the one-row base-relation fallback the main-query path already has. Fix: when FROM is empty and `array_join` is present, emit `FROM system.one` (CH) / `FROM (SELECT 1) AS _unwind` (Databricks).

## Tests
- New per-dialect regression test `unwind_in_cte_per_dialect` — verified it **fails without the fix**.
- Verified related variations via `cg`: UNWIND+WITH passthrough, UNWIND+WITH+aggregation, and MATCH+UNWIND+WITH (real table preserved, property mapped).
- Full lib suite green (1456 passed); integration/golden suites green (283); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)