### PR TITLE
fix(sql): map date() to Spark to_date for Databricks

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -141,14 +141,22 @@ lazy_static::lazy_static! {
             }),
         });
 
-        // date() -> toDate(arg) or today() if no args
+        // date() -> CH toDate(arg) / Spark to_date(arg). No-arg = current date:
+        // CH today() / Spark current_date(). Spark has no toDate/today().
         m.insert("date", FunctionMapping {
             neo4j_name: "date",
             clickhouse_name: "toDate",
-            databricks_name: None,
+            databricks_name: Some("to_date"),
             arg_transform: Some(|args| {
                 if args.is_empty() {
-                    vec!["today()".to_string()]
+                    use crate::server::query_context::get_current_dialect;
+                    use crate::sql_generator::SqlDialect;
+                    let now = if matches!(get_current_dialect(), SqlDialect::Databricks) {
+                        "current_date()"
+                    } else {
+                        "today()"
+                    };
+                    vec![now.to_string()]
                 } else {
                     vec![args[0].clone()]
                 }

--- a/tests/rust/integration/golden/sql_ir/fn_date__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_date__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toDate('2020-01-15') AS "d"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_date__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_date__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      to_date('2020-01-15') AS `d`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -189,6 +189,12 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_toboolean",
         "MATCH (u:User) RETURN toBoolean('true') AS r",
     ),
+    // date() -> CH toDate / Spark to_date. Spark has no toDate; the entry
+    // previously fell back to the CH name on Databricks (UNRESOLVED_ROUTINE).
+    (
+        "fn_date",
+        "MATCH (u:User) RETURN date('2020-01-15') AS d",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

`date()` rendered as ClickHouse `toDate()` on Databricks, which has no `toDate` → `UNRESOLVED_ROUTINE`. The no-arg current-date form also diverges (CH `today()` vs Spark `current_date()`).

| Cypher | CH | Spark (before) | Spark (after) |
|---|---|---|---|
| `date('2020-01-15')` | `toDate('2020-01-15')` | `toDate(...)` ❌ | `to_date('2020-01-15')` ✅ |
| `date()` | `toDate(today())` | `toDate(today())` ❌ | `to_date(current_date())` ✅ |

## Fix

`databricks_name: Some("to_date")` on the registry `date` entry, plus a dialect-aware no-arg transform (`today()` → `current_date()`).

## Verification

- Live, both engines: `date('2020-01-15')='2020-01-15'`, date comparison agrees.
- Golden regression `fn_date` (CH `toDate` / Databricks `to_date`).
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe (date/temporal suite) — same #442 class (`databricks_name: None` → CH-name fallback).

> Note: the date/temporal suite also surfaced a **deeper CH-side bug** (out of scope here): `year/month/day/quarter/dayOfWeek` and interval add/sub on a native `Date`/`DateTime` column HTTP-500 on ClickHouse, because the temporal-extraction arg is unconditionally wrapped in `fromUnixTimestamp64Milli(col)` (assumes epoch-millis BIGINT). Needs type-awareness at the wrap site — filed for a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)