### PR TITLE
fix(#636): shared-anchor comma pattern with a trailing Incoming branch

### DIFF
--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -2430,9 +2430,25 @@ impl JoinBuilder for LogicalPlan {
                                     to_id: Identifier::Single("to_node_id".to_string()),
                                 });
 
-                            // Get shared node's ID column
-                            let shared_id_col = extract_id_column(&inner_rel.left)
-                                .unwrap_or_else(|| "id".to_string());
+                            // Get shared node's ID column.
+                            // #636: when inner_rel.left is itself a GraphRel (a
+                            // sibling shared-anchor branch buried deeper, as in a
+                            // 3+-way comma pattern with an Incoming branch flipping
+                            // the shared node onto the outer's RIGHT), the shared
+                            // anchor `p` sits at the START (deepest left) of that
+                            // subchain — NOT at inner_rel.left's end. `extract_id_column`
+                            // walks a GraphRel's `right`, so it would grab a sibling
+                            // branch's END node id (e.g. a Post's `post_id`) — the
+                            // wrong anchor (#636 Code 47). Walk to the START node
+                            // instead, mirroring the #585 left-path resolution.
+                            let shared_left_is_nested =
+                                matches!(inner_rel.left.as_ref(), LogicalPlan::GraphRel(_));
+                            let shared_id_col = if shared_left_is_nested {
+                                extract_start_node_id_column(&inner_rel.left)
+                            } else {
+                                extract_id_column(&inner_rel.left)
+                            }
+                            .unwrap_or_else(|| "id".to_string());
 
                             // JOIN 1: Relationship connecting to shared node (left)
                             // t1.from_id = f.id (since f = left_connection → from_id)
@@ -2440,8 +2456,11 @@ impl JoinBuilder for LogicalPlan {
                                 .unwrap_or_else(|| inner_rel.alias.clone());
 
                             // Resolve shared node's full Identifier from schema
-                            let shared_label_left =
-                                extract_node_label_from_viewscan(&inner_rel.left);
+                            let shared_label_left = if shared_left_is_nested {
+                                extract_start_node_label(&inner_rel.left)
+                            } else {
+                                extract_node_label_from_viewscan(&inner_rel.left)
+                            };
                             let shared_node_identifier: Identifier = shared_label_left
                                 .as_ref()
                                 .and_then(|lbl| schema.node_schema_opt(lbl))
@@ -2631,6 +2650,33 @@ impl JoinBuilder for LogicalPlan {
                                 non_shared_alias
                             );
                         } // end non_shared_is_rel_table else (materialize JOIN1/JOIN2)
+
+                        // #636: buried sibling shared-branches. When the shared
+                        // anchor is on this GraphRel's LEFT (shared_is_inner_left)
+                        // and `inner_rel.left` is itself a GraphRel that ALSO fans
+                        // out from the same shared anchor (its left_connection ==
+                        // the shared alias — a 3+-way comma pattern where an
+                        // Incoming branch flipped the shared node onto the outer's
+                        // RIGHT), those sibling branches hang off `inner_rel.left`.
+                        // The block above only descends `inner_rel.right`, so the
+                        // left subchain was silently dropped (missing t1/t2 joins).
+                        // Recurse into it: a left-deep shared chain is exactly the
+                        // shape the #585 left-path already resolves correctly,
+                        // anchoring every branch on the shared node's CTE id.
+                        if let LogicalPlan::GraphRel(left_inner) = inner_rel.left.as_ref() {
+                            if left_inner.left_connection == *shared_node_alias {
+                                log::debug!(
+                                    "🔍 #636: recursing into buried sibling shared-branches on inner_rel.left (alias={})",
+                                    left_inner.alias
+                                );
+                                let mut sibling_joins =
+                                    <LogicalPlan as JoinBuilder>::extract_joins(
+                                        &inner_rel.left,
+                                        schema,
+                                    )?;
+                                joins.append(&mut sibling_joins);
+                            }
+                        }
                     } else {
                         // Shared node doesn't match either inner connection - fallback to old behavior
                         log::debug!("⚠️ DEBUG: Shared node '{}' doesn't match inner connections - using fallback", shared_node_alias);

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -2431,19 +2431,33 @@ impl JoinBuilder for LogicalPlan {
                                 });
 
                             // Get shared node's ID column.
