### PR TITLE
fix(sql): make range() inclusive (Cypher semantics; CH was silently wrong)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -422,12 +422,32 @@ lazy_static::lazy_static! {
             }),
         });
 
-        // range(start, end [, step]) -> range(start, end [, step])
+        // range(start, end [, step]) — Cypher range is INCLUSIVE of `end`.
+        //   CH `range(start, end [, step])` is EXCLUSIVE of `end`  -> bump end +1
+        //     (range(1,5) gave [1,2,3,4], must be [1,2,3,4,5]; silently wrong).
+        //   Spark has no `range`; `sequence(start, end [, step])` is inclusive -> use as-is.
         m.insert("range", FunctionMapping {
             neo4j_name: "range",
             clickhouse_name: "range",
-            databricks_name: None,
-            arg_transform: None,
+            databricks_name: Some("sequence"),
+            arg_transform: Some(|args| {
+                use crate::server::query_context::get_current_dialect;
+                use crate::sql_generator::SqlDialect;
+                // Spark sequence() is already inclusive — leave args untouched.
+                if matches!(get_current_dialect(), SqlDialect::Databricks) {
+                    return args.to_vec();
+                }
+                // ClickHouse range() is exclusive of `end`; make it inclusive by
+                // bumping the end bound (2nd arg) by 1. Works for the 2-arg and
+                // 3-arg (step) ascending forms.
+                if args.len() >= 2 {
+                    let mut out = args.to_vec();
+                    out[1] = format!("({}) + 1", args[1]);
+                    out
+                } else {
+                    args.to_vec()
+                }
+            }),
         });
 
         // ===== TYPE CONVERSION FUNCTIONS =====

--- a/tests/rust/integration/golden/sql_ir/fn_range__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_range__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      range(1, (5) + 1) AS "r"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/fn_range__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/fn_range__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      sequence(1, 5) AS `r`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -232,6 +232,13 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_reduce",
         "MATCH (u:User) RETURN reduce(s = 0, x IN [1, 2, 3] | s + x) AS r",
     ),
+    // range is INCLUSIVE in Cypher. CH range() is exclusive -> end bumped +1
+    // (was silently wrong: range(1,5) gave [1,2,3,4]); Spark has no range() ->
+    // sequence() (already inclusive).
+    (
+        "fn_range",
+        "MATCH (u:User) RETURN range(1, 5) AS r",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Problem

Cypher `range(start, end [, step])` is **inclusive** of `end`, but:
- **ClickHouse** `range()` is **exclusive** → `range(1,5)` returned `[1,2,3,4]` instead of `[1,2,3,4,5]` — silently wrong on the *primary* backend.
- **Databricks** has no `range()` at all → `UNRESOLVED_ROUTINE`.

## Fix

| Dialect | Before | After |
|---|---|---|
| ClickHouse | `range(1, 5)` → `[1,2,3,4]` ❌ | `range(1, (5)+1)` → `[1,2,3,4,5]` ✅ |
| Databricks | `range(1, 5)` ❌ | `sequence(1, 5)` → `[1,2,3,4,5]` ✅ |

CH bumps the end bound by 1 (inclusive); Databricks maps to `sequence()` (already inclusive). Handles the 2-arg and 3-arg (step) ascending forms.

## Verification

- Live, both engines: `range(1,5)` = `[1,2,3,4,5]`, `range(1,5,2)` = `[1,3,5]`.
- Golden regression `fn_range`; no existing test asserted the old (wrong) exclusive behavior.
- Gate: 1504 lib + 286 integration + 0 clippy.

Found by the CH↔Databricks parity probe. Descending / negative-step ranges remain unsupported on CH `range()` and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)