### PR TITLE
fix(planner): bind unlabeled endpoints of a polymorphic edge instead of pruning to empty

### DIFF
--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -1450,7 +1450,12 @@ impl TypeInference {
                             graph_schema
                                 .get_all_rel_schemas_for_type(rel_type)
                                 .into_iter()
-                                .map(|rs| rs.from_node.clone())
+                                // Polymorphic edges store `$any` as their from_node — a
+                                // sentinel, not a real label. Expand it to every concrete
+                                // node type so an unlabeled endpoint keeps all candidates
+                                // instead of being narrowed to the literal "$any" (which
+                                // matches nothing and would collapse the plan to Empty).
+                                .flat_map(|rs| graph_schema.expand_node_type(&rs.from_node))
                         })
                         .collect();
                     if !valid_types.is_empty() {
@@ -1471,7 +1476,9 @@ impl TypeInference {
                             graph_schema
                                 .get_all_rel_schemas_for_type(rel_type)
                                 .into_iter()
-                                .map(|rs| rs.to_node.clone())
+                                // Expand polymorphic `$any` to_node to all concrete node
+                                // types (see the from_node branch above).
+                                .flat_map(|rs| graph_schema.expand_node_type(&rs.to_node))
                         })
                         .collect();
                     if !valid_types.is_empty() {

--- a/src/query_planner/logical_plan/match_clause/traversal.rs
+++ b/src/query_planner/logical_plan/match_clause/traversal.rs
@@ -382,7 +382,26 @@ fn traverse_connected_pattern_with_mode<'a>(
                     "  ✓ Both nodes untyped, rel_labels has {} types",
                     types.len()
                 );
