### PR TITLE
feat(bolt): Neo4j-compat resolves schema-undeclared properties to NULL

### DIFF
--- a/src/graph_catalog/expression_parser.rs
+++ b/src/graph_catalog/expression_parser.rs
@@ -14,11 +14,11 @@
 /// - Lambdas: `arrayMap(x -> expr, arr)`
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_until},
+    bytes::complete::{tag, tag_no_case, take_until},
     character::complete::{alphanumeric1, char, digit1, multispace0, one_of},
-    combinator::{map, map_res, opt, recognize},
+    combinator::{map, map_res, not, opt, peek, recognize},
     multi::{many0, separated_list0},
-    sequence::{delimited, preceded},
+    sequence::{delimited, preceded, terminated},
     IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
@@ -247,6 +247,9 @@ pub enum Literal {
     String(String),
     Integer(i64),
     Float(f64),
+    /// SQL NULL literal. Renders as bare `NULL` (no table-alias prefix), used
+    /// for Neo4j-compat resolution of properties not declared in the schema.
+    Null,
 }
 
 impl Literal {
@@ -255,6 +258,7 @@ impl Literal {
             Literal::String(s) => format!("'{}'", s.replace('\'', "''")),
             Literal::Integer(i) => i.to_string(),
             Literal::Float(f) => f.to_string(),
+            Literal::Null => "NULL".to_string(),
         }
     }
 }