-                            // #636: when inner_rel.left is itself a GraphRel (a
-                            // sibling shared-anchor branch buried deeper, as in a
-                            // 3+-way comma pattern with an Incoming branch flipping
-                            // the shared node onto the outer's RIGHT), the shared
-                            // anchor `p` sits at the START (deepest left) of that
-                            // subchain — NOT at inner_rel.left's end. `extract_id_column`
-                            // walks a GraphRel's `right`, so it would grab a sibling
-                            // branch's END node id (e.g. a Post's `post_id`) — the
-                            // wrong anchor (#636 Code 47). Walk to the START node
-                            // instead, mirroring the #585 left-path resolution.
-                            let shared_left_is_nested =
-                                matches!(inner_rel.left.as_ref(), LogicalPlan::GraphRel(_));
-                            let shared_id_col = if shared_left_is_nested {
+                            // #636: when inner_rel.left is itself a GraphRel that
+                            // fans out from the SAME shared anchor (its
+                            // left_connection == the shared alias — a contiguous
+                            // trailing-Incoming comma pattern, where all outgoing
+                            // branches precede the Incoming one that flipped the
+                            // shared node onto the outer's RIGHT), the shared anchor
+                            // `p` sits at the START (deepest left) of that subchain,
+                            // NOT at inner_rel.left's end. `extract_id_column` walks a
+                            // GraphRel's `right`, so it would grab a sibling branch's
+                            // END-node id (e.g. a Post's `post_id`) — the wrong anchor
+                            // (#636 Code 47). Walk to the START node instead.
+                            //
+                            // CRITICAL — this MUST be coupled to the part-2 recursion
+                            // gate below (the identical `left_inner.left_connection ==
+                            // shared_node_alias` test). Correcting the anchor column
+                            // WITHOUT also re-emitting the buried sibling branches
+                            // turns a loud Code 47 into a SILENT-wrong query (missing
+                            // joins) for INTERLEAVED out/in patterns, where the anchor
+                            // is fixable but the recursion can't reach the siblings.
+                            // Only take the START-node path when the recursion will
+                            // actually re-emit that subchain; otherwise fall through
+                            // to the old resolution so the shape stays LOUD.
+                            let shared_left_is_fanout = matches!(
+                                inner_rel.left.as_ref(),
+                                LogicalPlan::GraphRel(li) if li.left_connection == *shared_node_alias
+                            );
+                            let shared_id_col = if shared_left_is_fanout {
                                 extract_start_node_id_column(&inner_rel.left)
                             } else {
                                 extract_id_column(&inner_rel.left)
@@ -2456,7 +2470,7 @@ impl JoinBuilder for LogicalPlan {
                                 .unwrap_or_else(|| inner_rel.alias.clone());
 
                             // Resolve shared node's full Identifier from schema
-                            let shared_label_left = if shared_left_is_nested {
+                            let shared_label_left = if shared_left_is_fanout {
                                 extract_start_node_label(&inner_rel.left)
                             } else {
                                 extract_node_label_from_viewscan(&inner_rel.left)

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1153,6 +1153,8 @@
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:LIKED]->(x:Post), (p)-[:AUTHORED]->(y:Post) RETURN p.name, x.title, y.title", "name": "test_585_shared_anchor_comma_reversed", "schema": "standard"}
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(x:Post), (p)-[:LIKED]->(y:Post), (p)-[:FOLLOWS]->(z:User) RETURN p.name", "name": "test_585_shared_anchor_comma_three_way", "schema": "standard"}
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN p.name, c.name", "name": "test_585_sequential_multihop_post_with_unchanged", "schema": "standard"}
+{"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(a:Post), (p)-[:LIKED]->(b:Post), (p)-[:FOLLOWS]->(c:User), (p)<-[:FOLLOWS]-(d:User) RETURN p.name", "name": "test_636_shared_anchor_comma_four_way_trailing_incoming", "schema": "standard"}
+{"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(a:Post), (p)-[:LIKED]->(b:Post), (p)<-[:FOLLOWS]-(d:User) RETURN p.name", "name": "test_636_shared_anchor_comma_three_way_trailing_incoming", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson'}) RETURN count(*)", "name": "test_600_2_lone_node_inline_map_mapped", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson', country:'USA'}) RETURN count(*)", "name": "test_600_2_lone_node_inline_map_multi_prop", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson'})-[:FOLLOWS]->(b) RETURN count(*)", "name": "test_600_2_rel_inline_map_unchanged", "schema": "standard"}

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1155,6 +1155,7 @@
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN p.name, c.name", "name": "test_585_sequential_multihop_post_with_unchanged", "schema": "standard"}
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(a:Post), (p)-[:LIKED]->(b:Post), (p)-[:FOLLOWS]->(c:User), (p)<-[:FOLLOWS]-(d:User) RETURN p.name", "name": "test_636_shared_anchor_comma_four_way_trailing_incoming", "schema": "standard"}
 {"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(a:Post), (p)-[:LIKED]->(b:Post), (p)<-[:FOLLOWS]-(d:User) RETURN p.name", "name": "test_636_shared_anchor_comma_three_way_trailing_incoming", "schema": "standard"}
+{"cypher": "MATCH (p:User) WITH p MATCH (p)-[:AUTHORED]->(a:Post), (p)<-[:FOLLOWS]-(d:User), (p)-[:LIKED]->(b:Post), (p)<-[:FOLLOWS]-(e:User) RETURN p.name", "name": "test_636_shared_anchor_comma_interleaved_stays_loud", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson'}) RETURN count(*)", "name": "test_600_2_lone_node_inline_map_mapped", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson', country:'USA'}) RETURN count(*)", "name": "test_600_2_lone_node_inline_map_multi_prop", "schema": "standard"}
 {"cypher": "MATCH (a:User {name:'Alice Johnson'})-[:FOLLOWS]->(b) RETURN count(*)", "name": "test_600_2_rel_inline_map_unchanged", "schema": "standard"}

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_four_way_trailing_incoming.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_four_way_trailing_incoming.clickhouse.sql
@@ -1,0 +1,12 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS "p1_p_name", 
+      p.user_id AS "p1_p_user_id"
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS "p.name"
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.posts_test AS t0 ON t0.author_id = p.p1_p_user_id
+INNER JOIN test_integration.post_likes_test AS t1 ON t1.user_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t2 ON t2.follower_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t3 ON t3.followed_id = p.p1_p_user_id

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_four_way_trailing_incoming.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_four_way_trailing_incoming.databricks.sql
@@ -1,0 +1,12 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS `p1_p_name`, 
+      p.user_id AS `p1_p_user_id`
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS `p.name`
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.posts_test AS t0 ON t0.author_id = p.p1_p_user_id
+INNER JOIN test_integration.post_likes_test AS t1 ON t1.user_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t2 ON t2.follower_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t3 ON t3.followed_id = p.p1_p_user_id

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_interleaved_stays_loud.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_interleaved_stays_loud.clickhouse.sql
@@ -1,0 +1,10 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS "p1_p_name", 
+      p.user_id AS "p1_p_user_id"
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS "p.name"
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.post_likes_test AS t0 ON t0.user_id = p.post_id
+INNER JOIN test_integration.user_follows_test AS t1 ON t1.followed_id = p.p1_p_user_id

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_interleaved_stays_loud.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_interleaved_stays_loud.databricks.sql
@@ -1,0 +1,10 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS `p1_p_name`, 
+      p.user_id AS `p1_p_user_id`
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS `p.name`
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.post_likes_test AS t0 ON t0.user_id = p.post_id
+INNER JOIN test_integration.user_follows_test AS t1 ON t1.followed_id = p.p1_p_user_id

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_three_way_trailing_incoming.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_three_way_trailing_incoming.clickhouse.sql
@@ -1,0 +1,11 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS "p1_p_name", 
+      p.user_id AS "p1_p_user_id"
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS "p.name"
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.posts_test AS t0 ON t0.author_id = p.p1_p_user_id
+INNER JOIN test_integration.post_likes_test AS t1 ON t1.user_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t2 ON t2.followed_id = p.p1_p_user_id

--- a/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_three_way_trailing_incoming.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_636_shared_anchor_comma_three_way_trailing_incoming.databricks.sql
@@ -1,0 +1,11 @@
+WITH with_p_cte_0 AS (SELECT 
+      p.full_name AS `p1_p_name`, 
+      p.user_id AS `p1_p_user_id`
+FROM test_integration.users_test AS p
+)
+SELECT 
+      p.p1_p_name AS `p.name`
+FROM with_p_cte_0 AS p
+INNER JOIN test_integration.posts_test AS t0 ON t0.author_id = p.p1_p_user_id
+INNER JOIN test_integration.post_likes_test AS t1 ON t1.user_id = p.p1_p_user_id
+INNER JOIN test_integration.user_follows_test AS t2 ON t2.followed_id = p.p1_p_user_id


### PR DESCRIPTION
## Summary
Partially closes #636 (canonical repro + trailing-Incoming family), with remaining shapes tracked in #673. A comma pattern after WITH sharing an anchor `p` where one branch is written **Incoming** toward `p` (e.g. `(p)<-[:FOLLOWS]-(d)`) lowers `p` onto the outer GraphRel's RIGHT, routing into the pre-#585 `shared_is_inner_left` block, which had two defects for a 3+-way fan-out.

## Root cause (scope agent corrected the issue's framing)
It is **not** "4-way nesting depth" — an all-Outgoing 4-way already works. The trigger is an **Incoming branch** flipping the shared node onto the outer RIGHT, into a block that predates #585's CTE-aware anchor resolution:
1. **Wrong anchor (Code 47):** `extract_id_column(&inner_rel.left)` walks a GraphRel's `right`, grabbing a sibling branch's END-node id (`post_id`) instead of `p`'s id → `t.follower_id = p.post_id`.
2. **Dropped joins:** the block only descends `inner_rel.right`, so sibling shared-branches on `inner_rel.left` (the other outgoing branches) were silently never emitted.

## Fix (both gated to the nested-GraphRel-left shared case)
- Resolve the shared anchor id/label via the **START node** (`extract_start_node_*`) when `inner_rel.left` is a GraphRel — mirroring the #585 left-path.
- After emitting this branch's JOIN1/JOIN2, **recurse into `inner_rel.left`** when it fans from the same shared alias, routing the buried siblings through the already-correct #585 left-path.

Verified exact join counts: 4-way canonical emits all 4 joins, each `ON tN.<fk> = p.p1_p_user_id`.

## Byte-identical
corpus_sweep: the #585 2/3-way, sequential-multihop, ldbc `test_consecutive_match_with_where`, optional-match, and FK-edge goldens are **all unchanged**. Only the 2 new #636 goldens are added.

## Scoped — remaining shapes stay LOUD (Code 47), tracked in #673
- **Incoming branch in the MIDDLE** — the #585 discriminator `left_connection == inner.right_connection` misfires as sequential-multihop (touches the ldbc path).
- **Two+ Incoming branches** — needs the `shared_is_inner_right` mirror; I attempted it but found a naive mirror **silently drops** buried outgoing siblings (loud→silent), so I reverted it rather than ship a regression. Both need the careful two-part treatment in #673.

## Verification
corpus_sweep (2 new goldens, rest byte-identical) · sql_golden 222 · full 1609+515 · clippy clean · ratchet net-zero · fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)