### PR TITLE
fix(sql): map replace/head/last/stdev to Spark names for Databricks

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -257,7 +257,7 @@ lazy_static::lazy_static! {
         m.insert("replace", FunctionMapping {
             neo4j_name: "replace",
             clickhouse_name: "replaceAll",
-            databricks_name: None,
+            databricks_name: Some("replace"), // Spark literal 3-arg replace
             arg_transform: None,
         });
 
@@ -365,7 +365,7 @@ lazy_static::lazy_static! {
         m.insert("head", FunctionMapping {
             neo4j_name: "head",
             clickhouse_name: "arrayElement",
-            databricks_name: None,
+            databricks_name: Some("element_at"), // Spark 1-based element access
             arg_transform: Some(|args| {
                 if !args.is_empty() {
                     vec![args[0].clone(), "1".to_string()]
@@ -405,7 +405,7 @@ lazy_static::lazy_static! {
         m.insert("last", FunctionMapping {
             neo4j_name: "last",
             clickhouse_name: "arrayElement",
-            databricks_name: None,
+            databricks_name: Some("element_at"), // Spark element_at supports -1 (last)
             arg_transform: Some(|args| {
                 if !args.is_empty() {
                     vec![args[0].clone(), "-1".to_string()]
@@ -608,7 +608,7 @@ lazy_static::lazy_static! {
         m.insert("stdev", FunctionMapping {
             neo4j_name: "stDev",
             clickhouse_name: "stddevSamp",
-            databricks_name: None,
+            databricks_name: Some("stddev_samp"),
             arg_transform: None,
         });
 
@@ -616,7 +616,7 @@ lazy_static::lazy_static! {
         m.insert("stdevp", FunctionMapping {
             neo4j_name: "stDevP",
             clickhouse_name: "stddevPop",
-            databricks_name: None,
+            databricks_name: Some("stddev_pop"),
             arg_transform: None,
         });
 

--- a/tests/rust/integration/golden/sql_ir/fn_head_last__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_head_last__clickhouse.sql
@@ -1,0 +1,8 @@
+WITH with_ns_cte_0 AS (SELECT 
+      groupArray(u.full_name) AS "ns"
+FROM social.users_bench AS u
+)
+SELECT 
+      arrayElement(ns.ns, 1) AS "h", 
+      arrayElement(ns.ns, -1) AS "l"
+FROM with_ns_cte_0 AS ns

--- a/tests/rust/integration/golden/sql_ir/fn_head_last__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_head_last__databricks.sql
@@ -1,0 +1,8 @@
+WITH with_ns_cte_0 AS (SELECT 
+      collect_list(u.full_name) AS `ns`
+FROM social.users_bench AS u
+)
+SELECT 
+      element_at(ns.ns, 1) AS `h`, 
+      element_at(ns.ns, -1) AS `l`
+FROM with_ns_cte_0 AS ns

--- a/tests/rust/integration/golden/sql_ir/fn_replace__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_replace__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      replaceAll(u.full_name, 'a', 'X') AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_replace__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_replace__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      replace(u.full_name, 'a', 'X') AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_stdev__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_stdev__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      stddevSamp(u.user_id) AS "s"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_stdev__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_stdev__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      stddev_samp(u.user_id) AS `s`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -166,6 +166,22 @@ const CORPUS: &[(&str, &str)] = &[
         "multi_type_rel_type_fn",
         "MATCH (a:User)-[r:FOLLOWS|AUTHORED]->(b) RETURN type(r) AS t",
     ),
+    // Dialect function-name mappings (regression for the Databricks overrides):
+    // replace -> CH replaceAll / Spark replace; head/last -> CH arrayElement /
+    // Spark element_at; stdev -> CH stddevSamp / Spark stddev_samp. Previously all
+    // emitted the CH name on Databricks (unmapped function -> execution error).
+    (
+        "fn_replace",
+        "MATCH (u:User) RETURN replace(u.name, 'a', 'X') AS r",
+    ),
+    (
+        "fn_head_last",
+        "MATCH (u:User) WITH collect(u.name) AS ns RETURN head(ns) AS h, last(ns) AS l",
+    ),
+    (
+        "fn_stdev",
+        "MATCH (u:User) RETURN stdev(u.user_id) AS s",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

The Databricks parity probe on `social_integration` surfaced a class of **unmapped functions**: their registry entries had `databricks_name: None`, so they fell back to the ClickHouse name and **errored at execution on Databricks** (unknown function):

| Cypher fn | emitted (Spark error) | fixed |
|---|---|---|
| `replace` | `replaceAll` | `replace` |
| `head` | `arrayElement` | `element_at` |
| `last` | `arrayElement` | `element_at` (Spark `element_at(-1)` = last) |
| `stdev` | `stddevSamp` | `stddev_samp` |
| `stdevp` | `stddevPop` | `stddev_pop` |

## Fix
Add `databricks_name: Some(...)` overrides in `function_registry.rs`. CH output unchanged.

## Verification
- Parity probe: `replace`/`head`/`last`/`stdev` all flip to **MATCH** CH↔Databricks.
- Golden regression `fn_replace`, `fn_head_last`, `fn_stdev` — CH keeps `replaceAll`/`arrayElement`/`stddevSamp`; Databricks emits `replace`/`element_at`/`stddev_samp`.
- **1504 lib + 288 integration** pass; clippy clean.

## Deferred
`range` — Cypher `range(1,5)` is *inclusive*, CH `range` *exclusive*, Spark `sequence` inclusive. Needs semantic/arg handling (and CH may already be off for Cypher `range`); filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)