### PR TITLE
docs(schema): disable isolated ExternalIP label in zeek_dns_graph example

### DIFF
--- a/schemas/examples/zeek_dns_graph.yaml
+++ b/schemas/examples/zeek_dns_graph.yaml
@@ -56,13 +56,18 @@ graph_schema:
 
     # A SUBSET of the SAME view via `filter:` — public/external IPs only.
     # Shows how one view serves multiple labels/positions without extra views.
-    - label: ExternalIP
-      database: zeek
-      table: all_ips
-      node_id: ip
-      property_mappings:
-        ip: ip
-      filter: "NOT startsWith(ip, '192.168.') AND NOT startsWith(ip, '10.')"
+    #
+    # DISABLED: no edge references ExternalIP, so it renders as isolated dots in a
+    # graph browser (every relationship uses IP/Domain). Kept here, commented, as a
+    # `filter:` usage example. To use it, give it an edge (e.g. an ACCESS edge whose
+    # endpoint is ExternalIP) or query it directly with `MATCH (n:ExternalIP)`.
+    # - label: ExternalIP
+    #   database: zeek
+    #   table: all_ips
+    #   node_id: ip
+    #   property_mappings:
+    #     ip: ip
+    #   filter: "NOT startsWith(ip, '192.168.') AND NOT startsWith(ip, '10.')"
 
     - label: Domain
       database: zeek


### PR DESCRIPTION
`ExternalIP` in the `zeek_dns_graph` example is referenced by **no edge** (every relationship uses `IP`/`Domain`), so it renders as isolated dots in a graph browser and double-clicking it does nothing / appears to "disappear". Comment it out — kept as a `filter:`-feature usage example with a note on re-enabling it via an edge (e.g. `ACCESS`) — so the demo graph is fully connected.

No engine change; example schema only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)