### PR TITLE
fix(render): keep pattern_union for multi-type rel (different tables) inside a top-level UNION

### DIFF
--- a/src/render_plan/from_builder.rs
+++ b/src/render_plan/from_builder.rs
@@ -964,6 +964,17 @@ impl LogicalPlan {
                 LogicalPlan::GroupBy(group_by) => find_graph_rel(&group_by.input),
                 LogicalPlan::Unwind(u) => find_graph_rel(&u.input),
                 LogicalPlan::GraphJoins(gj) => find_graph_rel(&gj.input),
+                LogicalPlan::GraphNode(gn) => find_graph_rel(&gn.input),
+                // Pagination wrappers may sit between an outer GraphJoins and the
+                // GraphRel — e.g. a top-level Cypher UNION branch renders as
+                // GraphJoins → Limit → GraphJoins → Projection → GraphRel. Without
+                // traversing these, a multi-type rel's pattern_combinations check is
+                // bypassed and the FROM collapses to a single raw edge table instead
+                // of the self-contained pattern_union CTE (mirrors join_builder's
+                // find_graph_rel, which already descends through them).
+                LogicalPlan::OrderBy(order_by) => find_graph_rel(&order_by.input),
+                LogicalPlan::Skip(skip) => find_graph_rel(&skip.input),
+                LogicalPlan::Limit(limit) => find_graph_rel(&limit.input),
                 // For multi-hop patterns: CartesianProduct(GraphRel(r1), GraphRel(r2))
                 // Traverse left to find the first (FROM anchor) GraphRel
                 LogicalPlan::CartesianProduct(cp) => find_graph_rel(&cp.left),

--- a/src/render_plan/tests/pattern_union_rel_property_tests.rs
+++ b/src/render_plan/tests/pattern_union_rel_property_tests.rs
@@ -118,6 +118,104 @@ fn multi_type_rel_property_resolves_to_cte_column_not_physical() {
     );
 }
 
