### PR TITLE
fix(sql): correct trim() (was invalid trim(BOTH arg), 500 on ClickHouse)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -187,15 +187,14 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
-        // trim() -> trim(BOTH ' ' FROM arg) - ClickHouse trim removes all whitespace by default
+        // trim() -> trim(arg). Bare trim(str) removes leading/trailing whitespace
+        // on both CH and Spark. The old arg_transform emitted `trim(BOTH arg)`
+        // (missing the `' ' FROM`), which is invalid SQL and 500'd on CH.
         m.insert("trim", FunctionMapping {
             neo4j_name: "trim",
             clickhouse_name: "trim",
             databricks_name: None,
-            arg_transform: Some(|args| {
-                // ClickHouse: trim(BOTH str)
-                vec![format!("BOTH {}", args[0])]
-            }),
+            arg_transform: None,
         });
 
         // substring(str, start [, length]) -> substring(str, start+1, length)

--- a/tests/rust/integration/golden/sql_ir/fn_trim__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_trim__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      trim(u.full_name) AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_trim__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_trim__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      trim(u.full_name) AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -189,6 +189,12 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_toboolean",
         "MATCH (u:User) RETURN toBoolean('true') AS r",
     ),
+    // trim -> bare trim(arg) on both dialects. The old arg_transform emitted
+    // `trim(BOTH arg)` (missing `' ' FROM`), invalid SQL that 500'd on CH.
+    (
+        "fn_trim",
+        "MATCH (u:User) RETURN trim(u.name) AS r",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

`trim()` rendered as `trim(BOTH '  hi  ')` — the `arg_transform` prepended `BOTH` but omitted the `' ' FROM`, producing invalid SQL:

```
trim(BOTH '  hi  ')   -- not valid: needs `trim(BOTH ' ' FROM '  hi  ')`
```

ClickHouse returned **HTTP 500**; Databricks would reject it too (CH just errored first in the probe).

## Fix

Bare `trim(str)` removes leading/trailing whitespace **identically on both CH and Spark**, so the transform is unnecessary — drop it. Now renders `trim(u.name)`.

## Verification

- Live, both engines: `trim('  hi  ')` = `'hi'`.
- Golden regression `fn_trim` (both dialects render clean `trim(...)`).
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe (string suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)