### PR TITLE
fix(render): project * for empty outer SELECT over a heterogeneous denorm node union

### DIFF
--- a/src/render_plan/tests/denormalized_unlabeled_node_tests.rs
+++ b/src/render_plan/tests/denormalized_unlabeled_node_tests.rs
@@ -160,6 +160,45 @@ fn unlabeled_node_is_not_null_filter_over_all_denormalized_schema_materializes_u
 }
 
 #[test]
+fn whole_node_return_over_heterogeneous_denormalized_schema_has_aligned_union() {
+    // Whole-node `RETURN n` over a heterogeneous all-denormalized schema (IP,
+    // Domain, ResolvedIP — each with a DIFFERENT property set) expands into a
+    // UNION where every label-position leaf branch must project the SAME aligned
+    // column set (each label's real columns + NULL for the others), wrapped in a
+    // subquery whose OUTER SELECT projects those columns.
+    //
+    // Two historical defects this guards against:
+    //   1. An EMPTY outer projection (`SELECT  FROM (...)`) — ClickHouse Code 62.
+    //   2. Nested per-label `UNION DISTINCT` sub-branches padded inconsistently,
+    //      giving mismatched column counts across leaves.
+    let sql = cypher_to_sql("MATCH (n) RETURN n LIMIT 5");
+
+    // Defect 1: the outer SELECT over the union must NOT be empty.
+    assert!(
+        !sql.contains("SELECT  FROM"),
+        "outer SELECT over the heterogeneous union must not be empty; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains(") AS __union"),
+        "heterogeneous whole-node union must be wrapped in a subquery; SQL:\n{sql}"
+    );
+
+    // Defect 2: every leaf branch must project the SAME aligned column set. This
+    // heterogeneous schema yields three distinct node properties (ip_address,
+    // domain_name, answers); each of those aligned column aliases must appear the
+    // same number of times — once per leaf branch. Equal, non-zero counts prove
+    // consistent arity across all leaves (padded with NULL where absent).
+    let answers = count(&sql, "AS \"n.answers\"");
+    let domain = count(&sql, "AS \"n.domain_name\"");
+    let ip = count(&sql, "AS \"n.ip_address\"");
+    assert!(
+        answers > 0 && answers == domain && domain == ip,
+        "every leaf branch must project the same aligned column set \
+         (answers={answers}, domain_name={domain}, ip_address={ip}); SQL:\n{sql}"
+    );
+}
+
+#[test]
 fn labeled_denormalized_node_property_is_unchanged() {
     // Control: the LABELED form already worked and must be byte-for-byte preserved
     // (the UNLABELED fix must compose with, not alter, the labeled path).

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3921,7 +3921,17 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
                         })
                         .collect::<Vec<_>>()
                         .join(", ");
-                    sql.push_str(&alias_select);
+                    // A whole-node `RETURN n` over a heterogeneous denormalized
+                    // union carries no explicit outer SELECT items (the aligned
+                    // node columns live in each union branch). Emitting an empty
+                    // projection produces invalid `SELECT  FROM (...)` (ClickHouse
+                    // Code 62). Pass the union's aligned columns straight through
+                    // with `*` in that case.
+                    if alias_select.is_empty() {
+                        sql.push('*');
+                    } else {
+                        sql.push_str(&alias_select);
+                    }
                 }
             } else if !plan.select.items.is_empty() {
                 sql.push_str(&plan.select.to_sql());


### PR DESCRIPTION
## Problem (residual from the Browser batch)

`MATCH (n) RETURN n` over a fully-denormalized schema where **multiple labels with different property sets** survive (e.g. zeek_dns `IP`/`Domain`/`ResolvedIP`) produced `SELECT  FROM (...)` — an **empty outer projection** → ClickHouse **Code 62** syntax error. This is Browser's "view all nodes" default on such a schema.

The aligned node columns live inside each union branch (`normalize_union_branches` already NULL-pads/aligns every leaf, including nested from/to unions, via the recursion from #426), so the outer `plan.select.items` is empty.

## Fix

`to_sql_query.rs` (`needs_subquery` UNION rendering): when the outer `alias_select` is empty for a non-aggregation UNION, emit `*` to pass the union's aligned columns through instead of an invalid empty SELECT list.

### Before / after
```
SELECT  FROM ( ... )   -- before: Code 62
SELECT * FROM ( ... )  -- after: executes; returns heterogeneous nodes
```

Verified live against ClickHouse: `MATCH (n) RETURN n` on zeek_dns returns IP/Domain/ResolvedIP rows with aligned (NULL-padded) columns.

## Tests

`whole_node_return_over_heterogeneous_denormalized_schema_has_aligned_union` (outer SELECT non-empty; every leaf branch shares the aligned column set). All 1500 lib tests pass; clippy clean with `-D warnings`. Controls (`RETURN n.ip_address`, labeled `RETURN n`, non-denorm, #426 bidirectional) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)