### PR TITLE
fix(planner): materialize denormalized node-only query from source table(s) only

### DIFF
--- a/src/query_planner/logical_plan/match_clause/view_scan.rs
+++ b/src/query_planner/logical_plan/match_clause/view_scan.rs
@@ -70,7 +70,23 @@ pub fn try_generate_view_scan(
         if let Some(metadata) = schema.get_denormalized_node_metadata(label) {
             let rel_types = metadata.get_relationship_types();
 
-            if rel_types.len() > 1 || metadata.id_sources.values().any(|v| v.len() > 1) {
+            // Materialize the node from its SOURCE table(s) ONLY. A denormalized
+            // node may participate in many relationship types, but its non-id
+            // properties live exclusively in its denormalized source table(s) —
+            // never in foreign edge tables (e.g. `airport_cities`/`city_airports`
+            // for Airport, which carry only the edge FK, not OriginCityName).
+            // Drive the multi-branch UNION off the number of distinct denormalized
+            // NODE DEFINITIONS (= distinct source tables, e.g. zeek `IP` in
+            // `dns_log` and `conn_log`), NOT the relationship count. A single-source
+            // node (e.g. Airport in `flights`) falls through to the SINGLE-TABLE
+            // case below, which builds the from/to dimension over that one table.
+            let base_label = label.rsplit("::").next().unwrap_or(label);
+            let denorm_def_count = schema
+                .get_all_node_schemas_for_label(base_label)
+                .iter()
+                .filter(|(_, s)| s.is_denormalized)
+                .count();
+            if denorm_def_count > 1 {
                 // MULTI-TABLE CASE: Node appears in multiple tables/positions
                 log::info!(
                     "✓ Denormalized node '{}' appears in {} relationship type(s) - creating multi-table UNION",

--- a/src/render_plan/tests/denormalized_foreign_edge_id_tests.rs
+++ b/src/render_plan/tests/denormalized_foreign_edge_id_tests.rs
@@ -124,3 +124,76 @@ fn coupled_flight_edge_unchanged() {
         "coupled FLIGHT must scan flights exactly once (no extra joins); SQL:\n{sql}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Stage 2 — B2: node-only denormalized materialization (the "dimension")
+// ---------------------------------------------------------------------------
+
+/// A denormalized node referenced on its own (`MATCH (a:Airport) RETURN ...`)
+/// must materialize from its `denormalized_source_table` (`flights`) ONLY,
+/// exposing PROPERTY-named columns, via a DISTINCT union over the from/to
+/// positions. It must NEVER enumerate the foreign edge tables
+/// (`airport_cities`/`city_airports`) that carry only the edge FK and lack the
+/// node's property columns (`OriginCityName`, etc.).
+#[test]
+fn node_only_airport_dimension_unions_over_source_table_only() {
+    let sql = translate("MATCH (a:Airport) RETURN a.code, a.city");
+
+    // Materializes over the source table on BOTH positions.
+    assert!(
+        sql.contains(r#"Origin AS "a.code""#) && sql.contains(r#"OriginCityName AS "a.city""#),
+        "FROM-position branch must select source-table columns; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains(r#"Dest AS "a.code""#) && sql.contains(r#"DestCityName AS "a.city""#),
+        "TO-position branch must select source-table columns; SQL:\n{sql}"
+    );
+
+    // The source table is scanned (one branch per position).
+    assert_eq!(
+        sql.matches("test_integration.flights").count(),
+        2,
+        "node-only dimension must union the two source-table positions; SQL:\n{sql}"
+    );
+
+    // It must NOT enumerate the foreign edge tables — those have no
+    // OriginCityName/DestCityName columns.
+    assert!(
+        !sql.contains("airport_cities") && !sql.contains("city_airports"),
+        "node-only must not union over foreign edge tables; SQL:\n{sql}"
+    );
+}
+
+/// Full-node expansion (`RETURN a`) of a denormalized node also materializes
+/// the source-table dimension only, expanding every declared property.
+#[test]
+fn node_only_airport_full_expansion_over_source_table_only() {
+    let sql = translate("MATCH (a:Airport) RETURN a");
+
+    assert!(
+        !sql.contains("airport_cities") && !sql.contains("city_airports"),
+        "full node expansion must not union over foreign edge tables; SQL:\n{sql}"
+    );
+    // All three declared properties present from the source table.
+    assert!(
+        sql.contains(r#"OriginState AS "a.state""#) || sql.contains(r#"DestState AS "a.state""#),
+        "state property must come from the source table; SQL:\n{sql}"
+    );
+}
+
+/// LAZY guarantee (Stage 1 preserved): when ONLY the node_id is used through a
+/// foreign edge, NO dimension/source-table join is introduced — the id is read
+/// straight from the edge FK and `flights` is never touched.
+#[test]
+fn located_in_id_only_has_no_source_table_join() {
+    let sql = translate("MATCH (a:Airport)-[:LOCATED_IN]->(c:City) RETURN a.code, c.name");
+
+    assert!(
+        sql.contains(r#"airport_code AS "a.code""#),
+        "id-only a.code must read the edge FK; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("flights"),
+        "id-only access must NOT introduce a source-table (flights) join; SQL:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem (B2)

A denormalized node (virtual node_id; properties embedded in a source table via `from_node_properties`/`to_node_properties`) materialized for a **node-only** query was built by enumerating **every** table the label appears in. The multi-table `UNION` branch was gated on **relationship count**, so a node touching several edge types (`Airport`: FLIGHT/LOCATED_IN/SERVES) unioned over its **foreign edge tables** (`airport_cities`, `city_airports`) too — projecting source-table columns (`OriginCityName`/`DestCityName`) that those edge tables don't have → invalid SQL.

```
-- MATCH (a:Airport) RETURN a.code, a.city   (before)
... UNION over city_airports/airport_cities projecting OriginCityName (nonexistent there) ...
```

## Fix

A denormalized node's non-id properties live **only** in its denormalized source table(s), never in foreign edge tables. Re-gate the multi-table `UNION` on the number of distinct denormalized node **definitions** (= distinct source tables, e.g. zeek `IP` in `dns_log` + `conn_log`) rather than the relationship count. A single-source node (`Airport` in `flights`) falls through to the single-table case, which already builds the correct from/to dimension over that one table:

```sql
SELECT a.Origin AS "a.code", a.OriginCityName AS "a.city" FROM test_integration.flights
UNION DISTINCT
SELECT a.Dest   AS "a.code", a.DestCityName  AS "a.city" FROM test_integration.flights
```

Genuine multi-source denormalized nodes (zeek `IP`) keep the multi-table `UNION` **unchanged**. Stage-1 (foreign-edge id-via-FK), coupled FLIGHT, and zeek outputs are byte-for-byte unchanged (verified).

## Scope

This is the **node-only half (B2)** of the denormalized-dimension work. The foreign-edge **non-id property** join (B1 — `RETURN a.city` *through* LOCATED_IN) is a larger multi-subsystem feature (split id-vs-dimension alias resolution + lazy gating on referenced properties + predicate pushdown / `ANY`-join) and remains a documented follow-up.

## Tests

`denormalized_foreign_edge_id_tests` — node-only dimension over source table only; full `RETURN a` expansion; lazy id-only has no source-table join. All 1484 lib tests pass; clippy clean with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)