### PR TITLE
fix(planner): detect VLP endpoints through UNWIND so they aren't dropped from WITH-CTE projection (#410)

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -5286,6 +5286,11 @@ fn detect_vlp_endpoint_from_plan(plan: &LogicalPlan, alias: &str) -> Option<VlpE
         LogicalPlan::Filter(filter) => detect_vlp_endpoint_from_plan(&filter.input, alias),
         LogicalPlan::Limit(limit) => detect_vlp_endpoint_from_plan(&limit.input, alias),
         LogicalPlan::GraphJoins(gj) => detect_vlp_endpoint_from_plan(&gj.input, alias),
+        // UNWIND wraps the MATCH in a WITH segment (`MATCH ...VLP... UNWIND ... WITH b,n`),
+        // so recurse into its input to find the VLP GraphRel below — otherwise a VLP
+        // endpoint like `b` is missed here, falls through to STEP 3, and is rendered
+        // against a non-existent base alias instead of the VLP CTE's end_* columns. (#410)
+        LogicalPlan::Unwind(u) => detect_vlp_endpoint_from_plan(&u.input, alias),
         LogicalPlan::WithClause(wc) => detect_vlp_endpoint_from_plan(&wc.input, alias),
         LogicalPlan::OrderBy(ob) => detect_vlp_endpoint_from_plan(&ob.input, alias),
         LogicalPlan::Skip(skip) => detect_vlp_endpoint_from_plan(&skip.input, alias),

--- a/src/render_plan/tests/databricks_emit_spike_tests.rs
+++ b/src/render_plan/tests/databricks_emit_spike_tests.rs
@@ -559,6 +559,36 @@ async fn multi_unwind_in_cte_projects_all_vars() {
     }
 }
 
+/// Regression for issue #410: a VLP endpoint (`b`) carried through a WITH segment
+/// alongside an UNWIND must keep its OWN columns in the CTE projection — including
+/// its id. Previously `detect_vlp_endpoint_from_plan` had no `Unwind` arm, so it
+/// stopped at the UNWIND node and never found the VLP GraphRel below; `b` then fell
+/// through to the base-table expansion and was dropped from the CTE projection,
+/// causing the outer `b.id` to silently resolve to the UNWIND column.
+#[tokio::test]
+async fn vlp_endpoint_kept_in_cte_with_unwind() {
+    // setup_test_schema's User node_id is named `id`, so `b.id` exercises the id path.
+    let cypher =
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) UNWIND [1, 2] AS n WITH b, n RETURN b.id, n";
+    let sql = cypher_to_sql(cypher);
+
+    // The CTE body must project b's id as its own VLP column (end_id → p1_b_id),
+    // not drop it. Before the fix the projection had only `n`.
+    assert!(
+        sql.contains("p1_b_id"),
+        "VLP endpoint b's id must be projected in the CTE (p1_b_id); got:\n{sql}"
+    );
+    assert!(
+        sql.contains("end_id AS \"p1_b_id\""),
+        "b's id must come from the VLP CTE's end_id column; got:\n{sql}"
+    );
+    // The outer `b.id` must resolve to b's own column, never to the UNWIND column `n`.
+    assert!(
+        sql.contains("p1_b_id AS \"b.id\""),
+        "outer b.id must map to b's id column, not the UNWIND column; got:\n{sql}"
+    );
+}
+
 /// Regression for issue #405: a bidirectional (undirected) variable-length path
 /// combined with an UNWIND in the same WITH segment produces a *structured* CTE
 /// body with an inline UNION (the two VLP direction branches). The plan-level


### PR DESCRIPTION
## Summary
Fixes #410. A variable-length-path endpoint (`b`) carried through a WITH segment that also contains an UNWIND was dropped from the CTE projection, and the outer `b.<prop>` silently resolved to the UNWIND column.

```
MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) UNWIND [1,2] AS n WITH b, n RETURN b.id, n
```
Before — CTE body dropped `b` entirely (`SELECT n AS "n" ...`), outer `b.id` → `b_n.n`.
After (LDBC, end-to-end):
```sql
with_b_n_cte_0 AS (SELECT end_firstName AS "p1_b_firstName", end_id AS "p1_b_id", n AS "n"
                   FROM vlp_a_b AS t ARRAY JOIN [1,2] AS n)
SELECT b_n.p1_b_id AS "b.id", b_n.p1_b_firstName AS "b.firstName", b_n.n AS "n" FROM ...
```

## Root cause
`detect_vlp_endpoint_from_plan` had **no `LogicalPlan::Unwind` arm**. Walking the WITH segment (`Unwind → … → GraphRel(VLP)`) it hit the Unwind node, fell to `_ => None`, and never reached the VLP `GraphRel`. So `b` wasn't recognized as a VLP endpoint, fell through to base-table expansion, was rendered against a non-existent base alias (`b.full_name`), and dropped. Fix: recurse through `Unwind` into its input.

## Verification
- End-to-end on **LDBC** (`b.id`, `b.firstName`) and **social** (`b.name`, `b.user_id`): CTE projects b's `end_*` columns; outer resolves to b's own columns.
- New `vlp_endpoint_kept_in_cte_with_unwind` test — verified to **fail without the fix**.
- Full lib suite green (1459); integration green (283); fmt + clippy clean.

## Known residual (separate, filed as #411)
A **generic `.id`** reference when the schema's node_id property is *renamed* (e.g. `user_id`) is still pruned from explicit-projection WITH-CTE bodies — affects non-VLP too, lives in the forward-mapping. Distinct root cause; out of scope here. The benchmark schema uses `user_id`, so `b.id` specifically remains subject to #411; `b.user_id`/`b.name` and all LDBC properties are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)