+// Two edge types sharing a `timestamp` property (mapped to physical column
+// `ts`) whose tables are DIFFERENT (`dns_log` vs `dns_resolutions`). The
+// multi-type expansion must still build a `pattern_union` CTE even when the rel
+// pattern is one branch of a top-level Cypher UNION.
+const SCHEMA_YAML_DIFFERENT_TABLES: &str = r#"
+name: pattern_union_rel_prop_multitable_test
+graph_schema:
+  nodes:
+    - label: IP
+      database: zeek
+      table: all_ips
+      node_id: ip
+      property_mappings:
+        ip: ip
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: query
+      property_mappings:
+        name: query
+  edges:
+    - type: REQUESTED
+      database: zeek
+      table: dns_log
+      from_node: IP
+      to_node: Domain
+      from_id: "id.orig_h"
+      to_id: query
+      property_mappings:
+        timestamp: ts
+        uid: uid
+    - type: RESOLVED_TO
+      database: zeek
+      table: dns_resolutions
+      from_node: Domain
+      to_node: IP
+      from_id: domain
+      to_id: resolved_ip
+      property_mappings:
+        timestamp: ts
+"#;
+
+// Full statement path (handles top-level Cypher UNION, which `parse_query`
+// does not) reusing the production translator entry point.
+fn cypher_to_sql_with(schema_yaml: &str, cypher: &str) -> String {
+    let graph_schema = GraphSchemaConfig::from_yaml_str(schema_yaml)
+        .expect("parse schema yaml")
+        .to_graph_schema()
+        .expect("build graph schema");
+    let (sql, _lp, _ctx) = crate::sql_generator::emitters::clickhouse::cypher_to_sql_with_metadata(
+        cypher,
+        &graph_schema,
+        100,
+    )
+    .expect("translate cypher to sql");
+    sql
+}
+
+#[test]
+fn multi_type_rel_property_in_top_level_union_keeps_pattern_union() {
+    // Browser property-key probe shape: a node branch (dropped — no node has
+    // `timestamp`) UNION ALL a relationship branch. The rel branch's multi-type
+    // expansion, whose two edge types live in DIFFERENT tables, must still build
+    // a pattern_union CTE and reference the property-named CTE column — NOT
+    // collapse to a single raw edge table with a `r.timestamp` column that does
+    // not exist there.
+    let sql = cypher_to_sql_with(
+        SCHEMA_YAML_DIFFERENT_TABLES,
+        "MATCH (n) WHERE n.timestamp IS NOT NULL \
+         RETURN DISTINCT 'node' AS entity, n.timestamp AS timestamp LIMIT 25\n\
+         UNION ALL\n\
+         MATCH ()-[r]-() WHERE r.timestamp IS NOT NULL \
+         RETURN DISTINCT 'relationship' AS entity, r.timestamp AS timestamp LIMIT 25",
+    );
+
+    // The multi-type expansion must survive the enclosing UNION as a CTE with
+    // both edge types' tables present.
+    assert!(
+        sql.contains("pattern_union_r"),
+        "expected a pattern_union CTE for the multi-type relationship inside the top-level UNION; SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("zeek.dns_log") && sql.contains("zeek.dns_resolutions"),
+        "pattern_union CTE must span BOTH edge tables; SQL:\n{sql}"
+    );
+
+    // The outer query must reference the property-named CTE column, never emit a
+    // bare `r.timestamp` against a raw edge table that lacks that column.
+    assert!(
+        sql.contains("FROM pattern_union_r AS r"),
+        "outer query must read from the pattern_union CTE; SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("FROM zeek.dns_log AS r"),
+        "outer query must NOT collapse to a single raw edge table; SQL:\n{sql}"
+    );
+}
+
 #[test]
 fn single_type_rel_property_still_uses_physical_column() {
     // `server` exists on only the REQUESTED edge → single-type, no pattern_union.


### PR DESCRIPTION
## Problem

A Browser property-key probe on a relationship property present on **multiple edge types in different tables** (e.g. `zeek_dns_graph`: `timestamp`→`ts` on `REQUESTED`/`dns_log` and `RESOLVED_TO`/`dns_resolutions`), inside the node-UNION-rel probe, generated a single raw `FROM dns_log AS r` referencing the *property* name `r.timestamp` (the column is `ts`, and only one edge type) → **Code 47**.

Works on `zeek_dns` (both edges in one table) and works on `zeek_dns_graph` *in isolation* — only the UNION-context + different-tables combo broke.

## Root cause

The multi-type rel is **not** dropped in the logical plan (it keeps `pattern_combinations`). The drop is in **render**: a top-level UNION branch adds an extra outer `GraphJoins` layer → `GraphJoins → Limit → GraphJoins → Projection → GraphRel`. The FROM builder's local `find_graph_rel` (in `extract_from_graph_joins`) had **no arm for `Limit`/`Skip`/`OrderBy`**, so it couldn't reach the `GraphRel`, skipped selecting the `pattern_union_r` CTE as FROM, and fell back to the single raw edge-table marker. The sibling `find_graph_rel` in `join_builder.rs` already descends those wrappers — the two were inconsistent.

## Fix

Add `Limit`/`Skip`/`OrderBy`/`GraphNode` arms to from_builder's `find_graph_rel`, matching join_builder. Early pattern_union selection only fires when `pattern_combinations.is_some()`, so non-multi-type queries are unaffected, and #424's property-name retention is correct again (a real CTE exists).

### Before / after
```
FROM zeek.dns_log AS r ... r.timestamp        -- before: Code 47
WITH pattern_union_r AS (REQUESTED ⋃ RESOLVED_TO) SELECT ... FROM pattern_union_r AS r   -- after
```
Verified executing against live data.

## Tests

`multi_type_rel_property_in_top_level_union_keeps_pattern_union` + the #424 tests stay green. 1500 lib tests pass; clippy clean with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)