### PR TITLE
fix(sql): correct negative list indexing (Cypher [-1] was silently wrong)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -6211,9 +6211,25 @@ impl RenderExpr {
                         // 1-based index (Cypher 0-based + 1). CH `arr[i]` is 1-based;
                         // Spark `arr[i]` is 0-based, so Databricks must use the 1-based
                         // `element_at(arr, i)` instead. CH form is left byte-identical.
+                        //
+                        // Negative indices (Cypher `-1` = last) map UNCHANGED: both CH
+                        // arrayElement(arr,-1) and Spark element_at(arr,-1) already mean
+                        // "last", so a blind +1 wrongly shifts `-1`->`0` (CH then returns
+                        // the type default, silently wrong). Cypher `-1` reaches here as
+                        // the expression `0 - 1` (the parser lowers unary minus that way),
+                        // so a literal-only guard misses it — the runtime `if` below
+                        // handles both literal and computed negative indices.
                         let idx_1based = match index.as_ref() {
-                            RenderExpr::Literal(Literal::Integer(n)) => format!("{}", n + 1),
-                            _ => format!("({})+1", index.to_sql()),
+                            // Non-negative integer literal: clean compile-time +1.
+                            RenderExpr::Literal(Literal::Integer(n)) if *n >= 0 => {
+                                format!("{}", n + 1)
+                            }
+                            // General/runtime index: +1 only when non-negative. `if` is
+                            // spelled the same and evaluates identically on CH and Spark.
+                            _ => {
+                                let i = index.to_sql();
+                                format!("if(({i}) >= 0, ({i})+1, ({i}))")
+                            }
                         };
                         match crate::server::query_context::get_current_dialect() {
                             crate::sql_generator::SqlDialect::Databricks => {

--- a/tests/rust/integration/golden/sql_ir/list_index_negative__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/list_index_negative__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      [10, 20, 30][if((0 - 1) >= 0, (0 - 1)+1, (0 - 1))] AS "last", 
+      [10, 20, 30][1] AS "first"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/list_index_negative__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/list_index_negative__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      element_at(array(10, 20, 30), if((0 - 1) >= 0, (0 - 1)+1, (0 - 1))) AS `last`, 
+      element_at(array(10, 20, 30), 1) AS `first`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -166,6 +166,16 @@ const CORPUS: &[(&str, &str)] = &[
         "multi_type_rel_type_fn",
         "MATCH (a:User)-[r:FOLLOWS|AUTHORED]->(b) RETURN type(r) AS t",
     ),
+    // Negative list index: Cypher `[-1]` = last element. Both CH arrayElement and
+    // Spark element_at already treat -1 as last, so it must render UNCHANGED (not
+    // offset by +1). The old +1 shifted -1 -> 0, and CH `arr[0]` silently returned
+    // the type default (0) instead of the last element. Guards CH `[-1]` /
+    // Databricks `element_at(..., -1)`; a non-negative index (index0 -> [1]) is the
+    // control.
+    (
+        "list_index_negative",
+        "MATCH (u:User) RETURN [10, 20, 30][-1] AS last, [10, 20, 30][0] AS first",
+    ),
     // Dialect function-name mappings (regression for the Databricks overrides):
     // replace -> CH replaceAll / Spark replace; head/last -> CH arrayElement /
     // Spark element_at; stdev -> CH stddevSamp / Spark stddev_samp. Previously all


### PR DESCRIPTION
## Problem

`list[-1]` (Cypher: last element) rendered as `list[(0-1)+1]` = `list[0]`, so **ClickHouse silently returned the type default** (e.g. `0`) instead of the last element. Databricks was equally wrong.

The array-subscript renderer blindly added `+1` to every index (to convert Cypher's 0-based indexing to the 1-based accessors — CH `arr[i]`, Spark `element_at`). But negative indices must pass through **unchanged**: both CH `arrayElement(arr,-1)` and Spark `element_at(arr,-1)` already mean "last", matching Cypher.

## Why a literal guard isn't enough

Cypher `-1` reaches the renderer as the expression `0 - 1` (the parser lowers unary minus that way), not a negative literal. So the fix guards at **runtime**:

```
if(idx >= 0, idx+1, idx)
```

`if` is spelled and evaluates identically on CH and Spark. Non-negative integer literals keep the clean compile-time `n+1` fast path (no churn — verified only the new golden uses the runtime form).

| Cypher | Before (CH) | After |
|---|---|---|
| `[10,20,30][-1]` | `0` ❌ | `30` ✅ |
| `[10,20,30][-2]` | (default) ❌ | `20` ✅ |
| `[10,20,30][0]` | `10` ✅ | `10` ✅ |
| `[10,20,30][2]` | `30` ✅ | `30` ✅ |

## Verification

- Live, both engines: `[-1]=30, [-2]=20, [0]=10, [2]=30`
- Dialect-aware golden regression (`list_index_negative`)
- Gate: 1504 lib + 286 integration + 0 clippy

Found by the CH↔Databricks parity probe (list/collection suite) — same loop that produced #441/#442/#443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)