### PR TITLE
test(#635): lock coupled FK-edge rel-var VLP WHERE-filter (already correct)

### DIFF
--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1145,6 +1145,9 @@
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WITH o, r WHERE r.customer_id > 2 RETURN o.order_id ORDER BY o.order_id", "name": "test_633_fk_edge_coupled_rel_var_post_with_where", "schema": "fk_edge"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WHERE r.customer_id > 2 RETURN r.customer_id ORDER BY r.customer_id", "name": "test_633_fk_edge_where_binds_rel_var_unchanged", "schema": "fk_edge"}
 {"cypher": "MATCH (c:Object)-[r:PARENT]->(p:Object) WHERE r.parent_id > 0 RETURN c.name", "name": "test_633_self_ref_fk_edge_where_stays_loud", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (c:Object)-[r:PARENT*1..3]->(p:Object) WHERE r.parent_id > 0 RETURN p.name", "name": "test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (c:Object)<-[r:PARENT*1..3]-(p:Object) WHERE r.parent_id > 0 RETURN p.name", "name": "test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (c:Object)-[r:PARENT*1..3]->(p:Object) WHERE r.parent_id > 0 AND p.name = 'x' RETURN p.name", "name": "test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound", "schema": "fk_edge_self_ref"}
 {"cypher": "MATCH (a:User)-[:FOLLOWS]-(b:User) UNWIND [1, 2] AS n RETURN b.name, n", "name": "test_624_undirected_unwind_single_hop", "schema": "standard"}
 {"cypher": "MATCH (a:User)-[:FOLLOWS]-(b:User) UNWIND [1, 2] AS n WITH b, n RETURN b.name, n", "name": "test_624_undirected_unwind_with_barrier", "schema": "standard"}
 {"cypher": "MATCH (a:User)-[:FOLLOWS]-(b:User)-[:FOLLOWS]-(c:User) UNWIND [1, 2] AS n RETURN c.name, n", "name": "test_624_undirected_unwind_multi_hop_uniqueness", "schema": "standard"}

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.clickhouse.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_c_p_inner AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.object_id, end_node.object_id] as path_nodes,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE end_node.name = 'x' AND start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        vp.end_name as end_name
+    FROM vlp_c_p_inner vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+),
+vlp_c_p AS (
+    SELECT * FROM vlp_c_p_inner WHERE (end_name = 'x')
+)
+SELECT 
+      t.end_name AS "p.name"
+FROM vlp_c_p AS t

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.databricks.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_c_p_inner AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.object_id, end_node.object_id) as path_nodes,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE end_node.name = 'x' AND start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        vp.end_name as end_name
+    FROM vlp_c_p_inner vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+),
+vlp_c_p AS (
+    SELECT * FROM vlp_c_p_inner WHERE (end_name = 'x')
+)
+SELECT 
+      t.end_name AS `p.name`
+FROM vlp_c_p AS t

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.clickhouse.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_p_c AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.object_id, end_node.object_id] as path_nodes,
+        start_node.name as start_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        new_start.name as start_name
+    FROM vlp_p_c vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+)
+SELECT 
+      t.start_name AS "p.name"
+FROM vlp_p_c AS t

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.databricks.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_p_c AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.object_id, end_node.object_id) as path_nodes,
+        start_node.name as start_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        new_start.name as start_name
+    FROM vlp_p_c vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+)
+SELECT 
+      t.start_name AS `p.name`
+FROM vlp_p_c AS t

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.clickhouse.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_c_p AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.object_id, end_node.object_id] as path_nodes,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        vp.end_name as end_name
+    FROM vlp_c_p vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+)
+SELECT 
+      t.end_name AS "p.name"
+FROM vlp_c_p AS t

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.databricks.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_c_p AS (
+    SELECT 
+        start_node.object_id as start_id,
+        end_node.object_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.object_id, end_node.object_id) as path_nodes,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_single start_node
+    JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
+    WHERE start_node.parent_id > 0
+    UNION ALL
+    SELECT
+        new_start.object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        vp.end_name as end_name
+    FROM vlp_c_p vp
+    JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
+    JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND new_start.parent_id > 0
+)
+SELECT 
+      t.end_name AS `p.name`
+FROM vlp_c_p AS t


### PR DESCRIPTION
## Summary

Closes #635 as **not-a-bug + regression lock**. #635 asked whether an FK-edge coupled rel-var in a `WHERE` on a variable-length pattern (`MATCH (o)-[r:PLACED_BY*1..2]->(c) WHERE r.customer_id > 2 ...`) dangles. The issue itself said "First reproduce: does such a shape even reach a dangling `r`, or does the VLP CTE bind it?" — the answer is **the VLP CTE binds it correctly**.

## Investigation

- **`PLACED_BY` (fk_edge.yaml) is non-transitive**, so `*1..2` degenerates to a single hop → no VLP CTE, already covered by #633.
- A **real coupled VLP CTE** needs a transitive (self-referencing) FK-edge, e.g. `filesystem_single` `PARENT`. There, `WHERE r.parent_id > 0` on `(c)-[r:PARENT*1..3]->(p)` pushes the filter into the CTE, mapping the coupled rel-var to the edge-scan alias (`start_node.parent_id` in the base scan, `new_start.parent_id` in the recursive scan) — correct and symmetric for both directions.
- This is the deliberate "HOLISTIC FIX Dec 26, 2025" path (`vlp_rewrite.rs:784-788`, `cte_extraction.rs` `relationship_filters`): FK-edge VLP relationship filters are handled inside CTE generation.

### Differential matrix (coupled `filesystem_single PARENT*` vs standard `social FOLLOWS*`)

| shape | coupled | standard |
|---|---|---|
| `WHERE r.<col>` (the #635 subject) | ✅ ok | ✅ ok |
| `WHERE r.<col>` post-WITH | dangles | dangles |
| `RETURN r.<col>` | dangles | dangles |
| `count(r)` | dangles | dangles |
| `WITH …, count(r)` | dangles | dangles |
| `ORDER BY r.<col>` | ✅ ok | ✅ ok |

Every dangling shape dangles **identically on coupled and standard** → they are the general VLP rel-var *projection* gap (**#620**), not a coupled-specific FK-edge defect. #635's WHERE-filter subject is not among them.

## Change

No source change (behavior already correct). Adds **3 regression goldens** on the `fk_edge_self_ref` schema to lock the working coupled VLP WHERE-r SQL against silent regression: outgoing, incoming (reversed-written), compound (`r`-filter AND node-filter). All bind `r.parent_id` to the edge-scan alias — no bare `r.` dangle.

## Gates

- Corpus sweep byte-identical (only the 3 new entries added); deterministic across two runs
- Ratchet net-zero
- 515 integration tests pass; fmt clean; clippy clean

## Follow-up

The genuinely-dangling VLP rel-var *projection* shapes (`RETURN r`, `count(r)`, post-WITH `WHERE r`) are schema-agnostic and belong to **#620** (Undirected/VLP CTE column-projection gaps), which already lists `RETURN-r` among its shapes. Recommend #635 be closed and those shapes tracked under #620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)