### PR TITLE
fix(planner): return a clean error for list comprehension in RETURN (was a server panic)

### DIFF
--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -1505,8 +1505,10 @@ impl Union {
     }
 }
 
-impl<'a> From<CypherReturnItem<'a>> for ProjectionItem {
-    fn from(value: CypherReturnItem<'a>) -> Self {
+impl<'a> TryFrom<CypherReturnItem<'a>> for ProjectionItem {
+    type Error = crate::query_planner::logical_expr::errors::LogicalExprError;
+
+    fn try_from(value: CypherReturnItem<'a>) -> Result<Self, Self::Error> {
         // Determine the column alias using this priority:
         // 1. Explicit AS alias (highest priority)
         // 2. Original text from the query (preserves user input exactly)
@@ -1533,11 +1535,10 @@ impl<'a> From<CypherReturnItem<'a>> for ProjectionItem {
             }
         };
 
-        ProjectionItem {
-            expression: LogicalExpr::try_from(value.expression)
-                .expect("Failed to convert RETURN expression - invalid Cypher syntax"),
+        Ok(ProjectionItem {
+            expression: LogicalExpr::try_from(value.expression)?,
             col_alias,
-        }
+        })
     }
 }
 
@@ -2106,7 +2107,7 @@ mod tests {
             original_text: None,
         };
 
-        let projection_item = ProjectionItem::from(ast_return_item);
+        let projection_item = ProjectionItem::try_from(ast_return_item).unwrap();
 
         match projection_item.expression {
             LogicalExpr::TableAlias(alias) => assert_eq!(alias.0, "customer_name"),

--- a/src/query_planner/logical_plan/plan_builder.rs
+++ b/src/query_planner/logical_plan/plan_builder.rs
@@ -236,7 +236,7 @@ pub fn build_logical_plan(
 
     if let Some(return_clause) = &query_ast.return_clause {
         logical_plan =
-            return_clause::evaluate_return_clause(return_clause, logical_plan, &mut plan_ctx);
+            return_clause::evaluate_return_clause(return_clause, logical_plan, &mut plan_ctx)?;
     }
 
     if let Some(order_clause) = &query_ast.order_by_clause {

--- a/src/query_planner/logical_plan/return_clause.rs
+++ b/src/query_planner/logical_plan/return_clause.rs
@@ -532,7 +532,7 @@ pub fn evaluate_return_clause<'a>(
     return_clause: &ReturnClause<'a>,
     plan: Arc<LogicalPlan>,
     plan_ctx: &mut PlanCtx,
-) -> Arc<LogicalPlan> {
+) -> Result<Arc<LogicalPlan>, crate::query_planner::logical_plan::errors::LogicalPlanError> {
     crate::debug_print!("========================================");
     crate::debug_print!("⚠️ RETURN CLAUSE DISTINCT = {}", return_clause.distinct);
     crate::debug_print!(
@@ -553,10 +553,14 @@ pub fn evaluate_return_clause<'a>(
     let (rewritten_return_items, plan, pattern_comp_metas) =
         rewrite_pattern_comprehensions(return_clause.return_items.clone(), plan, plan_ctx);
 
+    // Fallible: a RETURN expression may fail to lower (e.g. a list comprehension
+    // that no rewrite pass handled). Propagate as a clean planning error instead
+    // of panicking the worker (was `ProjectionItem::from(...)` with an internal
+    // `.expect()`, which crashed the whole server on otherwise-valid Cypher).
     let projection_items: Vec<ProjectionItem> = rewritten_return_items
         .iter()
-        .map(|item| ProjectionItem::from(item.clone()))
-        .collect();
+        .map(|item| ProjectionItem::try_from(item.clone()))
+        .collect::<Result<Vec<_>, _>>()?;
 
     // If input is a Union, handle specially
     if let LogicalPlan::Union(union) = plan.as_ref() {
@@ -565,7 +569,11 @@ pub fn evaluate_return_clause<'a>(
         // Check if we have aggregations
         if has_aggregation(&projection_items) {
             crate::debug_println!("DEBUG: Union + aggregation detected - using subquery pattern");
-            return build_union_with_aggregation(union, &projection_items, return_clause.distinct);
+            return Ok(build_union_with_aggregation(
+                union,
+                &projection_items,
+                return_clause.distinct,
+            ));
         }
 
         // No aggregation - push Projection into each branch as before
@@ -594,10 +602,10 @@ pub fn evaluate_return_clause<'a>(
             union.union_type.clone()
         };
 
-        return Arc::new(LogicalPlan::Union(Union {
+        return Ok(Arc::new(LogicalPlan::Union(Union {
             inputs: projected_branches,
             union_type,
-        }));
+        })));
     }
 
     let result = Arc::new(LogicalPlan::Projection(Projection {
@@ -614,7 +622,7 @@ pub fn evaluate_return_clause<'a>(
             false
         }
     );
-    result
+    Ok(result)
 }
 
 /// Build a Union with aggregation using subquery pattern.

--- a/tests/rust/integration/parameter_function_test.rs
+++ b/tests/rust/integration/parameter_function_test.rs
@@ -417,3 +417,21 @@ fn test_function_on_parameter_in_return() {
     // Verify function applied to parameter
     assert!(sql.to_lowercase().contains("upper(") || sql.to_lowercase().contains("ucase("));
 }
+
+#[test]
+fn test_list_comprehension_in_return_errors_not_panics() {
+    // Regression: a list comprehension in RETURN reaches ProjectionItem
+    // conversion without any rewrite pass having lowered it. That conversion
+    // used to `.expect()` on the failing `LogicalExpr::try_from`, PANICKING the
+    // worker thread and taking down the whole server on otherwise-valid Cypher.
+    // It must now surface as a clean planning error (Err), not a panic.
+    let query = "MATCH (n:User) RETURN [x IN [1, 2, 3, 4] WHERE x > 2] AS r";
+    let ast = parse_query(query).expect("Failed to parse query");
+    let schema = create_test_schema();
+
+    let result = build_logical_plan(&ast, &schema, None, None, None);
+    assert!(
+        result.is_err(),
+        "list comprehension in RETURN should return a planning error, not panic"
+    );
+}


### PR DESCRIPTION
## Problem

A list comprehension in a `RETURN` projection — e.g. `RETURN [x IN [1,2,3] WHERE x > 2]` — is not lowered by any rewrite pass, so it reaches `LogicalExpr::try_from`, which returns `Err(ListComprehensionNotRewritten)`. The `From<CypherReturnItem> for ProjectionItem` conversion **`.expect()`ed** on that `Result`:

```rust
expression: LogicalExpr::try_from(value.expression)
    .expect("Failed to convert RETURN expression - invalid Cypher syntax"),
```

→ **panicked the worker thread and took down the whole server** on otherwise-valid Cypher. (`catch_panic` logs it but the process still dies.)

## Fix

The parallel **WITH**-item path already propagated this cleanly via `TryFrom`; the **RETURN** path didn't. This mirrors it:

- `From<CypherReturnItem> for ProjectionItem` → `TryFrom` (propagates the `LogicalExprError`)
- `evaluate_return_clause` now returns `Result<..>`. The cascade stops immediately: its one caller, `build_logical_plan`, already returns a `Result`, so it just gains a `?`.

**No behavior change for valid queries** — this is strictly the error path. The query now returns a clean planning error instead of crashing the server:

```
Plan error: LogicalPlanError: Query planning error: Logical expression error:
ListComprehension should have been rewritten during query planning
```

## Verification

- New regression test `test_list_comprehension_in_return_errors_not_panics` (asserts `Err`, not panic).
- Live via `cg`: comprehension → clean error (exit 1, no backtrace); valid queries unaffected.
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe (list suite) — its comprehension cases repeatedly killed the local server mid-run. (Implementing list-comprehension lowering is separate future work; this just stops the crash.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)