### PR TITLE
fix(render): drop spurious self-join for denormalized edge in pattern-union expand

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4179,8 +4179,20 @@ pub fn extract_ctes_with_context(
                         // the row count. Skip the join for a coupled endpoint; its
                         // columns already reference rel_table. Not applied to
                         // self-joins (both endpoints aliased distinctly there).
-                        let from_coupled = !is_self_join && raw_from_table == rel_table;
-                        let to_coupled = !is_self_join && raw_to_table == rel_table;
+                        //
+                        // Coupling requires BOTH (a) same physical table AND (b) the
+                        // node-id column == the edge's endpoint-id column. Only then
+                        // is the join condition (`node.id = rel.endpoint_id`) a
+                        // tautology that is safe to drop. If a node is embedded in the
+                        // edge table under a DIFFERENT id column (node_id `user_id` vs
+                        // edge `author_id`), the join is a real selective filter and
+                        // must be kept.
+                        let from_coupled = !is_self_join
+                            && raw_from_table == rel_table
+                            && from_node_id.columns() == rel_from_col.columns();
+                        let to_coupled = !is_self_join
+                            && raw_to_table == rel_table
+                            && to_node_id.columns() == rel_to_col.columns();
                         let mut node_joins = String::new();
                         if !from_coupled {
                             node_joins.push_str(&format!(

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4170,6 +4170,28 @@ pub fn extract_ctes_with_context(
                             fm.array_literal(&format!("'{base_rel_type}'"));
                         let rel_properties_lit = fm.array_literal(&rel_properties_json);
 
+                        // A denormalized edge embeds an endpoint node in the edge
+                        // table itself (e.g. AUTHORED with Post embedded in
+                        // posts_test, so raw_to_table == rel_table). That endpoint
+                        // IS the edge row — joining its table again would emit a
+                        // spurious unaliased self-join
+                        // (`posts_test.post_id = posts_test.post_id`) that explodes
+                        // the row count. Skip the join for a coupled endpoint; its
+                        // columns already reference rel_table. Not applied to
+                        // self-joins (both endpoints aliased distinctly there).
+                        let from_coupled = !is_self_join && raw_from_table == rel_table;
+                        let to_coupled = !is_self_join && raw_to_table == rel_table;
+                        let mut node_joins = String::new();
+                        if !from_coupled {
+                            node_joins.push_str(&format!(
+                                " INNER JOIN {from_join_expr} ON {from_join_cond}"
+                            ));
+                        }
+                        if !to_coupled {
+                            node_joins
+                                .push_str(&format!(" INNER JOIN {to_join_expr} ON {to_join_cond}"));
+                        }
+
                         let branch_sql = format!(
                             "SELECT \
                                 '{from_label}' AS start_type, \
@@ -4180,9 +4202,7 @@ pub fn extract_ctes_with_context(
                                 {rel_properties_lit} as rel_properties, \
                                 {} as start_properties, \
                                 {} as end_properties{direct_rel_cols} \
-                            FROM {rel_table} \
-                            INNER JOIN {from_join_expr} ON {from_join_cond} \
-                            INNER JOIN {to_join_expr} ON {to_join_cond}{where_clause} \
+                            FROM {rel_table}{node_joins}{where_clause} \
                             LIMIT 1000",
                             start_properties_json,
                             end_properties_json,

--- a/src/render_plan/tests/denormalized_multitype_expand_tests.rs
+++ b/src/render_plan/tests/denormalized_multitype_expand_tests.rs
@@ -94,9 +94,99 @@ fn unlabeled_expand_no_denormalized_edge_self_join() {
         "denormalized edge table must not be self-joined on its own id; SQL:\n{sql}"
     );
 
-    // The non-denormalized LIKED branch should still join its separate node tables.
+    // ...but the AUTHORED branch's NON-coupled User endpoint join must SURVIVE.
+    // (Post is coupled — embedded in posts — so only its self-join is dropped;
+    // User lives in a separate table and must still be joined.)
     assert!(
-        sql.contains("test_db.post_likes"),
-        "expected the LIKED (traditional) edge branch to be present; SQL:\n{sql}"
+        sql.contains("INNER JOIN test_db.users ON test_db.users.user_id = test_db.posts.author_id"),
+        "AUTHORED branch must keep the non-coupled User join; SQL:\n{sql}"
+    );
+
+    // The non-denormalized LIKED branch is traditional — BOTH node tables are
+    // separate from the edge table, so BOTH joins must be present.
+    assert!(
+        sql.contains(
+            "INNER JOIN test_db.users ON test_db.users.user_id = test_db.post_likes.user_id"
+        ),
+        "LIKED branch must join the User table; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains(
+            "INNER JOIN test_db.posts ON test_db.posts.post_id = test_db.post_likes.post_id"
+        ),
+        "LIKED branch must join the Post table; SQL:\n{sql}"
+    );
+}
+
+/// A node embedded in the edge table but keyed on a DIFFERENT column than the
+/// edge's endpoint id is NOT coupled — the join is a real selective filter and
+/// must be retained (regression guard for the table-equality-only coupling bug).
+#[test]
+fn embedded_node_with_distinct_id_column_keeps_join() {
+    const YAML: &str = r#"
+name: distinct_id_embed_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+    - label: Session
+      database: test_db
+      table: events
+      node_id: session_id
+      property_mappings:
+        session_id: session_id
+  edges:
+    # Session is embedded in the `events` edge table, BUT the edge keys it on
+    # `sess_ref` while Session's node_id is `session_id`. Same table, different
+    # column → the join is a real selective filter, not the
+    # `events.session_id = events.session_id` tautology, so it must be kept.
+    # (User lives in its own `users` table, so this is not a self-join.)
+    - type: STARTED
+      database: test_db
+      table: events
+      from_node: User
+      to_node: Session
+      from_id: actor_id
+      to_id: sess_ref
+      property_mappings: {}
+    - type: TOUCHED
+      database: test_db
+      table: touches
+      from_node: User
+      to_node: Session
+      from_id: user_id
+      to_id: session_id
+      property_mappings: {}
+"#;
+    let graph_schema = GraphSchemaConfig::from_yaml_str(YAML)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema");
+    let ast = open_cypher_parser::parse_query("MATCH (n)-[r]-(o) WHERE n.user_id = 1 RETURN r, o")
+        .expect("parse cypher");
+    let (logical_plan, mut plan_ctx) =
+        build_logical_plan(&ast, &graph_schema, None, None, None).expect("build logical plan");
+    use crate::query_planner::{analyzer, optimizer};
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let render_plan = logical_plan.to_render_plan(&graph_schema).expect("render");
+    let sql = clickhouse_query_generator::generate_sql(render_plan, 100);
+
+    // Session is embedded in `events` but keyed on session_id while the STARTED
+    // edge keys on sess_ref — same table, different column → the join is selective
+    // and must be kept (NOT dropped as a coupled tautology).
+    assert!(
+        sql.contains(
+            "INNER JOIN test_db.events ON test_db.events.session_id = test_db.events.sess_ref"
+        ),
+        "embedded node with a distinct id column must keep its selective join; SQL:\n{sql}"
     );
 }

--- a/src/render_plan/tests/denormalized_multitype_expand_tests.rs
+++ b/src/render_plan/tests/denormalized_multitype_expand_tests.rs
@@ -1,0 +1,102 @@
+//! Regression test for the Neo4j-Browser unlabeled-expand row explosion.
+//!
+//! An unlabeled undirected expand `MATCH (n)-[r]-(o)` over a multi-edge-type schema
+//! renders a per-edge-type UNION CTE (`pattern_union_<alias>`). For a DENORMALIZED
+//! edge whose to-node is embedded in the edge table itself (e.g. `AUTHORED` with the
+//! `Post` node living in the same `posts` table as the edge), the branch generator
+//! used to emit a spurious unaliased self-join of the edge table on its own id
+//! (`posts.post_id = posts.post_id`). That tautology join multiplied rows — a single
+//! User's expand exploded into >1000 rows. The fix skips the join for an endpoint
+//! whose table IS the edge table (its columns already reference the edge table).
+
+use crate::{
+    clickhouse_query_generator, graph_catalog::config::GraphSchemaConfig,
+    graph_catalog::graph_schema::GraphSchema, open_cypher_parser,
+    query_planner::logical_plan::plan_builder::build_logical_plan,
+    render_plan::plan_builder::RenderPlanBuilder,
+};
+
+const SCHEMA_YAML: &str = r#"
+name: denorm_expand_test
+graph_schema:
+  nodes:
+    - label: User
+      database: test_db
+      table: users
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+    - label: Post
+      database: test_db
+      table: posts
+      node_id: post_id
+      property_mappings:
+        post_id: post_id
+        title: post_title
+  edges:
+    # Denormalized edge: the AUTHORED edge AND the Post node both live in `posts`.
+    - type: AUTHORED
+      database: test_db
+      table: posts
+      from_node: User
+      to_node: Post
+      from_id: author_id
+      to_id: post_id
+      is_denormalized: true
+      property_mappings: {}
+    # A second edge type forces the multi-type pattern-union expansion path.
+    - type: LIKED
+      database: test_db
+      table: post_likes
+      from_node: User
+      to_node: Post
+      from_id: user_id
+      to_id: post_id
+      property_mappings: {}
+"#;
+
+fn schema() -> GraphSchema {
+    GraphSchemaConfig::from_yaml_str(SCHEMA_YAML)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema")
+}
+
+fn cypher_to_sql(cypher: &str) -> String {
+    let graph_schema = schema();
+    let ast = open_cypher_parser::parse_query(cypher).expect("parse cypher");
+    let (logical_plan, mut plan_ctx) =
+        build_logical_plan(&ast, &graph_schema, None, None, None).expect("build logical plan");
+
+    use crate::query_planner::{analyzer, optimizer};
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+
+    let render_plan = logical_plan
+        .to_render_plan(&graph_schema)
+        .expect("render plan");
+    clickhouse_query_generator::generate_sql(render_plan, 100)
+}
+
+#[test]
+fn unlabeled_expand_no_denormalized_edge_self_join() {
+    let sql = cypher_to_sql("MATCH (n)-[r]-(o) WHERE n.user_id = 1 RETURN r, o LIMIT 25");
+
+    // The denormalized AUTHORED branch must NOT self-join the edge table on its own
+    // id — that tautology is the row-explosion bug.
+    assert!(
+        !sql.contains("test_db.posts.post_id = test_db.posts.post_id"),
+        "denormalized edge table must not be self-joined on its own id; SQL:\n{sql}"
+    );
+
+    // The non-denormalized LIKED branch should still join its separate node tables.
+    assert!(
+        sql.contains("test_db.post_likes"),
+        "expected the LIKED (traditional) edge branch to be present; SQL:\n{sql}"
+    );
+}

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -1,4 +1,5 @@
 mod databricks_emit_spike_tests;
+mod denormalized_multitype_expand_tests;
 mod denormalized_property_tests;
 mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;


### PR DESCRIPTION
## Summary

Fixes the **row explosion** in Neo4j Browser's click-to-expand. An unlabeled undirected expand `MATCH (n)-[r]-(o)` over a multi-edge-type schema builds a per-edge-type UNION CTE (`pattern_union_<alias>`). The branch generator always emitted:

```sql
FROM rel_table INNER JOIN from_node ON … INNER JOIN to_node ON …
```

For a **denormalized edge** whose endpoint node is embedded in the edge table (e.g. `AUTHORED` with the `Post` node living in the same `posts_test` table as the edge), the to-node's table *is* the edge table, so the join degenerated into a spurious unaliased self-join on its own id:

```sql
INNER JOIN posts_test ON posts_test.post_id = posts_test.post_id   -- tautology → cartesian
```

That multiplied rows: expanding one User returned **1,146 rows** instead of ~9.

## Fix

Skip the node join when the endpoint's table equals the edge table — the endpoint IS the edge row and its columns already reference the edge table. Guarded by `!is_self_join` so the aliased same-table-both-endpoints case (Airport-FLIGHT-Airport) is unaffected.

## Verification

- `User:1` undirected expand on `social_integration` → **9 rows** (3 follows + 3 authored + 3 liked), matching the data (was 1,146).
- AUTHORED branch SQL: `FROM posts_test INNER JOIN users_test ON user_id = author_id` (no self-join).
- Traditional edges (LIKED, separate `post_likes_test`) and self-join edges (FOLLOWS, User→User aliased) **unchanged**.
- Regression test added (`unlabeled_expand_no_denormalized_edge_self_join`); full lib suite (1472) green; clippy `-D warnings` clean.

## Scope

The reverse/incoming direction of an unlabeled undirected expand (clicking the *to-node* side, e.g. a Post) is a separate, larger enhancement — not in this PR.

Part of the Neo4j-Browser unlabeled-pattern cluster (#415 exposed it). Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)