### PR TITLE
fix(planner): infer anonymous endpoint labels by position, not direction (FK-edge undirected expand)

### DIFF
--- a/src/query_planner/analyzer/graph_context.rs
+++ b/src/query_planner/analyzer/graph_context.rs
@@ -173,35 +173,30 @@ pub fn get_graph_context<'a>(
             source: e,
         })?;
 
-    // Try to get left label, or infer from relationship if anonymous
-    // IMPORTANT: Must consider direction when inferring labels!
-    // For (a)<-[:REL]-(b) with Incoming direction:
-    //   - left (a) connects to to_id, so left label is rel.to_node
-    //   - right (b) connects to from_id, so right label is rel.from_node
-    // For (a)-[:REL]->(b) with Outgoing direction:
-    //   - left (a) connects to from_id, so left label is rel.from_node
-    //   - right (b) connects to to_id, so right label is rel.to_node
+    // Try to get left label, or infer from relationship if anonymous.
+    //
+    // The parser NORMALIZES connection aliases so that `left_connection` is
+    // ALWAYS the relationship's from-side and `right_connection` the to-side,
+    // regardless of the arrow direction — see `compute_connection_aliases`
+    // (Incoming swaps start/end so left = from-node). BidirectionalUnion's
+    // Incoming branch performs the same swap. So an anonymous node's inferred
+    // label follows position, NOT `graph_rel.direction`: left = from_node,
+    // right = to_node. This matches `compute_pattern_context`'s anonymous
+    // inference. Flipping by direction here (the old behavior) was a latent
+    // bug — masked whenever TypeInference had already filled the label, but
+    // surfacing for BidirectionalUnion-generated Incoming branches over
+    // FK-edges, where the anonymous endpoint stayed unlabeled and got resolved
+    // to the wrong node table (Code 47: reading `from_id`/`to_id` off the node
+    // table instead of the FK-edge table).
     let left_label = match left_ctx.get_label_str() {
         Ok(label) => label,
-        Err(_) => {
-            // Anonymous node - infer from relationship schema considering direction
-            match graph_rel.direction {
-                Direction::Incoming => rel_schema_for_inference.to_node.clone(),
-                _ => rel_schema_for_inference.from_node.clone(),
-            }
-        }
+        Err(_) => rel_schema_for_inference.from_node.clone(),
     };
 
     // Try to get right label, or infer from relationship if anonymous
     let right_label = match right_ctx.get_label_str() {
         Ok(label) => label,
-        Err(_) => {
-            // Anonymous node - infer from relationship schema considering direction
-            match graph_rel.direction {
-                Direction::Incoming => rel_schema_for_inference.from_node.clone(),
-                _ => rel_schema_for_inference.to_node.clone(),
-            }
-        }
+        Err(_) => rel_schema_for_inference.to_node.clone(),
     };
 
     // NOTE: For polymorphic $any nodes, this function should not be called.

--- a/tests/rust/integration/browser_expand_tests.rs
+++ b/tests/rust/integration/browser_expand_tests.rs
@@ -212,6 +212,49 @@ async fn test_fk_edge_customer_simple() {
     assert!(sql_lower.contains("select"), "Should produce valid SQL");
 }
 
+/// REGRESSION (bug G): undirected FK-edge expand with a typed anchor and an
+/// anonymous other endpoint (`(c:Customer)-[r:PLACED_BY]-(o)`) must read the
+/// edge id columns from the FK-edge table (orders) and use the correct FK join
+/// key — NOT from the customers node table.
+///
+/// PLACED_BY is Order→Customer and IS the orders table (FK column customer_id).
+/// BidirectionalUnion prunes the invalid Outgoing branch and keeps the Incoming
+/// branch, which swaps left/right so `o` (from-side = Order) becomes the FROM
+/// anchor. Because TypeInference leaves `o` unlabeled under Direction::Either,
+/// `get_graph_context` previously flipped the anonymous role by direction and
+/// resolved `o` to the customers table, generating
+/// `FROM customers AS o INNER JOIN orders AS r ON r.order_id = o.order_id`
+/// (ClickHouse Code 47 — customers has no order_id). The endpoint's inferred
+/// label must follow position (left = from_node), matching compute_pattern_context.
+#[tokio::test]
+async fn test_fk_edge_undirected_reads_edge_ids_from_edge_table() {
+    let schema = create_fk_edge_schema();
+    let sql = generate_expand_sql(
+        &schema,
+        "MATCH (c:Customer)-[r:PLACED_BY]-(o) WHERE c.customer_id = 103 RETURN r",
+    )
+    .await;
+
+    let sql_lower = sql.to_lowercase();
+    assert!(sql_lower.contains("select"), "Should produce valid SQL");
+    // The FK-edge (orders) table is the anchor supplying r.from_id/r.to_id.
+    assert!(
+        sql_lower.contains("test.orders"),
+        "Undirected FK-edge expand must scan the orders (FK-edge) table:\n{sql}"
+    );
+    // Broken output joined the edge on a non-existent node-table order_id.
+    assert!(
+        !sql_lower.contains("r.order_id = o.order_id"),
+        "Must not join the FK-edge on a node-table order_id key:\n{sql}"
+    );
+    // With RETURN r + FK collapse, the customers node table is not referenced;
+    // its presence would mean `o` was mis-resolved to the customers table.
+    assert!(
+        !sql_lower.contains("customers"),
+        "Undirected FK-edge RETURN r must not read from the customers node table:\n{sql}"
+    );
+}
+
 // ===========================================================================
 // Denormalized schema tests
 // ===========================================================================


### PR DESCRIPTION
## Problem (bug G)

An **undirected** expand over an **FK-edge** — `MATCH (c:Customer)-[r:PLACED_BY]-(o) WHERE c.customer_id='103' RETURN r` on the `fk_edge` schema (where `PLACED_BY` *is* the `orders_fk` table with a `customer_id` FK) — generated invalid SQL:
```sql
FROM db_fk_edge.customers_fk AS o
INNER JOIN db_fk_edge.orders_fk AS r ON r.order_id = o.order_id   -- customers_fk has no order_id → Code 47
WHERE o.customer_id = '103'
```
The edge's id columns were read from the **node** table and the join key was wrong. (Surfaced via Browser expand on a Customer node.)

## Root cause

`get_graph_context()` inferred an unlabeled endpoint's label by **flipping on `graph_rel.direction`** (Incoming → left=`to_node`). But the parser already **normalizes** every pattern so `left_connection` is always the relationship's from-side and `right_connection` the to-side — `direction` is only a marker, and BidirectionalUnion's Incoming branch does the same swap. So the flip double-counted, mis-assigning the endpoint label/table.

## Fix

Infer by **position** unconditionally — `left = from_node`, `right = to_node` — matching `compute_pattern_context` (which already computes the join strategy correctly). The undirected FK-edge expand now renders identically to the working directed form:
```sql
SELECT o.order_id AS "r.from_id", o.customer_id AS "r.to_id"
FROM db_fk_edge.orders_fk AS o WHERE o.customer_id = '103' LIMIT 25
```
Directed patterns and non-FK multi-type expands (pattern_union) are unchanged.

## Tests

`test_fk_edge_undirected_reads_edge_ids_from_edge_table`. **1556 lib + 285 integration** tests pass (incl. golden snapshots, all `fk_edge`/`cs_fk_edge` tests); clippy clean with `-D warnings`. Broad direction controls (directed/undirected/incoming across schemas) verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)