### PR TITLE
fix(#620): VLP WITH-item endpoint id-property resolves to start_id/end_id

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -7714,6 +7714,26 @@ pub(crate) fn build_chained_with_match_cte_plan(
                                                                     if !db_to_cypher.is_empty() {
                                                                         translate_db_columns_to_cypher_properties(&mut expr, &db_to_cypher);
                                                                     }
+                                                                    // #620: rewrite endpoint id-property access
+                                                                    // (a.user_id) to the VLP CTE's authoritative id
+                                                                    // column (t.start_id/t.end_id) BEFORE the generic
+                                                                    // prefix rewrite, which would otherwise blindly
+                                                                    // build `start_user_id` (a column the CTE never
+                                                                    // projects → Code 47).
+                                                                    let mut id_columns: HashMap<String, String> = HashMap::new();
+                                                                    for col_meta in col_metadata {
+                                                                        if col_meta.is_id_column {
+                                                                            id_columns.insert(
+                                                                                col_meta.cypher_alias.clone(),
+                                                                                col_meta.cypher_property.clone(),
+                                                                            );
+                                                                        }
+                                                                    }
+                                                                    if !id_columns.is_empty() {
+                                                                        crate::render_plan::vlp_rewrite::rewrite_vlp_id_property_columns(
+                                                                            &mut expr, &mappings, &id_columns, from_alias,
+                                                                        );
+                                                                    }
                                                                     log::debug!("🔧 VLP WITH item rewrite: mappings={:?}, from_alias={}", mappings, from_alias);
                                                                     rewrite_render_expr_for_vlp_with_from_alias(&mut expr, &mappings, from_alias);
                                                                 }

--- a/src/render_plan/vlp_rewrite.rs
+++ b/src/render_plan/vlp_rewrite.rs
@@ -245,6 +245,88 @@ fn rewrite_expr_for_vlp_end_nodes(
     }
 }
 
