### PR TITLE
fix(#646): composite-id self-referencing FK-edge multi-column join

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -79,7 +79,7 @@ Exit: one fully green scheduled nightly run + xpass count ~0.
 ### P-1 — Keep a small silent-wrong bug lane open  (standing, ≤1 agent)
 Open issues that are NOT the reverse-mapping class and are individually
 fixable: ~~#647~~ **DONE (#652, `91475be3`)**, #644 (denorm OPTIONAL-VLP anchor
-join, loud — **in flight**), #646 (composite self-ref FK-edge, loud), #641
+join, loud — **in flight**), ~~#646~~ **DONE (composite self-ref FK-edge)**, #641
 (#589 gate holes), #640 (EXISTS beyond single-hop), #636 (4-way shared-anchor),
 #635 (FK-edge coupled rel-var on VLP), ~~#648~~ **DONE (untyped count(r)
 multi-type)**, ~~#649~~ **DONE (leading UNWIND before MATCH)**. Prefer
@@ -191,6 +191,25 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-25: **#646 composite self-ref FK-edge** (P-1 bug lane, follow-up to
+  #632) — a self-referencing FK-edge (edge table == node table) with a COMPOSITE
+  node_id emitted a malformed single-column join `child."parent_region, parent_id"
+  = parent.region` → Code 47. #632's self-ref FK-detection used
+  `first_col(node_id)` + a `String` compare, so for composite ids the whole
+  comma-joined FK string became one bogus quoted identifier. Fix (Left branch
+  only — self-ref always routes join_side=Left): compare full column SETS
+  (`Identifier::from_comma_separated(from_id).columns()` vs `node_id.columns()`;
+  FK = the {from,to} side ≠ node_id) and emit `Composite` Identifiers through
+  `resolve_identifier` + `add_identifier_condition` (zips positionally →
+  `child.parent_region = parent.region AND child.parent_id = parent.object_id`).
+  Byte-identical for single-column self-ref (filesystem PARENT FK=from_id, ldbc
+  REPLY_OF FK=to_id) — corpus_sweep 0 changes. New fixture
+  `schemas/test/composite_self_ref_fk.yaml` + executable-oracle sql_golden test
+  (both directions × both dialects). VLP/CTE-path composite truncation
+  (`cte_manager` get_fk_edge_node_id_column `columns[0]` TODO) is a documented
+  follow-up, out of scope. Column-order is a positional author invariant (FK
+  cols must align with node_id cols), mirroring the non-self-ref composite path.
 
 - 2026-07-25: **#648 untyped count(r) multi-type** (P-1 bug lane) — regression
   from #502 (bisect a10886aa). `MATCH (u:TestUser)-[r]->(o:TestUser) RETURN

--- a/schemas/test/composite_self_ref_fk.yaml
+++ b/schemas/test/composite_self_ref_fk.yaml
@@ -1,0 +1,39 @@
+# Composite-id self-referencing FK-edge schema (regression fixture for #646)
+#
+# Like filesystem_single, but the node_id is COMPOSITE ([region, object_id]) and
+# the parent FK is likewise composite ([parent_region, parent_id]). Exercises the
+# composite branch of the self-referencing FkEdgeJoin fix.
+#
+#   fs_objects_composite
+#   +--------+-----------+---------+-----------------+-------------+
+#   | region | object_id | name    | parent_region   | parent_id   |  <- composite FK to same table
+#   +--------+-----------+---------+-----------------+-------------+
+#
+# Cypher pattern: (child:Object)-[:PARENT]->(parent:Object)
+# Expected SQL:   child.parent_region = parent.region
+#             AND child.parent_id     = parent.object_id
+
+name: composite_self_ref_fk
+version: "1.0"
+description: "Composite-id self-referencing FK-edge pattern (#646 regression fixture)"
+
+graph_schema:
+  nodes:
+    - label: Object
+      database: test_integration
+      table: fs_objects_composite
+      node_id: [region, object_id]
+      property_mappings:
+        region: region
+        object_id: object_id
+        name: name
+        type: object_type
+
+  edges:
+    - type: PARENT
+      database: test_integration
+      table: fs_objects_composite  # Same table as the node (self-referencing)
+      from_id: [parent_region, parent_id]  # composite FK column set (child side)
+      to_id: [region, object_id]           # composite target PK (parent side)
+      from_node: Object
+      to_node: Object

