### PR TITLE
fix(bolt): parse RUN/BEGIN extra metadata so database switching works

### DIFF
--- a/src/packstream/de.rs
+++ b/src/packstream/de.rs
@@ -178,12 +178,19 @@ impl<'de> Deserializer<'de> {
         }
 
         match v {
-            Visitation::SeqAsTuple(2) => {
-                return if self.bytes[0] == 0x92 {
+            // Bolt message struct fields arrive as `n` consecutive top-level
+            // items with no surrounding list marker. Honor an explicit tiny-list
+            // marker when present, otherwise read `n` consecutive items. Arity 3
+            // is required for the RUN message's optional `extra` field (which
+            // carries the selected database, tenant, role, …); previously only
+            // arity 2 was handled and the 3rd field was silently dropped.
+            Visitation::SeqAsTuple(n @ (2 | 3)) => {
+                let tiny_list_marker = 0x90 | (n as u8);
+                return if self.bytes[0] == tiny_list_marker {
                     self.bytes.advance(1);
-                    Self::parse_list(v, 2, self.bytes, visitor)
+                    Self::parse_list(v, n, self.bytes, visitor)
                 } else {
-                    visitor.visit_seq(ItemsParser::new(2, self.bytes))
+                    visitor.visit_seq(ItemsParser::new(n, self.bytes))
                 };
             }
             Visitation::RawBytes => {

--- a/src/packstream/mod.rs
+++ b/src/packstream/mod.rs
@@ -552,6 +552,37 @@ mod tests {
         roundtrip(&input, (42, "1337".to_owned()))
     }
 
+    // Bolt message struct fields (RUN, BEGIN, …) arrive as consecutive top-level
+    // values with NO surrounding list marker. These two tests lock that the
+    // deserializer reads such bare fields as a tuple for both arity 2 (query,
+    // parameters) and arity 3 (query, parameters, extra). The arity-3 case is a
+    // regression guard: the RUN `extra` map carries the selected database via
+    // `db`, and it was previously dropped, pinning every Bolt connection to the
+    // default schema.
+    #[test]
+    fn tuple2_bare_struct_fields() {
+        let input = bolt().tiny_string("RETURN 1").tiny_map(0).build();
+        let (query, params): (String, BTreeMap<String, String>) = from_bytes(input).unwrap();
+        assert_eq!(query, "RETURN 1");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn tuple3_bare_struct_fields() {
+        let input = bolt()
+            .tiny_string("RETURN n") // field 0: query
+            .tiny_map(0) // field 1: parameters {}
+            .tiny_map(1) // field 2: extra { "db": "zeek_dns" }
+            .tiny_string("db")
+            .tiny_string("zeek_dns")
+            .build();
+        let (query, params, extra): (String, BTreeMap<String, String>, BTreeMap<String, String>) =
+            from_bytes(input).unwrap();
+        assert_eq!(query, "RETURN n");
+        assert!(params.is_empty());
+        assert_eq!(extra.get("db").map(String::as_str), Some("zeek_dns"));
+    }
+
     #[test_case(&[0xA0], BTreeMap::new(); "empty")]
     #[test_case(&[0xA1, 0x83, 0x6F, 0x6E, 0x65, 0x2A], [("one".to_owned(), 42)].into_iter().collect(); "tiny")]
     #[test_case(&[0xD8, 0x1A, 0x81, 0x41, 0x01, 0x81, 0x42, 0x02, 0x81, 0x43, 0x03, 0x81, 0x44, 0x04, 0x81, 0x45, 0x05, 0x81, 0x46, 0x06, 0x81, 0x47, 0x07, 0x81, 0x48, 0x08, 0x81, 0x49, 0x09, 0x81, 0x4A, 0x0A, 0x81, 0x4B, 0x0B, 0x81, 0x4C, 0x0C, 0x81, 0x4D, 0x0D, 0x81, 0x4E, 0x0E, 0x81, 0x4F, 0x0F, 0x81, 0x50, 0x10, 0x81, 0x51, 0x11, 0x81, 0x52, 0x12, 0x81, 0x53, 0x13, 0x81, 0x54, 0x14, 0x81, 0x55, 0x15, 0x81, 0x56, 0x16, 0x81, 0x57, 0x17, 0x81, 0x58, 0x18, 0x81, 0x59, 0x19, 0x81, 0x5A, 0x1A], ('A'..='Z').map(|c| (c.to_string(), ((c as u32) - ('@' as u32)) as i64)).collect(); "map_8")]

--- a/src/server/bolt_protocol/connection.rs
+++ b/src/server/bolt_protocol/connection.rs
@@ -353,22 +353,38 @@ where
                 // Parse all fields from the remaining bytes
                 let field_bytes = Bytes::from(cursor[2..].to_vec());
 
-                // Parse as tuple: (String, HashMap<String, Value>, Option<HashMap<String, Value>>)
-                let fields: (String, HashMap<String, serde_json::Value>) =
-                    packstream::from_bytes(field_bytes.clone()).map_err(|e| {
+                // RUN is `query, parameters, extra` in Bolt 4.0+. The optional
+                // 3rd `extra` map carries the selected database (`db`), tenant,
+                // role, etc. — it MUST be parsed so database switching via the
+                // Bolt protocol (Neo4j Browser's database dropdown, driver
+                // `database=`) works. Parsing only the first two fields silently
+                // dropped `db`, pinning every connection to the default schema.
+                let values = if field_count == 3 {
+                    let fields: (
+                        String,
+                        HashMap<String, serde_json::Value>,
+                        HashMap<String, serde_json::Value>,
+                    ) = packstream::from_bytes(field_bytes).map_err(|e| {
                         BoltError::invalid_message(format!("Failed to parse RUN fields: {:?}", e))
                     })?;
-
-                // Convert to BoltMessage values
-                let values = vec![
-                    BoltValue::Json(Value::String(fields.0)), // query
-                    BoltValue::Json(Value::Object(serde_json::Map::from_iter(
-                        fields.1.into_iter(),
-                    ))), // parameters
-                ];
-
-                // If field_count == 3, we'd parse the optional extra map here
-                // For now, RUN with 2 fields is most common
+                    vec![
+                        BoltValue::Json(Value::String(fields.0)), // query
+                        BoltValue::Json(Value::Object(serde_json::Map::from_iter(fields.1))), // parameters
+                        BoltValue::Json(Value::Object(serde_json::Map::from_iter(fields.2))), // extra (db/tenant/role)
+                    ]
+                } else {
+                    let fields: (String, HashMap<String, serde_json::Value>) =
+                        packstream::from_bytes(field_bytes).map_err(|e| {
+                            BoltError::invalid_message(format!(
+                                "Failed to parse RUN fields: {:?}",
+                                e
+                            ))
+                        })?;
+                    vec![
+                        BoltValue::Json(Value::String(fields.0)), // query
+                        BoltValue::Json(Value::Object(serde_json::Map::from_iter(fields.1))), // parameters
+                    ]
+                };
 
                 Ok(BoltMessage::new(signature, values))
             }
@@ -395,6 +411,32 @@ where
                         metadata,
                     )))],
                 ))
