### PR TITLE
fix(planner): project all UNWIND vars when multiple UNWINDs wrap into a CTE (#404)

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -8755,6 +8755,13 @@ pub(crate) fn build_chained_with_match_cte_plan(
                         // AND through nested UNWINDs: `UNWIND .. AS x UNWIND .. AS y` binds
                         // both x and y, and each must be emitted as a column (not expanded
                         // as a graph alias, which would drop it from the CTE projection). (#404)
+                        //
+                        // NOTE: this deliberately STOPS at a WithClause barrier (no
+                        // `WithClause` arm) — `plan_to_render` is already `wc.input`, so any
+                        // deeper WithClause is a prior segment whose UNWIND vars are now CTE
+                        // columns and must NOT be re-emitted as bare columns. The similar
+                        // `find_unwind_aliases` helper below DOES cross the barrier on purpose
+                        // (for ID-column detection), so the two are not interchangeable.
                         fn collect_unwind_aliases(
                             plan: &LogicalPlan,
                             out: &mut std::collections::HashSet<String>,

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -8749,23 +8749,32 @@ pub(crate) fn build_chained_with_match_cte_plan(
                             }
                         }
 
-                        // Extract UNWIND alias from plan if present — UNWIND aliases are simple
+                        // Extract ALL UNWIND aliases from plan — UNWIND aliases are simple
                         // ARRAY JOIN column references, not table aliases to expand.
                         // Must recurse through wrapping nodes (Filter, Projection, etc.)
-                        // since UNWIND may not be at the top level.
-                        fn find_unwind_alias(plan: &LogicalPlan) -> Option<&str> {
+                        // AND through nested UNWINDs: `UNWIND .. AS x UNWIND .. AS y` binds
+                        // both x and y, and each must be emitted as a column (not expanded
+                        // as a graph alias, which would drop it from the CTE projection). (#404)
+                        fn collect_unwind_aliases(
+                            plan: &LogicalPlan,
+                            out: &mut std::collections::HashSet<String>,
+                        ) {
                             match plan {
-                                LogicalPlan::Unwind(u) => Some(u.alias.as_str()),
-                                LogicalPlan::Filter(f) => find_unwind_alias(&f.input),
-                                LogicalPlan::Projection(p) => find_unwind_alias(&p.input),
-                                LogicalPlan::OrderBy(ob) => find_unwind_alias(&ob.input),
-                                LogicalPlan::Limit(lim) => find_unwind_alias(&lim.input),
-                                LogicalPlan::Skip(s) => find_unwind_alias(&s.input),
-                                LogicalPlan::GroupBy(gb) => find_unwind_alias(&gb.input),
-                                _ => None,
+                                LogicalPlan::Unwind(u) => {
+                                    out.insert(u.alias.clone());
+                                    collect_unwind_aliases(&u.input, out);
+                                }
+                                LogicalPlan::Filter(f) => collect_unwind_aliases(&f.input, out),
+                                LogicalPlan::Projection(p) => collect_unwind_aliases(&p.input, out),
+                                LogicalPlan::OrderBy(ob) => collect_unwind_aliases(&ob.input, out),
+                                LogicalPlan::Limit(lim) => collect_unwind_aliases(&lim.input, out),
+                                LogicalPlan::Skip(s) => collect_unwind_aliases(&s.input, out),
+                                LogicalPlan::GroupBy(gb) => collect_unwind_aliases(&gb.input, out),
+                                _ => {}
                             }
                         }
-                        let unwind_alias = find_unwind_alias(plan_to_render);
+                        let mut unwind_aliases = std::collections::HashSet::new();
+                        collect_unwind_aliases(plan_to_render, &mut unwind_aliases);
 
                         let select_items: Vec<SelectItem> = items.iter()
                                     .flat_map(|item| {
@@ -8773,7 +8782,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                         match &item.expression {
                                             crate::query_planner::logical_expr::LogicalExpr::TableAlias(alias) => {
                                                 // UNWIND aliases are ARRAY JOIN columns — emit a simple column reference
-                                                if unwind_alias == Some(alias.0.as_str()) {
+                                                if unwind_aliases.contains(alias.0.as_str()) {
                                                     log::debug!("🔧 build_chained_with_match_cte_plan: UNWIND alias '{}' — simple column reference", alias.0);
                                                     return vec![SelectItem {
                                                         expression: super::render_expr::RenderExpr::ColumnAlias(

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -516,6 +516,49 @@ async fn unwind_in_cte_per_dialect() {
     );
 }
 
+/// Regression for issue #404: with MULTIPLE UNWINDs in one segment wrapped into
+/// a CTE (`UNWIND .. AS x UNWIND .. AS y WITH x, y ...`), every UNWIND variable
+/// must appear in the CTE projection. Previously only the outermost UNWIND alias
+/// was recognized; the others were treated as graph aliases, expanded to nothing,
+/// and dropped from the SELECT — so the outer query referenced an undefined column.
+#[tokio::test]
+async fn multi_unwind_in_cte_projects_all_vars() {
+    let cypher = "UNWIND [1, 2] AS x UNWIND [3, 4] AS y WITH x, y WHERE x < y RETURN x, y";
+
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = with_query_context(
+            QueryContext {
+                dialect,
+                ..QueryContext::default()
+            },
+            async { cypher_to_sql(cypher) },
+        )
+        .await;
+        // Isolate the CTE body's projection list (between `(SELECT` and its `FROM`)
+        // so we don't accidentally match the OUTER SELECT's `x_y.x AS "x"`.
+        let cte_projection = sql
+            .split("(SELECT")
+            .nth(1)
+            .and_then(|s| s.split("FROM").next())
+            .unwrap_or("");
+        // The bug dropped `x` from this projection, leaving only `y AS "y"`.
+        assert!(
+            cte_projection.contains("x AS") && cte_projection.contains("y AS"),
+            "{dialect:?}: CTE projection must include both x and y; got projection:\n{cte_projection}\n--- full SQL ---\n{sql}"
+        );
+        // Both array expansions must be present (guards the #401 path too).
+        let expansions = if dialect == SqlDialect::Databricks {
+            sql.matches("LATERAL VIEW explode(").count()
+        } else {
+            sql.matches("ARRAY JOIN").count()
+        };
+        assert_eq!(
+            expansions, 2,
+            "{dialect:?}: expected 2 array expansions (x and y); got {expansions} in:\n{sql}"
+        );
+    }
+}
+
 /// `RETURN DISTINCT expr ORDER BY expr`: Spark resolves ORDER BY against the
 /// DISTINCT output, so the sort term must reference the projection's backtick
 /// alias, not the underlying `table.col`. ClickHouse keeps `table.col`.


### PR DESCRIPTION
## Summary
Fixes #404. With multiple UNWINDs in one segment wrapped into a CTE, only the outermost UNWIND variable appeared in the CTE projection; the others were silently dropped, so the outer query referenced an undefined column.

```
UNWIND [1,2] AS x UNWIND [3,4] AS y WITH x, y WHERE x < y RETURN x, y
```
Before — CTE body (CH):
```sql
SELECT y AS "y"            -- ❌ x missing
FROM system.one ARRAY JOIN [3,4] AS y ARRAY JOIN [1,2] AS x WHERE x < y
```
After:
```sql
SELECT x AS "x", y AS "y"  -- ✓ both projected
FROM system.one ARRAY JOIN [3,4] AS y ARRAY JOIN [1,2] AS x WHERE x < y
```

## Root cause
`find_unwind_alias` in `build_chained_with_match_cte_plan` returned a **single** alias and never recursed into a nested UNWIND's input. So for `WITH x, y`, only the matched alias took the simple-column path; the others fell into `expand_table_alias_to_select_items` (graph-alias expansion), which returned nothing → dropped. Replaced with `collect_unwind_aliases` (a `HashSet` recursing through nested UNWINDs); the per-item check now tests set membership. The array expansions themselves were already correct (via the #401 path).

## Tests
- New `multi_unwind_in_cte_projects_all_vars` (per-dialect) — isolates the CTE projection so it can't be fooled by the outer SELECT; verified to **fail without the fix**.
- Manually verified: single-UNWIND (regression-safe), 3 UNWINDs, and mixed MATCH+UNWIND (graph alias `u` expanded, unwind alias `part` emitted as column).
- Full lib suite green (1457); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)