@@ -602,6 +606,15 @@ fn parse_identifier_str(input: &str) -> IResult<&str, &str> {
 /// Parse literal: 'string', 123, 45.67
 fn parse_literal_expr(input: &str) -> IResult<&str, ClickHouseExpr> {
     alt((
+        // NULL literal — word-bounded so it doesn't swallow identifiers that
+        // merely start with "null" (e.g. a column named `null_count`).
+        map(
+            terminated(
+                tag_no_case("null"),
+                not(peek(alt((alphanumeric1, tag("_"))))),
+            ),
+            |_| ClickHouseExpr::Literal(Literal::Null),
+        ),
         // String literal: 'hello'
         map(
             delimited(char('\''), take_until("'"), char('\'')),
@@ -642,6 +655,32 @@ mod tests {
     fn test_column_with_underscore() {
         let pv = parse_property_value("first_name").unwrap();
         assert_eq!(pv.to_sql("u"), "u.first_name");
+    }
+
+    #[test]
+    fn test_null_literal_renders_bare() {
+        // Used by Neo4j-compat resolution of schema-undeclared properties: a
+        // NULL literal must render as bare `NULL`, never prefixed with a table
+        // alias. Case-insensitive.
+        let pv = PropertyValue::Expression("NULL".to_string());
+        assert_eq!(pv.to_sql("u"), "NULL");
+        assert_eq!(pv.to_sql_column_only(), "NULL");
+        let lower = PropertyValue::Expression("null".to_string());
+        assert_eq!(lower.to_sql("u"), "NULL");
+    }
+
+    #[test]
+    fn test_null_is_word_bounded() {
+        // Identifiers that merely start with "null" must NOT be parsed as the
+        // NULL literal — they are ordinary columns.
+        assert_eq!(
+            parse_property_value("null_count").unwrap().to_sql("u"),
+            "u.null_count"
+        );
+        assert_eq!(
+            parse_property_value("nullable").unwrap().to_sql("u"),
+            "u.nullable"
+        );
     }
 
     #[test]

--- a/src/query_planner/analyzer/view_resolver.rs
+++ b/src/query_planner/analyzer/view_resolver.rs
@@ -146,7 +146,7 @@ impl<'a> ViewResolver<'a> {
         // still resolve to a real column, not be nulled. Known columns are: the
         // node id column(s), every column targeted by a property mapping, and the
         // denormalized from/to mapping columns.
-        let is_known_column = node_schema.node_id.columns().iter().any(|c| *c == property)
+        let is_known_column = node_schema.node_id.columns().contains(&property)
             || node_schema
                 .property_mappings
                 .values()
@@ -237,12 +237,12 @@ impl<'a> ViewResolver<'a> {
         // edge table: a structural id column (endpoints + optional edge id) or a
         // column targeted by a property mapping (the fallback is also reached
         // with an already-resolved column name). These are never nulled.
-        let is_known_column = rel_schema.from_id.columns().iter().any(|c| *c == property)
-            || rel_schema.to_id.columns().iter().any(|c| *c == property)
+        let is_known_column = rel_schema.from_id.columns().contains(&property)
+            || rel_schema.to_id.columns().contains(&property)
             || rel_schema
                 .edge_id
                 .as_ref()
-                .is_some_and(|e| e.columns().iter().any(|c| *c == property))
+                .is_some_and(|e| e.columns().contains(&property))
             || rel_schema
                 .property_mappings
                 .values()

--- a/src/query_planner/analyzer/view_resolver.rs
+++ b/src/query_planner/analyzer/view_resolver.rs
@@ -138,8 +138,52 @@ impl<'a> ViewResolver<'a> {
             }
         }
 
-        // Fallback to identity mapping (property name = column name)
-        // This supports wide tables without requiring hundreds of explicit mappings
+        // The property is neither a declared property name (checked above) nor a
+        // role-mapped denormalized property. Decide whether it is nonetheless a
+        // real column of this node's table. Property resolution can run in two
+        // passes, so the fallback is also reached with an ALREADY-resolved column
+        // name (e.g. `full_name`, the value of the `name` mapping) — those must
+        // still resolve to a real column, not be nulled. Known columns are: the
+        // node id column(s), every column targeted by a property mapping, and the
+        // denormalized from/to mapping columns.
+        let is_known_column = node_schema.node_id.columns().iter().any(|c| *c == property)
+            || node_schema
+                .property_mappings
+                .values()
+                .any(|v| v.get_columns().iter().any(|c| c == property))
+            || node_schema
+                .from_properties
+                .as_ref()
+                .is_some_and(|m| m.values().any(|c| c == property))
+            || node_schema
+                .to_properties
+                .as_ref()
+                .is_some_and(|m| m.values().any(|c| c == property));
+        if is_known_column {
+            return Ok(
+                crate::graph_catalog::expression_parser::PropertyValue::Column(
+                    property.to_string(),
+                ),
+            );
+        }
+
+        // In Neo4j-compat mode, a property that resolves to no known column is
+        // treated as absent and resolves to NULL — matching Neo4j's schemaless
+        // semantics where `n.missing` is null, not an error. This is what lets
+        // Neo4j Browser / graph-notebook work: clicking a property key that
+        // belongs to a different label runs `MATCH (n) WHERE n.prop IS NOT NULL`,
+        // which must return empty rather than a ClickHouse "unknown identifier"
+        // error.
+        if crate::server::query_context::server_neo4j_compat() {
+            return Ok(
+                crate::graph_catalog::expression_parser::PropertyValue::Expression(
+                    "NULL".to_string(),
+                ),
+            );
+        }
+
+        // Default (non-compat): identity mapping (property name = column name).
+        // Supports wide tables without requiring hundreds of explicit mappings.
         Ok(crate::graph_catalog::expression_parser::PropertyValue::Column(property.to_string()))
     }
 
@@ -184,14 +228,42 @@ impl<'a> ViewResolver<'a> {
             rel_schema.table_name
         );
 
-        // Try explicit mapping first, fallback to identity mapping (property name = column name)
-        // This supports wide tables without requiring hundreds of explicit mappings
-        Ok(rel_schema
-            .property_mappings
-            .get(property)
-            .cloned()
-            .unwrap_or_else(|| {
-                crate::graph_catalog::expression_parser::PropertyValue::Column(property.to_string())
-            }))
+        // Try explicit mapping first.
+        if let Some(mapped) = rel_schema.property_mappings.get(property) {
+            return Ok(mapped.clone());
+        }
+
+        // Resolve as a real column when the property is a known column of the
+        // edge table: a structural id column (endpoints + optional edge id) or a
+        // column targeted by a property mapping (the fallback is also reached
+        // with an already-resolved column name). These are never nulled.
+        let is_known_column = rel_schema.from_id.columns().iter().any(|c| *c == property)
+            || rel_schema.to_id.columns().iter().any(|c| *c == property)
+            || rel_schema
+                .edge_id
+                .as_ref()
+                .is_some_and(|e| e.columns().iter().any(|c| *c == property))
+            || rel_schema
+                .property_mappings
+                .values()
+                .any(|v| v.get_columns().iter().any(|c| c == property));
+        if is_known_column {
+            return Ok(
+                crate::graph_catalog::expression_parser::PropertyValue::Column(
+                    property.to_string(),
+                ),
+            );
+        }
+
+        // Undeclared relationship property: NULL in Neo4j-compat mode (Neo4j
+        // schemaless semantics), identity-mapped column otherwise (wide tables).
+        if crate::server::query_context::server_neo4j_compat() {
+            return Ok(
+                crate::graph_catalog::expression_parser::PropertyValue::Expression(
+                    "NULL".to_string(),
+                ),
+            );
+        }
+        Ok(crate::graph_catalog::expression_parser::PropertyValue::Column(property.to_string()))
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -105,6 +105,13 @@ pub async fn run() {
 pub async fn run_with_config(config: ServerConfig) {
     dotenv().ok();
 
+    // Propagate Neo4j-compat mode process-wide so property resolution can treat
+    // schema-undeclared properties as NULL (Neo4j schemaless semantics) instead
+    // of identity-mapped columns that error at the database. Set once here, used
+    // by the query planner; embedded/`cg` never call this so they keep the
+    // identity-mapping default.
+    query_context::set_server_neo4j_compat(config.neo4j_compat_mode);
+
     // Test that logging is working
     log::debug!("=== SERVER STARTING (debug log test) ===");
     log::info!(

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -135,6 +135,25 @@ fn server_dialect() -> SqlDialect {
     SERVER_DIALECT.get().copied().unwrap_or_default()
 }
 
+/// Process-wide Neo4j-compatibility flag for server-handled queries. Set once at
+/// server startup from `--neo4j-compat-mode`. When on, property resolution treats
+/// a property that the schema does not declare as NULL (Neo4j schemaless
+/// semantics) instead of an identity-mapped column that would error at the
+/// database. Off (the default) preserves the identity-mapping wide-table path.
+/// Embedded/`cg` never set this, so they keep the default behavior.
+static SERVER_NEO4J_COMPAT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Enable process-wide Neo4j-compat property resolution. Idempotent (first write
+/// wins); call once during server init before serving requests.
+pub fn set_server_neo4j_compat(enabled: bool) {
+    let _ = SERVER_NEO4J_COMPAT.set(enabled);
+}
+
+/// Whether the server is running in Neo4j-compat mode (default false).
+pub fn server_neo4j_compat() -> bool {
+    SERVER_NEO4J_COMPAT.get().copied().unwrap_or(false)
+}
+
 impl QueryContext {
     /// Create a new query context with schema name.
     ///


### PR DESCRIPTION
## Summary

In `--neo4j-compat-mode`, a property that resolves to **no known column** of a node/edge table now renders as `NULL` instead of an identity-mapped column that errors at the database (ClickHouse `Code: 47` unknown identifier). This matches Neo4j's schemaless semantics (`n.missing` is null, not an error) and is what lets Neo4j Browser / graph-notebook work: clicking a property key that belongs to a different label runs `MATCH (n) WHERE n.prop IS NOT NULL`, which must return empty rather than fail.

Resolution is driven entirely by the **schema's declared mappings** — no table introspection.

## Changes

- **`expression_parser`** — add `Literal::Null` (renders bare `NULL`, never alias-prefixed) and parse a word-bounded `NULL` keyword (so `null_count` stays an ordinary column).
- **`query_context`** — process-wide `SERVER_NEO4J_COMPAT` flag, set once at server init from `--neo4j-compat-mode` (mirrors the existing `SERVER_DIALECT`). Embedded/`cg` never set it, so they keep the identity-mapping default.
- **`view_resolver`** — in the node/relationship property fallback, resolve to a real column when the name is a **known column** (id columns, any property-mapping target column, denormalized from/to columns). Property resolution runs in two passes, so the fallback is also reached with an already-resolved column name (e.g. `full_name`, the value of the `name` mapping) — those must still resolve, not be nulled. Only genuinely-unknown properties become NULL, and only in compat mode.

**Non-compat mode (`cg`, embedded, non-Browser servers) is byte-identical** — the fallback still always returns `Column`. The NULL path is gated entirely on `--neo4j-compat-mode`.

## Verification

Live: `MATCH (n:Airport) WHERE n.departure_time IS NOT NULL` (a FLIGHT relationship property queried on a node) returns empty instead of `Code: 47`, while mapped properties (`name`→`full_name`, `email`→`email_address`) still resolve to their real columns.

graph-notebook compat suite 24/26 (the 2 fails are pre-existing/unrelated — `dbms.components` name + parser leniency); full lib suite (1468) green; unit tests added for NULL-literal rendering + word-boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)