### PR TITLE
fix(sql): map ltrim/rtrim/=~ to Spark names for Databricks

### DIFF
--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -72,6 +72,19 @@ pub fn contains_predicate(haystack: &str, needle: &str) -> String {
     }
 }
 
+/// Render a Cypher `=~` regex match (`RegexMatch` operator) for the active dialect.
+///
+/// ClickHouse spells it `match(haystack, pattern)`; Spark/Databricks has no
+/// `match` function and uses `rlike(str, regexp)` (both return a boolean).
+/// Emitted from every `RegexMatch` render site so the two dialects stay in sync.
+pub fn regex_match_predicate(haystack: &str, pattern: &str) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        SqlDialect::Databricks => format!("rlike({}, {})", haystack, pattern),
+        _ => format!("match({}, {})", haystack, pattern),
+    }
+}
+
 /// Resolve a SQL function name to its active-dialect spelling via the function
 /// registry, falling back to `name` unchanged when it has no registry entry.
 ///

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -582,19 +582,19 @@ lazy_static::lazy_static! {
 
         // ===== ADDITIONAL STRING FUNCTIONS =====
 
-        // ltrim() -> trimLeft()
+        // ltrim() -> CH trimLeft() / Spark ltrim(). Spark has no trimLeft.
         m.insert("ltrim", FunctionMapping {
             neo4j_name: "lTrim",
             clickhouse_name: "trimLeft",
-            databricks_name: None,
+            databricks_name: Some("ltrim"),
             arg_transform: None,
         });
 
-        // rtrim() -> trimRight()
+        // rtrim() -> CH trimRight() / Spark rtrim(). Spark has no trimRight.
         m.insert("rtrim", FunctionMapping {
             neo4j_name: "rTrim",
             clickhouse_name: "trimRight",
-            databricks_name: None,
+            databricks_name: Some("rtrim"),
             arg_transform: None,
         });
 

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -272,8 +272,11 @@ impl ToSql for LogicalExpr {
                         Ok(format!("({} >= {})", operands_sql[0], operands_sql[1]))
                     }
                     Operator::RegexMatch => {
-                        // ClickHouse uses match() function for regex matching
-                        Ok(format!("match({}, {})", operands_sql[0], operands_sql[1]))
+                        // CH match() / Spark rlike() — dialect-aware.
+                        Ok(super::common::regex_match_predicate(
+                            &operands_sql[0],
+                            &operands_sql[1],
+                        ))
                     }
                     Operator::And => Ok(format!("({} AND {})", operands_sql[0], operands_sql[1])),
                     Operator::Or => Ok(format!("({} OR {})", operands_sql[0], operands_sql[1])),

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -5930,7 +5930,7 @@ impl RenderExpr {
 
                 // Special handling for RegexMatch - ClickHouse uses match() function
                 if op.operator == Operator::RegexMatch && rendered.len() == 2 {
-                    return format!("match({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::regex_match_predicate(&rendered[0], &rendered[1]);
                 }
 
                 // IN/NOT IN with CTE entity column → subquery for set membership.
@@ -6327,7 +6327,7 @@ impl RenderExpr {
 
                 // Special handling for RegexMatch - ClickHouse uses match() function
                 if op.operator == Operator::RegexMatch && rendered.len() == 2 {
-                    return format!("match({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::regex_match_predicate(&rendered[0], &rendered[1]);
                 }
 
                 // IN/NOT IN with CTE entity column → subquery for set membership.
@@ -6524,7 +6524,7 @@ impl ToSql for OperatorApplication {
 
         // Special handling for RegexMatch - ClickHouse uses match() function
         if self.operator == Operator::RegexMatch && rendered.len() == 2 {
-            return format!("match({}, {})", &rendered[0], &rendered[1]);
+            return super::common::regex_match_predicate(&rendered[0], &rendered[1]);
         }
 
         // IN/NOT IN with CTE entity column → subquery for set membership.

--- a/tests/rust/integration/golden/sql_ir/fn_ltrim_rtrim__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_ltrim_rtrim__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      trimLeft(u.full_name) AS "l", 
+      trimRight(u.full_name) AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_ltrim_rtrim__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_ltrim_rtrim__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      ltrim(u.full_name) AS `l`, 
+      rtrim(u.full_name) AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_regex_match__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_regex_match__clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS "u.user_id"
+FROM social.users_bench AS u
+WHERE match(u.full_name, '.*a.*')

--- a/tests/rust/integration/golden/sql_ir/fn_regex_match__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_regex_match__databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS `u.user_id`
+FROM social.users_bench AS u
+WHERE rlike(u.full_name, '.*a.*')

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -189,6 +189,20 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_toboolean",
         "MATCH (u:User) RETURN toBoolean('true') AS r",
     ),
+    // Dialect string-fn mappings: ltrim/rtrim -> CH trimLeft/trimRight but Spark
+    // has no trimLeft/trimRight (uses ltrim/rtrim). Previously emitted the CH name
+    // on Databricks (UNRESOLVED_ROUTINE `trimLeft`).
+    (
+        "fn_ltrim_rtrim",
+        "MATCH (u:User) RETURN ltrim(u.name) AS l, rtrim(u.name) AS r",
+    ),
+    // `=~` regex match -> CH match() / Spark rlike(). Spark has no match(); the
+    // previous hardcoded match() at every RegexMatch render site errored on
+    // Databricks (UNRESOLVED_ROUTINE `match`).
+    (
+        "fn_regex_match",
+        "MATCH (u:User) WHERE u.name =~ '.*a.*' RETURN u.user_id",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

Three string operations emitted the **ClickHouse** spelling on Databricks and errored with `UNRESOLVED_ROUTINE` (Spark has no such routine):

| Cypher | CH | Spark (before) | Spark (after) |
|---|---|---|---|
| `ltrim(s)` | `trimLeft(s)` | `trimLeft(s)` ❌ | `ltrim(s)` ✅ |
| `rtrim(s)` | `trimRight(s)` | `trimRight(s)` ❌ | `rtrim(s)` ✅ |
| `s =~ re` | `match(s, re)` | `match(s, re)` ❌ | `rlike(s, re)` ✅ |

## Fix

- `ltrim`/`rtrim`: add `databricks_name` in the function registry (`Some("ltrim")`/`Some("rtrim")`).
- `=~`: the `RegexMatch` operator was rendered as a hardcoded `match(a, b)` at **four** sites (`to_sql.rs` + three in `to_sql_query.rs`). Added a shared `common::regex_match_predicate` helper (mirrors the existing `contains_predicate`) that emits CH `match` / Spark `rlike` — so both dialects stay in sync from one place.

## Verification

- Spark spellings verified via raw SQL (`ltrim`/`rtrim`/`rlike` all resolve).
- Live, both engines: `ltrim('  hi  ')='hi  '`, `rtrim('  hi  ')='  hi'`, `=~` agree.
- Dialect-aware goldens `fn_ltrim_rtrim` + `fn_regex_match` (CH keeps `trimLeft`/`trimRight`/`match`; Databricks gets `ltrim`/`rtrim`/`rlike`).
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe (string suite) — same #442 class: a `FunctionMapping` with `databricks_name: None` (or a hardcoded CH spelling) silently mis-emits for Databricks until probed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)