+/// Pre-pass for the VLP WITH-item rewrite: rewrite any endpoint **id-property**
+/// PropertyAccess (`a.user_id` where `a` is a VLP endpoint whose id property is
+/// `user_id`) directly to the VLP CTE's authoritative id column (`t.start_id` /
+/// `t.end_id`), then mark it done by moving it off the endpoint alias.
+///
+/// Why this is needed (#620): the generic prefix rewriter below turns
+/// `a.user_id` into `t.start_user_id` by blindly prefixing the column name. But
+/// the VLP CTE names the id column `start_id`/`end_id`
+/// (`VLP_START_ID_COLUMN`/`VLP_END_ID_COLUMN`), never `start_{id_db_col}`, so the
+/// blind form references a column the CTE never projects → Code 47 at execution
+/// (e.g. `WITH a.user_id AS x` over an undirected VLP). Non-id properties are
+/// unaffected: the CTE does name them `start_{db_col}` (e.g. `start_name`), which
+/// the generic rewriter reproduces correctly.
+///
+/// `id_columns` maps a VLP endpoint Cypher alias (`a`, `b`) to its id Cypher
+/// property (`user_id`), built from the CTE metadata at the call site. After this
+/// pre-pass the id PropertyAccess sits on `vlp_from_alias` (not an endpoint alias
+/// in `mappings`), so the generic rewriter leaves it untouched.
+pub fn rewrite_vlp_id_property_columns(
+    expr: &mut RenderExpr,
+    mappings: &HashMap<String, String>,
+    id_columns: &HashMap<String, String>,
+    vlp_from_alias: &str,
+) {
+    match expr {
+        RenderExpr::PropertyAccessExp(prop_access) => {
+            let alias = &prop_access.table_alias.0;
+            if let (Some(internal_alias), Some(id_prop)) =
+                (mappings.get(alias), id_columns.get(alias))
+            {
+                if prop_access.column.raw() == id_prop.as_str() {
+                    let id_col = if internal_alias.starts_with("start_") {
+                        crate::query_planner::join_context::VLP_START_ID_COLUMN
+                    } else if internal_alias.starts_with("end_") {
+                        crate::query_planner::join_context::VLP_END_ID_COLUMN
+                    } else {
+                        return;
+                    };
+                    prop_access.table_alias.0 = vlp_from_alias.to_string();
+                    prop_access.column = PropertyValue::Column(id_col.to_string());
+                }
+            }
+        }
+        RenderExpr::OperatorApplicationExp(op_app) => {
+            for operand in &mut op_app.operands {
+                rewrite_vlp_id_property_columns(operand, mappings, id_columns, vlp_from_alias);
+            }
+        }
+        RenderExpr::ScalarFnCall(func) => {
+            for arg in &mut func.args {
+                rewrite_vlp_id_property_columns(arg, mappings, id_columns, vlp_from_alias);
+            }
+        }
+        RenderExpr::AggregateFnCall(func) => {
+            for arg in &mut func.args {
+                rewrite_vlp_id_property_columns(arg, mappings, id_columns, vlp_from_alias);
+            }
+        }
+        RenderExpr::InSubquery(in_exp) => {
+            rewrite_vlp_id_property_columns(&mut in_exp.expr, mappings, id_columns, vlp_from_alias);
+        }
+        RenderExpr::Case(case_exp) => {
+            if let Some(scrutinee) = &mut case_exp.expr {
+                rewrite_vlp_id_property_columns(scrutinee, mappings, id_columns, vlp_from_alias);
+            }
+            for (when_expr, then_expr) in &mut case_exp.when_then {
+                rewrite_vlp_id_property_columns(when_expr, mappings, id_columns, vlp_from_alias);
+                rewrite_vlp_id_property_columns(then_expr, mappings, id_columns, vlp_from_alias);
+            }
+            if let Some(else_expr) = &mut case_exp.else_expr {
+                rewrite_vlp_id_property_columns(else_expr, mappings, id_columns, vlp_from_alias);
+            }
+        }
+        RenderExpr::List(items) => {
+            for item in items {
+                rewrite_vlp_id_property_columns(item, mappings, id_columns, vlp_from_alias);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Enhanced version that takes the FROM alias into account.
 /// For VLP CTEs, the FROM clause looks like: FROM vlp_a_b AS t
 /// So we need to use the alias (t) when rendering, and also add property prefixes (start_/end_).

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1192,3 +1192,8 @@
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b:User) WHERE a.is_active = true RETURN a.name, count(b) AS c ORDER BY a.name", "name": "test_647_end_anchored_optional_vlp_anchor_gate", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b:User) WHERE b.is_active = true RETURN a.name, count(b) AS c ORDER BY a.name", "name": "test_647_end_anchored_optional_vlp_far_endpoint_filter", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b:User) RETURN a.name, b.name ORDER BY a.name, b.name", "name": "test_647_end_anchored_optional_vlp_endpoint_projection", "schema": "standard"}
+{"cypher": "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) WITH a.user_id AS x, b.user_id AS y RETURN x, y", "name": "test_620_undirected_vlp_with_endpoint_id_projection", "schema": "standard"}
+{"cypher": "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) WITH DISTINCT a.user_id AS x RETURN x", "name": "test_620_undirected_vlp_with_distinct_endpoint_id", "schema": "standard"}
+{"cypher": "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) WITH a, count(b) AS c RETURN a.user_id, c", "name": "test_620_undirected_vlp_with_count_far_endpoint", "schema": "standard"}
+{"cypher": "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WITH a.user_id AS x, b.user_id AS y RETURN x, y", "name": "test_620_directed_vlp_with_endpoint_id_projection", "schema": "standard"}
+{"cypher": "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) WITH a.user_id AS id, a.name AS nm RETURN nm ORDER BY nm", "name": "test_620_undirected_vlp_with_id_and_name_mixed", "schema": "standard"}

--- a/tests/rust/integration/golden/corpus/standard/test_620_directed_vlp_with_endpoint_id_projection.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_directed_vlp_with_endpoint_id_projection.clickhouse.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges
+    FROM vlp_a_b vp
+    JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+), 
+with_x_y_cte_0 AS (SELECT 
+      t.start_id AS "x", 
+      t.end_id AS "y"
+FROM vlp_a_b AS t
+)
+SELECT 
+      x_y.x AS "x", 
+      x_y.y AS "y"
+FROM with_x_y_cte_0 AS x_y

--- a/tests/rust/integration/golden/corpus/standard/test_620_directed_vlp_with_endpoint_id_projection.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_directed_vlp_with_endpoint_id_projection.databricks.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges
+    FROM vlp_a_b vp
+    JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+), 
+with_x_y_cte_0 AS (SELECT 
+      t.start_id AS `x`, 
+      t.end_id AS `y`
+FROM vlp_a_b AS t
+)
+SELECT 
+      x_y.x AS `x`, 
+      x_y.y AS `y`
+FROM with_x_y_cte_0 AS x_y

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_count_far_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_count_far_endpoint.clickhouse.sql
@@ -1,0 +1,40 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+), 
+with_a_c_cte_0 AS (SELECT 
+      start_id AS "p1_a_user_id", 
+      count(t.end_id) AS "c"
+FROM vlp_a_b AS t
+GROUP BY t.start_id
+)
+SELECT 
+      a_c.p1_a_user_id AS "a.user_id", 
+      a_c.c AS "c"
+FROM with_a_c_cte_0 AS a_c

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_count_far_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_count_far_endpoint.databricks.sql
@@ -1,0 +1,40 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+), 
+with_a_c_cte_0 AS (SELECT 
+      start_id AS `p1_a_user_id`, 
+      count(t.end_id) AS `c`
+FROM vlp_a_b AS t
+GROUP BY t.start_id
+)
+SELECT 
+      a_c.p1_a_user_id AS `a.user_id`, 
+      a_c.c AS `c`
+FROM with_a_c_cte_0 AS a_c

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_distinct_endpoint_id.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_distinct_endpoint_id.clickhouse.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+), 
+with_x_cte_0 AS (SELECT DISTINCT 
+      t.start_id AS "x"
+FROM vlp_a_b AS t
+)
+SELECT 
+      x.x AS "x"
+FROM with_x_cte_0 AS x

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_distinct_endpoint_id.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_distinct_endpoint_id.databricks.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+), 
+with_x_cte_0 AS (SELECT DISTINCT 
+      t.start_id AS `x`
+FROM vlp_a_b AS t
+)
+SELECT 
+      x.x AS `x`
+FROM with_x_cte_0 AS x

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_endpoint_id_projection.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_endpoint_id_projection.clickhouse.sql
@@ -1,0 +1,39 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+), 
+with_x_y_cte_0 AS (SELECT 
+      t.start_id AS "x", 
+      t.end_id AS "y"
+FROM vlp_a_b AS t
+)
+SELECT 
+      x_y.x AS "x", 
+      x_y.y AS "y"
+FROM with_x_y_cte_0 AS x_y

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_endpoint_id_projection.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_endpoint_id_projection.databricks.sql
@@ -1,0 +1,39 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+), 
+with_x_y_cte_0 AS (SELECT 
+      t.start_id AS `x`, 
+      t.end_id AS `y`
+FROM vlp_a_b AS t
+)
+SELECT 
+      x_y.x AS `x`, 
+      x_y.y AS `y`
+FROM with_x_y_cte_0 AS x_y

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_id_and_name_mixed.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_id_and_name_mixed.clickhouse.sql
@@ -1,0 +1,40 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges,
+        start_node.full_name as start_name
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges,
+        vp.start_name as start_name
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+), 
+with_id_nm_cte_0 AS (SELECT 
+      t.start_name AS "nm"
+FROM vlp_a_b AS t
+)
+SELECT 
+      id_nm.nm AS "nm"
+FROM with_id_nm_cte_0 AS id_nm
+ORDER BY id_nm.nm ASC

