### PR TITLE
fix(render): resolve multi-type rel property to pattern_union CTE column, not physical column

### DIFF
--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -645,6 +645,29 @@ impl ProjectionTagging {
                     return Ok(());
                 }
 
+                // Multi-type relationship (untyped `[r]` resolving to >1 relationship
+                // type) is rendered via a `pattern_union` CTE that projects each
+                // relationship property under its *property* name (e.g. `... AS
+                // timestamp`). Per CLAUDE.md §2 (forward resolution through a CTE
+                // barrier), the outer reference must use that property-named CTE
+                // column directly, so we must NOT reverse-map the property to a
+                // physical schema column here. Leave it as-is.
+                let is_multi_type_rel = table_ctx.is_relation()
+                    && table_ctx.get_labels().map(|l| l.len() > 1).unwrap_or(false);
+                if is_multi_type_rel {
+                    log::info!(
+                        "🎯 projection_tagging: Skipping property resolution for multi-type relationship '{}' (pattern_union CTE-backed, labels: {:?})",
+                        property_access.table_alias.0,
+                        table_ctx.get_labels()
+                    );
+                    let projection_item = ProjectionItem {
+                        expression: item.expression.clone(),
+                        col_alias: item.col_alias.clone(),
+                    };
+                    table_ctx.insert_projection(projection_item);
+                    return Ok(());
+                }
+
                 // Get label for property resolution
                 let label = match table_ctx.get_label_opt() {
                     Some(l) => l,

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1844,6 +1844,42 @@ pub(crate) fn get_relationship_type_for_alias(alias: &str, plan: &LogicalPlan) -
     }
 }
 
