### PR TITLE
fix(planner): resolve generic .id through WITH-CTE when node_id is renamed (#411)

### DIFF
--- a/src/query_planner/analyzer/property_requirements_analyzer.rs
+++ b/src/query_planner/analyzer/property_requirements_analyzer.rs
@@ -350,6 +350,24 @@ impl PropertyRequirementsAnalyzer {
         }
     }
 
+    /// Resolve the Cypher property name that maps to an alias's node_id column.
+    ///
+    /// Returns the property whose schema mapping equals the node's `node_id` column —
+    /// e.g. `"user_id"` for a `User` node whose `node_id` is `user_id`, or `"id"` when
+    /// the schema literally names the id property `id`. Returns `None` if the alias has
+    /// no resolvable label/node schema (e.g. it's a relationship or a CTE projection).
+    fn node_id_property_name(plan_ctx: &PlanCtx, alias: &str) -> Option<String> {
+        let label = plan_ctx.get_table_ctx(alias).ok()?.get_label_opt()?;
+        let node_schema = plan_ctx.schema().node_schema(&label).ok()?;
+        let id_col = node_schema.node_id.column_or_error().ok()?;
+        // Find the Cypher property whose column mapping equals the node_id column.
+        node_schema
+            .property_mappings
+            .iter()
+            .find(|(_, mapped)| mapped.raw() == id_col)
+            .map(|(prop, _)| prop.clone())
+    }
+
     /// Extract property requirements from an expression
     fn analyze_expression(expr: &LogicalExpr, requirements: &mut PropertyRequirements) {
         match expr {
@@ -514,6 +532,41 @@ impl AnalyzerPass for PropertyRequirementsAnalyzer {
                         );
                         requirements.require_all(end);
                     }
+                }
+            }
+        }
+
+        // Post-process: normalize generic `.id` to the node's real node_id property.
+        //
+        // Cypher's `.id` is a synonym for node identity, but property pruning and CTE
+        // column naming key on the Cypher property name. When a schema renames its
+        // node_id (e.g. `User.user_id` instead of a literal `id` property), a generic
+        // `b.id` registers the literal `"id"`, which never matches the schema's
+        // `"user_id"` — so the id gets pruned out of WITH-CTE projections and the outer
+        // post-WITH reference dangles. For each alias that requires generic `"id"`, also
+        // require the node's actual node_id Cypher property so pruning keeps it by name.
+        // (Outer resolution of the generic `.id` is handled in variable_scope::resolve.)
+        // See issue #411.
+        let id_requiring_aliases: Vec<String> = requirements
+            .aliases()
+            .filter(|a| {
+                !requirements.requires_all(a)
+                    && requirements
+                        .get_requirements(a)
+                        .map(|props| props.contains("id"))
+                        .unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+        for alias in &id_requiring_aliases {
+            if let Some(id_prop) = Self::node_id_property_name(plan_ctx, alias) {
+                if id_prop != "id" {
+                    log::info!(
+                        "📋 Normalizing generic '.id' for alias '{}' → also require node_id property '{}'",
+                        alias,
+                        id_prop
+                    );
+                    requirements.require_property(alias, &id_prop);
                 }
             }
         }

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -5700,13 +5700,16 @@ pub(crate) fn expand_table_alias_to_select_items(
                 // (these are the VLP CTE column names, not raw DB column names)
                 // So we should NOT prefix them again - use them directly
                 if let Ok(id_col) = plan.find_id_column_for_alias(alias) {
-                    // 🔧 FIX: Don't double-prefix VLP ID columns
-                    // If the id_col already starts with the prefix (start_id, end_id), use it directly
-                    // Otherwise, apply the prefix (e.g., user_id -> end_user_id)
+                    // 🔧 FIX: Don't double-prefix VLP ID columns.
+                    // The VLP recursive CTE ALWAYS names the identity column `start_id`/`end_id`
+                    // (generic `_id` suffix), regardless of the schema's node_id property name —
+                    // see `add_property_selections` in cte_manager which skips `prop.alias == "id"`
+                    // and emits the id explicitly as `start_id`/`end_id`. So a renamed node_id
+                    // (e.g. `user_id`) must still reference `end_id`, NOT `end_user_id` (issue #411).
                     let vlp_col_name = if id_col.starts_with(col_prefix) {
                         id_col.clone()
                     } else {
-                        format!("{}_{}", col_prefix, id_col)
+                        format!("{}_id", col_prefix)
                     };
                     // 🔧 CRITICAL FIX (Jan 23, 2026): Don't use explicit table alias for VLP columns during WITH clause expansion
                     // During WITH clause rendering, the FROM alias isn't final yet, so we generate columns without
@@ -11902,14 +11905,23 @@ pub(crate) fn build_chained_with_match_cte_plan(
                     .collect();
 
                 // Get labels from current plan tree — try renamed alias first,
-                // then fall back to original alias (for renamed variables)
-                let labels = crate::query_planner::logical_expr::expression_rewriter::find_label_for_alias_in_plan(
-                    &current_plan, alias,
-                ).or_else(|| {
-                    crate::query_planner::logical_expr::expression_rewriter::find_label_for_alias_in_plan(
-                        &current_plan, lookup_alias,
-                    )
-                }).map(|l| vec![l]).unwrap_or_default();
+                // then fall back to original alias (for renamed variables).
+                // After the WITH→CTE rewrite, `current_plan` may no longer expose the
+                // source node (e.g. a graph-rel MATCH gets restructured), so also fall
+                // back to the WITH bodies (`with_plans`), which still contain the source
+                // GraphNode and its label. Missing labels break generic `.id` resolution
+                // for renamed node_ids. (issue #411)
+                use crate::query_planner::logical_expr::expression_rewriter::find_label_for_alias_in_plan;
+                let labels = find_label_for_alias_in_plan(&current_plan, alias)
+                    .or_else(|| find_label_for_alias_in_plan(&current_plan, lookup_alias))
+                    .or_else(|| {
+                        with_plans.iter().find_map(|p| {
+                            find_label_for_alias_in_plan(p, alias)
+                                .or_else(|| find_label_for_alias_in_plan(p, lookup_alias))
+                        })
+                    })
+                    .map(|l| vec![l])
+                    .unwrap_or_default();
 
                 scope_cte_variables.insert(
                     alias.clone(),

--- a/src/render_plan/tests/issue_411_generic_id_tests.rs
+++ b/src/render_plan/tests/issue_411_generic_id_tests.rs
@@ -1,0 +1,351 @@
+//! Regression tests for issue #411 — generic `.id` dropped from / mis-resolved in
+//! WITH→CTE projection when a schema's node_id property is **renamed**.
+//!
+//! Cypher's `.id` is a synonym for node identity, but property pruning, CTE column
+//! naming, and post-WITH resolution all key on the Cypher property name. When the
+//! `User` node's id is the property `user_id` (column `user_id`) — with no property
+//! literally named `id` — a generic `b.id` reference used to be:
+//!   1. pruned out of the WITH-CTE projection (the literal `"id"` requirement never
+//!      matched the schema's `"user_id"` property), and
+//!   2. mis-resolved in the outer SELECT to a raw DB column the CTE never exposed
+//!      (`b.user_id`), or — for graph-rel shapes whose CTE variable lost its label —
+//!      to an unrelated node's id column (`b.post_id`, a Post id!).
+//!
+//! The fix spans three chokepoints:
+//!   (A) `PropertyRequirementsAnalyzer`: a generic `"id"` requirement also requires the
+//!       node's real node_id Cypher property, so pruning keeps the id by name.
+//!   (B) `variable_scope::resolve`: a missed generic `.id` lookup retries with the
+//!       node's actual node_id property (both the by-alias and by-cte-name branches).
+//!   (C) `build_chained_with_match_cte_plan`: the WITH CTE variable's labels are
+//!       recovered from the WITH bodies when the rewritten plan no longer exposes the
+//!       source node — without labels, (B) can't find the node_id property.
+//! Plus a VLP-specific fix: the VLP CTE always names its identity column `start_id`/
+//! `end_id`, so a renamed node_id must reference `end_id`, not `end_user_id`.
+
+use crate::{
+    clickhouse_query_generator,
+    graph_catalog::config::Identifier,
+    graph_catalog::graph_schema::{GraphSchema, NodeIdSchema, NodeSchema, RelationshipSchema},
+    graph_catalog::schema_types::SchemaType,
+    open_cypher_parser,
+    query_planner::logical_plan::plan_builder::build_logical_plan,
+    render_plan::plan_builder::RenderPlanBuilder,
+};
+use std::collections::HashMap;
+
+fn cypher_to_sql(cypher: &str) -> String {
+    cypher_to_sql_with_schema(cypher, &renamed_id_schema())
+}
+
+fn cypher_to_sql_with_schema(cypher: &str, graph_schema: &GraphSchema) -> String {
+    let ast = open_cypher_parser::parse_query(cypher).expect("Failed to parse Cypher query");
+
+    let (logical_plan, mut plan_ctx) = build_logical_plan(&ast, graph_schema, None, None, None)
+        .expect("Failed to build logical plan");
+
+    use crate::query_planner::analyzer;
+    use crate::query_planner::optimizer;
+
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+
+    let render_plan = logical_plan
+        .to_render_plan(graph_schema)
+        .expect("Failed to build render plan");
+
+    clickhouse_query_generator::generate_sql(render_plan, 100)
+}
+
+fn prop_col(name: &str) -> crate::graph_catalog::expression_parser::PropertyValue {
+    crate::graph_catalog::expression_parser::PropertyValue::Column(name.to_string())
+}
+
+/// Schema where `User`'s node_id is the **renamed** property `user_id` (column
+/// `user_id`) — there is no property literally named `id`. A `Post` node (node_id
+/// `post_id`) is present to catch label-confusion regressions.
+fn renamed_id_schema() -> GraphSchema {
+    schema_with_user_node_id("user_id")
+}
+
+/// Contrast schema where `User`'s node_id is literally `id`. The same queries must
+/// keep emitting the historical (already-correct) SQL.
+fn id_named_schema() -> GraphSchema {
+    schema_with_user_node_id("id")
+}
+
+fn schema_with_user_node_id(id_prop: &str) -> GraphSchema {
+    let mut nodes = HashMap::new();
+    let mut relationships = HashMap::new();
+
+    let user_node = NodeSchema {
+        database: "test_db".to_string(),
+        table_name: "users".to_string(),
+        column_names: vec![
+            id_prop.to_string(),
+            "full_name".to_string(),
+            "age".to_string(),
+        ],
+        primary_keys: id_prop.to_string(),
+        node_id: NodeIdSchema::single(id_prop.to_string(), SchemaType::Integer),
+        property_mappings: [
+            (id_prop.to_string(), prop_col(id_prop)),
+            ("name".to_string(), prop_col("full_name")),
+            ("age".to_string(), prop_col("age")),
+        ]
+        .into_iter()
+        .collect(),
+        view_parameters: None,
+        engine: None,
+        use_final: None,
+        filter: None,
+        is_denormalized: false,
+        from_properties: None,
+        to_properties: None,
+        denormalized_source_table: None,
+        label_column: None,
+        label_value: None,
+        node_id_types: None,
+        source: None,
+        property_types: HashMap::new(),
+        id_generation: None,
+    };
+    nodes.insert("User".to_string(), user_node);
+
+    let post_node = NodeSchema {
+        database: "test_db".to_string(),
+        table_name: "posts".to_string(),
+        column_names: vec!["post_id".to_string(), "title".to_string()],
+        primary_keys: "post_id".to_string(),
+        node_id: NodeIdSchema::single("post_id".to_string(), SchemaType::Integer),
+        property_mappings: [
+            ("post_id".to_string(), prop_col("post_id")),
+            ("title".to_string(), prop_col("title")),
+        ]
+        .into_iter()
+        .collect(),
+        view_parameters: None,
+        engine: None,
+        use_final: None,
+        filter: None,
+        is_denormalized: false,
+        from_properties: None,
+        to_properties: None,
+        denormalized_source_table: None,
+        label_column: None,
+        label_value: None,
+        node_id_types: None,
+        source: None,
+        property_types: HashMap::new(),
+        id_generation: None,
+    };
+    nodes.insert("Post".to_string(), post_node);
+
+    let follows_rel = RelationshipSchema {
+        database: "test_db".to_string(),
+        table_name: "follows".to_string(),
+        column_names: vec!["from_id".to_string(), "to_id".to_string()],
+        from_node: "User".to_string(),
+        to_node: "User".to_string(),
+        from_node_table: "users".to_string(),
+        to_node_table: "users".to_string(),
+        from_id: Identifier::from("from_id"),
+        to_id: Identifier::from("to_id"),
+        from_node_id_dtype: SchemaType::Integer,
+        to_node_id_dtype: SchemaType::Integer,
+        property_mappings: HashMap::new(),
+        view_parameters: None,
+        engine: None,
+        use_final: None,
+        filter: None,
+        edge_id: None,
+        type_column: None,
+        from_label_column: None,
+        to_label_column: None,
+        from_node_properties: None,
+        to_node_properties: None,
+        from_label_values: None,
+        to_label_values: None,
+        is_fk_edge: false,
+        constraints: None,
+        edge_id_types: None,
+        source: None,
+        property_types: HashMap::new(),
+    };
+    relationships.insert("FOLLOWS::User::User".to_string(), follows_rel);
+
+    GraphSchema::build(1, "test_db".to_string(), nodes, relationships)
+}
+
+/// Every CTE column the outer SELECT references must be defined by the CTE body.
+/// Catches the core #411 failure: outer references `b.<col>` for a `<col>` the CTE
+/// never projected, producing invalid SQL.
+fn assert_outer_refs_are_defined(sql: &str) {
+    // Collect CTE column aliases (`... AS "p1_b_user_id"`). CTE body aliases use the
+    // p{N}_alias_prop form; the final SELECT uses dotted display aliases (`AS "b.id"`).
+    let defined: std::collections::HashSet<String> = sql
+        .match_indices("AS \"")
+        .filter_map(|(i, _)| {
+            let rest = &sql[i + 4..];
+            let end = rest.find('"')?;
+            let alias = &rest[..end];
+            // Only CTE-style aliases (no dot) are columns later referenced as b.<alias>.
+            if alias.contains('.') {
+                None
+            } else {
+                Some(alias.to_string())
+            }
+        })
+        .collect();
+
+    // Any `b.p{N}_...` reference in the final SELECT must be a defined CTE column.
+    for (i, _) in sql.match_indices("b.p") {
+        let rest = &sql[i + 2..];
+        let end = rest
+            .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .unwrap_or(rest.len());
+        let col = &rest[..end];
+        assert!(
+            defined.contains(col),
+            "outer references CTE column `b.{col}` that the CTE never defines; got:\n{sql}"
+        );
+    }
+}
+
+// ===========================================================================
+// Repro A — non-VLP simple `WITH b`
+// ===========================================================================
+
+#[test]
+fn repro_a_non_vlp_simple_with_generic_id() {
+    let sql = cypher_to_sql("MATCH (b:User) WITH b WHERE b.age > 0 RETURN b.id, b.name");
+    // CTE must project the id under its real node_id property name.
+    assert!(
+        sql.contains("AS \"p1_b_user_id\""),
+        "CTE must project the renamed node_id as p1_b_user_id; got:\n{sql}"
+    );
+    // Outer must reference the CTE column, preserving the `b.id` display alias.
+    assert!(
+        sql.contains("p1_b_user_id AS \"b.id\""),
+        "outer must map generic .id to the CTE id column; got:\n{sql}"
+    );
+    // Must NOT reach past the CTE to a raw base column.
+    assert!(
+        !sql.contains("b.user_id AS \"b.id\""),
+        "outer must not reference the raw base column through the CTE; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+#[test]
+fn repro_a_explicit_user_id_still_works() {
+    let sql = cypher_to_sql("MATCH (b:User) WITH b RETURN b.user_id, b.name");
+    assert!(
+        sql.contains("p1_b_user_id AS \"b.user_id\""),
+        "explicit b.user_id must resolve to the CTE id column; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+// ===========================================================================
+// Repro B — graph-rel `WITH b` (also exercised the b.post_id label-confusion)
+// ===========================================================================
+
+#[test]
+fn repro_b_graph_rel_with_generic_id() {
+    let sql = cypher_to_sql(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WITH b WHERE b.age > 0 RETURN b.id, b.name",
+    );
+    assert!(
+        sql.contains("AS \"p1_b_user_id\""),
+        "CTE must project the renamed node_id; got:\n{sql}"
+    );
+    assert!(
+        sql.contains("p1_b_user_id AS \"b.id\""),
+        "outer must map generic .id to the CTE id column; got:\n{sql}"
+    );
+    // The label-confusion regression: b is a User, never a Post.
+    assert!(
+        !sql.contains("post_id"),
+        "b must not be mis-resolved to a Post id; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+// ===========================================================================
+// Repro C — VLP endpoint
+// ===========================================================================
+
+#[test]
+fn repro_c_vlp_endpoint_explicit_user_id() {
+    let sql = cypher_to_sql("MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WITH b RETURN b.user_id");
+    // The VLP CTE always names the identity `end_id` — never `end_user_id`.
+    assert!(
+        sql.contains("end_id AS \"p1_b_user_id\""),
+        "VLP CTE must reference end_id (not end_user_id) for the renamed node_id; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_user_id"),
+        "VLP CTE must not prefix the renamed node_id property; got:\n{sql}"
+    );
+    assert!(
+        sql.contains("p1_b_user_id AS \"b.user_id\""),
+        "outer must reference the CTE id column; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+#[test]
+fn repro_c2_vlp_endpoint_generic_id() {
+    let sql = cypher_to_sql("MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WITH b RETURN b.id");
+    assert!(
+        sql.contains("end_id AS \"p1_b_user_id\""),
+        "VLP CTE must reference end_id for the renamed node_id; got:\n{sql}"
+    );
+    assert!(
+        sql.contains("p1_b_user_id AS \"b.id\""),
+        "outer must map generic .id to the CTE id column; got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("post_id"),
+        "VLP endpoint b must not be mis-resolved to a Post id; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+// ===========================================================================
+// Contrast — id-named schema must keep its historical (correct) output
+// ===========================================================================
+
+#[test]
+fn contrast_id_named_non_vlp_unchanged() {
+    let sql = cypher_to_sql_with_schema(
+        "MATCH (b:User) WITH b WHERE b.age > 0 RETURN b.id, b.name",
+        &id_named_schema(),
+    );
+    assert!(
+        sql.contains("p1_b_id AS \"b.id\""),
+        "id-named schema must keep p1_b_id mapping; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}
+
+#[test]
+fn contrast_id_named_vlp_unchanged() {
+    let sql = cypher_to_sql_with_schema(
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WITH b RETURN b.id",
+        &id_named_schema(),
+    );
+    assert!(
+        sql.contains("end_id AS \"p1_b_id\""),
+        "id-named VLP must keep end_id → p1_b_id; got:\n{sql}"
+    );
+    assert!(
+        sql.contains("p1_b_id AS \"b.id\""),
+        "id-named VLP outer must map .id to p1_b_id; got:\n{sql}"
+    );
+    assert_outer_refs_are_defined(&sql);
+}

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -1,5 +1,6 @@
 mod databricks_emit_spike_tests;
 mod denormalized_property_tests;
+mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;
 mod polymorphic_edge_tests;
 mod variable_length_tests;

--- a/src/render_plan/variable_scope.rs
+++ b/src/render_plan/variable_scope.rs
@@ -145,6 +145,14 @@ impl<'a> VariableScope<'a> {
                     column: cypher_property.to_string(),
                 };
             }
+            // Generic `.id` synonym: Cypher's `.id` is the node identity. When a schema
+            // renames its node_id (e.g. `User.user_id`), the CTE projected the identity
+            // column under the real property name (`user_id`), so a literal `.id` lookup
+            // misses the mapping. Retry using the node's actual node_id property. (issue #411)
+            if let Some(resolved) = self.resolve_generic_id_in_cte(alias, cypher_property, cte_info)
+            {
+                return resolved;
+            }
             log::debug!(
                 "VariableScope: {}.{} is CTE-scoped but property not found in mapping",
                 alias,
@@ -177,6 +185,16 @@ impl<'a> VariableScope<'a> {
                     column: cte_col.clone(),
                 };
             }
+            // Generic `.id` synonym for a renamed node_id — see the by-alias branch
+            // above. Retry with the node's actual id property. (issue #411)
+            // NOTE: here `alias` is the CTE *name* (e.g. JOIN-condition references), which
+            // won't resolve via `find_label_for_alias_in_plan`, so this relies on
+            // `cte_info.labels` being populated. When it isn't, generic `.id` stays
+            // Unresolved — matching pre-#411 behavior for this path (no regression).
+            if let Some(resolved) = self.resolve_generic_id_in_cte(alias, cypher_property, cte_info)
+            {
+                return resolved;
+            }
         }
         if found_cte {
             log::debug!(
@@ -202,6 +220,73 @@ impl<'a> VariableScope<'a> {
         }
 
         ResolvedProperty::Unresolved
+    }
+
+    /// Resolve a generic `.id` reference against a CTE variable whose node_id property
+    /// is renamed (e.g. `user_id`). Returns the CTE column the identity was projected
+    /// under, or `None` when `cypher_property` isn't `"id"`, the node_id is literally
+    /// `"id"`, or the CTE doesn't expose the id. Shared by the by-alias and by-cte-name
+    /// resolution branches. (issue #411)
+    fn resolve_generic_id_in_cte(
+        &self,
+        alias: &str,
+        cypher_property: &str,
+        cte_info: &CteVariableInfo,
+    ) -> Option<ResolvedProperty> {
+        if cypher_property != "id" {
+            return None;
+        }
+        let id_prop = self.node_id_property_for_alias(alias, cte_info)?;
+        if id_prop == "id" {
+            return None;
+        }
+        let cte_col = cte_info.property_mapping.get(&id_prop)?;
+        let from_alias = cte_info.effective_from_alias();
+        log::debug!(
+            "VariableScope: {}.id → CTE column {}.{} (via renamed node_id '{}')",
+            alias,
+            from_alias,
+            cte_col,
+            id_prop
+        );
+        Some(ResolvedProperty::CteColumn {
+            cte_name: from_alias,
+            column: cte_col.clone(),
+        })
+    }
+
+    /// Resolve the Cypher property name that maps to an alias's node_id column.
+    ///
+    /// Prefers the labels recorded on the CTE variable (preserved across the WITH
+    /// barrier); falls back to resolving the alias's label from the plan tree. Returns
+    /// the property whose schema mapping equals the node's `node_id` column — e.g.
+    /// `"user_id"` for a renamed node_id, or `"id"` when the schema names it literally.
+    fn node_id_property_for_alias(
+        &self,
+        alias: &str,
+        cte_info: &CteVariableInfo,
+    ) -> Option<String> {
+        let labels: Vec<String> = if !cte_info.labels.is_empty() {
+            cte_info.labels.clone()
+        } else {
+            find_label_for_alias_in_plan(self.plan, alias)
+                .into_iter()
+                .collect()
+        };
+        for label in labels {
+            if let Ok(node_schema) = self.schema.node_schema(&label) {
+                if let Ok(id_col) = node_schema.node_id.column_or_error() {
+                    if let Some((prop, _)) = node_schema
+                        .property_mappings
+                        .iter()
+                        .find(|(_, mapped)| mapped.raw() == id_col)
+                    {
+                        return Some(prop.clone());
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// Check if an alias is a CTE-scoped variable.


### PR DESCRIPTION
Fixes #411.

## Problem

Cypher's generic `.id` is a synonym for node identity, but property pruning, CTE column naming, and post-WITH resolution all key on the **Cypher property name**. When a schema **renames** its node_id (e.g. the `User` node's id is the property `user_id`/column `user_id`, with no property literally named `id`), a generic `b.id` across a `WITH` barrier was:

1. **pruned out** of the WITH-CTE projection (the literal `"id"` requirement never matched the schema's `"user_id"`), and
2. **mis-resolved** in the outer SELECT to a raw DB column the CTE never exposed (`b.user_id`) — or, for graph-rel shapes whose CTE variable lost its label, to an unrelated node's id column (`b.post_id`, a Post id!).

Result: invalid SQL (or silently wrong column).

## Fix

Coordinated across the divergent expansion/resolution paths:

- **`PropertyRequirementsAnalyzer`** — a generic `"id"` requirement also requires the node's real node_id Cypher property, so requirement-driven pruning keeps the id column by its real name.
- **`variable_scope::resolve`** — a missed generic `.id` lookup retries with the node's actual node_id property (both the by-alias and by-cte-name branches), so the outer SELECT references the CTE id column and preserves the `b.id` display alias.
- **`build_chained_with_match_cte_plan`** — recover the CTE variable's labels from the WITH bodies when the rewritten plan no longer exposes the source node. Without labels the resolver above can't find the node_id property; this also fixes the entangled `b.post_id` label-confusion for graph-rel WITH.
- **VLP endpoint** — the recursive VLP CTE always names its identity column `start_id`/`end_id`; a renamed node_id must reference `end_id`, not `end_user_id`.

`id`-named schemas (e.g. LDBC) and explicit `b.user_id` references emit **unchanged** SQL.

## Tests

New regression tests in `src/render_plan/tests/issue_411_generic_id_tests.rs` cover non-VLP simple, graph-rel, and VLP endpoint shapes on both a renamed-node_id schema and an id-named schema, with a helper that asserts every CTE column the outer SELECT references is actually defined by the CTE.

## Validation

- `cargo test -p clickgraph --lib`: 1466 passed (1459 baseline + 7 new)
- Full `pytest tests/integration/` (non-bolt): 3461 passed, 0 failed
- `cargo fmt` / `cargo clippy --all-targets`: clean
- Adversarial subagent review: 0 must-fix findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)