-                if types.len() > 1 {
+                // Polymorphic edges (e.g. one `interactions` table holding many edge
+                // types with `$any` endpoints via from_label_column/to_label_column)
+                // have no concrete from_node/to_node to bind unlabeled endpoints to.
+                // Without this, a single-type pattern like `()-[:SHARED]->()` would
+                // fall through with both node scans Empty and the whole pattern would
+                // be pruned to the `SELECT 1 AS "_empty"` placeholder. Route such
+                // patterns through the same deferred-UNION path as multi-type
+                // patterns: `$any` endpoints expand to all concrete node labels (see
+                // `expand_node_type`), producing a real query over the edge table
+                // filtered by the requested type for each (from, type, to) combination.
+                let has_polymorphic_any = {
+                    let graph_schema = plan_ctx.schema();
+                    types.iter().any(|t| {
+                        graph_schema
+                            .rel_schemas_for_type(t)
+                            .iter()
+                            .any(|s| s.from_node == "$any" || s.to_node == "$any")
+                    })
+                };
+                if types.len() > 1 || has_polymorphic_any {
                     log::info!(
                         "🔀 PatternResolver 2.0: Fully untyped multi-type pattern with {} types",
                         types.len()

--- a/src/render_plan/tests/mod.rs
+++ b/src/render_plan/tests/mod.rs
@@ -8,6 +8,7 @@ mod multiple_relationship_tests;
 mod pattern_union_dotted_column_tests;
 mod pattern_union_rel_property_tests;
 mod polymorphic_edge_tests;
+mod polymorphic_unlabeled_path_tests;
 mod variable_length_tests;
 mod vlp_property_pruning_tests;
 mod where_clause_filter_tests;

--- a/src/render_plan/tests/polymorphic_unlabeled_path_tests.rs
+++ b/src/render_plan/tests/polymorphic_unlabeled_path_tests.rs
@@ -1,0 +1,161 @@
+//! Regression test for unlabeled path/expand patterns over a POLYMORPHIC edge.
+//!
+//! A polymorphic edge uses one physical table to hold many edge types, with
+//! generic (`$any`) endpoints resolved at query time via `from_label_column` /
+//! `to_label_column`. When a Neo4j-Browser-style query leaves BOTH endpoints
+//! unlabeled — e.g. `MATCH p=()-[:SHARED]->()` — the planner used to fail to
+//! bind the endpoints (there is no concrete `from_node`/`to_node` to scan) and
+//! pruned the entire pattern to the `SELECT 1 AS "_empty" WHERE false`
+//! placeholder, so the query returned nothing regardless of the data.
+//!
+//! The fix routes single-type polymorphic patterns through the same
+//! deferred-UNION path as multi-type patterns: `$any` endpoints expand to the
+//! concrete node labels, producing a real query over the edge table filtered by
+//! the requested type for each (from, type, to) combination. The result may
+//! legitimately be empty for a type with no rows, but the SQL must be a real
+//! query against the edge table, never the `_empty` placeholder.
+
+use crate::{
+    clickhouse_query_generator, graph_catalog::config::GraphSchemaConfig,
+    graph_catalog::graph_schema::GraphSchema, open_cypher_parser,
+    query_planner::logical_plan::plan_builder::build_logical_plan,
+    render_plan::plan_builder::RenderPlanBuilder,
+};
+
+// Mirrors `schemas/test/unified_test_multi_schema.yaml` schema_name
+// `social_polymorphic`: one `interactions` table with `$any` endpoints driven by
+// from_type/to_type label columns and an interaction_type discriminator.
+const SCHEMA_YAML: &str = r#"
+name: social_polymorphic
+graph_schema:
+  nodes:
+    - label: User
+      database: brahmand
+      table: users_bench
+      node_id: user_id
+      property_mappings:
+        user_id: user_id
+        name: full_name
+        email: email_address
+    - label: Post
+      database: brahmand
+      table: posts_bench
+      node_id: post_id
+      property_mappings:
+        post_id: post_id
+        title: content
+        content: content
+        created: created_at
+  edges:
+    - polymorphic: true
+      database: brahmand
+      table: interactions
+      from_id: from_id
+      to_id: to_id
+      type_column: interaction_type
+      from_label_column: from_type
+      to_label_column: to_type
+      type_values:
+        - FOLLOWS
+        - LIKES
+        - AUTHORED
+        - COMMENTED
+        - SHARED
+      edge_id: [from_id, to_id, interaction_type, timestamp]
+      property_mappings:
+        created_at: timestamp
+        weight: interaction_weight
+"#;
+
+fn schema() -> GraphSchema {
+    GraphSchemaConfig::from_yaml_str(SCHEMA_YAML)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema")
+}
+
+fn cypher_to_sql(cypher: &str) -> String {
+    let graph_schema = schema();
+    let ast = open_cypher_parser::parse_query(cypher).expect("parse cypher");
+    let (logical_plan, mut plan_ctx) =
+        build_logical_plan(&ast, &graph_schema, None, None, None).expect("build logical plan");
+
+    use crate::query_planner::{analyzer, optimizer};
+    let logical_plan =
+        analyzer::initial_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan =
+        analyzer::intermediate_analyzing(logical_plan, &mut plan_ctx, &graph_schema).unwrap();
+    let logical_plan = optimizer::initial_optimization(logical_plan, &mut plan_ctx).unwrap();
+    let logical_plan = optimizer::final_optimization(logical_plan, &mut plan_ctx).unwrap();
+
+    let render_plan = logical_plan
+        .to_render_plan(&graph_schema)
+        .expect("render plan");
+    clickhouse_query_generator::generate_sql(render_plan, 100)
+}
+
+/// The pruned placeholder shape produced when a pattern is dropped entirely.
+fn is_empty_placeholder(sql: &str) -> bool {
+    sql.contains("_empty") && sql.contains("WHERE false")
+}
+
+#[test]
+fn unlabeled_single_type_polymorphic_path_is_real_query() {
+    // `()-[:SHARED]->()` — SHARED has no rows in the data, but the SQL must still
+    // be a real query over the edge table, not the `_empty` placeholder.
+    let sql = cypher_to_sql("MATCH p=()-[:SHARED]->() RETURN p LIMIT 25");
+    assert!(
+        !is_empty_placeholder(&sql),
+        "unlabeled polymorphic path must NOT prune to the _empty placeholder; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("interactions"),
+        "expected a real query over the polymorphic edge table `interactions`; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("interaction_type") && sql.contains("SHARED"),
+        "expected the edge query to be filtered by the requested type; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn unlabeled_single_type_polymorphic_path_follows() {
+    // FOLLOWS HAS data — proves the placeholder was never about missing rows.
+    let sql = cypher_to_sql("MATCH p=()-[:FOLLOWS]->() RETURN p LIMIT 5");
+    assert!(
+        !is_empty_placeholder(&sql),
+        "unlabeled polymorphic path must NOT prune to the _empty placeholder; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("interactions") && sql.contains("FOLLOWS"),
+        "expected a real query over `interactions` filtered by FOLLOWS; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn unlabeled_anytype_polymorphic_path_is_real_query() {
+    // `()-[]->()` — no rel type: real query over all type_values.
+    let sql = cypher_to_sql("MATCH p=()-[]->() RETURN p LIMIT 5");
+    assert!(
+        !is_empty_placeholder(&sql),
+        "unlabeled any-type polymorphic path must NOT prune to the _empty placeholder; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("interactions"),
+        "expected a real query over the polymorphic edge table `interactions`; SQL:\n{sql}"
+    );
+}
+
+#[test]
+fn labeled_polymorphic_pattern_still_renders_real_join() {
+    // CONTRAST: the labeled case must keep rendering its real join SQL.
+    let sql = cypher_to_sql("MATCH (a:User)-[:SHARED]->(b:Post) RETURN a,b LIMIT 5");
+    assert!(
+        !is_empty_placeholder(&sql),
+        "labeled polymorphic pattern must render real SQL; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("users_bench") && sql.contains("interactions") && sql.contains("posts_bench"),
+        "labeled pattern must join the concrete node tables through interactions; SQL:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem (bug E)

A path/expand with **unlabeled** endpoints over a **polymorphic** edge (`from_label_column`/`to_label_column`, `$any` endpoints) was pruned to the empty placeholder (`SELECT 1 AS "_empty" WHERE false`) — returning nothing **regardless of data**. `MATCH p=()-[:SHARED]->()`, `()-[:FOLLOWS]->()` (which has rows), and bare `()-[]->()` all yielded nothing, while the **labeled** `(a:User)-[:SHARED]->(b:Post)` worked. High-impact: Browser's default `MATCH p=()-[]->()` / `()-[r]-()` exploration returned nothing on *any* polymorphic schema.

## Root cause

For a polymorphic edge, `RelationshipSchema.from_node`/`to_node` is the `$any` sentinel. `TypeInference::infer_pattern_types` narrowed each untyped node's candidate labels to the literal set `{"$any"}` — which no real node label is in — so candidates went empty and the analyzer collapsed the whole plan to `LogicalPlan::Empty`.

## Fix

- **`type_inference.rs`** (`infer_pattern_types` untyped-node narrowing): expand each rel-schema endpoint via `graph_schema.expand_node_type()` (`$any` → all concrete node labels; concrete label → `[label]`) instead of the raw `from_node`/`to_node`. Non-polymorphic edges are unaffected (`expand_node_type(label) == [label]`).
- **`traversal.rs`**: the fully-untyped deferred-UNION (`pattern_combinations`) path was gated on `types.len() > 1`; add `has_polymorphic_any` so a single-type polymorphic pattern also takes it — `$any` endpoints expand to concrete labels, one real edge-table-filtered branch per `(from, type, to)` combo.

### Before / after (social_polymorphic)
```
()-[:SHARED]->()  : _empty WHERE false   →   FROM brahmand.interactions ... WHERE interaction_type = 'SHARED' AND from_type=... AND to_type=...
()-[]->()         : _empty               →   pattern_union, 20 branches (5 types × 4 combos), each with interaction_type filter
(a:User)-[:SHARED]->(b:Post) (contrast)  : unchanged (joins users_bench/posts_bench)
```

## Tests

`polymorphic_unlabeled_path_tests` (3 unlabeled cases reference `interactions` + the type filter, not `_empty`; labeled contrast still joins node tables). All 1493 lib tests pass (existing `polymorphic_edge_tests` stay green); clippy clean with `-D warnings`. Non-polymorphic `social_integration` unlabeled path verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)