### PR TITLE
fix(planner): project node_id for whole-node RETURN n over a virtual-id denormalized node

### DIFF
--- a/src/query_planner/analyzer/projected_columns_resolver.rs
+++ b/src/query_planner/analyzer/projected_columns_resolver.rs
@@ -49,7 +49,7 @@ impl ProjectedColumnsResolver {
         let view_scan = Self::find_view_scan(&node.input)?;
 
         // Use PatternSchemaContext to determine node access strategy
-        match plan_ctx.get_node_strategy(&node.alias, rel_alias) {
+        let computed = match plan_ctx.get_node_strategy(&node.alias, rel_alias) {
             Some(NodeAccessStrategy::EmbeddedInEdge { .. }) => {
                 // Denormalized node: properties come from edge table
                 Self::compute_denormalized_properties(
@@ -90,7 +90,59 @@ impl ProjectedColumnsResolver {
                 properties.sort_by(|a, b| a.0.cmp(&b.0));
                 Some(properties)
             }
+        };
+
+        Self::ensure_node_id_projected(computed, node, view_scan, plan_ctx)
+    }
+
+    /// Ensure a denormalized node's declared `node_id` appears among its projected columns.
+    ///
+    /// The Bolt result transformer (`server/bolt_protocol/result_transformer.rs`) builds a
+    /// node's `elementId` by matching the node's declared `node_id` NAME against the projected
+    /// property names. For a denormalized node whose `node_id` is virtual — i.e. its name is
+    /// NOT itself one of the exposed properties (e.g. zeek Domain `node_id: query`, exposed
+    /// only as `name: query`) — the projected list omits any column the transformer recognizes
+    /// as the id. Whole-node `RETURN n` then runs, but the transformer logs "Missing ID column"
+    /// and drops the node, so Neo4j Browser shows "unknown error".
+    ///
+    /// This appends `{id_name → alias.id_column}` when the id name is absent, so `RETURN n`
+    /// also projects `{alias}.{id_name}`, mirroring how a normal node projects its id column.
+    /// No-op when the id name is already projected (e.g. Airport `code`, or any normal node
+    /// whose id is in `property_mappings`) or for non-denormalized nodes.
+    fn ensure_node_id_projected(
+        cols: Option<Vec<(String, String)>>,
+        node: &GraphNode,
+        view_scan: &ViewScan,
+        plan_ctx: &PlanCtx,
+    ) -> Option<Vec<(String, String)>> {
+        let mut cols = cols?;
+
+        // Only denormalized nodes can have a node_id absent from their projected
+        // properties; normal nodes always carry their id via property_mappings.
+        if !view_scan.is_denormalized {
+            return Some(cols);
         }
+
+        let label = node.label.as_deref()?;
+        let id_name = plan_ctx
+            .schema()
+            .node_schema(label)
+            .ok()
+            .and_then(|ns| ns.node_id.columns().first().map(|s| s.to_string()))?;
+
+        let already_projected = cols.iter().any(|(prop_name, _)| prop_name == &id_name);
+        if !already_projected {
+            let qualified = format!("{}.{}", node.alias, view_scan.id_column);
+            log::debug!(
+                "🔧 ProjectedColumnsResolver: injecting node_id '{}' → '{}' for denormalized node '{}' (whole-node viz id)",
+                id_name,
+                qualified,
+                node.alias
+            );
+            cols.push((id_name, qualified));
+        }
+
+        Some(cols)
     }
 
     /// Find ViewScan in the plan (might be wrapped in Filters, etc.)

--- a/src/query_planner/logical_plan/match_clause/view_scan.rs
+++ b/src/query_planner/logical_plan/match_clause/view_scan.rs
@@ -19,6 +19,33 @@ use crate::query_planner::logical_plan::plan_builder::LogicalPlanResult;
 use crate::query_planner::logical_plan::{LogicalPlan, Union, UnionType, ViewScan};
 use crate::query_planner::plan_ctx::PlanCtx;
 
+/// Ensure a denormalized node's declared `node_id` is projectable as its own property.
+///
+/// Denormalized nodes expose their properties via `from_node_properties` /
+/// `to_node_properties` (Cypher-name → DB-column). The Bolt result transformer
+/// (`server/bolt_protocol/result_transformer.rs`) builds a node's `elementId` by
+/// looking up the node's declared `node_id` NAME among the projected properties.
+///
+/// When `node_id` is also a normal property (e.g. Airport `node_id: code` with a
+/// `code` property), the id is already projected and nothing is needed. But when
+/// `node_id` is a VIRTUAL id whose name is NOT a property key (e.g. zeek Domain
+/// `node_id: query` exposed only as `name: query`), the whole-node `RETURN n`
+/// projection never emits a column the transformer recognizes as the id, so the
+/// node is dropped and Neo4j Browser shows "unknown error" ("Missing ID column").
+///
+/// This injects an explicit `{id_prop_name → id_column}` entry (only when absent)
+/// so `RETURN n` also projects `{alias}.{id_prop_name}`, mirroring how a normal
+/// node projects its id column. No-op when the id name is already a property.
+fn ensure_node_id_property(
+    props: &mut HashMap<String, PropertyValue>,
+    id_prop_name: &str,
+    id_column: &str,
+) {
+    props
+        .entry(id_prop_name.to_string())
+        .or_insert_with(|| PropertyValue::Column(id_column.to_string()));
+}
+
 /// Try to generate a ViewScan for a node by looking up the label in the schema from plan_ctx.
 ///
 /// This function handles several complex cases:
@@ -114,10 +141,11 @@ pub fn try_generate_view_scan(
                                 );
 
                                 // Populate property_mapping from from_props so full node expansion works
-                                let property_mapping: HashMap<String, PropertyValue> = from_props
-                                    .iter()
-                                    .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
-                                    .collect();
+                                let mut property_mapping: HashMap<String, PropertyValue> =
+                                    from_props
+                                        .iter()
+                                        .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
+                                        .collect();
 
                                 // Get the actual ID column name from node_id property
                                 let id_prop_name = node_schema
@@ -130,6 +158,14 @@ pub fn try_generate_view_scan(
                                     .get(&id_prop_name)
                                     .cloned()
                                     .unwrap_or_else(|| id_prop_name.clone());
+
+                                // Make the node_id projectable so the Bolt transformer can
+                                // build the elementId for whole-node `RETURN n` viz.
+                                ensure_node_id_property(
+                                    &mut property_mapping,
+                                    &id_prop_name,
+                                    &id_column,
+                                );
 
                                 log::info!(
                                     "✓ FROM branch for '{}': id_prop='{}', id_column='{}', {} properties",
@@ -187,7 +223,7 @@ pub fn try_generate_view_scan(
                                 );
 
                                 // Populate property_mapping from to_props so full node expansion works
-                                let property_mapping: HashMap<String, PropertyValue> = to_props
+                                let mut property_mapping: HashMap<String, PropertyValue> = to_props
                                     .iter()
                                     .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
                                     .collect();
@@ -203,6 +239,14 @@ pub fn try_generate_view_scan(
                                     .get(&id_prop_name)
                                     .cloned()
                                     .unwrap_or_else(|| id_prop_name.clone());
+
+                                // Make the node_id projectable so the Bolt transformer can
+                                // build the elementId for whole-node `RETURN n` viz.
+                                ensure_node_id_property(
+                                    &mut property_mapping,
+                                    &id_prop_name,
+                                    &id_column,
+                                );
 
                                 log::info!(
                                     "✓ TO branch for '{}': id_prop='{}', id_column='{}', {} properties",
@@ -362,7 +406,7 @@ pub fn try_generate_view_scan(
                 full_table_name.clone(),
                 None,
                 from_property_mapping, // Use FROM properties as property_mapping
-                from_id_column,
+                from_id_column.clone(),
                 vec![],
                 vec![],
             );
@@ -373,6 +417,10 @@ pub fn try_generate_view_scan(
                     .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
                     .collect()
             });
+            // Make the node_id projectable for whole-node `RETURN n` viz (Bolt transformer).
+            if let Some(props) = from_scan.from_node_properties.as_mut() {
+                ensure_node_id_property(props, &id_prop_name, &from_id_column);
+            }
             from_scan.schema_filter = node_schema.filter.clone();
             from_scan.node_label = Some(base_label.to_string());
             // Note: to_node_properties is None - this is the FROM branch
@@ -382,7 +430,7 @@ pub fn try_generate_view_scan(
                 full_table_name,
                 None,
                 to_property_mapping, // Use TO properties as property_mapping
-                to_id_column,
+                to_id_column.clone(),
                 vec![],
                 vec![],
             );
@@ -393,6 +441,10 @@ pub fn try_generate_view_scan(
                     .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
                     .collect()
             });
+            // Make the node_id projectable for whole-node `RETURN n` viz (Bolt transformer).
+            if let Some(props) = to_scan.to_node_properties.as_mut() {
+                ensure_node_id_property(props, &id_prop_name, &to_id_column);
+            }
             to_scan.schema_filter = node_schema.filter.clone();
             to_scan.node_label = Some(base_label.to_string());
             // Note: from_node_properties is None - this is the TO branch
@@ -437,7 +489,7 @@ pub fn try_generate_view_scan(
             full_table_name,
             None,
             HashMap::new(),
-            single_id_column,
+            single_id_column.clone(),
             vec![],
             vec![],
         );
@@ -455,6 +507,13 @@ pub fn try_generate_view_scan(
                 .map(|(k, v)| (k.clone(), PropertyValue::Column(v.clone())))
                 .collect()
         });
+        // Make the node_id projectable for whole-node `RETURN n` viz (Bolt transformer).
+        if let Some(props) = view_scan.from_node_properties.as_mut() {
+            ensure_node_id_property(props, &id_prop_name, &single_id_column);
+        }
+        if let Some(props) = view_scan.to_node_properties.as_mut() {
+            ensure_node_id_property(props, &id_prop_name, &single_id_column);
+        }
         view_scan.schema_filter = node_schema.filter.clone();
         // Extract base label from potentially qualified name (e.g., "brahmand::flights_denorm::Airport" -> "Airport")
         let base_label = if label.contains("::") {

--- a/src/render_plan/tests/denormalized_virtual_id_viz_tests.rs
+++ b/src/render_plan/tests/denormalized_virtual_id_viz_tests.rs
@@ -1,0 +1,116 @@
+//! Regression tests for whole-node `RETURN n` visualization over a DENORMALIZED
+//! node whose `node_id` is VIRTUAL (its declared name is not itself one of the
+//! exposed properties).
+//!
+//! A denormalized node embeds its properties in a source table via
+//! `from_node_properties`/`to_node_properties` and has an empty `property_mappings`.
+//! Clicking a node label in Neo4j Browser runs `MATCH (n:Label) RETURN n`.
+//!
+//! The Bolt result transformer (`server/bolt_protocol/result_transformer.rs`)
+//! builds each node's `elementId` by matching the node's declared `node_id` NAME
+//! against the projected property names. When `node_id` is virtual — e.g. zeek
+//! `Domain` with `node_id: query` exposed only as `name: query` — the whole-node
+//! projection used to emit ONLY `n.query AS "n.name"`, so nothing was projected
+//! under the id name `query`. The transformer then logged "Missing ID column
+//! 'query'" and dropped the node → Browser "unknown error".
+//!
+//! After the fix, `ProjectedColumnsResolver` injects the node_id column under its
+//! declared name (`n.query AS "n.query"`) so the transformer can build the id,
+//! mirroring how a normal node (`MATCH (u:User) RETURN u`) projects `user_id`.
+//! When `node_id` is already an exposed property (e.g. Airport `node_id: code`),
+//! nothing extra is injected.
+
+use crate::clickhouse_query_generator::cypher_to_sql;
+use crate::graph_catalog::config::GraphSchemaConfig;
+use crate::server::query_context::{set_current_schema, with_query_context, QueryContext};
+use std::sync::Arc;
+
+/// Denormalized node `Domain` with a VIRTUAL scalar node_id (`query`) that is not
+/// itself an exposed property (only `name: query` is).
+const SCHEMA_YAML: &str = r#"
+name: zeek_virtual_id_test
+version: "1.0"
+graph_schema:
+  nodes:
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: query
+      property_mappings: {}
+      from_node_properties:
+        name: query
+      to_node_properties:
+        name: query
+    - label: IP
+      database: zeek
+      table: dns_log
+      node_id: "id.orig_h"
+      property_mappings: {}
+      from_node_properties:
+        ip: "id.orig_h"
+      to_node_properties:
+        ip: "id.resp_h"
+  edges:
+    - type: REQUESTED
+      database: zeek
+      table: dns_log
+      from_id: "id.orig_h"
+      to_id: query
+      from_node: IP
+      to_node: Domain
+      edge_id: uid
+      property_mappings:
+        uid: uid
+"#;
+
+/// Translate Cypher → SQL through the same task-local-context path the `cg` tool
+/// and embedded API use.
+fn translate(cypher: &str) -> String {
+    let schema = Arc::new(
+        GraphSchemaConfig::from_yaml_str(SCHEMA_YAML)
+            .expect("parse schema yaml")
+            .to_graph_schema()
+            .expect("build graph schema"),
+    );
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        with_query_context(QueryContext::new(None), async move {
+            set_current_schema(Arc::clone(&schema));
+            cypher_to_sql(cypher, &schema, 100).expect("translate cypher")
+        })
+        .await
+    })
+}
+
+#[test]
+fn whole_node_return_projects_virtual_node_id_column() {
+    let sql = translate("MATCH (n:Domain) RETURN n LIMIT 25");
+
+    // The node_id column must be projected under its declared name so the Bolt
+    // transformer can build the elementId (previously MISSING → "Missing ID column").
+    assert!(
+        sql.contains(r#"n.query AS "n.query""#),
+        "whole-node RETURN n must project the node_id column as n.query; SQL:\n{sql}"
+    );
+
+    // The existing property projection must remain unchanged.
+    assert!(
+        sql.contains(r#"n.query AS "n.name""#),
+        "the `name` property projection must be preserved; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn property_only_return_is_unchanged() {
+    // `RETURN n.name` is a property-specific lookup and must NOT gain an id column.
+    let sql = translate("MATCH (n:Domain) RETURN n.name");
+
+    assert!(
+        sql.contains(r#"n.query AS "n.name""#),
+        "the `name` property projection must be present; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains(r#"AS "n.query""#),
+        "property-only RETURN n.name must not project a separate id column; SQL:\n{sql}"
+    );
+}

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -2,6 +2,7 @@ mod databricks_emit_spike_tests;
 mod denormalized_foreign_edge_id_tests;
 mod denormalized_multitype_expand_tests;
 mod denormalized_property_tests;
+mod denormalized_virtual_id_viz_tests;
 mod fixed_path_denormalized_edge_tests;
 mod issue_411_generic_id_tests;
 mod multiple_relationship_tests;


### PR DESCRIPTION
## Problem (bug A)

Clicking a node label in Neo4j Browser runs `MATCH (n:Label) RETURN n`. For a **denormalized** node whose `node_id` is **virtual** — its declared `node_id` name is not itself an exposed property (e.g. zeek `Domain`: `node_id: query`, exposed only as `name: query`, `property_mappings: {}`) — the whole-node projection emitted only the property (`n.query AS "n.name"`) and never projected the node_id column. The Bolt result-transformer looks up the node_id column to build the `elementId`, found it **Missing** (`Missing ID column 'query'`), dropped the node, and Browser showed **"unknown error"**.

This is a common action: *any* "click a label to view its nodes" on a denormalized schema failed.

## Fix

When expanding a whole-node `RETURN n` for a denormalized node, ensure the node_id column is projected:
- **`projected_columns_resolver.rs`** (authoritative live path): `compute_projected_columns_for_node` routes through new `ensure_node_id_projected()` — for a denormalized node, if the declared node_id name isn't already a projected property, append `{id_name → alias.id_column}`.
- **`view_scan.rs`** (fallback path when `projected_columns` is `None`): `ensure_node_id_property()` at the denormalized node-only ViewScan sites.

**No-op** when the node_id name is already an exposed property (normal nodes; Airport `code`) or for non-denormalized nodes — byte-for-byte unchanged.

### Before / after (`MATCH (n:Domain) RETURN n`)
```
n.query AS "n.name"                          -- before: no id column → transform drops node
n.query AS "n.name", n.query AS "n.query"    -- after: node_id projected → elementId built
```

Out of scope: the `ResolvedIP` `Array(String)` node_id variant (no crash; full `arrayJoin` modeling deferred).

## Tests

`denormalized_virtual_id_viz_tests` (`RETURN n` projects `n.query`; `RETURN n.name` does not). All 1491 lib tests pass; clippy clean with `-D warnings`. Verified #423 (Airport node-only) and normal `RETURN u` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)