### PR TITLE
fix(render): fixed_path renderer — quote dotted cols once + bind denormalized edge node (t3)

### DIFF
--- a/src/graph_catalog/expression_parser.rs
+++ b/src/graph_catalog/expression_parser.rs
@@ -106,6 +106,22 @@ impl PropertyValue {
         }
     }
 
+    /// Return the bare physical column name for a `Column`, leaving it UNQUOTED
+    /// so a downstream consumer can quote it exactly once at render time.
+    ///
+    /// This is the counterpart to [`to_sql_column_only`](Self::to_sql_column_only),
+    /// which quotes special-character columns itself. Strategy/property maps that
+    /// are later wrapped in `PropertyValue::Column` (and re-quoted by the renderer)
+    /// must use THIS method — otherwise a column like `id.orig_h` is quoted twice
+    /// (`"""id.orig_h"""`). `Expression` values have no single-column form, so they
+    /// fall back to rendered SQL to preserve existing behavior.
+    pub fn raw_column_name(&self) -> String {
+        match self {
+            PropertyValue::Column(col) => col.clone(),
+            PropertyValue::Expression(_) => self.to_sql_column_only(),
+        }
+    }
+
     /// Get raw value (for debugging)
     pub fn raw(&self) -> &str {
         match self {

--- a/src/graph_catalog/pattern_schema.rs
+++ b/src/graph_catalog/pattern_schema.rs
@@ -785,7 +785,7 @@ impl PatternSchemaContext {
                 properties: rel_schema
                     .property_mappings
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                    .map(|(k, v)| (k.clone(), v.raw_column_name()))
                     .collect(),
             }
         } else {
@@ -797,7 +797,7 @@ impl PatternSchemaContext {
                 properties: rel_schema
                     .property_mappings
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                    .map(|(k, v)| (k.clone(), v.raw_column_name()))
                     .collect(),
             }
         }
@@ -849,7 +849,7 @@ impl PatternSchemaContext {
                     properties: left_node_schema
                         .property_mappings
                         .iter()
-                        .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                        .map(|(k, v)| (k.clone(), v.raw_column_name()))
                         .collect(),
                 };
                 let right = NodeAccessStrategy::OwnTable {
@@ -858,7 +858,7 @@ impl PatternSchemaContext {
                     properties: right_node_schema
                         .property_mappings
                         .iter()
-                        .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                        .map(|(k, v)| (k.clone(), v.raw_column_name()))
                         .collect(),
                 };
                 (left, right)
@@ -880,7 +880,7 @@ impl PatternSchemaContext {
                         properties: left_node_schema
                             .property_mappings
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                            .map(|(k, v)| (k.clone(), v.raw_column_name()))
                             .collect(),
                     }
                 };
@@ -897,7 +897,7 @@ impl PatternSchemaContext {
                         properties: right_node_schema
                             .property_mappings
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                            .map(|(k, v)| (k.clone(), v.raw_column_name()))
                             .collect(),
                     }
                 };
@@ -943,7 +943,7 @@ impl PatternSchemaContext {
                 properties: node_schema
                     .property_mappings
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.to_sql_column_only()))
+                    .map(|(k, v)| (k.clone(), v.raw_column_name()))
                     .collect(),
             })
         }

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -1813,6 +1813,57 @@ impl LogicalPlan {
         }
     }
 
