### PR TITLE
fix(#648): untyped count(r) over multi-type relationship

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -81,10 +81,10 @@ Open issues that are NOT the reverse-mapping class and are individually
 fixable: ~~#647~~ **DONE (#652, `91475be3`)**, #644 (denorm OPTIONAL-VLP anchor
 join, loud — **in flight**), #646 (composite self-ref FK-edge, loud), #641
 (#589 gate holes), #640 (EXISTS beyond single-hop), #636 (4-way shared-anchor),
-#635 (FK-edge coupled rel-var on VLP), #648 (untyped count(r) multi-type),
-~~#649~~ **DONE (leading UNWIND before MATCH)**. Prefer silent-wrong over
-loud-error fixes. Rule §1.6 applies: if root cause lands in the reverse-mapping
-class, gate loud + document, move on.
+#635 (FK-edge coupled rel-var on VLP), ~~#648~~ **DONE (untyped count(r)
+multi-type)**, ~~#649~~ **DONE (leading UNWIND before MATCH)**. Prefer
+silent-wrong over loud-error fixes. Rule §1.6 applies: if root cause lands in
+the reverse-mapping class, gate loud + document, move on.
 
 ### P-2 — P1.2: the five WITH functions  ☑ (done — `refactor/p12-five-with-fns`)
 `REFACTORING_SAFETY_PLAN.md` §4.2. Delivered: the missing P1.1 `walk()` /
