### PR TITLE
refactor(P-4 F3): carry structural pattern in RenderExpr::PatternCount

### DIFF
--- a/docs/design/FORWARD_RESOLUTION_PLAN.md
+++ b/docs/design/FORWARD_RESOLUTION_PLAN.md
@@ -466,6 +466,27 @@ Each is independent and byte-identical (same SQL, built later from structure):
 `to_sql()` at render. Rewriters recurse into it. Corpus byte-identical.
 Fixes the size()-pattern member of the residue (candidate **#613**).
 
+> **✅ F3 outcome (2026-07-25, landed) — byte-identical (C1, partial).** Scoped down
+> from "drop `sql`, render at emit" to **carry `pattern` + keep a validated `sql`
+> cache** (variant C1), because the full flip is NOT byte-identical and has zero
+> payoff until a rewriter actually mutates the pattern (which is #613 itself).
+> Delivered: added `pattern: PathPattern` to `render_expr::PatternCount` alongside
+> the (now validated-cache) `sql`; extracted `pub(crate) render_pattern_count_sql`
+> as the single source of the `coalesce(<subquery>,0)` string; the `TryFrom` bake
+> site keeps the `?` (invalid patterns — bare node / shortestPath / missing schema
+> — still abort render at the same `Result` boundary, so the infallible emit never
+> panics). All 6 `pc.sql` consumers (2 emit + 4 pre-render optimizer text-scans)
+> unchanged; `correlated_aliases` still structurally computed so the `:2213` guard
+> takes the same branch. **Error-path crux (verified):** `RenderExpr::to_sql`
+> returns `String` (infallible) but `generate_pattern_count_sql` returns `Result`
+> called in exactly one place (bake site) — deferring generation into emit would
+> force a panic/marker on erroring inputs, so C2 (drop the cache) was rejected.
+> Corpus + 220 goldens byte-identical; 2,156 tests; clippy clean; ratchet net-zero;
+> adversarial review 0 real findings. Branch `refactor/f3-patterncount-carry-pattern`.
+> **Still #613's job (out of scope here):** making rewriters recurse into `pattern`,
+> and flipping emit to render from the (rewritten) `pattern` instead of the cache —
+> that flip is where the intentional SQL diff lives.
+
 **F4 — `ExistsSubquery` structured.** Same treatment via `generate_exists_sql`.
 Candidate **#595**.
 

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -116,7 +116,7 @@ string-emitting group (31 fns, `render_plan/pattern_comprehension_sql.rs`, 2,629
 extracted verbatim, `pub(crate)` re-exports, byte-identical goldens + corpus, ratchet
 net-zero; D7-rest deferred. **Next: P2.3 clause_extractors move.**
 
-### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+F2a done; F2b+ and F1b residue open)
+### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+F2a+F3 done; F2b/F4/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
 supersedes the stale `render_plan/AGENTS.md` §10 premise: the `reverse_mapping`
 field §10 says to delete was already removed in #115 (Feb 2026); the debt forked
@@ -192,6 +192,21 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-25: **P-4 F3** — first Phase-C slice. Added structural `pattern: PathPattern`
+  to `render_expr::PatternCount` (backs `size((a)-[:R]->(b))`) alongside the now
+  validated-`sql` cache, so a later slice (#613) can make rewriters recurse into it.
+  Byte-identical (variant **C1** — carry + cache): scoped DOWN from the plan's
+  "drop `sql`, render at emit" because that flip isn't byte-identical and has zero
+  payoff until a rewriter mutates the pattern (= #613). Extracted `render_pattern_count_sql`
+  as the single source of the `coalesce(...,0)` string; kept the `?` at the bake site so
+  invalid patterns still abort render at the same boundary (the infallible emit never
+  panics — the error-path crux). All 6 `pc.sql` consumers unchanged. Corpus + 220 goldens
+  byte-identical; 2,156 tests; clippy clean; ratchet net-zero; adversarial review 0 real
+  findings. Branch `refactor/f3-patterncount-carry-pattern`.
+- 2026-07-25: **P-4 F2c BLOCKED (docs, #665)** — recorded that F2c is NOT byte-identical:
+  the "also add DB column" reverse arms are load-bearing for whole-node expansion (18
+  goldens; property surfaces under both Cypher and DB-column names). Needs its own design
+  cycle, not a pure deletion.
 - 2026-07-25: **P-4 F2a** — deleted the M2 legacy CTE-property resolution
   mechanism (the task-local `cte_property_mappings` field, its four accessors
   `set_/get_/get_all_/clear_`, both producers — the deep-merge

--- a/src/render_plan/AGENTS.md
+++ b/src/render_plan/AGENTS.md
@@ -463,7 +463,7 @@ Cypher scope stack:           SQL equivalent:
 5. ❌ NOW we need to undo step 3: map `("person", "full_name")` → `"p6_person_full_name"`
 6. ❌ This requires `reverse_mapping: HashMap<(alias, db_column), cte_column>`
 7. ❌ Walk ALL expressions post-hoc, rewriting matching PropertyAccessExp entries
-8. ❌ `Raw(String)`, `ExistsSubquery { sql }`, `PatternCount { sql }` are opaque — SKIPPED
+8. ❌ `Raw(String)`, `ExistsSubquery { sql }`, `PatternCount { pattern, sql }` are opaque — SKIPPED (`PatternCount` now carries `pattern`; rewriter recursion still deferred to #613)
 
 **Why reverse_mapping is a hack:**
 - It's a post-hoc fixup: first resolve to DB columns, then try to undo it
@@ -513,7 +513,7 @@ Three expression types bake variable names into SQL strings too early:
 |------|--------------|---------|
 | `RenderExpr::Raw(sql)` | `render_expr.rs:914-918` — NOT (PathPattern) | `person.id` baked into string |
 | `ExistsSubquery { sql }` | `render_expr.rs:940-944` — ExistsSubquery | Same |
-| `PatternCount { sql }` | `render_expr.rs:975-978` — size(pattern) | Same |
+| `PatternCount { pattern, sql }` | `render_expr.rs:1721` — size(pattern); carries `pattern`, rewriters still skip (#613) | Same (cache) |
 
 All three call SQL-generation functions (`generate_not_exists_from_path_pattern()`,
 `generate_exists_sql()`, `generate_pattern_count_sql()`) during `TryFrom<LogicalExpr>

--- a/src/render_plan/plan_optimizer.rs
+++ b/src/render_plan/plan_optimizer.rs
@@ -3942,9 +3942,33 @@ mod tests {
             "ExistsSubquery should extract 'friend' from SQL"
         );
 
-        // PatternCount with alias.column pattern
+        // PatternCount with alias.column pattern. `correlated_aliases` is empty,
+        // so `collect_aliases_from_expr` falls back to scanning `sql` — the
+        // `pattern` field is inert here (only the cache is exercised).
         collect_aliases_from_expr(
             &RenderExpr::PatternCount(render_expr::PatternCount {
+                pattern: crate::query_planner::logical_expr::PathPattern::ConnectedPattern(vec![
+                    crate::query_planner::logical_expr::ConnectedPattern {
+                        start_node: Arc::new(crate::query_planner::logical_expr::NodePattern {
+                            name: Some("person".to_string()),
+                            label: None,
+                            labels: None,
+                            properties: None,
+                        }),
+                        relationship: crate::query_planner::logical_expr::RelationshipPattern {
+                            name: None,
+                            direction: crate::query_planner::logical_expr::Direction::Outgoing,
+                            labels: Some(vec!["R".to_string()]),
+                            properties: None,
+                        },
+                        end_node: Arc::new(crate::query_planner::logical_expr::NodePattern {
+                            name: None,
+                            label: None,
+                            labels: None,
+                            properties: None,
+                        }),
+                    },
+                ]),
                 sql: "(SELECT COUNT(*) FROM r WHERE person.id = r.Id)".to_string(),
                 correlated_aliases: vec![],
             }),

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -965,6 +965,20 @@ fn generate_pattern_count_sql(pattern: &PathPattern) -> Result<String, RenderBui
     }
 }
 
+/// Render `size((pattern))`: a correlated `COUNT(*)` subquery wrapped in
+/// `coalesce(..., 0)` (decorrelation turns the scalar subquery into a LEFT JOIN,
+/// so an outer row with zero matches yields NULL rather than 0; `size()` must
+/// return 0 there — #599). This is the single source of the `PatternCount` SQL
+/// string: the `TryFrom<LogicalExpr>` bake site calls it (behind `?`) to fill
+/// the validated `PatternCount::sql` cache. `pub(crate)` so a later slice (#613)
+/// can re-render from the carried `pattern` after rewriting it.
+pub(crate) fn render_pattern_count_sql(pattern: &PathPattern) -> Result<String, RenderBuildError> {
+    Ok(format!(
+        "coalesce({}, 0)",
+        generate_pattern_count_sql(pattern)?
+    ))
+}
+
 /// Generate NOT EXISTS SQL for a PathPattern (negative pattern matching / anti-join)
 ///
 /// For `NOT (a)-[:REL]-(b)` pattern, generates:
@@ -1197,7 +1211,8 @@ pub enum RenderExpr {
     /// Used in duration({days: 5}), point({x: 1, y: 2}), etc.
     MapLiteral(Vec<(String, RenderExpr)>),
 
-    /// Pattern count: pre-rendered SQL for `size((n)-[:REL]->())`
+    /// Pattern count for `size((n)-[:REL]->())` — carries the structural
+    /// `pattern` plus a validated SQL cache (see [`PatternCount`]).
     PatternCount(PatternCount),
 
     /// Array subscript: `array[index]`
@@ -1241,9 +1256,11 @@ pub enum RenderRewrite {
 /// DESCENT POLICY: recurses into value-carrying wrappers only. It does NOT
 /// descend into `InSubquery`/`ExistsSubquery` (a correlated subquery owns a
 /// separate FROM/alias scope — blindly rewriting into it is a different, riskier
-/// operation) nor `PatternCount` (pre-rendered SQL) nor `CteEntityRef` — those
-/// are cloned, matching every current caller's intent. A rewriter that DOES want
-/// to enter a subquery must handle it explicitly in `f` before returning Recurse.
+/// operation) nor `PatternCount` (carries a structural `pattern` + validated SQL
+/// cache; not descended until #613 makes rewriters recurse into the pattern) nor
+/// `CteEntityRef` — those are cloned, matching every current caller's intent. A
+/// rewriter that DOES want to enter a subquery must handle it explicitly in `f`
+/// before returning Recurse.
 pub fn map_render_expr<F>(expr: &RenderExpr, f: &mut F) -> RenderExpr
 where
     F: FnMut(&RenderExpr) -> RenderRewrite,
@@ -1316,8 +1333,9 @@ where
         },
 
         // Leaves + deliberately-not-descended nodes (subqueries own a separate
-        // scope; PatternCount is pre-rendered SQL). NO `_` catch-all — every
-        // variant is named so a new one forces a compile error here.
+        // scope; PatternCount carries a pattern + validated SQL cache, not
+        // descended until #613). NO `_` catch-all — every variant is named so a
+        // new one forces a compile error here.
         RenderExpr::PropertyAccessExp(_)
         | RenderExpr::Literal(_)
         | RenderExpr::Raw(_)
@@ -1348,11 +1366,21 @@ pub struct CteEntityRef {
     pub columns: Vec<String>,
 }
 
-/// Pattern count for size() on patterns
-/// Contains pre-rendered SQL for a correlated COUNT(*) subquery
+/// Pattern count for `size()` on patterns.
+///
+/// Carries the structural `pattern` (the source of truth) alongside a `sql`
+/// cache that is rendered *and validated* once at `LogicalExpr` → `RenderExpr`
+/// conversion via [`render_pattern_count_sql`]. Today every consumer reads the
+/// `sql` cache; the `pattern` is retained so a later slice (#613) can make the
+/// expression rewriters recurse into it. Until then the rewriters still SKIP
+/// this variant, so the cache stays authoritative and generation is unaffected
+/// by scope rewriting.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PatternCount {
-    /// Pre-rendered SQL for the pattern count subquery
+    /// Structural pattern being counted — source of truth for the `sql` cache.
+    pub pattern: PathPattern,
+    /// Validated pre-rendered SQL for the pattern-count subquery
+    /// (`coalesce(<count-subquery>, 0)`), cached from `pattern` at conversion.
     pub sql: String,
     /// #614: outer-scope aliases the correlated subquery references (the
     /// pattern's correlation anchors — the start node for pattern counts),
@@ -1691,14 +1719,17 @@ impl TryFrom<LogicalExpr> for RenderExpr {
                 })
             }
             LogicalExpr::PatternCount(pc) => {
-                // Generate the pattern count SQL (correlated COUNT(*) subquery).
-                // Decorrelation turns the scalar subquery into a LEFT JOIN, so an
-                // outer row with zero pattern matches yields NULL rather than 0;
-                // size() must return 0 there (#599). coalesce is dialect-neutral.
+                // Render + validate the pattern-count SQL once and cache it (see
+                // `render_pattern_count_sql`; coalesce → 0 on zero matches, #599).
+                // The `?` stays HERE so an invalid pattern (bare node,
+                // shortestPath, missing schema) aborts render at the same point
+                // as before rather than surfacing later at the infallible emit.
+                // The structural `pattern` is carried forward for #613.
                 let correlated_aliases = pattern_count_correlated_aliases(&pc.pattern);
-                let sql = generate_pattern_count_sql(&pc.pattern)?;
+                let sql = render_pattern_count_sql(&pc.pattern)?;
                 RenderExpr::PatternCount(PatternCount {
-                    sql: format!("coalesce({}, 0)", sql),
+                    pattern: pc.pattern.clone(),
+                    sql,
                     correlated_aliases,
                 })
             }

--- a/src/sql_generator/emitters/clickhouse/AGENTS.md
+++ b/src/sql_generator/emitters/clickhouse/AGENTS.md
@@ -366,7 +366,7 @@ sub-expressions. This means CTE scope rewriting **cannot reach inside them**:
 |---------|---------|-----------|-----------------|
 | `Raw(String)` | Opaque SQL | `render_expr.rs:914-918` | `"NOT EXISTS (SELECT 1 FROM ... WHERE ... = person.id)"` |
 | `ExistsSubquery { sql: String }` | Opaque SQL | `render_expr.rs:940-944` | `"EXISTS (SELECT 1 FROM ... WHERE ...)"` |
-| `PatternCount { sql: String }` | Opaque SQL | `render_expr.rs:975-978` | `"(SELECT count(*) FROM ... WHERE ... = a.id)"` |
+| `PatternCount { pattern, sql, correlated_aliases }` | Structural pattern + validated SQL cache (rewriters still skip — #613) | `render_expr.rs:1721` | `"coalesce((SELECT count(*) FROM ... WHERE ... = a.id), 0)"` |
 
 **Impact**: When these expressions appear after a WITH scope barrier, the embedded
 variable names (`person.id`, `a.id`) refer to the original table, not the CTE.


### PR DESCRIPTION
## P-4 F3 — first Phase-C slice (de-opaque, part 1)

`RenderExpr::PatternCount` (backs `size((a)-[:R]->(b))`) stored only a pre-baked `sql: String` generated eagerly in `TryFrom<LogicalExpr>` — an opaque string every expression rewriter skips. This adds the structural `pattern: PathPattern` alongside the (now validated-cache) `sql`, so a later slice (**#613**) can make rewriters recurse into it.

### Scope: C1 (carry + cache) — byte-identical
Scoped **down** from the plan's original "drop `sql`, render at emit": that flip is *not* byte-identical and has **zero payoff until a rewriter actually mutates the pattern** — which is #613 itself. So this slice carries the pattern and keeps the cache; the emit→pattern flip and rewriter recursion are #613.

- New `pub(crate) render_pattern_count_sql()` is the single source of the `coalesce(<subquery>, 0)` string (the wrapper previously lived at the bake site).
- The bake site **keeps the `?`**, so an invalid pattern (bare node, `shortestPath`, missing schema) still aborts render at the same `Result` boundary — the infallible `to_sql()` emit never has to panic or emit a marker. *(This error-path crux is why C2 — dropping the cache and rendering at emit — was rejected.)*
- All **6** `pc.sql` consumers (2 emit paths + 4 pre-render optimizer text-scans) read the identical cached string, unchanged. `correlated_aliases` still structurally computed → the `plan_optimizer.rs:2213` guard takes the same branch.
- Rewriter skip arms stay no-ops (#613 territory).

### Gate
- **corpus_sweep + 220 goldens byte-identical**; 2,156 tests pass; clippy clean; ratchet net-zero; `cargo fmt`.
- One in-module unit test rewritten to the 3-field shape (inert pattern; still exercises the empty-`correlated_aliases` SQL-scan fallback).
- Worktree-isolated adversarial review: **0 real findings** (one MINOR stale doc line-ref, fixed).

### Docs
`FORWARD_RESOLUTION_PLAN.md` F3 outcome + `PRIORITIES.md` P-4 status/merge-log + 2 AGENTS.md tables (stale `975-978` refs fixed) updated in this PR.

### Out of scope (→ #613)
Making rewriters recurse into `pattern`; flipping emit to render from the (rewritten) `pattern` instead of the cache — that flip is where the intentional SQL diff lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)