### PR TITLE
refactor(P-4 F4): carry structural subplan in RenderExpr::ExistsSubquery

### DIFF
--- a/docs/design/FORWARD_RESOLUTION_PLAN.md
+++ b/docs/design/FORWARD_RESOLUTION_PLAN.md
@@ -488,7 +488,21 @@ Fixes the size()-pattern member of the residue (candidate **#613**).
 > that flip is where the intentional SQL diff lives.
 
 **F4 — `ExistsSubquery` structured.** Same treatment via `generate_exists_sql`.
-Candidate **#595**.
+
+> **✅ F4 outcome (2026-07-25, landed) — byte-identical (C1, mirrors F3).** Added
+> `subplan: Arc<LogicalPlan>` (`#[serde(with = "serde_arc")]`, mirroring the input
+> `logical_expr::ExistsSubquery.subplan`) to `render_expr::ExistsSubquery` alongside
+> the now validated-`sql` cache. `generate_exists_sql` is already the single producer,
+> so the bake site just also stores `exists.subplan.clone()` (a cheap Arc bump) and
+> keeps the `?` — an EXISTS pattern that can't render still aborts render at the same
+> `Result` boundary. All 6 `es.sql` consumers (2 emit + 4 pre-render optimizer scans)
+> unchanged; the outer `EXISTS (...)` wrapper stays at the emit sites (unlike F3's
+> `coalesce`, which was at the bake site — nothing to extract here). Rewriter skip
+> arms stay no-ops (recursion into `subplan` = #595/#613). Corpus + 220 goldens
+> byte-identical; 2,156 tests; clippy clean; ratchet net-zero. Branch
+> `refactor/f4-existssubquery-carry-subplan`. **Still #595/#613's job:** making
+> rewriters recurse into `subplan`, and flipping emit to render from the (rewritten)
+> `subplan` instead of the cache.
 
 **F5 — NOT-EXISTS `Raw` → structured `NotExists` variant.** Replace the
 `RenderExpr::Raw(not_exists_sql)` at `:1630` with a structured type carrying the

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -116,7 +116,7 @@ string-emitting group (31 fns, `render_plan/pattern_comprehension_sql.rs`, 2,629
 extracted verbatim, `pub(crate)` re-exports, byte-identical goldens + corpus, ratchet
 net-zero; D7-rest deferred. **Next: P2.3 clause_extractors move.**
 
-### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+F2a+F3 done; F2b/F4/F5 and F1b residue open)
+### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
 supersedes the stale `render_plan/AGENTS.md` §10 premise: the `reverse_mapping`
 field §10 says to delete was already removed in #115 (Feb 2026); the debt forked
@@ -192,6 +192,15 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-25: **P-4 F4** — second Phase-C slice, mirrors F3. Added structural
+  `subplan: Arc<LogicalPlan>` to `render_expr::ExistsSubquery` (backs `EXISTS { pattern }`)
+  alongside the now validated-`sql` cache, so a later slice (#595/#613) can make rewriters
+  recurse into it. Byte-identical (C1 — carry + cache): `generate_exists_sql` is already the
+  single producer, bake site keeps the `?` (same error boundary) and stores an Arc clone of
+  the subplan; all 6 `es.sql` consumers unchanged; the `EXISTS (...)` wrapper stays at the
+  emit sites. serde via `#[serde(with = "serde_arc")]`, mirroring the input type. Corpus +
+  220 goldens byte-identical; 2,156 tests; clippy clean; ratchet net-zero. Branch
+  `refactor/f4-existssubquery-carry-subplan`.
 - 2026-07-25: **P-4 F3** — first Phase-C slice. Added structural `pattern: PathPattern`
   to `render_expr::PatternCount` (backs `size((a)-[:R]->(b))`) alongside the now
   validated-`sql` cache, so a later slice (#613) can make rewriters recurse into it.

--- a/src/render_plan/AGENTS.md
+++ b/src/render_plan/AGENTS.md
@@ -463,7 +463,7 @@ Cypher scope stack:           SQL equivalent:
 5. ❌ NOW we need to undo step 3: map `("person", "full_name")` → `"p6_person_full_name"`
 6. ❌ This requires `reverse_mapping: HashMap<(alias, db_column), cte_column>`
 7. ❌ Walk ALL expressions post-hoc, rewriting matching PropertyAccessExp entries
-8. ❌ `Raw(String)`, `ExistsSubquery { sql }`, `PatternCount { pattern, sql }` are opaque — SKIPPED (`PatternCount` now carries `pattern`; rewriter recursion still deferred to #613)
+8. ❌ `Raw(String)`, `ExistsSubquery { subplan, sql }`, `PatternCount { pattern, sql }` are opaque — SKIPPED (`ExistsSubquery`/`PatternCount` now carry structure; rewriter recursion still deferred to #595/#613)
 
 **Why reverse_mapping is a hack:**
 - It's a post-hoc fixup: first resolve to DB columns, then try to undo it
@@ -512,7 +512,7 @@ Three expression types bake variable names into SQL strings too early:
 | Type | Where created | Problem |
 |------|--------------|---------|
 | `RenderExpr::Raw(sql)` | `render_expr.rs:914-918` — NOT (PathPattern) | `person.id` baked into string |
-| `ExistsSubquery { sql }` | `render_expr.rs:940-944` — ExistsSubquery | Same |
+| `ExistsSubquery { subplan, sql }` | `render_expr.rs:1693` — ExistsSubquery; carries `subplan`, rewriters still skip (#595/#613) | Same (cache) |
 | `PatternCount { pattern, sql }` | `render_expr.rs:1721` — size(pattern); carries `pattern`, rewriters still skip (#613) | Same (cache) |
 
 All three call SQL-generation functions (`generate_not_exists_from_path_pattern()`,

--- a/src/render_plan/plan_optimizer.rs
+++ b/src/render_plan/plan_optimizer.rs
@@ -3929,9 +3929,14 @@ mod tests {
         );
         assert!(aliases.contains("col1"));
 
-        // ExistsSubquery with alias.column pattern
+        // ExistsSubquery with alias.column pattern. `correlated_aliases` is
+        // empty, so `collect_aliases_from_expr` falls back to scanning `sql` —
+        // the `subplan` field is inert here (only the cache is exercised).
         collect_aliases_from_expr(
             &RenderExpr::ExistsSubquery(render_expr::ExistsSubquery {
+                subplan: std::sync::Arc::new(
+                    crate::query_planner::logical_plan::LogicalPlan::Empty,
+                ),
                 sql: "EXISTS (SELECT 1 FROM t WHERE friend.id = t.PersonId)".to_string(),
                 correlated_aliases: vec![],
             }),

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -17,6 +17,7 @@ use crate::query_planner::logical_expr::{
 };
 use crate::query_planner::logical_plan::LogicalPlan;
 use crate::sql_generator::function_mapper::current_function_mapper;
+use crate::utils::serde_arc;
 
 use super::errors::RenderBuildError;
 
@@ -1201,7 +1202,8 @@ pub enum RenderExpr {
 
     InSubquery(InSubquery),
 
-    /// EXISTS subquery expression - checks if a pattern exists
+    /// EXISTS subquery expression — checks if a pattern exists. Carries the
+    /// structural `subplan` plus a validated SQL cache (see [`ExistsSubquery`]).
     ExistsSubquery(ExistsSubquery),
 
     /// Reduce expression: fold list into single value
@@ -1408,12 +1410,23 @@ pub struct ReduceExpr {
     pub expression: Box<RenderExpr>,
 }
 
-/// EXISTS subquery for render plan
+/// EXISTS subquery for render plan.
+///
+/// Carries the structural `subplan` (the EXISTS pattern's logical plan, the
+/// source of truth) alongside a `sql` cache rendered *and validated* once at
+/// `LogicalExpr` → `RenderExpr` conversion via [`generate_exists_sql`]. Today
+/// every consumer reads the `sql` cache; the `subplan` is retained so a later
+/// slice (#595/#613 forward-resolution) can make the expression rewriters
+/// recurse into it. Until then the rewriters still SKIP this variant, so the
+/// cache stays authoritative and generation is unaffected by scope rewriting.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ExistsSubquery {
-    /// Pre-rendered SQL for the EXISTS subquery
-    /// This is generated during conversion since EXISTS patterns
-    /// don't fit the normal query structure (no select items)
+    /// Structural EXISTS pattern — source of truth for the `sql` cache.
+    #[serde(with = "serde_arc")]
+    pub subplan: std::sync::Arc<LogicalPlan>,
+    /// Validated pre-rendered SQL for the EXISTS subquery body (WITHOUT the
+    /// outer `EXISTS (...)` wrapper — that is applied at the emit sites),
+    /// cached from `subplan` at conversion.
     pub sql: String,
     /// #614: outer-scope aliases the correlated subquery references (the
     /// endpoints classified outer-bound during generation, #596). Same
@@ -1678,10 +1691,15 @@ impl TryFrom<LogicalExpr> for RenderExpr {
                     .map(Box::new),
             },
             LogicalExpr::ExistsSubquery(exists) => {
-                // For EXISTS subqueries, generate SQL directly since they don't fit
-                // the normal RenderPlan structure (no select items needed)
+                // Render + validate the EXISTS body SQL once and cache it (see
+                // `generate_exists_sql`). The `?` stays HERE so an EXISTS pattern
+                // that can't render (missing schema, unsupported subplan) aborts
+                // render at the same point as before rather than surfacing later
+                // at the infallible emit. The structural `subplan` is carried
+                // forward for #595/#613.
                 let (sql, correlated_aliases) = generate_exists_sql(&exists)?;
                 RenderExpr::ExistsSubquery(ExistsSubquery {
+                    subplan: exists.subplan.clone(),
                     sql,
                     correlated_aliases,
                 })

--- a/src/sql_generator/emitters/clickhouse/AGENTS.md
+++ b/src/sql_generator/emitters/clickhouse/AGENTS.md
@@ -365,7 +365,7 @@ sub-expressions. This means CTE scope rewriting **cannot reach inside them**:
 | Variant | Carries | Created in | Example content |
 |---------|---------|-----------|-----------------|
 | `Raw(String)` | Opaque SQL | `render_expr.rs:914-918` | `"NOT EXISTS (SELECT 1 FROM ... WHERE ... = person.id)"` |
-| `ExistsSubquery { sql: String }` | Opaque SQL | `render_expr.rs:940-944` | `"EXISTS (SELECT 1 FROM ... WHERE ...)"` |
+| `ExistsSubquery { subplan, sql, correlated_aliases }` | Structural subplan + validated SQL cache (rewriters still skip — #595/#613) | `render_expr.rs:1693` | `"EXISTS (SELECT 1 FROM ... WHERE ...)"` |
 | `PatternCount { pattern, sql, correlated_aliases }` | Structural pattern + validated SQL cache (rewriters still skip — #613) | `render_expr.rs:1721` | `"coalesce((SELECT count(*) FROM ... WHERE ... = a.id), 0)"` |
 
 **Impact**: When these expressions appear after a WITH scope barrier, the embedded


### PR DESCRIPTION
## P-4 F4 — second Phase-C slice (de-opaque, mirrors F3)

`RenderExpr::ExistsSubquery` (backs `EXISTS { pattern }`) stored only a pre-baked `sql: String` generated eagerly in `TryFrom<LogicalExpr>` — an opaque string every rewriter skips. This adds the structural `subplan: Arc<LogicalPlan>` (`#[serde(with = "serde_arc")]`, mirroring the input `logical_expr::ExistsSubquery.subplan`) alongside the (now validated-cache) `sql`, so a later slice (**#595/#613**) can make rewriters recurse into it.

### Byte-identical (C1 — carry + cache)
- `generate_exists_sql` is already the single producer, so the bake site just also stores `exists.subplan.clone()` (a cheap Arc bump) and **keeps the `?`** — an EXISTS pattern that can't render still aborts render at the same `Result` boundary; the infallible emit never panics.
- All **6** `es.sql` consumers (2 emit paths + 4 pre-render optimizer text-scans) read the identical cached string, unchanged. `correlated_aliases` still populated identically → same optimizer guard branch.
- The outer `EXISTS (...)` wrapper stays at the emit sites (unlike F3's `coalesce`, which was at the bake site — nothing to extract here).
- Rewriter skip arms stay no-ops (recursion into `subplan` = #595/#613).

### Gate
- **corpus_sweep + 220 goldens byte-identical**; 2,156 tests pass; clippy clean; ratchet net-zero; `cargo fmt`.
- Shared collect-aliases unit test extended to the 3-field shape (inert `LogicalPlan::Empty` subplan; still exercises the empty-`correlated_aliases` SQL-scan fallback).
- Worktree-isolated adversarial review: **0 real findings** (all 7 checks pass, incl. serde_arc/PartialEq/dedup).

### Docs
`FORWARD_RESOLUTION_PLAN.md` F4 outcome + `PRIORITIES.md` P-4 status/merge-log + 2 AGENTS.md tables (stale `940-944` refs fixed) updated in this PR.

### Out of scope (→ #595/#613)
Making rewriters recurse into `subplan`; flipping emit to render from the (rewritten) `subplan` instead of the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)