+    /// Extract the physical source table (`db.table`) backing a plan node.
+    /// Walks through GraphNode/Filter wrappers down to the ViewScan.
+    fn plan_source_table(plan: &LogicalPlan) -> Option<String> {
+        match plan {
+            LogicalPlan::ViewScan(vs) => Some(vs.source_table.clone()),
+            LogicalPlan::GraphNode(gn) => Self::plan_source_table(&gn.input),
+            LogicalPlan::Filter(f) => Self::plan_source_table(&f.input),
+            _ => None,
+        }
+    }
+
+    /// For a fixed-hop path whose relationship is denormalized/coupled INTO one of
+    /// its endpoint tables (the edge row lives in the same physical row as that
+    /// endpoint — e.g. a Zeek `dns_log` row, or an `AUTHORED` edge stored in the
+    /// `posts` table), the edge has no separate scan in the FROM clause. Its
+    /// columns must therefore be rendered against the endpoint alias that IS bound.
+    ///
+    /// Returns `Some(alias)` only when that alias differs from `rel_alias` (i.e. the
+    /// edge is genuinely coupled to an endpoint). Returns `None` for a traditional
+    /// separate edge table (group_membership) and for the case where the embedded
+    /// endpoints already map onto the edge alias (ontime: nodes → edge), so the
+    /// existing `rel_alias` rendering is preserved unchanged.
+    fn coupled_edge_render_alias(
+        graph_rel: &crate::query_planner::logical_plan::GraphRel,
+        start_alias: &str,
+        end_alias: &str,
+        rel_alias: &str,
+    ) -> Option<String> {
+        let edge_table = Self::plan_source_table(&graph_rel.center)?;
+        let start_table = Self::plan_source_table(&graph_rel.left);
+        let end_table = Self::plan_source_table(&graph_rel.right);
+
+        // The coupled endpoint is the one whose physical table equals the edge table.
+        // Prefer the end endpoint when both match (fully-denormalized single table).
+        let endpoint_alias = if end_table.as_deref() == Some(edge_table.as_str()) {
+            end_alias
+        } else if start_table.as_deref() == Some(edge_table.as_str()) {
+            start_alias
+        } else {
+            return None; // traditional separate edge table — not coupled
+        };
+
+        // Follow any denormalized-alias remapping so we land on the alias that is
+        // actually bound in FROM. For ontime this resolves the embedded endpoint
+        // back onto the edge alias (== rel_alias), which we then filter out below.
+        let resolved = crate::render_plan::get_denormalized_alias_mapping(endpoint_alias)
+            .unwrap_or_else(|| endpoint_alias.to_string());
+
+        (resolved != rel_alias).then_some(resolved)
+    }
+
     /// Find GraphRel where the given alias is a left or right connection.
     /// Used to detect multi-type VLP context for whole-node expansion.
     fn find_graph_rel_for_alias(
@@ -2327,9 +2378,52 @@ impl LogicalPlan {
                     log::trace!("  ✗ End node '{}' not found in plan_ctx", end_alias);
                 }
 
+                // Relationship/edge property expansion.
+                //
+                // First handle the coupled case: when the edge is denormalized INTO
+                // one of its endpoint tables, the edge row shares that endpoint's
+                // physical row and has no separate scan in FROM. Render its columns
+                // against the endpoint alias that IS bound (e.g. a Zeek `dns_log`
+                // row, or an `AUTHORED` edge stored in the `posts` table) so they
+                // resolve instead of dangling on an unbound `rel_alias` (t3).
+                let coupled_edge_alias = graph_rel_ref.as_ref().and_then(|gr| {
+                    Self::coupled_edge_render_alias(gr, &start_alias, &end_alias, &rel_alias)
+                });
+                if let Some(edge_alias) = coupled_edge_alias {
+                    log::info!(
+                        "  📦 Coupled edge '{}' → binding properties to endpoint alias '{}'",
+                        rel_alias,
+                        edge_alias
+                    );
+                    if let Some(graph_rel) = &graph_rel_ref {
+                        if let Some(ref labels) = graph_rel.labels {
+                            if let Some(rel_type) = labels.first() {
+                                let schema = ctx.schema();
+                                let rel_props = schema
+                                    .get_relationship_properties(std::slice::from_ref(rel_type));
+                                for (prop_name, db_column) in rel_props {
+                                    // Expression uses the bound endpoint alias; the column
+                                    // alias keeps the `rel_alias.` prefix so path assembly
+                                    // (convert_path_branches_to_json) still groups it as the
+                                    // relationship's properties.
+                                    select_items.push(SelectItem {
+                                        expression: RenderExpr::PropertyAccessExp(PropertyAccess {
+                                            table_alias: RenderTableAlias(edge_alias.clone()),
+                                            column: PropertyValue::Column(db_column),
+                                        }),
+                                        col_alias: Some(ColumnAlias(format!(
+                                            "{}.{}",
+                                            rel_alias, prop_name
+                                        ))),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
                 // Expand relationship properties (ONLY if not denormalized)
                 // Denormalized relationships (e.g., AUTHORED) don't have a separate relationship table
-                if !is_rel_denormalized {
+                else if !is_rel_denormalized {
                     if let Some(typed_var) = ctx.lookup_variable(&rel_alias) {
                         log::debug!(
                             "  ✓ Found relationship '{}' in plan_ctx, is_entity={}, source={:?}",

--- a/src/render_plan/tests/fixed_path_denormalized_edge_tests.rs
+++ b/src/render_plan/tests/fixed_path_denormalized_edge_tests.rs
@@ -1,0 +1,252 @@
+//! Regression tests for the fixed-path renderer over denormalized/coupled edges.
+//!
+//! A single-edge-type path query (`MATCH p=()-[:T]->() RETURN p`) routes through the
+//! "fixed_path" renderer, which emits `tuple('fixed_path', t1, t2, t3)` plus the
+//! expanded node/edge property projections.
+//!
+//! Two historical bugs are guarded here:
+//!
+//! 1. **Over-quoting of dotted physical columns.** A physical column containing a dot
+//!    (e.g. Zeek's `id.orig_h`) was rendered in the SELECT projection as
+//!    `t1."""id.orig_h"""` — the strategy pre-quoted the name and the renderer quoted
+//!    it again. ClickHouse then fails with `Code 47: Identifier ... cannot be
+//!    resolved`. The column must be quoted exactly once (`t1."id.orig_h"`).
+//!
+//! 2. **Unbound relationship alias (`t3`).** When the edge is denormalized INTO one of
+//!    its endpoint tables (the edge row shares that endpoint's physical row), it has no
+//!    separate scan in FROM. Its columns were nonetheless emitted as `t3.<col>` while
+//!    only `t1`/`t2` were bound, leaving `t3` dangling. The edge columns must resolve
+//!    against the bound coupled-endpoint alias instead.
+
+use crate::clickhouse_query_generator::cypher_to_sql;
+use crate::graph_catalog::config::GraphSchemaConfig;
+use crate::server::query_context::{set_current_schema, with_query_context, QueryContext};
+use std::sync::Arc;
+
+/// Translate Cypher → SQL through the same task-local-context path the `cg` tool and
+/// embedded API use. Denormalized-alias registration (needed to bind the coupled edge
+/// to its endpoint row) lives in the task-local context, so the simpler render-only
+/// harness does not exercise the fixed-path property expansion.
+fn translate(schema_yaml: &str, cypher: &str) -> String {
+    let schema = Arc::new(
+        GraphSchemaConfig::from_yaml_str(schema_yaml)
+            .expect("parse schema yaml")
+            .to_graph_schema()
+            .expect("build graph schema"),
+    );
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        with_query_context(QueryContext::new(None), async move {
+            set_current_schema(Arc::clone(&schema));
+            cypher_to_sql(cypher, &schema, 100).expect("translate cypher")
+        })
+        .await
+    })
+}
+
+/// Fully-denormalized single-edge schema (both endpoints AND the edge live in the
+/// same `dns_log` row), with a dotted physical column on the start endpoint.
+const ZEEK_YAML: &str = r#"
+name: zeek_logs_min
+graph_schema:
+  nodes:
+    - label: IP
+      database: zeek
+      table: dns_log
+      node_id: "id.orig_h"
+      property_mappings: { ip: "id.orig_h" }
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: query
+      property_mappings: { name: query }
+  edges:
+    - type: DNS_REQUESTED
+      database: zeek
+      table: dns_log
+      from_id: "id.orig_h"
+      to_id: query
+      from_node: IP
+      to_node: Domain
+      property_mappings: { uid: uid, qtype: qtype_name, rcode: rcode_name, timestamp: ts, answers: answers }
+"#;
+
+/// Mixed-coupled schema: User and Post each have their OWN table, and the AUTHORED
+/// edge is denormalized INTO the posts table (coupled to the Post endpoint only).
+const SOCIAL_YAML: &str = r#"
+name: social_mixed_coupled
+graph_schema:
+  nodes:
+    - label: User
+      database: test_integration
+      table: users_test
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+    - label: Post
+      database: test_integration
+      table: posts_test
+      node_id: post_id
+      property_mappings:
+        post_id: post_id
+        content: post_content
+        created_at: post_date
+  edges:
+    - type: AUTHORED
+      database: test_integration
+      table: posts_test
+      from_id: author_id
+      to_id: post_id
+      from_node: User
+      to_node: Post
+      is_denormalized: true
+      property_mappings:
+        created_at: post_date
+"#;
+
+/// Parse the `(start, end, rel)` SQL aliases out of the
+/// `tuple('fixed_path', 't1', 't2', 't3')` path marker. Alias *numbering* is a
+/// process-global counter, so tests must not hard-code `t1/t2/t3` — they read the
+/// actual aliases here instead.
+fn fixed_path_aliases(sql: &str) -> (String, String, String) {
+    let start = sql
+        .find("tuple('fixed_path'")
+        .expect("fixed_path tuple present");
+    let close = sql[start..].find(')').expect("tuple close paren") + start;
+    let args: Vec<String> = sql[start..close]
+        .split('\'')
+        .filter(|s| s.len() > 1 && s.starts_with('t') && s[1..].chars().all(|c| c.is_ascii_digit()))
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(args.len(), 3, "expected 3 path aliases in {sql}");
+    (args[0].clone(), args[1].clone(), args[2].clone())
+}
+
+/// Return the SQL expression projected under column-alias label `"<label>"`.
+fn expr_for_label(sql: &str, label: &str) -> Option<String> {
+    let needle = format!("AS \"{label}\"");
+    let pos = sql.find(&needle)?;
+    let before = sql[..pos].trim_end();
+    let cut = before.rfind([',', '\n']).map(|i| i + 1).unwrap_or(0);
+    Some(before[cut..].trim().to_string())
+}
+
+/// Assert every table-qualified expression (`t<N>.col`, in expression position —
+/// i.e. NOT inside a `"t<N>.prop"` column-alias label) references an alias that is
+/// actually bound by a `<table> AS t<N>` in FROM/JOIN. This catches the dangling
+/// `t3.<col>` (edge alias not in FROM) regression without hard-coding alias numbers.
+fn assert_no_dangling_qualifiers(sql: &str) {
+    let bound: std::collections::HashSet<String> = sql
+        .split("AS ")
+        .skip(1)
+        .filter_map(|seg| {
+            let tok: String = seg
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            // FROM/JOIN aliases are bare (`t3`); column aliases are quoted ("...") → empty tok.
+            (!tok.is_empty()).then_some(tok)
+        })
+        .collect();
+
+    let bytes = sql.as_bytes();
+    for (dot, _) in sql.match_indices('.') {
+        let mut start = dot;
+        while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+            start -= 1;
+        }
+        let ident = &sql[start..dot];
+        let preceded_by_quote = start > 0 && bytes[start - 1] == b'"';
+        let is_table_alias = ident.len() >= 2
+            && ident.starts_with('t')
+            && ident[1..].chars().all(|c| c.is_ascii_digit());
+        if !preceded_by_quote && is_table_alias {
+            assert!(
+                bound.contains(ident),
+                "qualifier `{ident}.` references an unbound alias; SQL:\n{sql}"
+            );
+        }
+    }
+}
+
+#[test]
+fn fixed_path_dotted_column_quoted_exactly_once() {
+    let sql = translate(
+        ZEEK_YAML,
+        "MATCH p=()-[:DNS_REQUESTED]->() RETURN p LIMIT 25",
+    );
+
+    // Confirm we are exercising the fixed_path renderer.
+    assert!(
+        sql.contains("tuple('fixed_path'"),
+        "expected fixed_path renderer; SQL:\n{sql}"
+    );
+
+    // The dotted physical column must be quoted exactly once. The double-application
+    // bug produced `"""id.orig_h"""`; assert that pathological form is absent.
+    assert!(
+        sql.contains("\"id.orig_h\""),
+        "dotted column must be quoted once; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("\"\"\"id.orig_h\"\"\""),
+        "dotted column must NOT be triple-quoted (double-application of quoting); SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("\"\"id.orig_h\"\""),
+        "dotted column must NOT be double-quoted twice; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn fixed_path_coupled_edge_binds_to_endpoint_not_unbound_t3() {
+    let sql = translate(
+        ZEEK_YAML,
+        "MATCH p=()-[:DNS_REQUESTED]->() RETURN p LIMIT 25",
+    );
+
+    // The fully-denormalized edge has no separate scan: its columns must resolve to a
+    // bound endpoint alias, never a dangling `rel.<col>` whose alias is not in FROM.
+    assert_no_dangling_qualifiers(&sql);
+
+    // The edge property `uid` must still be projected (bound to the coupled endpoint),
+    // preserving the `<rel>.uid` column-alias label for path assembly.
+    let (_start, end, rel) = fixed_path_aliases(&sql);
+    let uid_expr =
+        expr_for_label(&sql, &format!("{rel}.uid")).expect("edge property uid must be projected");
+    assert_eq!(
+        uid_expr,
+        format!("{end}.uid"),
+        "edge uid must bind to the coupled endpoint row ({end}); SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn fixed_path_mixed_coupled_edge_binds_to_post_endpoint() {
+    let sql = translate(SOCIAL_YAML, "MATCH p=()-[:AUTHORED]->() RETURN p LIMIT 25");
+
+    assert!(
+        sql.contains("tuple('fixed_path'"),
+        "expected fixed_path renderer; SQL:\n{sql}"
+    );
+
+    // AUTHORED is denormalized into posts_test (the Post endpoint). The edge property
+    // `created_at` (→ post_date) must bind to the Post endpoint row, not a dangling rel
+    // alias. User (own table) is joined normally; Post is the coupled anchor.
+    assert_no_dangling_qualifiers(&sql);
+
+    let (_start, end, rel) = fixed_path_aliases(&sql);
+    let created_expr = expr_for_label(&sql, &format!("{rel}.created_at"))
+        .expect("edge created_at must be projected");
+    assert_eq!(
+        created_expr,
+        format!("{end}.post_date"),
+        "coupled edge created_at must resolve to the Post endpoint's post_date ({end}); SQL:\n{sql}"
+    );
+
+    assert!(
+        sql.contains(&format!("posts_test AS {end}")),
+        "Post endpoint table must be the bound anchor ({end}); SQL:\n{sql}"
+    );
+}

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -2,6 +2,7 @@ mod databricks_emit_spike_tests;
 mod denormalized_foreign_edge_id_tests;
 mod denormalized_multitype_expand_tests;
 mod denormalized_property_tests;
+mod fixed_path_denormalized_edge_tests;
 mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;
 mod pattern_union_dotted_column_tests;


### PR DESCRIPTION
## Problem (bug D)

Two bugs in the `fixed_path` renderer (single-edge-type path → `tuple('fixed_path','t1','t2','t3')`) over denormalized schemas:

**1. Over-quoting.** Dotted physical columns (Zeek `id.orig_h`) rendered as `t1."""id.orig_h"""` (triple-quoted) in the SELECT while the JOIN used the correct `t1."id.orig_h"` → ClickHouse **Code 47**. Root cause: `pattern_schema.rs` strategy property maps stored columns via `to_sql_column_only()` (which pre-quotes special-char names), but every consumer wraps the value in `PropertyValue::Column` and the renderer quotes **again** — hidden for normal columns (no-op), doubled for dotted ones.

**2. Unbound edge node `t3`.** For an edge denormalized **into** an endpoint table (the edge row *is* that endpoint's row), the renderer referenced `t3.*` but never bound `t3` (only the endpoint tables were in FROM/JOIN) → Code 47 (`t3.post_date` / `t3.uid` unresolved). Hit on:
- zeek `MATCH p=()-[:DNS_REQUESTED]->()` (both endpoints denormalized in `dns_log`)
- `AUTHORED` denormalized into `posts_test` (User own table, Post+edge coupled — a **very common** shape)

## Fix

1. New `PropertyValue::raw_column_name()` returns the bare physical column; the 7 strategy-map sites in `pattern_schema.rs` now store raw names so the renderer quotes exactly once.
2. `select_builder` detects an edge coupled into an endpoint table and renders the edge's columns against the bound endpoint alias (keeping the `rel_alias` column-alias label for path assembly).

### Before / after
```
t1."""id.orig_h""" ...                 -- before: Code 47
t3.post_date AS "t3.created_at" ...     -- before: t3 unbound, Code 47
-- after (AUTHORED, denorm into posts_test):
t2.post_date AS "t3.created_at"   FROM posts_test AS t2 INNER JOIN users_test AS t1 ON t1.user_id = t2.author_id
-- after (zeek): all edge cols bound to t2, t2."id.orig_h" quoted once, single FROM dns_log AS t2
```

**Unchanged (verified):** traditional separate edge tables (`group_membership_simple`), `ontime` fully-denormalized path, and the prior denorm fixes #420–#423 (zeek pattern_union path, LOCATED_IN id-via-FK, node-only dimension).

## Tests

`fixed_path_denormalized_edge_tests` (dotted col quoted once; no dangling `t3` qualifier; edge property binds to the coupled endpoint — zeek + mixed AUTHORED). All 1487 lib tests pass; clippy clean with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)