### PR TITLE
fix(sql): correct type(r) array index on multi-type edges (CH silent-wrong + Databricks error)

### DIFF
--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -929,8 +929,14 @@ impl ProjectionTagging {
                                                     table_alias: TableAlias("t".to_string()), // VLP CTE uses 't' alias
                                                     column: crate::graph_catalog::expression_parser::PropertyValue::Column("path_relationships".to_string()),
                                                 })),
+                                                // ArraySubscript uses the 0-based Cypher convention (the
+                                                // renderer adds +1 for CH's 1-based arrays). type(r) on a
+                                                // 1-hop wants the FIRST relationship → index 0, not 1.
+                                                // (Index 1 rendered as [2], out of bounds on a 1-element
+                                                // path_relationships array: CH silently returned "" while
+                                                // Spark/Databricks errored INVALID_ARRAY_INDEX.)
                                                 index: Box::new(LogicalExpr::Literal(
-                                                    crate::query_planner::logical_expr::Literal::Integer(1),
+                                                    crate::query_planner::logical_expr::Literal::Integer(0),
                                                 )),
                                             };
                                             return Ok(());

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -6190,21 +6190,39 @@ impl RenderExpr {
                 pc.sql.clone()
             }
             RenderExpr::ArraySubscript { array, index } => {
-                // Array subscript in ClickHouse: array[index]
-                // Cypher uses 0-based indexing; ClickHouse uses 1-based.
-                // For integer literals we add +1 at compile time.
-                // For expression indices we emit (expr)+1 without an explicit cast
-                // so ClickHouse's own type checker catches bad types (e.g. floats,
-                // strings) rather than silently coercing them.
-                // Exception: string-literal indices are map-key accesses
-                //   (e.g. top['score']) and must NOT be offset.
+                // Cypher uses 0-based indexing; array element access is 1-based on
+                // both CH (`arr[i]`) and Spark (`element_at(arr, i)` — Spark's own
+                // `arr[i]` subscript is 0-based, so it can't be used directly). The
+                // mapper picks the right 1-based accessor per dialect.
+                // For integer literals we add +1 at compile time; for expression
+                // indices we emit (expr)+1 without a cast so the engine's type
+                // checker catches bad types (floats, strings) rather than coercing.
+                // Exception: string-literal indices are MAP-KEY accesses
+                //   (e.g. top['score']) — `arr['key']` works on both dialects and
+                //   must NOT be offset or routed through element_at.
                 let array_sql = array.to_sql();
-                let index_sql = match index.as_ref() {
-                    RenderExpr::Literal(Literal::Integer(n)) => format!("{}", n + 1),
-                    RenderExpr::Literal(Literal::String(_)) => index.to_sql(),
-                    _ => format!("({})+1", index.to_sql()),
-                };
-                format!("{}[{}]", array_sql, index_sql)
+                match index.as_ref() {
+                    RenderExpr::Literal(Literal::String(_)) => {
+                        // Map-key access (e.g. top['score']) — `arr['key']` works on
+                        // both dialects and must NOT be offset or use element_at.
+                        format!("{}[{}]", array_sql, index.to_sql())
+                    }
+                    _ => {
+                        // 1-based index (Cypher 0-based + 1). CH `arr[i]` is 1-based;
+                        // Spark `arr[i]` is 0-based, so Databricks must use the 1-based
+                        // `element_at(arr, i)` instead. CH form is left byte-identical.
+                        let idx_1based = match index.as_ref() {
+                            RenderExpr::Literal(Literal::Integer(n)) => format!("{}", n + 1),
+                            _ => format!("({})+1", index.to_sql()),
+                        };
+                        match crate::server::query_context::get_current_dialect() {
+                            crate::sql_generator::SqlDialect::Databricks => {
+                                format!("element_at({}, {})", array_sql, idx_1based)
+                            }
+                            _ => format!("{}[{}]", array_sql, idx_1based),
+                        }
+                    }
+                }
             }
             RenderExpr::ArraySlicing { array, from, to } => {
                 // Array slicing -> arraySlice(arr, offset, length) (CH) / slice (Spark),

--- a/tests/rust/integration/golden/sql_ir/multi_type_rel_type_fn__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/multi_type_rel_type_fn__clickhouse.sql
@@ -1,0 +1,13 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Post' AS end_type, p2.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, toString(r1.user_id) AS r_from_id, toString(r1.post_id) AS r_to_id, formatRowNoNewline('JSONEachRow', p2.author_id AS author_id, p2.post_content AS content, p2.post_date AS date, p2.post_id AS post_id, p2.post_title AS title) AS end_properties, p2.author_id AS end_author_id, p2.post_content AS end_content, p2.post_date AS end_date, p2.post_id AS end_post_id, p2.post_title AS end_title, formatRowNoNewline('JSONEachRow', a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 1 AS hop_count, ['AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.authored_date)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id)] AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.authored_bench r1 ON a_1.user_id = r1.user_id
+INNER JOIN social.posts_bench p2 ON r1.post_id = p2.post_id
+)
+SELECT 
+      t.path_relationships[1] AS "t"
+FROM vlp_multi_type_a_b AS t
+UNION ALL 
+SELECT 
+      t.path_relationships[1] AS "t"
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/multi_type_rel_type_fn__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/multi_type_rel_type_fn__databricks.sql
@@ -1,0 +1,13 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Post' AS end_type, p2.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, string(r1.user_id) AS r_from_id, string(r1.post_id) AS r_to_id, to_json(struct(p2.author_id AS author_id, p2.post_content AS content, p2.post_date AS date, p2.post_id AS post_id, p2.post_title AS title)) AS end_properties, p2.author_id AS end_author_id, p2.post_content AS end_content, p2.post_date AS end_date, p2.post_id AS end_post_id, p2.post_title AS end_title, to_json(struct(a_1.city, a_1.country, a_1.email_address, a_1.is_active, a_1.full_name, a_1.registration_date, a_1.user_id)) AS start_properties, a_1.city AS start_city, a_1.country AS start_country, a_1.email_address AS start_email, a_1.is_active AS start_is_active, a_1.full_name AS start_name, a_1.registration_date AS start_registration_date, a_1.user_id AS start_user_id, 1 AS hop_count, array('AUTHORED') AS path_relationships, array(to_json(struct(r1.authored_date))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id)) AS path_nodes
+FROM social.users_bench a_1
+INNER JOIN social.authored_bench r1 ON a_1.user_id = r1.user_id
+INNER JOIN social.posts_bench p2 ON r1.post_id = p2.post_id
+)
+SELECT 
+      element_at(t.path_relationships, 1) AS `t`
+FROM vlp_multi_type_a_b AS t
+UNION ALL 
+SELECT 
+      element_at(t.path_relationships, 1) AS `t`
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -157,6 +157,15 @@ const CORPUS: &[(&str, &str)] = &[
         "vlp_multi_type",
         "MATCH (a:User)-[:FOLLOWS|AUTHORED*1..2]->(b) RETURN b",
     ),
