### PR TITLE
fix(#649): accept leading UNWIND before MATCH

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -192,6 +192,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-25: **#649 leading UNWIND** (P-1 bug lane, `fix/649-leading-unwind`,
+  PR #669) — `UNWIND [...] AS x MATCH (n) WHERE n.p = x RETURN n` (UNWIND as the
+  first clause) was rejected; pre-#516 it "passed" only by silently dropping
+  everything from MATCH on. `parse_query_with_nom` now parses leading UNWINDs
+  before the reading clauses and threads them (leading-first) into the same flat
+  `unwind_clauses` list the trailing form uses, so the planner builds the
+  identical `Unwind(Match(...))` plan → byte-identical SQL to `MATCH ... UNWIND`.
+  NOT a new `ReadingClause::Unwind` variant (an order-preserving Unwind-wraps-
+  Match plan was prototyped and dropped the ARRAY JOIN — renderer only emits it
+  when Unwind wraps Match). Scoped diff: corpus `test_unwind_list` .err→.sql
+  (ARRAY JOIN / LATERAL VIEW), only transition in the 517-golden sweep. Removed
+  matrix strict-xfail `test_unwind_with_match`; ldbc_bi_4 now PARSES and fails
+  loud `UnionColumnMismatch` (silent-drop → loud, union-arm alignment deferred).
+  +3 parser unit tests. Adversarial worktree review: 0 blockers, 2 nits (one
+  "keep as-is"). Gates: corpus/sql_golden/1609+513/clippy/ratchet/fmt.
+
 - 2026-07-25: **P-4 F4** — second Phase-C slice, mirrors F3. Added structural
   `subplan: Arc<LogicalPlan>` to `render_expr::ExistsSubquery` (backs `EXISTS { pattern }`)
   alongside the now validated-`sql` cache, so a later slice (#595/#613) can make rewriters

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -82,9 +82,9 @@ fixable: ~~#647~~ **DONE (#652, `91475be3`)**, #644 (denorm OPTIONAL-VLP anchor
 join, loud — **in flight**), #646 (composite self-ref FK-edge, loud), #641
 (#589 gate holes), #640 (EXISTS beyond single-hop), #636 (4-way shared-anchor),
 #635 (FK-edge coupled rel-var on VLP), #648 (untyped count(r) multi-type),
-#649 (leading UNWIND). Prefer silent-wrong over loud-error fixes. Rule §1.6
-applies: if root cause lands in the reverse-mapping class, gate loud + document,
-move on.
+~~#649~~ **DONE (leading UNWIND before MATCH)**. Prefer silent-wrong over
+loud-error fixes. Rule §1.6 applies: if root cause lands in the reverse-mapping
+class, gate loud + document, move on.
 
 ### P-2 — P1.2: the five WITH functions  ☑ (done — `refactor/p12-five-with-fns`)
 `REFACTORING_SAFETY_PLAN.md` §4.2. Delivered: the missing P1.1 `walk()` /

--- a/docs/wiki/Cypher-Language-Reference.md
+++ b/docs/wiki/Cypher-Language-Reference.md
@@ -816,6 +816,21 @@ RETURN q.query, d.name, resolved_ip
 
 **Note**: UNWIND on array columns generates ClickHouse `ARRAY JOIN` for optimal performance.
 
+### Leading UNWIND (before MATCH)
+
+`UNWIND` may appear as the first clause, before `MATCH` — the Neo4j-legal form for
+driving a match from a list of values:
+
+```cypher
+-- For each name in the list, match the matching user
+UNWIND ['Alice', 'Bob', 'Charlie'] AS name
+MATCH (u:User) WHERE u.name = name
+RETURN u.name, u.email
+```
+
+This is equivalent to writing the `UNWIND` after the `MATCH`; both build the same
+`ARRAY JOIN` over the matched rows with the `WHERE` applied on top.
+
 ---
 
 ## ORDER BY, LIMIT, SKIP

--- a/src/open_cypher_parser/mod.rs
+++ b/src/open_cypher_parser/mod.rs
@@ -209,7 +209,10 @@ pub fn parse_query_with_nom(
     // `MATCH ... UNWIND ...` form (ARRAY JOIN over the matched rows, then WHERE).
     // For filter-correlated queries (`UNWIND xs AS x MATCH (n) WHERE n.p = x`)
     // this is semantically exact. Shapes where the unwound variable is itself a
-    // pattern node still surface downstream rather than being silently mis-planned.
+    // pattern node inherit the existing trailing-UNWIND planner behavior verbatim
+    // (byte-identical to `MATCH ... UNWIND ...`); this parser change neither fixes
+    // nor worsens those — e.g. LDBC bi-4 now parses and fails loud downstream
+    // instead of being silently truncated at the top-level parse.
     let (input, leading_unwind_clauses): (&str, Vec<UnwindClause>) =
         many0(unwind_clause::parse_unwind_clause).parse(input)?;
 

--- a/src/open_cypher_parser/mod.rs
+++ b/src/open_cypher_parser/mod.rs
@@ -201,6 +201,18 @@ pub fn parse_query_with_nom(
         many0(use_clause::parse_use_clause).parse(input)?;
     let use_clause = use_clauses.into_iter().last();
 
+    // Parse leading UNWIND clauses (Neo4j-legal `UNWIND ... AS x MATCH ...`, #649).
+    // Cypher allows UNWIND as the first reading clause; the grammar historically
+    // accepted it only after MATCH. We parse any leading UNWINDs here and thread
+    // them into the trailing `unwind_clauses` list below, so the planner builds
+    // the same `Unwind(Match(...))` plan it already builds for the accepted
+    // `MATCH ... UNWIND ...` form (ARRAY JOIN over the matched rows, then WHERE).
+    // For filter-correlated queries (`UNWIND xs AS x MATCH (n) WHERE n.p = x`)
+    // this is semantically exact. Shapes where the unwound variable is itself a
+    // pattern node still surface downstream rather than being silently mis-planned.
+    let (input, leading_unwind_clauses): (&str, Vec<UnwindClause>) =
+        many0(unwind_clause::parse_unwind_clause).parse(input)?;
+
     // Parse reading clauses (MATCH and OPTIONAL MATCH can appear in any order)
     let (input, reading_clauses): (&str, Vec<ReadingClause>) =
         many0(parse_reading_clause).parse(input)?;
@@ -228,8 +240,19 @@ pub fn parse_query_with_nom(
     // Supports multiple consecutive UNWIND for cartesian product
     // Example: MATCH (n) UNWIND n.items AS item RETURN item
     // Example: UNWIND [1,2] AS x UNWIND [10,20] AS y RETURN x, y
-    let (input, unwind_clauses): (&str, Vec<UnwindClause>) =
+    let (input, trailing_unwind_clauses): (&str, Vec<UnwindClause>) =
         many0(unwind_clause::parse_unwind_clause).parse(input)?;
+
+    // Prepend any leading UNWINDs (#649) to the trailing UNWINDs so the planner
+    // sees a single ordered `unwind_clauses` list and builds `Unwind(Match(...))`
+    // exactly as it does for the already-accepted `MATCH ... UNWIND ...` form.
+    let unwind_clauses: Vec<UnwindClause> = if leading_unwind_clauses.is_empty() {
+        trailing_unwind_clauses
+    } else {
+        let mut merged = leading_unwind_clauses;
+        merged.extend(trailing_unwind_clauses);
+        merged
+    };
 
     let (input, with_clause): (&str, Option<WithClause>) =
         opt(with_clause::parse_with_clause).parse(input)?;
@@ -466,6 +489,60 @@ mod tests {
             }
             Err(e) => panic!("Full query parsing failed: {:?}", e),
         }
+    }
+
+    /// #649: a leading UNWIND (Neo4j-legal `UNWIND ... AS x MATCH ...`) must parse.
+    /// It is threaded into `unwind_clauses` alongside the following MATCH so the
+    /// planner builds the same `Unwind(Match(...))` plan as `MATCH ... UNWIND ...`.
+    #[test]
+    fn test_parse_leading_unwind_before_match() {
+        let query =
+            "UNWIND ['Alice', 'Bob'] AS name MATCH (u:User) WHERE u.name = name RETURN u.name";
+        let ast = parse_query(query).expect("leading UNWIND before MATCH should parse");
+
+        // The leading UNWIND lands in unwind_clauses.
+        assert_eq!(ast.unwind_clauses.len(), 1, "Expected one UNWIND clause");
+        assert_eq!(ast.unwind_clauses[0].alias, "name");
+
+        // The MATCH is still captured (its WHERE is a per-MATCH clause).
+        assert!(!ast.match_clauses.is_empty(), "Expected MATCH clause");
+        assert!(
+            ast.match_clauses[0].where_clause.is_some(),
+            "Expected per-MATCH WHERE clause"
+        );
+        assert!(ast.return_clause.is_some(), "Expected RETURN clause");
+    }
+
+    /// #649: a leading UNWIND followed by a trailing UNWIND (either side of the
+    /// MATCH) must collect both, leading first, preserving cartesian order.
+    #[test]
+    fn test_parse_leading_and_trailing_unwind() {
+        let query = "UNWIND [1, 2] AS x MATCH (u:User) UNWIND [3, 4] AS y RETURN u.name, x, y";
+        let ast = parse_query(query).expect("leading + trailing UNWIND should parse");
+
+        assert_eq!(ast.unwind_clauses.len(), 2, "Expected two UNWIND clauses");
+        assert_eq!(
+            ast.unwind_clauses[0].alias, "x",
+            "leading UNWIND comes first"
+        );
+        assert_eq!(
+            ast.unwind_clauses[1].alias, "y",
+            "trailing UNWIND comes second"
+        );
+        assert!(!ast.match_clauses.is_empty(), "Expected MATCH clause");
+    }
+
+    /// #649 guard: a standalone leading UNWIND with no following MATCH must keep
+    /// its pre-existing behavior (routed through the trailing UNWIND path).
+    #[test]
+    fn test_parse_standalone_leading_unwind_unchanged() {
+        let query = "UNWIND [1, 2, 3] AS x RETURN x";
+        let ast = parse_query(query).expect("standalone UNWIND should parse");
+
+        assert_eq!(ast.unwind_clauses.len(), 1, "Expected one UNWIND clause");
+        assert_eq!(ast.unwind_clauses[0].alias, "x");
+        assert!(ast.match_clauses.is_empty(), "No MATCH clause expected");
+        assert!(ast.return_clause.is_some(), "Expected RETURN clause");
     }
 
     #[test]

--- a/tests/integration/matrix/test_comprehensive.py
+++ b/tests/integration/matrix/test_comprehensive.py
@@ -533,18 +533,8 @@ class TestUnwind:
         result = execute_query(query)  # UNWIND doesn't need schema
         assert result["success"], f"Query failed: {query}\nResult: {result['body']}"
     
-    @pytest.mark.xfail(
-        reason="Feature gap: the grammar only accepts UNWIND *after* the "
-        "reading clauses (MATCH ... UNWIND ... RETURN), not the Neo4j-legal "
-        "leading form UNWIND ... MATCH ... RETURN. Before the #516 strict "
-        "all-consuming parser this 'passed' only because the lenient parser "
-        "silently DISCARDED everything from MATCH onward (silent-wrong); it "
-        "now fails loud at parse. Needs a tracked issue for leading-UNWIND "
-        "support. Remove marker when the parser accepts UNWIND before MATCH.",
-        strict=True,
-    )
     def test_unwind_with_match(self, server_running, schema_config, query_generator):
-        """Test: UNWIND ... MATCH ..."""
+        """Test: UNWIND ... MATCH ... (leading UNWIND before MATCH, #649)."""
         query = query_generator.unwind_with_match()
         result = execute_query(query, schema_name=schema_config.name)
         assert result["success"], f"Query failed: {query}\nResult: {result['body']}"

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.clickhouse.err
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.clickhouse.err
@@ -1,1 +1,0 @@
-parse error: Parsing Failure: OpenCypherParsingError { errors: [("MATCH (u:User) WHERE u.name = name\n            RETURN u.name, u.email", "Unexpected tokens after query"), ("MATCH (u:User) WHERE u.name = name\n            RETURN u.name, u.email", "Unparsed input")] }

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.name AS "u.name", 
+      u.email AS "u.email"
+FROM data_security.ds_users AS u
+ARRAY JOIN ['Alice', 'Bob', 'Charlie'] AS name
+WHERE u.name = name

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.databricks.err
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.databricks.err
@@ -1,1 +1,0 @@
-parse error: Parsing Failure: OpenCypherParsingError { errors: [("MATCH (u:User) WHERE u.name = name\n            RETURN u.name, u.email", "Unexpected tokens after query"), ("MATCH (u:User) WHERE u.name = name\n            RETURN u.name, u.email", "Unparsed input")] }

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_unwind_list.databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      u.name AS `u.name`, 
+      u.email AS `u.email`
+FROM data_security.ds_users AS u
+LATERAL VIEW explode(array('Alice', 'Bob', 'Charlie')) AS name
+WHERE u.name = name

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -448,17 +448,14 @@ async fn ldbc_bi_3() {
 }
 
 #[tokio::test]
-#[ignore = "pre-existing parser gap (found while fixing #516, NOT caused by it): the second \
-    UNION ALL arm of bi-4-workaround.cypher opens with `UNWIND topForums AS topForum1 \
-    MATCH (person:Person)<-[:HAS_MEMBER]-(topForum1:Forum) ...` — UNWIND before MATCH at the \
-    top level of a query/union-arm. parse_query_with_nom() only parses UNWIND clauses *after* \
-    MATCH/OPTIONAL MATCH (src/open_cypher_parser/mod.rs), unlike with_clause.rs's nested \
-    subsequent_unwind/subsequent_match chain, which already supports that ordering. Before \
-    #516's all-consuming top-level parse fix, this silently truncated the whole arm (MATCH, \
-    WITH, RETURN, ORDER BY, LIMIT all silently dropped as 'trailing garbage') and the test \
-    still passed because it only asserts non-empty SQL containing SELECT — a live example of \
-    the exact silent-drop bug class #516 fixes. Fixing the UNWIND-before-MATCH ordering gap \
-    itself is a separate, out-of-scope parser feature; tracked for future work, not fixed here."]
+#[ignore = "leading UNWIND before MATCH now PARSES (#649), so the bi-4-workaround union \
+    arm `UNWIND topForums AS topForum1 MATCH (person:Person)<-[:HAS_MEMBER]-(topForum1:Forum) \
+    ...` is no longer silently truncated. It now fails LOUD and honest with \
+    UnionColumnMismatch (arm 1 projects personId/personFirstName/... while arm 0 projects \
+    creationDate/firstName/id/... — the two UNION ALL arms emit columns in different order/\
+    naming). That column-alignment gap across union arms is a separate downstream issue, \
+    tracked apart from the parser fix; the silent-drop bug class #516 hardened against is \
+    resolved here (loud, not silent). Un-ignore when union-arm column alignment is fixed."]
 async fn ldbc_bi_4() {
     let schema = load_ldbc_schema();
     // Official bi-4 uses CALL subquery; use adapted workaround with UNION ALL


### PR DESCRIPTION
## Summary
Closes #649. Neo4j-legal `UNWIND [...] AS x MATCH (n) WHERE n.p = x RETURN n` (UNWIND as the **first** clause) was rejected — the grammar only accepted UNWIND *after* the reading clauses. Pre-#516 this "passed" only by silently discarding everything from MATCH onward (a silent-wrong #516 correctly turned loud). This closes the feature gap.

## Approach
`parse_query_with_nom` now parses any **leading** UNWINDs before the reading clauses and threads them (leading-first) into the same `unwind_clauses` list the trailing form already uses. The planner builds `Unwind(Match(...))` regardless of source clause order (ARRAY JOIN over matched rows, WHERE on top), so leading UNWIND emits **byte-identical SQL** to the accepted `MATCH ... UNWIND ...` form. For the filter-correlated shape in the issue this is semantically exact.

**Deliberately NOT a new `ReadingClause::Unwind` variant.** An order-preserving `Unwind`-wraps-`Match` plan was prototyped and *dropped the ARRAY JOIN* (renderer only emits it when Unwind wraps Match, which the input-plan shape didn't produce). The flat-trailing route reuses the proven, correct emit path. Shapes where the unwound variable is itself a **pattern node** (LDBC bi-4) are not silently mis-planned: bi-4 now **parses and fails loud** with `UnionColumnMismatch` (a separate downstream union-arm alignment issue) instead of silently truncating the arm — a ground-rule-1 improvement.

## Changes
- `src/open_cypher_parser/mod.rs` — parse leading UNWIND, merge into `unwind_clauses`; +3 regression unit tests (leading / leading+trailing / standalone-unchanged)
- corpus `test_unwind_list` — `.err` goldens flip to `.sql` (`ARRAY JOIN` ClickHouse / `LATERAL VIEW explode` Databricks)
- matrix `test_unwind_with_match` — remove `strict=True` xfail (now passes)
- `ldbc_bi_4` — update `#[ignore]` note (silent-drop → loud `UnionColumnMismatch`)
- docs — Cypher-Language-Reference leading-UNWIND subsection; PRIORITIES #649 done

## Verification
- **corpus_sweep** (517 filtered, locks success+error goldens): only `test_unwind_list` transitions — scoped, intended
- **sql_golden** 220 ✅
- full suite 1609 + 513 ✅ · clippy clean · ratchet net-zero · fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)