### PR TITLE
fix(planner): mixed-label anchor expand emits valid UNION SQL (fixes Browser Code 47 crash)

### DIFF
--- a/src/query_planner/optimizer/filter_into_graph_rel.rs
+++ b/src/query_planner/optimizer/filter_into_graph_rel.rs
@@ -88,6 +88,133 @@ fn extract_referenced_aliases(expr: &LogicalExpr, aliases: &mut std::collections
     }
 }
 
+/// Collect the columns referenced under a specific alias in an expression.
+///
+/// Returns the raw column names of every `PropertyAccessExp` whose table alias
+/// equals `alias`. Used to detect predicates that reference a column the target
+/// scan does not have.
+fn columns_for_alias(expr: &LogicalExpr, alias: &str, out: &mut std::collections::HashSet<String>) {
+    match expr {
+        LogicalExpr::PropertyAccessExp(pa) if pa.table_alias.0 == alias => {
+            out.insert(pa.column.raw().to_string());
+        }
+        LogicalExpr::PropertyAccessExp(_) => {}
+        LogicalExpr::OperatorApplicationExp(op) | LogicalExpr::Operator(op) => {
+            for o in &op.operands {
+                columns_for_alias(o, alias, out);
+            }
+        }
+        LogicalExpr::ScalarFnCall(f) => {
+            for a in &f.args {
+                columns_for_alias(a, alias, out);
+            }
+        }
+        LogicalExpr::AggregateFnCall(f) => {
+            for a in &f.args {
+                columns_for_alias(a, alias, out);
+            }
+        }
+        LogicalExpr::Case(c) => {
+            if let Some(e) = &c.expr {
+                columns_for_alias(e, alias, out);
+            }
+            for (w, t) in &c.when_then {
+                columns_for_alias(w, alias, out);
+                columns_for_alias(t, alias, out);
+            }
+            if let Some(e) = &c.else_expr {
+                columns_for_alias(e, alias, out);
+            }
+        }
+        LogicalExpr::List(items) => {
+            for i in items {
+                columns_for_alias(i, alias, out);
+            }
+        }
+        LogicalExpr::InSubquery(s) => columns_for_alias(&s.expr, alias, out),
+        _ => {}
+    }
+}
+
+/// Build the set of DB columns a node ViewScan can legitimately be filtered on:
+/// its property-mapping keys (Cypher property names) and column values, plus the
+/// id column and any from/to id columns.
+fn scan_known_columns(
+    view_scan: &crate::query_planner::logical_plan::ViewScan,
+) -> std::collections::HashSet<String> {
+    let mut cols = std::collections::HashSet::new();
+    for (prop, val) in &view_scan.property_mapping {
+        cols.insert(prop.clone());
+        cols.insert(val.raw().to_string());
+    }
+    cols.insert(view_scan.id_column.clone());
+    if let Some(from_id) = &view_scan.from_id {
+        for c in from_id.columns() {
+            cols.insert(c.to_string());
+        }
+    }
+    if let Some(to_id) = &view_scan.to_id {
+        for c in to_id.columns() {
+            cols.insert(c.to_string());
+        }
+    }
+    cols
+}
+
+/// Drop predicates that reference `alias` columns which the target `view_scan`
+/// does not have. This prevents cross-branch contamination when a UNION splits a
+/// single anchor variable into per-label branches: the shared `PlanCtx` holds the
+/// filters of ALL branches under the same alias (e.g. `a.ip IN [...]` from the IP
+/// branch and `a.query IN [...]` from the Domain branch). Pushing every one into
+/// every scan yields invalid predicates like `a.query` on a table that has no
+/// `query` column (ClickHouse Code 47).
+///
+/// The tell-tale of that cross-label merge is that a SINGLE alias carries filters
+/// on TWO OR MORE distinct id columns (one per label). Only then do we prune:
+/// keep the predicates whose columns exist on this scan, drop the definitively
+/// foreign ones. When the alias references at most one distinct column we return
+/// the filters untouched — this leaves ordinary single-label pushdown AND
+/// polymorphic multi-type expands (e.g. an unlabeled endpoint `b.post_id IN [...]`
+/// that legitimately spans User|Post and is rewritten to `t.end_id` downstream)
+/// completely unaffected.
+fn retain_filters_for_scan(
+    filters: &[LogicalExpr],
+    alias: &str,
+    view_scan: &crate::query_planner::logical_plan::ViewScan,
+) -> Vec<LogicalExpr> {
+    // Distinct columns this alias is filtered on across all its predicates.
+    let mut all_cols = std::collections::HashSet::new();
+    for f in filters {
+        columns_for_alias(f, alias, &mut all_cols);
+    }
+    // <2 distinct columns ⇒ no per-label merge possible ⇒ nothing to prune.
+    if all_cols.len() < 2 {
+        return filters.to_vec();
+    }
+
+    let known = scan_known_columns(view_scan);
+    filters
+        .iter()
+        .filter(|f| {
+            let mut referenced = std::collections::HashSet::new();
+            columns_for_alias(f, alias, &mut referenced);
+            // Keep if it references no alias columns, or at least one valid column.
+            referenced.is_empty() || referenced.iter().any(|c| known.contains(c))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Find the node ViewScan directly under a GraphRel connection subtree.
+/// Handles `GraphNode(ViewScan)` and bare `ViewScan`; returns None otherwise.
+fn scan_under(plan: &LogicalPlan) -> Option<&crate::query_planner::logical_plan::ViewScan> {
+    match plan {
+        LogicalPlan::ViewScan(vs) => Some(vs),
+        LogicalPlan::GraphNode(gn) => scan_under(gn.input.as_ref()),
+        _ => None,
+    }
+}
+
 /// Optimizer pass that pushes Filter predicates into GraphRel.where_predicate
 ///
 /// This pass looks for patterns like:
@@ -330,7 +457,14 @@ impl OptimizerPass for FilterIntoGraphRel {
                 if let LogicalPlan::ViewScan(view_scan) = graph_node.input.as_ref() {
                     // Get filters for THIS specific alias only
                     if let Some(table_ctx) = plan_ctx.get_mut_table_ctx_opt(&graph_node.alias) {
-                        let filters = table_ctx.get_filters();
+                        // Drop predicates that reference columns this scan's label does
+                        // not have (cross-branch contamination via shared PlanCtx when a
+                        // UNION splits one anchor variable into per-label branches).
+                        let filters = retain_filters_for_scan(
+                            table_ctx.get_filters(),
+                            &graph_node.alias,
+                            view_scan,
+                        );
                         log::info!(
                             "FilterIntoGraphRel: Found table_ctx for alias '{}', filters.len() = {}",
                             graph_node.alias,
@@ -514,16 +648,21 @@ impl OptimizerPass for FilterIntoGraphRel {
                         };
 
                         if matches_viewscan {
+                            // Drop predicates referencing columns this scan does not have
+                            // (cross-branch contamination via shared PlanCtx in a per-label
+                            // UNION split — see retain_filters_for_scan docs).
+                            let kept = retain_filters_for_scan(filters, alias, view_scan);
                             log::trace!(
-                                "FilterIntoGraphRel: Found {} matching filters for alias '{}': {:?}",
+                                "FilterIntoGraphRel: Found {} matching filters for alias '{}' ({} kept after column guard): {:?}",
                                 filters.len(),
                                 alias,
+                                kept.len(),
                                 filters
                             );
 
                             // For ViewScan, filters are already in Column form (not PropertyAccess)
                             // So we just use them directly without qualification
-                            filters_to_apply.extend(filters.clone());
+                            filters_to_apply.extend(kept);
                         }
                     }
 
@@ -618,7 +757,13 @@ impl OptimizerPass for FilterIntoGraphRel {
                                 if let Ok(table_ctx) = plan_ctx
                                     .get_table_ctx_from_alias_opt(&Some(graph_node.alias.clone()))
                                 {
-                                    let filters = table_ctx.get_filters();
+                                    // Guard against foreign-column predicates (shared-PlanCtx
+                                    // cross-branch contamination in per-label UNION splits).
+                                    let filters = retain_filters_for_scan(
+                                        table_ctx.get_filters(),
+                                        &graph_node.alias,
+                                        view_scan,
+                                    );
                                     if !filters.is_empty() {
                                         log::trace!(
                                         "FilterIntoGraphRel: Found {} filters for GraphNode alias '{}': {:?}",
@@ -626,7 +771,7 @@ impl OptimizerPass for FilterIntoGraphRel {
                                         graph_node.alias,
                                         filters
                                     );
-                                        filters_to_apply.extend(filters.clone());
+                                        filters_to_apply.extend(filters);
                                     }
                                 }
 
@@ -787,7 +932,13 @@ impl OptimizerPass for FilterIntoGraphRel {
                     if let Ok(table_ctx) = plan_ctx
                         .get_table_ctx_from_alias_opt(&Some(graph_rel.left_connection.clone()))
                     {
-                        let filters = table_ctx.get_filters().clone();
+                        let mut filters = table_ctx.get_filters().clone();
+                        // Drop foreign-column predicates for this connection's label
+                        // (cross-branch contamination via shared PlanCtx).
+                        if let Some(scan) = scan_under(graph_rel.left.as_ref()) {
+                            filters =
+                                retain_filters_for_scan(&filters, &graph_rel.left_connection, scan);
+                        }
                         if !filters.is_empty() {
                             log::debug!(
                                 "FilterIntoGraphRel: Found {} filters for left connection alias '{}' in GraphRel",
@@ -818,7 +969,14 @@ impl OptimizerPass for FilterIntoGraphRel {
                     if let Ok(table_ctx) = plan_ctx
                         .get_table_ctx_from_alias_opt(&Some(graph_rel.right_connection.clone()))
                     {
-                        let filters = table_ctx.get_filters().clone();
+                        let mut filters = table_ctx.get_filters().clone();
+                        if let Some(scan) = scan_under(graph_rel.right.as_ref()) {
+                            filters = retain_filters_for_scan(
+                                &filters,
+                                &graph_rel.right_connection,
+                                scan,
+                            );
+                        }
                         if !filters.is_empty() {
                             log::trace!(
                                 "FilterIntoGraphRel: Found {} filters for right connection alias '{}' in GraphRel",

--- a/src/render_plan/from_builder.rs
+++ b/src/render_plan/from_builder.rs
@@ -1061,6 +1061,15 @@ impl LogicalPlan {
                     log::debug!("🔍 find_multi_type_graph_rel: Checking GraphNode input");
                     find_multi_type_graph_rel(&gn.input)
                 }
+                // Presentation wrappers must not block multi-type CTE detection.
+                // A per-label UNION split places LIMIT INSIDE each branch as
+                // `GraphJoins → Limit → GraphJoins → … → GraphRel`; without these
+                // arms the outer GraphJoins' input (Limit) short-circuits detection,
+                // and FROM falls back to a raw node table instead of the
+                // vlp_multi_type CTE, producing invalid SQL.
+                LogicalPlan::Limit(l) => find_multi_type_graph_rel(&l.input),
+                LogicalPlan::Skip(s) => find_multi_type_graph_rel(&s.input),
+                LogicalPlan::OrderBy(o) => find_multi_type_graph_rel(&o.input),
                 _ => {
                     log::debug!(
                         "🔍 find_multi_type_graph_rel: No match for plan type {:?}",

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -101,6 +101,23 @@ pub fn logical_plan_to_render_plan(
     logical_plan.to_render_plan(schema)
 }
 
+/// Public wrapper over `to_render_plan_with_ctx`, mirroring the server pipeline.
+///
+/// The server (HTTP + Bolt handlers) always renders via `to_render_plan_with_ctx`
+/// so that analysis-phase metadata in `PlanCtx` (VLP endpoints, multi-type joins,
+/// etc.) is available during rendering. The bare `logical_plan_to_render_plan`
+/// wrapper omits that context and can diverge from server output for polymorphic /
+/// multi-type expands. Use this wrapper when faithful server-parity rendering is
+/// required (e.g. regression tests for browser expand SQL).
+pub fn logical_plan_to_render_plan_with_ctx(
+    logical_plan: crate::query_planner::logical_plan::LogicalPlan,
+    schema: &crate::graph_catalog::graph_schema::GraphSchema,
+    plan_ctx: Option<&crate::query_planner::plan_ctx::PlanCtx>,
+) -> Result<RenderPlan, errors::RenderBuildError> {
+    use plan_builder::RenderPlanBuilder;
+    logical_plan.to_render_plan_with_ctx(schema, plan_ctx, None)
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct RenderPlan {
     pub ctes: CteItems,

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -1125,6 +1125,163 @@ fn build_multi_type_vlp_aliases(plan: &RenderPlan) -> HashMap<String, String> {
 /// Rewrite property access in SELECT, GROUP BY items for VLP queries
 /// Maps Cypher aliases (a, b) to CTE column names (start_xxx, end_xxx)
 /// For VLP, the CTE includes properties named using the Cypher property name: start_email, start_name, etc.
+/// True if `expr` references `alias` anywhere as a PropertyAccess table alias.
+fn render_expr_references_alias(expr: &RenderExpr, alias: &str) -> bool {
+    match expr {
+        RenderExpr::PropertyAccessExp(pa) => pa.table_alias.0 == alias,
+        // Some render paths carry qualified columns as a bare `Column("t.col")`
+        // string rather than a structured PropertyAccess.
+        RenderExpr::Column(col) => col
+            .raw()
+            .strip_prefix(alias)
+            .is_some_and(|rest| rest.starts_with('.')),
+        RenderExpr::OperatorApplicationExp(op) => op
+            .operands
+            .iter()
+            .any(|o| render_expr_references_alias(o, alias)),
+        RenderExpr::ScalarFnCall(f) => f
+            .args
+            .iter()
+            .any(|a| render_expr_references_alias(a, alias)),
+        RenderExpr::AggregateFnCall(f) => f
+            .args
+            .iter()
+            .any(|a| render_expr_references_alias(a, alias)),
+        RenderExpr::List(items) => items.iter().any(|i| render_expr_references_alias(i, alias)),
+        _ => false,
+    }
+}
+
+/// Drop *disconnected* JOINs — those whose entire ON condition never references
+/// the joined table's own alias — when the FROM is a multi-type VLP CTE.
+///
+/// A per-label anchor UNION split materialises the end node inside each
+/// `vlp_multi_type_*` CTE (its `end_*` columns), yet the outer GraphJoins still
+/// emits a node-materialisation JOIN for that endpoint (e.g.
+/// `INNER JOIN zeek.all_ips AS o ON t.end_ip = t.start_query`). Its ON compares
+/// two VLP CTE columns and never mentions `o`, so it is a disconnected cross
+/// join against an alias nothing in the outer query reads — always spurious and
+/// invalid. Removing it is safe: the endpoint's properties already flow from the
+/// CTE's `end_*` projection.
+fn drop_disconnected_vlp_joins(plan: &mut RenderPlan) {
+    fn clean(from: &FromTableItem, joins: &mut JoinItems) {
+        let from_is_vlp = from
+            .0
+            .as_ref()
+            .is_some_and(|f| f.name.starts_with("vlp_multi_type_"));
+        if !from_is_vlp {
+            return;
+        }
+        joins.0.retain(|j| {
+            let connected = j
+                .joining_on
+                .iter()
+                .any(|op| op.operands.iter().any(|o| render_expr_references_alias(o, &j.table_alias)));
+            if !connected {
+                log::info!(
+                    "🧹 Dropping disconnected JOIN '{} AS {}' (ON never references its own alias) under VLP CTE FROM",
+                    j.table_name,
+                    j.table_alias
+                );
+            }
+            connected
+        });
+    }
+    let from = plan.from.clone();
+    clean(&from, &mut plan.joins);
+    if let Some(ref mut union) = plan.union.0 {
+        for branch in union.input.iter_mut() {
+            let bfrom = branch.from.clone();
+            clean(&bfrom, &mut branch.joins);
+        }
+    }
+}
+
+/// Strip a trailing `_<digits>` disambiguation suffix from a CTE name.
+/// `vlp_multi_type_a_o_2` → `vlp_multi_type_a_o`; `vlp_multi_type_a_o` unchanged.
+fn strip_cte_dedup_suffix(name: &str) -> &str {
+    if let Some(pos) = name.rfind('_') {
+        if name[pos + 1..].chars().all(|c| c.is_ascii_digit()) && pos + 1 < name.len() {
+            return &name[..pos];
+        }
+    }
+    name
+}
+
+/// Unify the projected columns of mixed-label anchor UNION branches.
+///
+/// A per-label anchor split produces one `vlp_multi_type_<a>_<o>` CTE per label
+/// (the duplicate renamed `..._2`, `..._3`). All of them share the SAME pattern
+/// and therefore the SAME CTE-column shape (`start_*`, `end_*`, `r_from_id`, …),
+/// each read through the same alias `t`. Sibling branches rendered independently
+/// can end up with FEWER columns (e.g. missing `t.r_from_id`), making the UNION
+/// ALL arity-inconsistent (ClickHouse rejects it).
+///
+/// Rebuild each same-pattern branch's SELECT to the base's column ORDER: for each
+/// base column, keep the BRANCH's own item when it already projects that alias
+/// (preserving per-branch literals like `'Domain' AS __start_label__`), otherwise
+/// borrow the base's item — which references only `t.<col>` present identically in
+/// the branch's CTE. Branch-specific label literals are thus preserved while
+/// missing CTE columns are filled in.
+fn unify_mixed_anchor_branch_selects(plan: &mut RenderPlan) {
+    let base_from = match plan.from.0.as_ref() {
+        Some(f) if f.name.starts_with("vlp_multi_type_") => f.name.clone(),
+        _ => return,
+    };
+    let base_pattern = strip_cte_dedup_suffix(&base_from).to_string();
+    let base_items = plan.select.items.clone();
+    if let Some(ref mut union) = plan.union.0 {
+        for branch in union.input.iter_mut() {
+            let same_pattern = branch
+                .from
+                .0
+                .as_ref()
+                .is_some_and(|f| strip_cte_dedup_suffix(&f.name) == base_pattern);
+            if !same_pattern || branch.select.items.len() == base_items.len() {
+                continue;
+            }
+            // Only borrow base columns that reference a CTE column (`t.<col>`),
+            // which is present identically in the branch's same-pattern CTE. Never
+            // fabricate a per-branch literal (e.g. a label constant) from the base.
+            let branch_from_alias = branch
+                .from
+                .0
+                .as_ref()
+                .and_then(|f| f.alias.clone())
+                .unwrap_or_else(|| VLP_CTE_FROM_ALIAS.to_string());
+            let unified: Vec<crate::render_plan::SelectItem> = base_items
+                .iter()
+                .filter_map(|base_item| {
+                    let alias = base_item.col_alias.as_ref();
+                    if let Some(own) = branch
+                        .select
+                        .items
+                        .iter()
+                        .find(|bi| bi.col_alias.as_ref() == alias && alias.is_some())
+                    {
+                        Some(own.clone())
+                    } else if render_expr_references_alias(
+                        &base_item.expression,
+                        &branch_from_alias,
+                    ) {
+                        Some(base_item.clone())
+                    } else {
+                        // Missing and not a borrowable CTE column — leave it out
+                        // rather than invent a value; arity handled by other means.
+                        None
+                    }
+                })
+                .collect();
+            log::info!(
+                "🧩 Unifying mixed-anchor branch SELECT ({} → {} columns) to base order",
+                branch.select.items.len(),
+                unified.len()
+            );
+            branch.select.items = unified;
+        }
+    }
+}
+
 fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
     log::debug!("🔍 TRACING: rewrite_vlp_select_aliases called - checking for VLP CTEs");
     // 🔧 FIX: If FROM references a WITH CTE (not the raw VLP CTE), skip this rewriting
@@ -1164,7 +1321,23 @@ fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
                 .iter()
                 .all(|c| c.vlp_cypher_end_alias.as_deref() == first_end);
 
-        if fan_in_ctes.len() > 1 && all_same_end {
+        // A genuine spoke/fan-in `(a)-->(x), (b)-->(x), (c)-->(x)` has DISTINCT
+        // start aliases converging on one end — those CTEs are conjunctive and
+        // must be INNER JOINed on end_id. In contrast, a mixed-label anchor
+        // expand `MATCH (a)-[r]-(o)` whose `a` was split by elementId into per-label
+        // UNION-ALL branches produces multiple VLP CTEs that ALL share the SAME
+        // start alias (`a`) and end alias (`o`). Those are ALTERNATIVE anchors
+        // (one per label), not a fan-in: they belong to separate UNION branches and
+        // must NOT be joined. Joining them yields an invalid cross-branch INNER JOIN
+        // (`vlp_multi_type_a_o INNER JOIN vlp_multi_type_a_o_2 ON ... end_id`) and
+        // suppresses per-branch VLP rewriting. Require >1 distinct start alias.
+        let distinct_start_aliases: std::collections::HashSet<&str> = fan_in_ctes
+            .iter()
+            .filter_map(|c| c.vlp_cypher_start_alias.as_deref())
+            .collect();
+        let is_genuine_fan_in = distinct_start_aliases.len() > 1;
+
+        if fan_in_ctes.len() > 1 && all_same_end && is_genuine_fan_in {
             log::info!(
                 "🔀 Fan-in VLP detected: {} CTEs all targeting '{}'",
                 fan_in_ctes.len(),
@@ -3510,8 +3683,27 @@ fn rewrite_cte_body_vlp_refs(plan: &mut RenderPlan, vlp_info: &VlpAliasInfo) {
                 None => continue,
             };
 
-            // Clone and rewrite filters for reverse branch
-            if let Some(ref filter) = original_filters {
+            // Filters: if this branch already carries its OWN filter, rewrite that
+            // in place with the branch's own VLP aliases. Only fall back to cloning
+            // the base plan's filter when the branch has none.
+            //
+            // Cloning-from-base is correct for an undirected VLP's reverse arm, which
+            // shares the base's start-node predicate and has no independent filter.
+            // It is WRONG for a mixed-label anchor UNION split, where each branch
+            // reads a DIFFERENT per-label VLP CTE and already holds its own predicate
+            // (e.g. `a.ip IN [...]` for the IP anchor vs `a.query IN [...]` for the
+            // Domain anchor). Overwriting with the base's predicate produced
+            // `t.start_query IN [...]` against a CTE that only has `start_ip`
+            // (ClickHouse Code 47).
+            if let Some(branch_own) = branch.filters.0.clone() {
+                branch.filters = FilterItems(Some(rewrite_expr_for_vlp(
+                    &branch_own,
+                    &reverse_aliases.0,
+                    &reverse_aliases.1,
+                    &reverse_aliases.2,
+                    false,
+                )));
+            } else if let Some(ref filter) = original_filters {
                 branch.filters = FilterItems(Some(rewrite_expr_for_vlp(
                     filter,
                     &reverse_aliases.0,
@@ -3521,8 +3713,11 @@ fn rewrite_cte_body_vlp_refs(plan: &mut RenderPlan, vlp_info: &VlpAliasInfo) {
                 )));
             }
 
-            // Clone and rewrite JOINs for reverse branch
-            if !original_joins.is_empty() {
+            // JOINs: rewrite the branch's own JOINs if present; otherwise clone the
+            // base plan's (same reverse-arm vs. independent-branch reasoning).
+            if !branch.joins.0.is_empty() {
+                rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
+            } else if !original_joins.is_empty() {
                 branch.joins = JoinItems(original_joins.clone());
                 rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
             }
@@ -3632,6 +3827,14 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
     // Rewrite VLP SELECT aliases before SQL generation
     // Maps Cypher aliases (a, b) to CTE column prefixes (start_, end_)
     plan = rewrite_vlp_select_aliases(plan);
+
+    // Remove spurious disconnected node-materialisation JOINs left over when a
+    // multi-type VLP CTE already materialises the endpoint (mixed-label anchor
+    // expand). See drop_disconnected_vlp_joins.
+    drop_disconnected_vlp_joins(&mut plan);
+
+    // Make per-label anchor UNION branches column-consistent (arity-safe).
+    unify_mixed_anchor_branch_selects(&mut plan);
 
     // 🔧 CRITICAL FIX: Sort JOINs by dependency to ensure correct SQL ordering
     // Topological sort ensures that if JOIN A references table B in its ON clause,

--- a/tests/rust/integration/browser_expand_tests.rs
+++ b/tests/rust/integration/browser_expand_tests.rs
@@ -18,6 +18,214 @@ use clickgraph::{
     server::query_context::{set_current_schema, with_query_context, QueryContext},
 };
 
+/// Full SERVER pipeline: parse → transform_id_functions (runs split_query_by_labels)
+/// → plan → render → SQL. This mirrors `src/server/handlers.rs` exactly and is the
+/// ONLY path that reproduces the mixed-label anchor bug (cg / generate_expand_sql
+/// feed post-rewrite Cypher without the transform's label-split side effects).
+async fn generate_expand_sql_via_server(
+    schema: &GraphSchema,
+    cypher: &str,
+    element_ids: &[&str],
+) -> String {
+    use clickgraph::query_planner::ast_transform;
+    use clickgraph::query_planner::evaluate_read_statement;
+    use clickgraph::server::bolt_protocol::id_mapper::IdMapper;
+
+    let schema = schema.clone();
+    let cypher = cypher.to_string();
+    let element_ids: Vec<String> = element_ids.iter().map(|s| s.to_string()).collect();
+
+    let ctx = QueryContext::new(Some("default".to_string()));
+    with_query_context(ctx, async move {
+        set_current_schema(std::sync::Arc::new(schema.clone()));
+
+        // Mirror the server's Bolt pipeline: substitute_cypher_parameters (Pass 3)
+        // rewrites `elementId(a) IN $nodeIds` into `id(a) IN [encoded_ints]` using
+        // compute_deterministic_id, and primes the IdMapper cache when Browser first
+        // fetched those nodes. We reproduce that state by priming the mapper here so
+        // transform_id_functions can decode each encoded int back to (label, id).
+        let mut id_mapper = IdMapper::new();
+        id_mapper.set_scope(Some("default".to_string()), None);
+        for eid in &element_ids {
+            id_mapper.get_or_assign(eid); // caches element_id <-> encoded int both ways
+        }
+
+        let (_rest, statement) = clickgraph::open_cypher_parser::parse_cypher_statement(&cypher)
+            .unwrap_or_else(|e| panic!("parse: {e:?}\nCypher: {cypher}"));
+
+        let arena = ast_transform::StringArena::new();
+        let (transformed, _labels) =
+            ast_transform::transform_id_functions(&arena, statement, &id_mapper, Some(&schema));
+
+        clickgraph::query_planner::logical_plan::reset_all_counters();
+
+        let (logical_plan, plan_ctx) =
+            evaluate_read_statement(transformed, &schema, None, None, None)
+                .unwrap_or_else(|e| panic!("plan: {e:?}\nCypher: {cypher}"));
+
+        // Server parity: render WITH plan_ctx (VLP endpoints / multi-type joins).
+        let render_plan = clickgraph::render_plan::logical_plan_to_render_plan_with_ctx(
+            logical_plan,
+            &schema,
+            Some(&plan_ctx),
+        )
+        .unwrap_or_else(|e| panic!("render: {e:?}\nCypher: {cypher}"));
+
+        clickgraph::clickhouse_query_generator::generate_sql(render_plan, 20)
+    })
+    .await
+}
+
+/// Build the post-`substitute_cypher_parameters` query form for a mixed/single
+/// anchor browser expand: `elementId(a) IN $nodeIds` becomes `id(a) IN [ints]`.
+fn encode_ids(element_ids: &[&str]) -> String {
+    use clickgraph::server::bolt_protocol::id_mapper::IdMapper;
+    element_ids
+        .iter()
+        .map(|e| IdMapper::compute_deterministic_id(e).to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn zeek_dns_schema() -> GraphSchema {
+    clickgraph::graph_catalog::config::GraphSchemaConfig::from_yaml_str(include_str!(
+        "zeek_dns_graph.yaml"
+    ))
+    .expect("parse zeek_dns_graph.yaml")
+    .to_graph_schema()
+    .expect("convert zeek schema")
+}
+
+/// Returns the SQL from the start of the OUTER query onward (after the WITH/CTE
+/// list closes), so assertions don't match inside CTE bodies. The CTE list ends
+/// with `)\nSELECT` (the last CTE closes with `)` + newline, not `),`).
+fn outer_query_fragment(sql: &str) -> &str {
+    if let Some(pos) = sql.find(")\nSELECT") {
+        // Skip the closing paren + newline, start at the outer SELECT.
+        return &sql[pos + 2..];
+    }
+    // No CTEs — the whole thing is the outer query.
+    let pos = sql.find("SELECT ").unwrap_or(0);
+    &sql[pos..]
+}
+
+/// Assert the outer FROM/JOIN clauses only reference `t` / `t_fi_*` / CTE names —
+/// never a bare Cypher anchor alias (`a`) or endpoint alias (`o`), which would be
+/// out of scope in the outer query and yield ClickHouse Code 47.
+fn assert_no_bare_anchor_aliases_in_outer(sql: &str) {
+    let outer = outer_query_fragment(sql);
+    for pat in [" AS a\n", " AS a ", " AS o\n", " AS o ", " AS a,", " AS o,"] {
+        assert!(
+            !outer.contains(pat),
+            "outer query must not bind bare anchor/endpoint alias ('{}'):\n{}",
+            pat.trim(),
+            outer
+        );
+    }
+    // The dotted node-materialisation column that leaked in the live capture.
+    assert!(
+        !outer.contains("id.orig_h"),
+        "outer query must not reference the phantom node-materialisation column `id.orig_h`:\n{outer}"
+    );
+}
+
+/// REGRESSION (mixed-label anchor expand → ClickHouse Code 47).
+///
+/// A Neo4j-Browser multi-node "expand" whose selected `nodeIds` are of MIXED
+/// labels (`IP` + `Domain`, backed by different tables) sends
+/// `MATCH (a)-[r]-(o) WHERE elementId(a) IN $nodeIds ...`. `transform_id_functions`
+/// runs `split_query_by_labels`, producing a per-label UNION. This used to emit
+/// invalid SQL: the two per-label anchor CTEs were combined with a `_fi_` INNER
+/// JOIN (they are ALTERNATIVE anchors, not a fan-in), plus a phantom node
+/// materialisation JOIN referencing out-of-scope `a`/`o` aliases → Code 47.
+///
+/// The fix must emit a valid UNION ALL of the two single-anchor expands.
+#[tokio::test]
+async fn mixed_label_anchor_expand_emits_valid_union() {
+    let schema = zeek_dns_schema();
+    let ids = ["IP:104.16.133.229-", "Domain:cloudflare.com-"];
+    // Post-substitute_cypher_parameters form: `elementId(a) IN $nodeIds`
+    // → `id(a) IN [encoded ints]`; the dedupe-CASE for `o` collapses to bare `o`.
+    let cypher = format!(
+        "MATCH (a)-[r]-(o) WHERE id(a) IN [{}] RETURN r, o LIMIT 100",
+        encode_ids(&ids)
+    );
+    let sql = generate_expand_sql_via_server(&schema, &cypher, &ids).await;
+
+    // Two per-label anchor CTEs combined with UNION ALL, not a `_fi_` INNER JOIN.
+    assert!(
+        sql.contains("vlp_multi_type_a_o") && sql.contains("vlp_multi_type_a_o_2"),
+        "expected two per-label anchor CTEs:\n{sql}"
+    );
+    assert!(
+        sql.contains("UNION ALL"),
+        "the two anchor branches must be combined with UNION ALL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("t_fi_"),
+        "alternative anchors must NOT be joined via the filter-injection `_fi_` INNER JOIN:\n{sql}"
+    );
+
+    // Outer query must be scoped to the VLP CTE alias `t` only.
+    assert_no_bare_anchor_aliases_in_outer(&sql);
+    let outer = outer_query_fragment(&sql);
+    assert!(
+        outer.contains("FROM vlp_multi_type_a_o AS t")
+            && outer.contains("FROM vlp_multi_type_a_o_2 AS t"),
+        "each outer branch must select FROM its own VLP CTE aliased `t`:\n{outer}"
+    );
+
+    // Each branch filters on ITS OWN CTE's start column (no cross-branch leak).
+    assert!(
+        outer.contains("t.start_ip IN ['104.16.133.229']"),
+        "IP anchor branch must filter on t.start_ip:\n{outer}"
+    );
+    assert!(
+        outer.contains("t.start_query IN ['cloudflare.com']"),
+        "Domain anchor branch must filter on t.start_query:\n{outer}"
+    );
+    // The IP anchor's column must never be applied to the Domain CTE and vice versa.
+    assert!(
+        !outer.contains("t.start_query IN ['104.16.133.229']")
+            && !outer.contains("t.start_ip IN ['cloudflare.com']"),
+        "branch filters must not be cross-contaminated:\n{outer}"
+    );
+
+    // Both UNION branches must project the same number of columns (arity-safe).
+    let branch_col_counts: Vec<usize> = outer
+        .split("UNION ALL")
+        .map(|b| b.matches("AS \"").count())
+        .collect();
+    assert!(
+        branch_col_counts.windows(2).all(|w| w[0] == w[1]),
+        "UNION branches must have equal column arity, got {branch_col_counts:?}:\n{outer}"
+    );
+}
+
+/// Single-label anchor expand (only one label in `nodeIds`) must stay valid and
+/// unchanged: one VLP CTE, FROM `t`, filter on its own start column, no UNION.
+#[tokio::test]
+async fn single_label_anchor_expand_unchanged() {
+    let schema = zeek_dns_schema();
+    let ids = ["IP:104.16.133.229-"];
+    let cypher = format!(
+        "MATCH (a)-[r]-(o) WHERE id(a) IN [{}] RETURN r, o LIMIT 100",
+        encode_ids(&ids)
+    );
+    let sql = generate_expand_sql_via_server(&schema, &cypher, &ids).await;
+
+    assert!(sql.contains("FROM vlp_multi_type_a_o AS t"), "SQL:\n{sql}");
+    assert!(
+        sql.contains("t.start_ip = '104.16.133.229'"),
+        "single anchor must filter on its own start column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("vlp_multi_type_a_o_2"),
+        "single-label anchor must not create a second CTE:\n{sql}"
+    );
+    assert_no_bare_anchor_aliases_in_outer(&sql);
+}
+
 use super::browser_test_schemas::*;
 
 // ---------------------------------------------------------------------------

--- a/tests/rust/integration/zeek_dns_graph.yaml
+++ b/tests/rust/integration/zeek_dns_graph.yaml
@@ -1,0 +1,109 @@
+# Zeek DNS — Graph model with ARRAY-FLATTENING VIEWS (reference example)
+# =============================================================================
+# Demonstrates modeling an ARRAY column (dns_log.answers — the list of resolved
+# IPs) as first-class graph NODES, without any array-valued node_id.
+#
+# Key technique (views are an under-used lever in schema mapping):
+#   1. Do the array flattening + column normalization in ClickHouse VIEWS.
+#   2. Point the schema's `table:` at the view; its `to_id:`/`node_id:` at the
+#      now-scalar column. A view is queried exactly like a table.
+#   3. Carve per-position SUBSETS of a view with `filter:` (a WHERE expression),
+#      instead of proliferating views or denormalized from/to property maps.
+#
+# Why not use the raw `answers` array as ResolvedIP.node_id?
+#   A node identity must be SCALAR (elementId, joins, dedup, filters). An
+#   Array(String) breaks all of that. The `arrayJoin` view turns the array into
+#   one scalar `resolved_ip` per row → each resolved IP becomes a proper node,
+#   unified with source IPs as ONE `IP` type. That unlocks pivots the array
+#   model can't express, e.g. domains sharing infrastructure:
+#     MATCH (d1:Domain)-[:RESOLVED_TO]->(ip:IP)<-[:RESOLVED_TO]-(d2:Domain)
+#     RETURN d1.name, ip.ip, d2.name
+#
+# -----------------------------------------------------------------------------
+# REQUIRED VIEWS (create once in ClickHouse; ALIAS/VIEW = computed on read, no
+# storage — "ClickHouse doesn't care"):
+#
+#   CREATE OR REPLACE VIEW zeek.dns_resolutions AS
+#     SELECT `id.orig_h`      AS src_ip,
+#            query            AS domain,
+#            arrayJoin(answers) AS resolved_ip,   -- 1 row per resolved IP
+#            ts, uid, qtype_name AS qtype, rcode_name AS rcode
+#     FROM zeek.dns_log;
+#
+#   CREATE OR REPLACE VIEW zeek.all_ips AS
+#     SELECT `id.orig_h` AS ip FROM zeek.dns_log
+#     UNION DISTINCT SELECT resolved_ip FROM zeek.dns_resolutions;
+#     -- add more IP-bearing sources here as they arrive, e.g.:
+#     -- UNION DISTINCT SELECT src_ip FROM zeek.access_log
+#     -- UNION DISTINCT SELECT dst_ip FROM zeek.access_log
+# =============================================================================
+
+name: zeek_dns_graph
+version: "1.0"
+
+graph_schema:
+  nodes:
+    # Unified IP node — source AND resolved IPs are the same entity.
+    # ONE table (the union view), ONE node_id, ONE property mapping: the
+    # per-position column difference (id.orig_h vs resolved_ip vs …) is absorbed
+    # by the view's UNION branches, NOT by denormalized from/to property maps.
+    - label: IP
+      database: zeek
+      table: all_ips
+      node_id: ip
+      property_mappings:
+        ip: ip
+
+    # A SUBSET of the SAME view via `filter:` — public/external IPs only.
+    # Shows how one view serves multiple labels/positions without extra views.
+    - label: ExternalIP
+      database: zeek
+      table: all_ips
+      node_id: ip
+      property_mappings:
+        ip: ip
+      filter: "NOT startsWith(ip, '192.168.') AND NOT startsWith(ip, '10.')"
+
+    - label: Domain
+      database: zeek
+      table: dns_log
+      node_id: query
+      property_mappings:
+        name: query
+
+  edges:
+    # Source IP queried a Domain (straight off dns_log).
+    - type: REQUESTED
+      database: zeek
+      table: dns_log
+      from_id: "id.orig_h"
+      to_id: query
+      from_node: IP
+      to_node: Domain
+      property_mappings:
+        timestamp: ts
+        uid: uid
+
+    # Domain resolved to each individual IP (from the arrayJoin view).
+    # to_id is the SCALAR `resolved_ip`, never the array.
+    # Optional per-edge subset: restrict to successful A-records with
+    #   filter: "qtype = 'A' AND rcode = 'NOERROR'"
+    - type: RESOLVED_TO
+      database: zeek
+      table: dns_resolutions
+      from_id: domain
+      to_id: resolved_ip
+      from_node: Domain
+      to_node: IP
+      property_mappings:
+        timestamp: ts
+
+    # Follow-on (add when the access_log table is available): IP -> IP.
+    # - type: ACCESS
+    #   database: zeek
+    #   table: access_log
+    #   from_id: src_ip
+    #   to_id: dst_ip
+    #   from_node: IP
+    #   to_node: IP
+    #   property_mappings: { timestamp: ts }


### PR DESCRIPTION
## Problem

A Neo4j-Browser **expand** whose selection spans **different labels** (e.g. an IP and a Domain — the *normal* chained-exploration flow in a heterogeneous/bipartite graph, since a node's neighbours are the opposite type) sent `elementId(a) IN [IP:.., Domain:..]`. `IdFunctionTransformer` correctly split this into a top-level `UNION` of `(a:IP)-[r]-(o)` and `(a:Domain)-[r]-(o)`, but the render/planner pipeline mishandled a UNION whose branches **reuse the same aliases** (`a`,`r`,`o`) with per-label VLP CTEs → invalid ClickHouse SQL (**Code 47**, `Unknown … identifier o.id.orig_h`).

Single-node / single-label expands were unaffected (verified live). This triggers whenever a selection touches nodes of >1 label.

## Root causes & fixes

1. **Filter cross-contamination (the Code 47 trigger).** Per-branch `PlanCtx` merge put both `a.ip IN […]` and `a.query IN […]` on alias `a`; `FilterIntoGraphRel` pushed all of them into every `a` scan → `a.query` on `all_ips`. **`retain_filters_for_scan`** drops a predicate only when the alias is filtered on **≥2 distinct id columns** and this scan lacks the referenced one (keeps ordinary + polymorphic pushdown intact).
2. **FROM fell back to a raw table** — `find_multi_type_graph_rel` now traverses `Limit`/`Skip`/`OrderBy`.
3. **`_fi_` cross-branch INNER JOIN** — fan-in detector now requires **distinct start aliases** (alternative anchors aren't a fan-in).
4. **Phantom node-materialization JOIN + branch filter overwrite** — `rewrite_cte_body_vlp_refs` rewrites a branch's own filter/joins; `drop_disconnected_vlp_joins` + `unify_mixed_anchor_branch_selects` clean the outer join & UNION arity.

### Before → after
```
-- before (invalid): t_fi_ INNER JOIN of alternative anchors + bare a/o + cross-contaminated WHERE (a.query IN.. AND a.ip IN..)
-- after (valid):
SELECT … FROM vlp_multi_type_a_o  AS t WHERE t.start_ip    IN ['104.16.133.229']
UNION ALL
SELECT … FROM vlp_multi_type_a_o_2 AS t WHERE t.start_query IN ['cloudflare.com']
```

## Tests

New pipeline-level harness `generate_expand_sql_via_server` (primes IdMapper → `transform_id_functions` → plan → render, mirroring the Bolt flow) + `mixed_label_anchor_expand_emits_valid_union`, `single_label_anchor_expand_unchanged`, fixture `zeek_dns_graph.yaml`. **1503 lib + 288 integration pass; clippy clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)