--- a/src/query_planner/analyzer/graph_join/join_generation.rs
+++ b/src/query_planner/analyzer/graph_join/join_generation.rs
@@ -368,22 +368,31 @@ pub fn generate_pattern_joins(
                     //     to_id=replyOfCommentId (FK) → FK = to_id.
                     // Correct join is always `child(from-node).FK = parent(to-node)
                     // .node_id`, verified live against both schemas.
-                    let node_id_col = first_col(&left_id); // self-ref: left/right same table
-                    let fk_col = if from_id == &node_id_col {
-                        to_id.clone()
+                    //
+                    // #646: composite-aware. `from_id`/`to_id` are comma-joined
+                    // strings; `left_id` is the node_id Identifier. Compare the
+                    // FULL column sets (not just `first_col`) — the PK is the side
+                    // whose columns equal node_id's, the FK is the other side. For
+                    // single-column ids this is byte-identical to the old
+                    // `from_id == first_col(node_id)` test. The composite pairing
+                    // (e.g. `child.parent_region = parent.region AND
+                    // child.parent_id = parent.object_id`) is emitted by
+                    // `add_identifier_condition`, which zips the two Identifiers
+                    // positionally — so the schema must declare the FK columns in
+                    // the SAME order as the node_id columns (an author invariant,
+                    // mirroring the non-self-ref composite FK-edge contract).
+                    let from_id_ident = Identifier::from_comma_separated(from_id);
+                    let node_id_cols = left_id.columns();
+                    let from_id_is_pk = from_id_ident.columns() == node_id_cols;
+                    let fk_ident = if from_id_is_pk {
+                        Identifier::from_comma_separated(to_id)
                     } else {
-                        from_id.clone()
+                        from_id_ident
                     };
-                    let r_selfref_left = Identifier::Single(helpers::resolve_column(
-                        &fk_col,
-                        t.left_cte_name,
-                        plan_ctx,
-                    ));
-                    let r_selfref_right = Identifier::Single(helpers::resolve_column(
-                        &node_id_col,
-                        t.right_cte_name,
-                        plan_ctx,
-                    ));
+                    let r_selfref_left =
+                        helpers::resolve_identifier(&fk_ident, t.left_cte_name, plan_ctx);
+                    let r_selfref_right =
+                        helpers::resolve_identifier(&left_id, t.right_cte_name, plan_ctx);
                     let (cond_left_id, cond_right_id) = if *is_self_referencing {
                         (&r_selfref_left, &r_selfref_right)
                     } else {

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -2067,6 +2067,45 @@ async fn self_referencing_fk_edge_joins_child_fk_to_parent_pk_632() {
     }
 }
 
+/// #646 regression: a COMPOSITE-id self-referencing FK-edge must emit a
+/// multi-column equality join, not a malformed single quoted identifier.
+///
+/// Before the fix the self-ref FK-detection used `first_col(node_id)` and a
+/// string compare, so for `node_id: [region, object_id]` /
+/// `from_id: [parent_region, parent_id]` it emitted the bogus
+/// `child."parent_region, parent_id" = parent.region` (Code 47). The
+/// composite-aware fix compares the full column SETS (FK = the {from,to} side
+/// whose columns != node_id's) and emits the zipped tuple equality
+/// `child.parent_region = parent.region AND child.parent_id = parent.object_id`.
+/// Byte-identical for single-column self-ref (see `..._632`).
+#[tokio::test]
+async fn composite_self_referencing_fk_edge_emits_multi_column_join_646() {
+    let schema = load_schema("schemas/test/composite_self_ref_fk.yaml");
+    // Both directions route through the same (Left) FkEdgeJoin self-ref path.
+    let queries = [
+        "MATCH (child:Object)-[:PARENT]->(parent:Object) RETURN child.name, parent.name",
+        "MATCH (parent:Object)<-[:PARENT]-(child:Object) RETURN child.name, parent.name",
+    ];
+    for cypher in queries {
+        for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+            let sql = render(&schema, cypher, dialect).await;
+            // Both composite columns must be joined (FK cols = parent PK cols).
+            assert!(
+                sql.contains("child.parent_region = parent.region")
+                    && sql.contains("child.parent_id = parent.object_id"),
+                "#646: composite self-ref join must pair BOTH id columns for \
+                 {dialect:?} / `{cypher}`, got:\n{sql}"
+            );
+            // The malformed comma-joined quoted identifier must be gone.
+            assert!(
+                !sql.contains("parent_region, parent_id"),
+                "#646: must NOT emit the malformed comma-joined identifier for \
+                 {dialect:?} / `{cypher}`:\n{sql}"
+            );
+        }
+    }
+}
+
 /// member's value). The whole-node GROUP BY optimization in `group_by_builder.rs`
 /// now expands to the full `node_id.columns()` set via the schema.
 #[tokio::test]


### PR DESCRIPTION
## Summary
Closes #646. Follow-up to #632. A self-referencing FK-edge (edge table == node table, `from_node == to_node`) with a **composite** node_id emitted a malformed single-column join `child."parent_region, parent_id" = parent.region` → ClickHouse Code 47.

## Root cause
#632's self-ref FK-detection (`join_generation.rs` `FkEdgeJoin::Left`) used `first_col(node_id)` and a `String` compare `from_id == node_id_col`. For a composite (`node_id=[region, object_id]`, `from_id=[parent_region, parent_id]`), `first_col` returns only `"region"`, the compare is false, and the whole comma-joined FK string became one bogus `Identifier::Single("parent_region, parent_id")`.

## Fix (Left branch only)
A self-ref FK-edge always routes `join_side=Left` (edge/from/to are the same physical table, so `pattern_schema.rs`'s `edge_table == right_table` fires first) — the Right branch is unreachable for self-ref and untouched.

Compare full column **sets** instead of `first_col`: `Identifier::from_comma_separated(from_id).columns()` vs `node_id.columns()`; the FK is whichever of `{from_id, to_id}` is **not** the node_id. Build both sides as `Composite` Identifiers through `resolve_identifier` + `add_identifier_condition` (already zips positionally):
```
child.parent_region = parent.region AND child.parent_id = parent.object_id
```

## Byte-identical for single-column self-ref
For single-col ids the set-compare yields the same FK choice as the old `first_col` string test:
- filesystem PARENT (FK=from_id) → `child.parent_id = parent.object_id` — unchanged
- ldbc REPLY_OF (FK=to_id) — unchanged

**corpus_sweep reports 0 changes**; the #632/#633/#584 self-ref goldens are all unchanged.

## Tests
- New fixture `schemas/test/composite_self_ref_fk.yaml`
- Executable-oracle sql_golden test (both directions × both dialects) asserting the paired multi-column join and the absence of the malformed comma-joined identifier

## Out of scope (documented follow-up)
The FkEdge **CTE/VLP** render path (`cte_manager` `get_fk_edge_node_id_column` `columns[0]` TODO) still truncates composite ids — a composite self-ref VLP `[:PARENT*1..n]` would hit that next. The direct single-hop join is fully fixed here.

## Verification
corpus_sweep (0 changes) · sql_golden 222 · full 1609+515 · clippy clean · ratchet net-zero · fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)