### PR TITLE
fix(sql): map reduce() to Spark aggregate() for Databricks

### DIFF
--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -85,6 +85,33 @@ pub fn regex_match_predicate(haystack: &str, pattern: &str) -> String {
     }
 }
 
+/// Render a Cypher `reduce(acc = init, x IN list | expr)` fold for the active
+/// dialect, from its already-rendered component strings.
+///
+/// ClickHouse has `arrayFold((x, acc) -> expr, list, init)`; Spark/Databricks
+/// has no `arrayFold` and uses `aggregate(list, init, (acc, x) -> expr)` (same
+/// semantics, different arg order + spelling). Emitted from every `ReduceExpr`
+/// render site so the two dialects stay in sync.
+pub fn reduce_fold_sql(
+    variable: &str,
+    accumulator: &str,
+    expr_sql: &str,
+    list_sql: &str,
+    init_sql: &str,
+) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        SqlDialect::Databricks => format!(
+            "aggregate({}, {}, ({}, {}) -> {})",
+            list_sql, init_sql, accumulator, variable, expr_sql
+        ),
+        _ => format!(
+            "arrayFold({}, {} -> {}, {}, {})",
+            variable, accumulator, expr_sql, list_sql, init_sql
+        ),
+    }
+}
+
 /// Resolve a SQL function name to its active-dialect spelling via the function
 /// registry, falling back to `name` unchanged when it has no registry entry.
 ///

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -392,9 +392,12 @@ impl ToSql for LogicalExpr {
                     init_sql
                 };
 
-                Ok(format!(
-                    "arrayFold({}, {} -> {}, {}, {})",
-                    reduce.variable, reduce.accumulator, expr_sql, list_sql, init_cast
+                Ok(super::common::reduce_fold_sql(
+                    &reduce.variable,
+                    &reduce.accumulator,
+                    &expr_sql,
+                    &list_sql,
+                    &init_cast,
                 ))
             }
             LogicalExpr::MapLiteral(entries) => {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -6158,9 +6158,12 @@ impl RenderExpr {
                     init_sql
                 };
 
-                format!(
-                    "arrayFold({}, {} -> {}, {}, {})",
-                    reduce.variable, reduce.accumulator, expr_sql, list_sql, init_cast
+                super::common::reduce_fold_sql(
+                    &reduce.variable,
+                    &reduce.accumulator,
+                    &expr_sql,
+                    &list_sql,
+                    &init_cast,
                 )
             }
             RenderExpr::MapLiteral(entries) => {

--- a/tests/rust/integration/golden/sql_ir/fn_reduce__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_reduce__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      arrayFold(x, s -> s + x, [1, 2, 3], toInt64(0)) AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_reduce__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_reduce__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      aggregate(array(1, 2, 3), bigint(0), (s, x) -> s + x) AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -225,6 +225,13 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_regex_match",
         "MATCH (u:User) WHERE u.name =~ '.*a.*' RETURN u.user_id",
     ),
+    // reduce -> CH arrayFold((x, acc) -> expr, list, init) / Spark
+    // aggregate(list, init, (acc, x) -> expr). Spark has no arrayFold; it
+    // previously emitted the CH name on Databricks (UNRESOLVED_ROUTINE).
+    (
+        "fn_reduce",
+        "MATCH (u:User) RETURN reduce(s = 0, x IN [1, 2, 3] | s + x) AS r",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

`reduce(acc = init, x IN list | expr)` rendered as ClickHouse `arrayFold((x, acc) -> expr, list, init)` on Databricks too, but Spark has no `arrayFold` → `UNRESOLVED_ROUTINE`.

## Fix

Spark's equivalent is `aggregate(list, init, (acc, x) -> expr)` — same fold, reordered args. Added a shared `common::reduce_fold_sql` helper (mirrors `regex_match_predicate`) used at **both** `ReduceExpr` render sites (`to_sql.rs` + `to_sql_query.rs`), so the dialects stay in sync from one place.

| Dialect | Output |
|---|---|
| ClickHouse | `arrayFold(x, s -> s + x, [1, 2, 3], toInt64(0))` (byte-identical, no churn) |
| Databricks | `aggregate(array(1, 2, 3), bigint(0), (s, x) -> s + x)` |

The dialect-aware int64 init cast (CH `toInt64` / Spark `bigint`) already came from the function mapper.

## Verification

- Live, both engines: `reduce(s = 0, x IN [1,2,3] | s + x)` = `6`.
- Golden regression `fn_reduce`.
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe (list/string suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)