### PR TITLE
fix(#662): carry node label under source alias so rename at continuation barrier resolves

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -6004,9 +6004,16 @@ impl WithBarrierScope {
 
     /// Record one exported alias's property mapping into both the CTE variable
     /// map and the unified variable registry (scalar-vs-node branch preserved).
+    ///
+    /// `source_alias` is the alias the CTE columns are prefixed under — the same
+    /// as `alias` for a plain export, but the ORIGINAL name for a rename
+    /// (`WITH u AS u3` → `alias = "u3"`, `source_alias = "u"`). The label carry
+    /// (#602/#662) keys on it so a rename that happens at the very barrier the
+    /// label must cross still inherits the label recorded under the source name.
     fn publish_alias(
         &mut self,
         alias: &str,
+        source_alias: &str,
         cte_name: &str,
         per_alias_mapping: &HashMap<String, String>,
         labels: &[String],
@@ -6028,12 +6035,29 @@ impl WithBarrierScope {
         // route back through node resolution and silently resolve to the old
         // node's id column (loud→silent). Gating the carry on a non-empty mapping
         // keeps scalars scalar and preserves main's behavior for them.
+        //
+        // #662: a rename AT the crossing barrier (`WITH u AS u3`) publishes under
+        // the NEW name (`u3`) while the label was recorded under the ORIGINAL
+        // (`u`). Look up the carried label under BOTH the published name and the
+        // `source_alias`, and record the carried-forward label under the new name
+        // too so a further barrier keeps finding it.
         let effective_labels: Vec<String> = if !labels.is_empty() {
             self.carried_labels
                 .insert(alias.to_string(), labels.to_vec());
             labels.to_vec()
         } else if !per_alias_mapping.is_empty() {
-            self.carried_labels.get(alias).cloned().unwrap_or_default()
+            let carried = self
+                .carried_labels
+                .get(alias)
+                .or_else(|| self.carried_labels.get(source_alias))
+                .cloned()
+                .unwrap_or_default();
+            if !carried.is_empty() && alias != source_alias {
+                // Re-key under the new published name for subsequent barriers.
+                self.carried_labels
+                    .insert(alias.to_string(), carried.clone());
+            }
+            carried
         } else {
             Vec::new()
         };
@@ -10583,7 +10607,13 @@ pub(crate) fn build_chained_with_match_cte_plan(
                     .map(|l| vec![l])
                     .unwrap_or_default();
 
-                with_scope.publish_alias(alias, &cte_name, &per_alias_mapping, &labels);
+                with_scope.publish_alias(
+                    alias,
+                    lookup_alias,
+                    &cte_name,
+                    &per_alias_mapping,
+                    &labels,
+                );
 
                 // Publish this alias's CTE scope (FROM alias + Cypher-property →
                 // CTE-column mapping) to a narrow, purpose-built task-local

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12181,6 +12181,44 @@ mod postwith_continuation_join_anchor_602 {
              node label and silently resolve `.id` to `user_id`:\n{sql}"
         );
     }
+
+    /// #662: a node RENAMED at the very barrier the label must cross
+    /// (`WITH u AS u3`) must still anchor its continuation join on the forwarded
+    /// CTE id column. The label was recorded under the source name `u`; the carry
+    /// looks it up under both the published name and the source alias so the
+    /// rename inherits it (previously loud Code 47 `u3.post_id`, same class as
+    /// #602).
+    #[tokio::test]
+    async fn rename_at_continuation_barrier_anchors_on_forwarded_id_662() {
+        let schema = load_schema(SchemaId::Standard.yaml_path());
+        let cypher = "MATCH (u:User)-[:FOLLOWS]->(f) \
+                      WITH u, count(f) AS fc \
+                      WITH u AS u3, fc \
+                      MATCH (u3)-[:AUTHORED]->(p) \
+                      RETURN u3.name, count(p) AS posts";
+        let sql = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+
+        // The renamed alias's continuation JOIN anchors on the forwarded CTE id
+        // column (still prefixed under the SOURCE alias `u`: `p1_u_user_id`).
+        assert!(
+            regex::Regex::new(r#"t\d+\.user_id = u3\.p1_u_user_id"#)
+                .unwrap()
+                .is_match(&sql),
+            "#662 regressed: renamed continuation alias must anchor on the \
+             forwarded CTE id column `u3.p1_u_user_id`:\n{sql}"
+        );
+        assert!(
+            !sql.contains("u3.post_id") && !sql.contains("= u3.id"),
+            "#662 regressed: renamed continuation alias anchors on an \
+             unresolved `.id` (renders `u3.post_id`, Code 47):\n{sql}"
+        );
+
+        // Determinism.
+        for _ in 0..5 {
+            let again = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+            assert_eq!(sql, again, "#662: nondeterministic render");
+        }
+    }
 }
 
 /// Regression tests for #551: a single-id denormalized node behind a


### PR DESCRIPTION
## Summary

Follow-up to #602 (P-4 F1b). The #602 label carry (`WithBarrierScope::carried_labels`) is keyed by the **published** alias name. When a node is renamed **at the very barrier** the label must cross, the new name has no recorded label, so the continuation join's `.id` operand stays unresolved and anchors on the wrong column.

```cypher
MATCH (u:User)-[:FOLLOWS]->(f)
WITH u, count(f) AS fc
WITH u AS u3, fc              -- rename AT the crossing barrier
MATCH (u3)-[:AUTHORED]->(p)
RETURN u3.name, count(p)
```
- Before: `ON t2.user_id = u3.post_id` → ClickHouse Code 47 (`u3.post_id` nonexistent; same #616 class as #602, identical on pre-#602 `main`).
- After: `ON t2.user_id = u3.p1_u_user_id` → correct.

## Fix

Thread the source alias (`lookup_alias`, already computed at the call site from `alias_rename_map`) into `publish_alias` as `source_alias`. The carry looks up the label under **both** the published name and the source alias, and re-keys it under the new name so a further barrier keeps finding it. The non-empty-`per_alias_mapping` guard (the #602 scalar-rebind protection) is unchanged — a scalar rebind still cannot inherit a stale node label.

## Verification

- **Live oracle** (social_benchmark, ClickHouse): baseline Code 47 → fixed returns correct rows matching the #602 control.
- **Rename variants**: single rename at crossing barrier, double rename (`u→u2→u3`, anchors on the intermediate `p2_u2_user_id`), rename+aggregate — all resolve.
- #602 core + scalar-rebind guard **byte-identical** (unchanged).
- Corpus sweep **byte-identical**; full suite (1606 lib + 513 integration) green; ratchet net-zero; +1 regression golden.

Closes #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)