### PR TITLE
fix(render): backtick-quote dotted physical columns in pattern-union expand

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4,6 +4,7 @@
 // Note: Helper functions for VLP CTE generation are kept for complex path patterns
 #![allow(dead_code)]
 
+use crate::clickhouse_query_generator::quote_identifier;
 use crate::clickhouse_query_generator::variable_length_cte::NodeProperty;
 use crate::graph_catalog::config::Identifier;
 use crate::graph_catalog::expression_parser::PropertyValue;
@@ -4015,11 +4016,15 @@ pub fn extract_ctes_with_context(
                             .property_mappings
                             .iter()
                             .map(|(cypher_name, prop_val)| {
-                                let col_name = match prop_val {
-                                    PropertyValue::Column(c) => c.clone(),
-                                    PropertyValue::Expression(e) => e.clone(), // Use expression as-is
+                                // Quote physical columns (dotted names like `id.orig_h` must be
+                                // backtick-quoted); expressions are emitted verbatim.
+                                let col_ref = match prop_val {
+                                    PropertyValue::Column(c) => {
+                                        format!("{rel_table}.{}", quote_identifier(c))
+                                    }
+                                    PropertyValue::Expression(e) => format!("{rel_table}.{e}"),
                                 };
-                                format!("{rel_table}.{col_name} AS {cypher_name}")
+                                format!("{col_ref} AS {cypher_name}")
                             })
                             .collect();
 
@@ -4039,24 +4044,22 @@ pub fn extract_ctes_with_context(
                         let start_prop_cols: Vec<String> = from_node_schema
                             .property_mappings
                             .values()
-                            .map(|prop_val| {
-                                let col_name = match prop_val {
-                                    PropertyValue::Column(c) => c.clone(),
-                                    PropertyValue::Expression(e) => e.clone(),
-                                };
-                                format!("{from_table}.{col_name}")
+                            .map(|prop_val| match prop_val {
+                                PropertyValue::Column(c) => {
+                                    format!("{from_table}.{}", quote_identifier(c))
+                                }
+                                PropertyValue::Expression(e) => format!("{from_table}.{e}"),
                             })
                             .collect();
 
                         let end_prop_cols: Vec<String> = to_node_schema
                             .property_mappings
                             .values()
-                            .map(|prop_val| {
-                                let col_name = match prop_val {
-                                    PropertyValue::Column(c) => c.clone(),
-                                    PropertyValue::Expression(e) => e.clone(),
-                                };
-                                format!("{to_table}.{col_name}")
+                            .map(|prop_val| match prop_val {
+                                PropertyValue::Column(c) => {
+                                    format!("{to_table}.{}", quote_identifier(c))
+                                }
+                                PropertyValue::Expression(e) => format!("{to_table}.{e}"),
                             })
                             .collect();
 
@@ -4081,18 +4084,24 @@ pub fn extract_ctes_with_context(
                         // Build WHERE clauses for polymorphic type filtering
                         let mut where_clauses = Vec::new();
                         if let Some(ref type_col) = rel_schema.type_column {
-                            where_clauses
-                                .push(format!("{rel_table}.{type_col} = '{base_rel_type}'"));
+                            where_clauses.push(format!(
+                                "{rel_table}.{} = '{base_rel_type}'",
+                                quote_identifier(type_col)
+                            ));
                         }
                         if let Some(ref from_lbl_col) = rel_schema.from_label_column {
                             where_clauses.push(format!(
-                                "{rel_table}.{from_lbl_col} = '{}'",
+                                "{rel_table}.{} = '{}'",
+                                quote_identifier(from_lbl_col),
                                 combo.from_label
                             ));
                         }
                         if let Some(ref to_lbl_col) = rel_schema.to_label_column {
-                            where_clauses
-                                .push(format!("{rel_table}.{to_lbl_col} = '{}'", combo.to_label));
+                            where_clauses.push(format!(
+                                "{rel_table}.{} = '{}'",
+                                quote_identifier(to_lbl_col),
+                                combo.to_label
+                            ));
                         }
                         let where_clause = if where_clauses.is_empty() {
                             String::new()
@@ -4104,24 +4113,28 @@ pub fn extract_ctes_with_context(
                         let cast_str = current_function_mapper().cast_string();
                         let start_id_expr = match from_node_id {
                             Identifier::Single(col) => {
-                                format!("{cast_str}({from_table}.{col})")
+                                format!("{cast_str}({from_table}.{})", quote_identifier(col))
                             }
                             Identifier::Composite(cols) => {
                                 let parts: Vec<String> = cols
                                     .iter()
-                                    .map(|c| format!("{cast_str}({from_table}.{c})"))
+                                    .map(|c| {
+                                        format!("{cast_str}({from_table}.{})", quote_identifier(c))
+                                    })
                                     .collect();
                                 format!("concat({})", parts.join(", '|', "))
                             }
                         };
                         let end_id_expr = match to_node_id {
                             Identifier::Single(col) => {
-                                format!("{cast_str}({to_table}.{col})")
+                                format!("{cast_str}({to_table}.{})", quote_identifier(col))
                             }
                             Identifier::Composite(cols) => {
                                 let parts: Vec<String> = cols
                                     .iter()
-                                    .map(|c| format!("{cast_str}({to_table}.{c})"))
+                                    .map(|c| {
+                                        format!("{cast_str}({to_table}.{})", quote_identifier(c))
+                                    })
                                     .collect();
                                 format!("concat({})", parts.join(", '|', "))
                             }
@@ -4132,7 +4145,13 @@ pub fn extract_ctes_with_context(
                             .columns()
                             .iter()
                             .zip(rel_from_col.columns().iter())
-                            .map(|(n, r)| format!("{from_table}.{n} = {rel_table}.{r}"))
+                            .map(|(n, r)| {
+                                format!(
+                                    "{from_table}.{} = {rel_table}.{}",
+                                    quote_identifier(n),
+                                    quote_identifier(r)
+                                )
+                            })
                             .collect();
                         let from_join_cond = from_join_parts.join(" AND ");
 
@@ -4140,7 +4159,13 @@ pub fn extract_ctes_with_context(
                             .columns()
                             .iter()
                             .zip(rel_to_col.columns().iter())
-                            .map(|(n, r)| format!("{to_table}.{n} = {rel_table}.{r}"))
+                            .map(|(n, r)| {
+                                format!(
+                                    "{to_table}.{} = {rel_table}.{}",
+                                    quote_identifier(n),
+                                    quote_identifier(r)
+                                )
+                            })
                             .collect();
                         let to_join_cond = to_join_parts.join(" AND ");
 
@@ -4150,11 +4175,13 @@ pub fn extract_ctes_with_context(
                             .map(|prop_name| {
                                 if let Some(prop_val) = rel_schema.property_mappings.get(prop_name)
                                 {
-                                    let col_name = match prop_val {
-                                        PropertyValue::Column(c) => c.clone(),
-                                        PropertyValue::Expression(e) => e.clone(),
+                                    let col_ref = match prop_val {
+                                        PropertyValue::Column(c) => {
+                                            format!("{rel_table}.{}", quote_identifier(c))
+                                        }
+                                        PropertyValue::Expression(e) => format!("{rel_table}.{e}"),
                                     };
-                                    format!(", {rel_table}.{col_name} AS {prop_name}")
+                                    format!(", {col_ref} AS {prop_name}")
                                 } else {
                                     format!(", NULL AS {prop_name}")
                                 }

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -2,6 +2,7 @@ mod databricks_emit_spike_tests;
 mod denormalized_property_tests;
 mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;
+mod pattern_union_dotted_column_tests;
 mod polymorphic_edge_tests;
 mod variable_length_tests;
 mod vlp_property_pruning_tests;

--- a/src/render_plan/tests/pattern_union_dotted_column_tests.rs
+++ b/src/render_plan/tests/pattern_union_dotted_column_tests.rs
@@ -1,0 +1,114 @@
+//! Regression test for dotted physical-column quoting in the pattern-union renderer.
+//!
+//! An unlabeled path/expand over a multi-edge-type denormalized schema renders a
+//! per-edge-type UNION CTE (`pattern_union_<alias>`). The branch generator
+//! interpolates raw physical column names into `{table}.{column}` references. When a
+//! physical column name contains a dot (e.g. Zeek's `id.orig_h`), the unquoted form
+//! `zeek.dns_log.id.orig_h` is parsed by ClickHouse as nested struct access and the
+//! identifier fails to resolve. Such columns must be backtick-quoted
+//! (`zeek.dns_log.`id.orig_h``), exactly as the labeled renderer already does.
+
+use crate::{
+    clickhouse_query_generator, graph_catalog::config::GraphSchemaConfig,
+    graph_catalog::graph_schema::GraphSchema, open_cypher_parser,
+    query_planner::logical_plan::plan_builder::build_logical_plan,
+    render_plan::plan_builder::RenderPlanBuilder,
+};
+
+const SCHEMA_YAML: &str = r#"
+name: dotted_col_test
+graph_schema:
+  nodes:
+    - label: IP
+      database: zeek
+      table: dns_log
+      node_id: ip
+      property_mappings:
+        ip: "id.orig_h"
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: domain
+      property_mappings:
+        domain: query
+  edges:
+    # Denormalized edge: both endpoints live in the dns_log edge table.
+    - type: REQUESTED
+      database: zeek
+      table: dns_log
+      from_node: IP
+      to_node: Domain
+      from_id: "id.orig_h"
+      to_id: query
+      is_denormalized: true
+      property_mappings:
+        server: "id.resp_h"
+    # A second edge type forces the multi-type pattern-union expansion path.
+    - type: RESOLVED_TO
+      database: zeek
+      table: dns_log
+      from_node: Domain
+      to_node: IP
+      from_id: query
+      to_id: "id.resp_h"
+      property_mappings: {}
+"#;
+
+fn schema() -> GraphSchema {
+    GraphSchemaConfig::from_yaml_str(SCHEMA_YAML)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema")
+}
+
+fn cypher_to_sql(cypher: &str) -> String {
+    let graph_schema = schema();
+    let ast = open_cypher_parser::parse_query(cypher).expect("parse cypher");
+    let (logical_plan, mut plan_ctx) =
+        build_logical_plan(&ast, &graph_schema, None, None, None).expect("build logical plan");
+
+    use crate::query_planner::{analyzer, optimizer};
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+
+    let render_plan = logical_plan
+        .to_render_plan(&graph_schema)
+        .expect("render plan");
+    clickhouse_query_generator::generate_sql(render_plan, 100)
+}
+
+#[test]
+fn pattern_union_quotes_dotted_physical_columns() {
+    let sql = cypher_to_sql("MATCH p=()-[]->() RETURN p LIMIT 25");
+
+    // Dotted physical columns must be backtick-quoted so ClickHouse does not
+    // interpret them as nested struct access.
+    assert!(
+        sql.contains("`id.orig_h`"),
+        "dotted column id.orig_h must be backtick-quoted; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("`id.resp_h`"),
+        "dotted column id.resp_h must be backtick-quoted; SQL:\n{sql}"
+    );
+
+    // The unquoted form (parsed as nested access) must NOT appear.
+    assert!(
+        !sql.contains("dns_log.id.orig_h"),
+        "unquoted dotted column dns_log.id.orig_h must not appear; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("dns_log.id.resp_h"),
+        "unquoted dotted column dns_log.id.resp_h must not appear; SQL:\n{sql}"
+    );
+
+    // Plain columns must remain unquoted (no over-quoting regression).
+    assert!(
+        sql.contains("dns_log.query"),
+        "plain column `query` should remain unquoted; SQL:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

The multi-edge-type pattern-union renderer (`pattern_union_<alias>` CTE in `cte_extraction.rs`) interpolated raw physical column names into `{table}.{column}` references **without quoting**. For a physical column whose name contains a dot — e.g. Zeek's `id.orig_h` / `id.resp_h` — the unquoted form `zeek.dns_log.id.orig_h` is parsed by ClickHouse as nested struct access, so the identifier fails to resolve.

Surfaced via Neo4j Browser: `MATCH p=()-[]->()` on the zeek_dns schema errored with "Identifier cannot be resolved".

## Fix

The labeled renderer already quotes these correctly (`n."id.orig_h"`). This applies the existing `quote_identifier` helper at every physical-column interpolation site in the pattern-union branch generator:

- rel-property columns (`formatRowNoNewline` + direct `AS` columns)
- start/end node property columns
- `start_id` / `end_id` expressions (single + composite)
- `INNER JOIN ... ON` conditions
- type/from-label/to-label filter columns

Expressions (`PropertyValue::Expression`) are still emitted verbatim; plain columns are unchanged (no over-quoting).

## Test

`pattern_union_dotted_column_tests::pattern_union_quotes_dotted_physical_columns` — asserts dotted columns are backtick-quoted, the unquoted nested-access form is absent, and plain columns stay unquoted.

Part of the Browser unlabeled-pattern robustness workstream (Group 1, path render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)