--- a/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_id_and_name_mixed.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_620_undirected_vlp_with_id_and_name_mixed.databricks.sql
@@ -1,0 +1,40 @@
+WITH RECURSIVE undir_edges_a_b_test_integration_user_follows_test AS (
+    SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+    UNION ALL
+    SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id, e.follower_id AS __cg_orig_from, e.followed_id AS __cg_orig_to FROM test_integration.user_follows_test AS e
+),
+vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges,
+        start_node.full_name as start_name
+    FROM test_integration.users_test AS start_node
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges,
+        vp.start_name as start_name
+    FROM vlp_a_b vp
+    JOIN undir_edges_a_b_test_integration_user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+), 
+with_id_nm_cte_0 AS (SELECT 
+      t.start_name AS `nm`
+FROM vlp_a_b AS t
+)
+SELECT 
+      id_nm.nm AS `nm`
+FROM with_id_nm_cte_0 AS id_nm
+ORDER BY id_nm.nm ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_vlp_crossfunctional__TestVLPWithClause_test_vlp_with_and_aggregation.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_vlp_crossfunctional__TestVLPWithClause_test_vlp_with_and_aggregation.clickhouse.sql
@@ -28,7 +28,7 @@ WITH RECURSIVE vlp_u1_u2 AS (
 ), 
 with_reach_count_u1_cte_0 AS (SELECT 
       anyLast(start_name) AS "p2_u1_name", 
-      count(DISTINCT t.end_user_id) AS "reach_count"
+      count(DISTINCT t.end_id) AS "reach_count"
 FROM vlp_u1_u2 AS t
 GROUP BY t.start_id
 )

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_vlp_crossfunctional__TestVLPWithClause_test_vlp_with_and_aggregation.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_vlp_crossfunctional__TestVLPWithClause_test_vlp_with_and_aggregation.databricks.sql
@@ -28,7 +28,7 @@ WITH RECURSIVE vlp_u1_u2 AS (
 ), 
 with_reach_count_u1_cte_0 AS (SELECT 
       any_value(start_name) AS `p2_u1_name`, 
-      count(DISTINCT t.end_user_id) AS `reach_count`
+      count(DISTINCT t.end_id) AS `reach_count`
 FROM vlp_u1_u2 AS t
 GROUP BY t.start_id
 )


