### PR TITLE
fix(sql): map toBoolean to toBool/boolean (invalid if() for string args)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -449,18 +449,14 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
-        // toBoolean() -> if(arg, 1, 0) - ClickHouse doesn't have native boolean conversion
+        // toBoolean() -> toBool() (CH) / boolean() (Spark). Both accept string
+        // ('true'/'false') and numeric args; the old if(arg,1,0) form broke on
+        // string inputs (CH: "Illegal type String ... of function if").
         m.insert("toboolean", FunctionMapping {
             neo4j_name: "toBoolean",
-            clickhouse_name: "if",
-            databricks_name: None,
-            arg_transform: Some(|args| {
-                if !args.is_empty() {
-                    vec![args[0].clone(), "1".to_string(), "0".to_string()]
-                } else {
-                    args.to_vec()
-                }
-            }),
+            clickhouse_name: "toBool",
+            databricks_name: Some("boolean"),
+            arg_transform: None,
         });
 
         // ===== AGGREGATION FUNCTIONS =====

--- a/tests/rust/integration/golden/sql_ir/fn_toboolean__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_toboolean__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toBool('true') AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_toboolean__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_toboolean__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      boolean('true') AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -182,6 +182,13 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_stdev",
         "MATCH (u:User) RETURN stdev(u.user_id) AS s",
     ),
+    // toBoolean -> CH toBool / Spark boolean. Both accept string ('true'/'false')
+    // and numeric args; the old if(arg,1,0) form emitted invalid SQL for string
+    // inputs (CH: "Illegal type String ... of function if").
+    (
+        "fn_toboolean",
+        "MATCH (u:User) RETURN toBoolean('true') AS r",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

`toBoolean()` was rendered as `if(arg, 1, 0)`, which only works for numeric args. For the string form Cypher requires — `toBoolean('true')` / `toBoolean('false')` — ClickHouse rejected the SQL:

```
Code: 43. DB::Exception: Illegal type String of first argument (condition)
of function if. Must be UInt8: In scope SELECT if('true', 1, 0) AS r
```

Databricks would have failed the same way (it fell back to the CH name since `databricks_name` was `None`).

## Fix

Map `toBoolean` to CH `toBool` / Spark `boolean`, dropping the `if(x,1,0)` arg-transform. Both functions natively accept **string** (`'true'`/`'false'`, case-insensitive) **and numeric** args, matching Cypher `toBoolean` semantics.

| Dialect | Before | After |
|---|---|---|
| ClickHouse | `if('true', 1, 0)` ❌ | `toBool('true')` ✅ |
| Databricks | `if('true', 1, 0)` ❌ | `boolean('true')` ✅ |

## Verification

- Live CH: `toBoolean('true')` → `true`
- Parity probe (math/type-conversion suite): `toBoolean` flips CH-error → **MATCH**; suite 20/20 clean (aside from `variance`, which is not a Cypher function → expected passthrough)
- Dialect-aware golden regression added (`fn_toboolean`)
- Gate: 1504 lib + 286 integration + 0 clippy

Found by the CH↔Databricks parity probe — same loop that produced #441/#442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)