@@ -191,6 +191,24 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-25: **#648 untyped count(r) multi-type** (P-1 bug lane) — regression
+  from #502 (bisect a10886aa). `MATCH (u:TestUser)-[r]->(o:TestUser) RETURN
+  count(r)` where two rel types connect TestUser→TestUser routes through the
+  `vlp_multi_type_*` UNION-ALL CTE (aliased `t`, generic `start_id`/`r_from_id`
+  cols) but the projection-tagging aggregate rewrite picked the FIRST type's
+  `from_id` and kept the Cypher alias `r` → `count(r.follower_id)` against a
+  CTE with no such column and an unbound alias → Code 47. Fix: new
+  `rel_alias_uses_multi_type_vlp` predicate (`logical_plan/mod.rs`, gated on
+  `rel.labels.len() > 1`) + a guard branch in `projection_tagging.rs` mirroring
+  the #526 `pattern_union` branch → emit `count(t.start_id)` (NULL-sensitive,
+  always-projected) / DISTINCT label-agnostic tuple over alias `t`. Blast
+  radius nil: typed count(r), count(*), single-type-untyped count(r), and
+  fully-unlabeled count(r) all unchanged (guard fires only on labels.len()>1).
+  Scoped diff: corpus `test_count_relationship_with_node_constraints` golden
+  flips from the BROKEN `count(r.follower_id)` to `count(t.start_id)` (both
+  dialects) — the only corpus transition. +executable-oracle sql_golden test;
+  removed py strict-xfail.
 
 - 2026-07-25: **#649 leading UNWIND** (P-1 bug lane, `fix/649-leading-unwind`,
   PR #669) — `UNWIND [...] AS x MATCH (n) WHERE n.p = x RETURN n` (UNWIND as the

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1441,6 +1441,15 @@ impl ProjectionTagging {
                                 // (always projected, non-NULL on a real edge row), aliased
                                 // `t` — mirroring the `pattern_union` branch above and the
                                 // NODE-side `node_is_multi_type_rel_endpoint` handling.
+                                //
+                                // NOTE: `rel_alias_uses_multi_type_vlp` intentionally does
+                                // NOT recurse past a `WITH` barrier (unlike the
+                                // pattern_union predicate), so the hardcoded `t`
+                                // (VLP_CTE_FROM_ALIAS) is only used while `t` is genuinely
+                                // in scope. Post-`WITH` the outer FROM is `with_r_cte_0 AS r`
+                                // and `t` is gone; that continuation-alias case is the
+                                // #602/#616 forward-resolution problem and is left as-is
+                                // (still loud) rather than emitting a dangling `t`.
                                 if input_plan
                                     .is_some_and(|p| p.rel_alias_uses_multi_type_vlp(t_alias))
                                 {

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1425,6 +1425,73 @@ impl ProjectionTagging {
                                     continue;
                                 }
 
+                                // #648: a relationship alias bound to a MULTI-TYPE
+                                // relationship (two+ candidate rel types between
+                                // labeled endpoints, e.g. `(u:TestUser)-[r]->(o:TestUser)`
+                                // with both TEST_FOLLOWS and TEST_FRIENDS_WITH) is
+                                // materialized by a `vlp_multi_type_*` UNION-ALL CTE
+                                // aliased `AS t` with generic label-agnostic columns
+                                // (`start_id`/`end_id`/`r_from_id`/...), NOT by any single
+                                // rel type's edge table. The per-label resolution below
+                                // would (incorrectly) pick the FIRST candidate type's
+                                // `from_id` (e.g. `follower_id`) and keep the Cypher rel
+                                // alias `r` — but that column doesn't exist on the CTE and
+                                // `r` is unbound (the CTE alias is `t`), so ClickHouse
+                                // errors Code 47. Route through the CTE's own `start_id`
+                                // (always projected, non-NULL on a real edge row), aliased
+                                // `t` — mirroring the `pattern_union` branch above and the
+                                // NODE-side `node_is_multi_type_rel_endpoint` handling.
+                                if input_plan
+                                    .is_some_and(|p| p.rel_alias_uses_multi_type_vlp(t_alias))
+                                {
+                                    let access = |col: &str| {
+                                        LogicalExpr::PropertyAccessExp(PropertyAccess {
+                                            table_alias: TableAlias(
+                                                crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
+                                                    .to_string(),
+                                            ),
+                                            column: crate::graph_catalog::expression_parser::PropertyValue::Column(
+                                                col.to_string(),
+                                            ),
+                                        })
+                                    };
+                                    let count_arg = if is_distinct {
+                                        // Full row identity across label spaces, matching
+                                        // the pattern_union DISTINCT shape above.
+                                        let path_rel_first = LogicalExpr::ArraySubscript {
+                                            array: Box::new(access("path_relationships")),
+                                            index: Box::new(LogicalExpr::Literal(
+                                                crate::query_planner::logical_expr::Literal::Integer(0),
+                                            )),
+                                        };
+                                        LogicalExpr::OperatorApplicationExp(OperatorApplication {
+                                            operator: Operator::Distinct,
+                                            operands: vec![LogicalExpr::ScalarFnCall(
+                                                ScalarFnCall {
+                                                    name: "tuple".to_string(),
+                                                    args: vec![
+                                                        access("start_type"),
+                                                        access("start_id"),
+                                                        access("end_type"),
+                                                        access("end_id"),
+                                                        path_rel_first,
+                                                    ],
+                                                },
+                                            )],
+                                        })
+                                    } else {
+                                        // NULL-sensitive single-column count on the
+                                        // always-projected `start_id` (#502 style).
+                                        access("start_id")
+                                    };
+                                    item.expression =
+                                        LogicalExpr::AggregateFnCall(AggregateFnCall {
+                                            name: aggregate_fn_call.name.clone(),
+                                            args: vec![count_arg],
+                                        });
+                                    continue;
+                                }
+
                                 // For relationships:
                                 // - count(r) -> count(<first edge_id column>) NULL-sensitive:
                                 //   under OPTIONAL MATCH a LEFT JOIN miss leaves the edge's own

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -1755,6 +1755,54 @@ impl LogicalPlan {
         }
     }
 
+    /// #648: is `rel_alias` bound to a MULTI-TYPE relationship (two or more
+    /// candidate relationship types between the endpoints, e.g.
+    /// `(u:TestUser)-[r]->(o:TestUser)` where both TEST_FOLLOWS and
+    /// TEST_FRIENDS_WITH connect TestUser→TestUser) — materialized by a
+    /// `vlp_multi_type_*` UNION-ALL CTE aliased `AS t` with generic columns
+    /// (`start_id`/`end_id`/`r_from_id`/...), NOT by any single rel type's
+    /// edge table?
+    ///
+    /// The rel-var analog of `node_is_multi_type_rel_endpoint`
+    /// (`analyzer/projection_tagging.rs`), which checks `gr.labels.len() > 1`
+    /// for NODE columns. `count(r)` over such a rel var must count the CTE's
+    /// own rows, not `count(r.<first-type's-from_id>)` — the first type's
+    /// FK column doesn't exist on the CTE and the alias `r` is unbound
+    /// (the CTE is aliased `t`), a ClickHouse Code 47. Distinct from
+    /// `rel_alias_uses_pattern_union` (`pattern_combinations` / unlabeled
+    /// endpoints, CTE aliased `pattern_union_r AS r`).
+    pub fn rel_alias_uses_multi_type_vlp(&self, rel_alias: &str) -> bool {
+        match self {
+            LogicalPlan::GraphRel(rel) => {
+                if rel.alias == rel_alias {
+                    return rel.labels.as_ref().is_some_and(|l| l.len() > 1);
+                }
+                rel.left.rel_alias_uses_multi_type_vlp(rel_alias)
+                    || rel.center.rel_alias_uses_multi_type_vlp(rel_alias)
+                    || rel.right.rel_alias_uses_multi_type_vlp(rel_alias)
+            }
+            LogicalPlan::GraphNode(node) => node.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::Filter(f) => f.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::Projection(p) => p.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::GraphJoins(gj) => gj.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::GroupBy(gb) => gb.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::OrderBy(ob) => ob.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::Skip(s) => s.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::Limit(l) => l.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::Cte(cte) => cte.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::WithClause(wc) => wc.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            LogicalPlan::CartesianProduct(cp) => {
+                cp.left.rel_alias_uses_multi_type_vlp(rel_alias)
+                    || cp.right.rel_alias_uses_multi_type_vlp(rel_alias)
+            }
+            LogicalPlan::Union(u) => u
+                .inputs
+                .iter()
+                .any(|i| i.rel_alias_uses_multi_type_vlp(rel_alias)),
+            _ => false,
+        }
+    }
+
     /// #483: is `alias` a connection (`left_connection`/`right_connection`) of
     /// an UNDIRECTED (`Direction::Either`) `GraphRel` in this plan? Returns
     /// `Some(true)` for the left/start connection, `Some(false)` for the

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -1761,16 +1761,26 @@ impl LogicalPlan {
     /// TEST_FRIENDS_WITH connect TestUser→TestUser) — materialized by a
     /// `vlp_multi_type_*` UNION-ALL CTE aliased `AS t` with generic columns
     /// (`start_id`/`end_id`/`r_from_id`/...), NOT by any single rel type's
-    /// edge table?
+    /// edge table — **in the current scope** (no `WITH` barrier crossed)?
     ///
     /// The rel-var analog of `node_is_multi_type_rel_endpoint`
     /// (`analyzer/projection_tagging.rs`), which checks `gr.labels.len() > 1`
     /// for NODE columns. `count(r)` over such a rel var must count the CTE's
     /// own rows, not `count(r.<first-type's-from_id>)` — the first type's
     /// FK column doesn't exist on the CTE and the alias `r` is unbound
-    /// (the CTE is aliased `t`), a ClickHouse Code 47. Distinct from
-    /// `rel_alias_uses_pattern_union` (`pattern_combinations` / unlabeled
-    /// endpoints, CTE aliased `pattern_union_r AS r`).
+    /// (the CTE is aliased `t`), a ClickHouse Code 47.
+    ///
+    /// Unlike `rel_alias_uses_pattern_union`, this **does NOT recurse through a
+    /// `WithClause` barrier**. The two CTEs render with DIFFERENT FROM aliases:
+    /// pattern_union is `pattern_union_r AS r` (the rel var itself) both pre-
+    /// and post-`WITH`, so its branch can always use `t_alias`; but the
+    /// multi_type CTE is `AS t` in-scope and, after a `WITH r` barrier, the
+    /// outer FROM becomes `with_r_cte_0 AS r` — the raw `t` alias is no longer
+    /// in scope. Correctly resolving the post-`WITH` continuation alias is the
+    /// #602/#616 forward-resolution-through-barrier problem (blocked on render-
+    /// phase timing), so this predicate deliberately declines post-`WITH`,
+    /// leaving that shape exactly as it was (loud, deferred) rather than
+    /// emitting a dangling `t`.
     pub fn rel_alias_uses_multi_type_vlp(&self, rel_alias: &str) -> bool {
         match self {
             LogicalPlan::GraphRel(rel) => {
@@ -1790,7 +1800,9 @@ impl LogicalPlan {
             LogicalPlan::Skip(s) => s.input.rel_alias_uses_multi_type_vlp(rel_alias),
             LogicalPlan::Limit(l) => l.input.rel_alias_uses_multi_type_vlp(rel_alias),
             LogicalPlan::Cte(cte) => cte.input.rel_alias_uses_multi_type_vlp(rel_alias),
-            LogicalPlan::WithClause(wc) => wc.input.rel_alias_uses_multi_type_vlp(rel_alias),
+            // Deliberately NO WithClause recursion — post-WITH the multi_type
+            // CTE alias `t` is out of scope (see doc above). Decline so the
+            // continuation falls through to its existing (main) behavior.
             LogicalPlan::CartesianProduct(cp) => {
                 cp.left.rel_alias_uses_multi_type_vlp(rel_alias)
                     || cp.right.rel_alias_uses_multi_type_vlp(rel_alias)

--- a/tests/integration/test_count_relationships.py
+++ b/tests/integration/test_count_relationships.py
@@ -71,15 +71,6 @@ class TestCountRelationships:
         total = get_single_value(response, "total", convert_to_int=True)
         assert total > 0
 
-    @pytest.mark.xfail(
-        reason="Product regression (bisected to #502 NULL-sensitive count(r), "
-        "a10886aa): count(r) over an UNTYPED multi-type rel routes through the "
-        "vlp_multi_type CTE but still emits count(r.follower_id) against the "
-        "CTE alias t, whose projection has no such column -> ClickHouse Code 47 "
-        "(loud, HTTP 500). count(*) and typed count(r) work. #620-family "
-        "(CTE projection contract). Remove marker when fixed.",
-        strict=True,
-    )
     def test_count_relationship_with_node_constraints(self, simple_graph):
         """
         Test relationship counting with node type constraints.

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_count_relationships__TestCountRelationships_test_count_relationship_with_node_constraints.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_count_relationships__TestCountRelationships_test_count_relationship_with_node_constraints.clickhouse.sql
@@ -10,5 +10,5 @@ INNER JOIN test_integration.friendships r1 ON u_1.user_id = r1.user_id_1
 INNER JOIN test_integration.users n2 ON r1.user_id_2 = n2.user_id
 )
 SELECT 
-      count(r.follower_id) AS "total"
+      count(t.start_id) AS "total"
 FROM vlp_multi_type_u_other AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_count_relationships__TestCountRelationships_test_count_relationship_with_node_constraints.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_count_relationships__TestCountRelationships_test_count_relationship_with_node_constraints.databricks.sql
@@ -10,5 +10,5 @@ INNER JOIN test_integration.friendships r1 ON u_1.user_id = r1.user_id_1
 INNER JOIN test_integration.users n2 ON r1.user_id_2 = n2.user_id
 )
 SELECT 
-      count(r.follower_id) AS `total`
+      count(t.start_id) AS `total`
 FROM vlp_multi_type_u_other AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -4123,6 +4123,70 @@ async fn denorm_count_relationship_resolves_edge_id_column_502() {
     }
 }
 
+/// #648 regression: untyped `count(r)` over a MULTI-TYPE relationship (two+
+/// candidate rel types between labeled endpoints) must count the
+/// `vlp_multi_type_*` CTE's own always-projected `start_id` column via the CTE
+/// alias `t` — NOT `count(r.<first-type's-from_id>)`, which references a column
+/// that doesn't exist on the CTE and an alias (`r`) that is never bound (the
+/// CTE is aliased `t`), a ClickHouse Code 47 at runtime. The rel-var sibling of
+/// #526's `pattern_union` fix (unlabeled endpoints) and #494's node-side
+/// multi-type-endpoint handling. `count(*)`, typed `count(r)`, single-type
+/// untyped `count(r)`, and fully-unlabeled `count(r)` are unaffected.
+#[tokio::test]
+async fn untyped_count_relationship_multi_type_uses_cte_column_648() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+
+    // TestUser->TestUser has TWO rel types (TEST_FOLLOWS, TEST_FRIENDS_WITH),
+    // so untyped `r` materializes a vlp_multi_type CTE aliased `t`.
+    let cypher = "MATCH (u:TestUser)-[r]->(other:TestUser) RETURN count(r) AS total";
+    let first = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+    for _ in 0..5 {
+        let again = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+        assert_eq!(
+            first, again,
+            "#648: render is nondeterministic:\nFIRST:\n{first}\nAGAIN:\n{again}"
+        );
+    }
+    // Must count the CTE's own column via alias `t`, never the first rel type's
+    // FK column against the unbound alias `r`.
+    assert!(
+        first.contains("count(t.start_id)"),
+        "#648: expected `count(t.start_id)` over the multi-type CTE, got:\n{first}"
+    );
+    assert!(
+        !first.contains("count(r."),
+        "#648: count(r) still references the unbound `r` alias / a per-type FK \
+         column that doesn't exist on the vlp_multi_type CTE (Code 47):\n{first}"
+    );
+
+    // count(DISTINCT r) must build a label-agnostic identity tuple over `t`,
+    // not a per-type edge_id tuple against `r`.
+    let distinct_cypher =
+        "MATCH (u:TestUser)-[r]->(other:TestUser) RETURN count(DISTINCT r) AS total";
+    let distinct = normalize(&render(&schema, distinct_cypher, SqlDialect::ClickHouse).await);
+    assert!(
+        distinct.contains("count(DISTINCT tuple(t.start_type, t.start_id"),
+        "#648: count(DISTINCT r) over multi-type CTE must use the label-agnostic \
+         `t` identity tuple, got:\n{distinct}"
+    );
+
+    // Guardrails: the fix must NOT touch the single-type untyped path (real
+    // edge table, alias `r`) — TestUser->TestProduct has only TEST_PURCHASED.
+    let single = normalize(
+        &render(
+            &schema,
+            "MATCH (u:TestUser)-[r]->(p:TestProduct) RETURN count(r) AS total",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        single.contains("count(r.user_id)") && single.contains("purchases AS r"),
+        "#648: single-type untyped count(r) must stay on the real edge-table \
+         path (regression guard), got:\n{single}"
+    );
+}
+
 /// #506 regression: an INCOMING-direction OPTIONAL MATCH on a denormalized
 /// schema (`MATCH (a:Airport) OPTIONAL MATCH (a)<-[:FLIGHT]-(b) ...`) must
 /// render the same shape as the OUTGOING direction — an anchor

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -4185,6 +4185,26 @@ async fn untyped_count_relationship_multi_type_uses_cte_column_648() {
         "#648: single-type untyped count(r) must stay on the real edge-table \
          path (regression guard), got:\n{single}"
     );
+
+    // Regression guard: the multi-type guard deliberately does NOT fire across a
+    // WITH barrier — post-WITH the CTE alias `t` is out of scope (the outer FROM
+    // is `with_r_cte_0 AS r`), so emitting `count(t.start_id)` there would dangle.
+    // The correct post-WITH continuation alias is the #602/#616 forward-
+    // resolution problem; until then this shape must stay exactly as before
+    // (still loud), never regress to a dangling `t`.
+    let with_barrier = normalize(
+        &render(
+            &schema,
+            "MATCH (u:TestUser)-[r]->(o:TestUser) WITH r RETURN count(r) AS total",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        !with_barrier.contains("count(t.start_id)"),
+        "#648: multi-type guard must NOT fire post-WITH (dangling `t` alias — \
+         the #602/#616 continuation problem), got:\n{with_barrier}"
+    );
 }
 
 /// #506 regression: an INCOMING-direction OPTIONAL MATCH on a denormalized


### PR DESCRIPTION
## Summary
Closes #648. Regression from #502 (bisect `a10886aa`). `MATCH (u:TestUser)-[r]->(o:TestUser) RETURN count(r)` — where **two** rel types (TEST_FOLLOWS, TEST_FRIENDS_WITH) connect TestUser→TestUser — routes the untyped `r` through a `vlp_multi_type_*` UNION-ALL CTE (aliased `t`, generic columns `start_id`/`end_id`/`r_from_id`/…). But the projection-tagging aggregate rewrite fell through to per-label schema resolution, picking the **first** candidate type's `from_id` (`follower_id`) and keeping the Cypher alias `r` → `count(r.follower_id)`: a column that doesn't exist on the CTE, against an alias that is never bound (the CTE is aliased `t`). **ClickHouse Code 47.**

`count(*)`, typed `count(r)`, single-type untyped `count(r)`, and fully-unlabeled `count(r)` (pattern_union CTE) all worked — only the multi-type-CTE rel-var aggregate lacked a discriminator.

## Fix
Mirrors the #526 `pattern_union` handling:
- **`logical_plan/mod.rs`**: new `rel_alias_uses_multi_type_vlp` predicate, gated on `rel.labels.len() > 1` — the rel-var analog of `node_is_multi_type_rel_endpoint`.
- **`projection_tagging.rs`**: a guard branch before per-label resolution. When it fires: `count(r)` → `count(t.start_id)` (always-projected, NULL-sensitive per #502 intent); `count(DISTINCT r)` → a label-agnostic identity tuple over alias `t`. Alias is `VLP_CTE_FROM_ALIAS` (`"t"`), never the dangling `r`.

## Blast radius — nil (guard fires only when `labels.len() > 1`)
| shape | output | status |
|---|---|---|
| typed `count(r)` | `count(r.follower_id)` FROM `follows AS r` | unchanged |
| `count(*)` multi-type | `count(*)` FROM `t` | unchanged |
| single-type untyped `count(r)` | `count(r.user_id)` FROM `purchases AS r` | unchanged |
| fully-unlabeled `count(r)` | `count(r.start_id)` FROM `pattern_union_r AS r` | unchanged |
| **untyped `count(r)` multi-type** | **`count(t.start_id)` FROM `t`** | **FIXED** |

## Verification
- **corpus_sweep** (517 filtered): only `test_count_relationship_with_node_constraints` transitions — golden flips from the BROKEN `count(r.follower_id)` to `count(t.start_id)` (both dialects). Scoped, intended.
- **sql_golden** 221 (added an executable-oracle #648 test with 3 regression guards) ✅
- full suite 1609 + 514 ✅ · clippy clean · ratchet net-zero · fmt
- removed py `strict=True` xfail (now passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)