+    // type(r) on a multi-type edge reads the CTE's `path_relationships` array.
+    // Regression guard for the array-index fix: the FIRST relationship is index 0
+    // (Cypher 0-based) -> renders 1-based as CH `path_relationships[1]` and
+    // Databricks `element_at(path_relationships, 1)`. The previous `[2]` was out of
+    // bounds on a 1-element array (CH silently returned ""; Databricks errored).
+    (
+        "multi_type_rel_type_fn",
+        "MATCH (a:User)-[r:FOLLOWS|AUTHORED]->(b) RETURN type(r) AS t",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

`type(r)` on a **multi-type / polymorphic edge** reads the multi-type CTE's `path_relationships` array, but accessed index **`[2]` of a 1-element array**. Surfaced by the Databricks parity harness on `social_polymorphic`:

```
MATCH (u:User)-[r]->(x) RETURN type(r)
  ClickHouse → ""                    (silent out-of-bounds → wrong result)
  Databricks → INVALID_ARRAY_INDEX    (strict error)
```

Two bugs:
1. **Off-by-one** — `projection_tagging` built the `ArraySubscript` with logical index `1`, but the convention is **0-based Cypher** (the renderer adds +1). The first relationship of a 1-hop is index `0`; `1` rendered as `[2]`.
2. **Spark 0-based subscript** — the renderer emitted `arr[i]` for both dialects, but Spark's `[]` is **0-based** (`array('a','b')[1]` → `'b'`) while CH's is 1-based.

## Fixes
- `projection_tagging`: logical index `1` → `0`.
- ArraySubscript renderer: dialect-aware — CH keeps `arr[i]` (byte-identical, **no golden churn**); Databricks uses `element_at(arr, i)` (1-based, matches CH). Map-key access (`arr['key']`) untouched.

## Verification
- `type(r)` now returns real types on **both** backends: `{AUTHORED:3, FOLLOWS:4, LIKES:3}`.
- New golden `multi_type_rel_type_fn` locks `path_relationships[1]` (CH) / `element_at(…, 1)` (Databricks).
- **1504 lib + 288 integration** pass; clippy clean; **LDBC parity sweep still 20/21** (no regression from the array-subscript change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)