+            }
+
+            signatures::BEGIN => {
+                // BEGIN has 1 field: extra metadata map, which may carry the
+                // selected database (`db`) for an explicit transaction (the
+                // Neo4j driver puts `database=` here for tx functions). Parse it
+                // so extract_begin_database() can switch schemas; previously this
+                // fell through to the empty-field default arm and `db` was lost.
+                if field_count >= 1 {
+                    let field_bytes = Bytes::from(cursor[2..].to_vec());
+                    let metadata: HashMap<String, Value> = packstream::from_bytes(field_bytes)
+                        .map_err(|e| {
+                            BoltError::invalid_message(format!(
+                                "Failed to parse BEGIN metadata: {}",
+                                e
+                            ))
+                        })?;
+                    Ok(BoltMessage::new(
+                        signature,
+                        vec![BoltValue::Json(Value::Object(serde_json::Map::from_iter(
+                            metadata,
+                        )))],
+                    ))
+                } else {
+                    Ok(BoltMessage::new(signature, vec![]))
+                }
             }
 
             _ => {


### PR DESCRIPTION
## Summary

Neo4j Browser's database dropdown (and any driver `database=`) selects a database by sending it in the Bolt `db` field of the RUN `extra` map (autocommit) or the BEGIN `extra` map (transactions). ClickGraph's wire decoder **dropped both**, so database switching over Bolt never worked — only an inline `USE <schema>` in the query text switched. This also made `db.schema.visualization()` resolve to the wrong (`default`) schema, so Neo4j Browser built its per-label caption/colour styling for the wrong graph.

## Root cause

- `connection.rs` decoded RUN as a 2-tuple `(query, parameters)`, discarding the optional 3rd `extra` field — the code even commented *"If field_count == 3, we'd parse the optional extra map here / For now, RUN with 2 fields is most common."*
- BEGIN fell through to the default arm that returns an empty field list.

So `extract_run_database()` / `extract_begin_database()` could never see `db`.

## Fix

- `connection.rs` — parse RUN's 3rd `extra` field when present, and parse BEGIN's `extra` metadata map.
- `packstream/de.rs` — the deserializer special-cased reading bare consecutive struct fields only for arity 2 (`SeqAsTuple(2)`); arity 3 fell through to list-parsing and failed. Generalized to arity 2 **and** 3.

## Verification

Live against a multi-schema server, `session(database=X)` (autocommit + transaction) now returns X's own labels, and `db.schema.visualization()` follows the selected database:

```
social_integration → User/Post     (was returning Airport!)
ontime_flights     → Airport
zeek_dns           → Domain/IP/ResolvedIP
```

Regression tests added (bare 2- and 3-field struct decode); full lib suite (1468) and bolt suite (92) green; graph-notebook compat suite stays 24/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)