### PR DESCRIPTION
## Summary

Fixes the id-projection shapes of #620. A `WITH a.user_id AS x` over a variable-length path projected the endpoint's **id** property as `t.start_user_id`/`t.end_user_id` — columns the VLP CTE never defines (it names the id column `start_id`/`end_id`) → **Code 47 at ClickHouse execution**.

## Root cause

The VLP CTE special-cases the id column as `start_id`/`end_id` (`VLP_START_ID_COLUMN`/`VLP_END_ID_COLUMN`) but names every other property `start_{db_col}`. The WITH-item rewriter `rewrite_render_expr_for_vlp_with_from_alias` (`vlp_rewrite.rs:331`) blindly prefixes the column name, so only the **id property** mismatches (`user_id` → `start_user_id`, which doesn't exist). Non-id props like `name` → `start_name` matched and worked. Confirmed the firing site with an `eprintln` probe.

## Fix

A targeted pre-pass `rewrite_vlp_id_property_columns` (vlp_rewrite.rs) runs **before** the generic prefix rewrite at the `build_chained_with_match_cte_plan` WITH-item site. Using the VLP CTE's own metadata (`is_id_column` + `cypher_property` per endpoint alias — the authoritative source), it rewrites the endpoint id-property `PropertyAccess` directly to `t.start_id`/`t.end_id`. That moves the node off its endpoint alias onto the VLP FROM alias, so the generic rewriter leaves it untouched. Non-id properties unaffected.

## Impact — directed AND undirected

The existing corpus golden `test_vlp_with_and_aggregation` — a **directed** `*1..2->` with `COUNT(DISTINCT u2.user_id)` — was locking silently-broken `count(DISTINCT t.end_user_id)` on main. Now corrected to `count(DISTINCT t.end_id)`. So this bug was broader than #620's undirected framing.

## Verified shapes (social_benchmark + standard corpus schema)

| shape | before | after |
|---|---|---|
| `WITH a.user_id AS x, b.user_id AS y` | `t.start_user_id`/`t.end_user_id` ✗ | `t.start_id`/`t.end_id` ✓ |
| `WITH DISTINCT a.user_id AS x` | ✗ | ✓ |
| `WITH a, count(b) AS c` | ✗ | ✓ |
| directed `WITH a.user_id AS x, b.user_id AS y` | ✗ (was in a frozen golden) | ✓ |
| `WITH a.user_id AS id, a.name AS nm` (mixed) | id ✗ | id→`start_id`, name→`start_name` ✓ |
| `WITH a.name AS x` (non-id, control) | ✓ | ✓ unchanged |

## Scope (deliberately narrow, per §1.6)

- **In:** endpoint id-property projection through a single WITH barrier.
- **Out:** the separate outer-barrier `.id` alphabetical fallback (`id_nm.post_id`, #616/#411 class, pre-existing on main — I used `RETURN nm` in the mixed golden to avoid coupling to it). The OPTIONAL anchor-gate shape from #620 is already fixed (#621, verified here).

## Gates

- 1609 lib + 222 sql_golden pass; corpus sweep clean (2 goldens corrected broken→correct, 5 new regression goldens); ratchet net-zero; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)