+/// Returns `true` when the relationship `alias` is backed by a multi-type
+/// `pattern_union` CTE (i.e. its `GraphRel` carries `pattern_combinations`).
+///
+/// When this is the case, the relationship's properties are projected by the
+/// CTE under their *property* names (e.g. `... AS timestamp`), so downstream
+/// references to `alias.<property>` must use the property-named CTE column and
+/// must NOT be reverse-mapped to the physical schema column (CLAUDE.md §2:
+/// forward-resolution through a CTE barrier).
+pub(crate) fn is_pattern_union_rel_alias(alias: &str, plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::GraphRel(rel) if rel.alias == alias => rel.pattern_combinations.is_some(),
+        LogicalPlan::GraphRel(rel) => {
+            is_pattern_union_rel_alias(alias, &rel.left)
+                || is_pattern_union_rel_alias(alias, &rel.center)
+                || is_pattern_union_rel_alias(alias, &rel.right)
+        }
+        LogicalPlan::GraphNode(node) => is_pattern_union_rel_alias(alias, &node.input),
+        LogicalPlan::Filter(filter) => is_pattern_union_rel_alias(alias, &filter.input),
+        LogicalPlan::Projection(proj) => is_pattern_union_rel_alias(alias, &proj.input),
+        LogicalPlan::GraphJoins(joins) => is_pattern_union_rel_alias(alias, &joins.input),
+        LogicalPlan::OrderBy(order_by) => is_pattern_union_rel_alias(alias, &order_by.input),
+        LogicalPlan::Skip(skip) => is_pattern_union_rel_alias(alias, &skip.input),
+        LogicalPlan::Limit(limit) => is_pattern_union_rel_alias(alias, &limit.input),
+        LogicalPlan::GroupBy(group_by) => is_pattern_union_rel_alias(alias, &group_by.input),
+        LogicalPlan::Cte(cte) => is_pattern_union_rel_alias(alias, &cte.input),
+        LogicalPlan::WithClause(with_clause) => {
+            is_pattern_union_rel_alias(alias, &with_clause.input)
+        }
+        LogicalPlan::Union(union) => union
+            .inputs
+            .iter()
+            .any(|input| is_pattern_union_rel_alias(alias, input)),
+        _ => false,
+    }
+}
+
 /// For denormalized schemas: get the relationship alias and ID column for a node alias
 /// Returns (rel_alias, id_column) if the node is denormalized, None otherwise
 fn get_denormalized_node_id_reference(alias: &str, plan: &LogicalPlan) -> Option<(String, String)> {

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -905,6 +905,34 @@ impl SelectBuilder for LogicalPlan {
                                 col_name
                             );
 
+                            // Multi-type relationship backed by a `pattern_union` CTE:
+                            // the CTE projects this relationship's properties as direct
+                            // columns under their PROPERTY names (e.g. `... AS timestamp`).
+                            // Per CLAUDE.md §2 (forward resolution through a CTE barrier),
+                            // reference the property-named CTE column directly — do NOT
+                            // remap it to the physical schema column via
+                            // get_properties_with_table_alias() below (that would emit
+                            // e.g. `r.ts`, which does not exist in the CTE → CH Code 47).
+                            if crate::render_plan::cte_extraction::is_pattern_union_rel_alias(
+                                cypher_alias,
+                                self,
+                            ) {
+                                log::info!(
+                                    "🔀 pattern_union relationship property '{}.{}': passing through property-named CTE column (no physical-column remap)",
+                                    cypher_alias,
+                                    col_name
+                                );
+                                select_items.push(SelectItem {
+                                    expression: item.expression.clone().try_into()?,
+                                    col_alias: item
+                                        .col_alias
+                                        .as_ref()
+                                        .map(|ca| ca.clone().try_into())
+                                        .transpose()?,
+                                });
+                                continue;
+                            }
+
                             // 🔧 FIX: Check if this is a multi-type VLP endpoint first
                             // Multi-type VLP endpoints need JSON extraction, not direct column access
                             if let Some(gr) = self.find_graph_rel_for_alias(cypher_alias) {

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -5,6 +5,7 @@ mod denormalized_property_tests;
 mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;
 mod pattern_union_dotted_column_tests;
+mod pattern_union_rel_property_tests;
 mod polymorphic_edge_tests;
 mod variable_length_tests;
 mod vlp_property_pruning_tests;

--- a/src/render_plan/tests/pattern_union_rel_property_tests.rs
+++ b/src/render_plan/tests/pattern_union_rel_property_tests.rs
@@ -1,0 +1,143 @@
+//! Regression test for relationship-property resolution over a multi-type
+//! `pattern_union` CTE.
+//!
+//! An unlabeled relationship `()-[r]-()` whose property exists on MULTIPLE
+//! relationship types renders a per-edge-type UNION CTE (`pattern_union_<alias>`).
+//! That CTE projects each relationship property as a direct column under its
+//! PROPERTY name (e.g. `zeek.dns_log.ts AS timestamp`). Per CLAUDE.md §2
+//! (forward resolution through a CTE barrier), a downstream `r.<property>`
+//! reference in the OUTER query must use the property-named CTE column
+//! (`r.timestamp`), NOT the physical schema column (`r.ts`) — the physical
+//! column does not exist in the CTE, so ClickHouse fails with Code 47.
+//!
+//! Contrast: a property that exists on only a SINGLE edge type does NOT build a
+//! pattern_union CTE and must keep referencing the physical column directly from
+//! the edge table.
+
+use crate::{
+    clickhouse_query_generator, graph_catalog::config::GraphSchemaConfig,
+    graph_catalog::graph_schema::GraphSchema, open_cypher_parser,
+    query_planner::logical_plan::plan_builder::build_logical_plan,
+    render_plan::plan_builder::RenderPlanBuilder,
+};
+
+// Two denormalized edge types sharing a `timestamp` property (mapped to physical
+// column `ts`), plus a `server` property that exists on only ONE edge type.
+const SCHEMA_YAML: &str = r#"
+name: pattern_union_rel_prop_test
+graph_schema:
+  nodes:
+    - label: IP
+      database: zeek
+      table: dns_log
+      node_id: ip
+      property_mappings:
+        ip: "id.orig_h"
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: domain
+      property_mappings:
+        domain: query
+  edges:
+    - type: REQUESTED
+      database: zeek
+      table: dns_log
+      from_node: IP
+      to_node: Domain
+      from_id: "id.orig_h"
+      to_id: query
+      is_denormalized: true
+      property_mappings:
+        timestamp: ts
+        server: "id.resp_h"
+    - type: RESOLVED_TO
+      database: zeek
+      table: dns_log
+      from_node: Domain
+      to_node: IP
+      from_id: query
+      to_id: "id.resp_h"
+      property_mappings:
+        timestamp: ts
+"#;
+
+fn schema() -> GraphSchema {
+    GraphSchemaConfig::from_yaml_str(SCHEMA_YAML)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema")
+}
+
+fn cypher_to_sql(cypher: &str) -> String {
+    let graph_schema = schema();
+    let ast = open_cypher_parser::parse_query(cypher).expect("parse cypher");
+    let (logical_plan, mut plan_ctx) =
+        build_logical_plan(&ast, &graph_schema, None, None, None).expect("build logical plan");
+
+    use crate::query_planner::{analyzer, optimizer};
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+
+    let render_plan = logical_plan
+        .to_render_plan(&graph_schema)
+        .expect("render plan");
+    clickhouse_query_generator::generate_sql(render_plan, 100)
+}
+
+#[test]
+fn multi_type_rel_property_resolves_to_cte_column_not_physical() {
+    let sql = cypher_to_sql(
+        "MATCH ()-[r]-() WHERE r.timestamp IS NOT NULL \
+         RETURN DISTINCT 'relationship' AS entity, r.timestamp AS timestamp LIMIT 25",
+    );
+
+    // The pattern_union CTE must exist and project the property-named column.
+    assert!(
+        sql.contains("pattern_union_r"),
+        "expected a pattern_union CTE for the multi-type relationship; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("AS timestamp"),
+        "CTE must project the relationship property under its property name; SQL:\n{sql}"
+    );
+
+    // The OUTER query must reference the property-named CTE column `r.timestamp`,
+    // never the physical column `r.ts` (which does not exist in the CTE).
+    assert!(
+        sql.contains("r.timestamp") || sql.contains("r.\"timestamp\""),
+        "outer query must reference the property-named CTE column r.timestamp; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("r.ts AS") && !sql.contains("r.\"ts\""),
+        "outer query must NOT reference the physical column r.ts; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn single_type_rel_property_still_uses_physical_column() {
+    // `server` exists on only the REQUESTED edge → single-type, no pattern_union.
+    let sql = cypher_to_sql(
+        "MATCH ()-[r]-() WHERE r.server IS NOT NULL \
+         RETURN DISTINCT 'relationship' AS entity, r.server AS server LIMIT 25",
+    );
+
+    // Single-type resolution maps to the physical column directly from the edge
+    // table (quoting style depends on dialect: `id.resp_h` or "id.resp_h").
+    assert!(
+        sql.contains("id.resp_h"),
+        "single-type relationship property must map to its physical column; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains(".server"),
+        "single-type relationship property must not leak the property name as a column; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("pattern_union_r"),
+        "single-type relationship must NOT build a pattern_union CTE; SQL:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem (bug C)

A Neo4j-Browser property-key click on a relationship property present on **multiple** relationship types (e.g. zeek `timestamp`, on both `REQUESTED` and `RESOLVED_TO`) failed with ClickHouse **Code 47**.

An untyped `[r]` resolving to >1 edge type renders via a `pattern_union` CTE that projects each relationship property under its **property** name (`zeek.dns_log.ts AS timestamp`). But the outer query reverse-mapped `r.timestamp` back to the **physical** column `r.ts`, which doesn't exist in the CTE:

```
SELECT DISTINCT 'relationship' AS entity, toString(r.ts) AS "timestamp" FROM pattern_union_r AS r
-- Code 47: Identifier 'r.ts' cannot be resolved from subquery r
```

This violates the forward-resolution rule (CLAUDE.md §2: after a CTE barrier, reference the CTE column directly).

## Fix

Two resolution sites both mapped the property → physical column:
- **`projection_tagging.rs`**: skip `resolve_relationship_property` for a multi-type relationship (`table_ctx` with >1 labels), keeping the property name — mirrors the existing multi-type-VLP guard.
- **`cte_extraction.rs`**: add `is_pattern_union_rel_alias(alias, plan)` (true when the matching `GraphRel` carries `pattern_combinations`).
- **`select_builder.rs`**: when the rel alias is pattern_union-backed, pass the property-named projection through unchanged instead of remapping via `get_properties_with_table_alias()`.

**Single-type** relationship properties (no `pattern_union`) are unchanged — still reference the physical column.

### Before / after
```
r.ts AS "timestamp"        -- before → Code 47
r.timestamp AS "timestamp" -- after  → references the CTE column, executable
```

## Tests

`pattern_union_rel_property_tests` (multi-type → CTE column; single-type → physical column, no pattern_union). All 1486 lib tests pass; clippy clean with `-D warnings`.

Part of the Neo4j-Browser unlabeled/property-probe robustness work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)