### PR TITLE
fix(#683): denorm OPTIONAL-VLP anchor count(a) resolves logical id to physical column

### DIFF
--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -648,6 +648,119 @@ pub(super) fn rewrite_denorm_optional_vlp_anchor_scan(
         from_ref.source = std::sync::Arc::new(LogicalPlan::Empty);
         from_ref.use_final = false;
     }
+
+    // #683: the anchor's own aggregate/projection may still reference the LOGICAL
+    // node id (`a.code`) — `count(a)` normalises (projection_tagging) to
+    // `count(a.<node_id.columns().first()>)` = `count(a.code)`, which the
+    // `__denorm_scan_{alias}` CTE never projects (it exposes the FROM-role
+    // physical `origin_code`). The JOIN-key rewrite above already mapped the join
+    // operand; mirror it across the SELECT / GROUP BY / HAVING / ORDER BY so the
+    // anchor's logical-id references resolve to the same physical column. Scoped
+    // to `(anchor_alias, logical_id)` only, so already-physical refs
+    // (`a.origin_code`) and non-id properties (`a.city` → `a.origin_city`, already
+    // resolved upstream) are untouched.
+    for item in render_plan.select.items.iter_mut() {
+        rewrite_anchor_logical_id_to_physical(
+            &mut item.expression,
+            &anchor_alias,
+            &logical_id,
+            from_id_col,
+        );
+    }
+    for expr in render_plan.group_by.0.iter_mut() {
+        rewrite_anchor_logical_id_to_physical(expr, &anchor_alias, &logical_id, from_id_col);
+    }
+    if let Some(having) = render_plan.having_clause.as_mut() {
+        rewrite_anchor_logical_id_to_physical(having, &anchor_alias, &logical_id, from_id_col);
+    }
+    for item in render_plan.order_by.0.iter_mut() {
+        rewrite_anchor_logical_id_to_physical(
+            &mut item.expression,
+            &anchor_alias,
+            &logical_id,
+            from_id_col,
+        );
+    }
+}
+
+/// #683: rewrite every `<anchor_alias>.<logical_id>` PropertyAccess in `expr` to
+/// `<anchor_alias>.<physical_id>`, recursing through aggregate/scalar/operator/
+/// CASE/list wrappers. Used by `rewrite_denorm_optional_vlp_anchor_scan` to align
+/// the anchor's logical-id references (e.g. the `count(a.code)` a bare `count(a)`
+/// normalises to) with the `__denorm_scan_{alias}` CTE's physical id column.
+fn rewrite_anchor_logical_id_to_physical(
+    expr: &mut RenderExpr,
+    anchor_alias: &str,
+    logical_id: &str,
+    physical_id: &str,
+) {
+    match expr {
+        RenderExpr::PropertyAccessExp(pa) => {
+            if pa.table_alias.0 == anchor_alias
+                && matches!(&pa.column, PropertyValue::Column(c) if c == logical_id)
+            {
+                pa.column = PropertyValue::Column(physical_id.to_string());
+            }
+        }
+        RenderExpr::AggregateFnCall(agg) => {
+            for arg in agg.args.iter_mut() {
+                rewrite_anchor_logical_id_to_physical(arg, anchor_alias, logical_id, physical_id);
+            }
+        }
+        RenderExpr::ScalarFnCall(func) => {
+            for arg in func.args.iter_mut() {
+                rewrite_anchor_logical_id_to_physical(arg, anchor_alias, logical_id, physical_id);
+            }
+        }
+        RenderExpr::OperatorApplicationExp(op) => {
+            for operand in op.operands.iter_mut() {
+                rewrite_anchor_logical_id_to_physical(
+                    operand,
+                    anchor_alias,
+                    logical_id,
+                    physical_id,
+                );
+            }
+        }
+        RenderExpr::Case(case) => {
+            if let Some(scrutinee) = case.expr.as_mut() {
+                rewrite_anchor_logical_id_to_physical(
+                    scrutinee,
+                    anchor_alias,
+                    logical_id,
+                    physical_id,
+                );
+            }
+            for (when_expr, then_expr) in case.when_then.iter_mut() {
+                rewrite_anchor_logical_id_to_physical(
+                    when_expr,
+                    anchor_alias,
+                    logical_id,
+                    physical_id,
+                );
+                rewrite_anchor_logical_id_to_physical(
+                    then_expr,
+                    anchor_alias,
+                    logical_id,
+                    physical_id,
+                );
+            }
+            if let Some(else_expr) = case.else_expr.as_mut() {
+                rewrite_anchor_logical_id_to_physical(
+                    else_expr,
+                    anchor_alias,
+                    logical_id,
+                    physical_id,
+                );
+            }
+        }
+        RenderExpr::List(items) => {
+            for item in items.iter_mut() {
+                rewrite_anchor_logical_id_to_physical(item, anchor_alias, logical_id, physical_id);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// #644 helper: find the single OPTIONAL variable-length GraphRel in `plan`

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -684,83 +684,33 @@ pub(super) fn rewrite_denorm_optional_vlp_anchor_scan(
 }
 
 /// #683: rewrite every `<anchor_alias>.<logical_id>` PropertyAccess in `expr` to
-/// `<anchor_alias>.<physical_id>`, recursing through aggregate/scalar/operator/
-/// CASE/list wrappers. Used by `rewrite_denorm_optional_vlp_anchor_scan` to align
-/// the anchor's logical-id references (e.g. the `count(a.code)` a bare `count(a)`
-/// normalises to) with the `__denorm_scan_{alias}` CTE's physical id column.
+/// `<anchor_alias>.<physical_id>`. Used by `rewrite_denorm_optional_vlp_anchor_scan`
+/// to align the anchor's logical-id references (e.g. the `count(a.code)` a bare
+/// `count(a)` normalises to) with the `__denorm_scan_{alias}` CTE's physical id
+/// column. Routed through the EXHAUSTIVE `map_render_expr` (§5 walker discipline)
+/// so every wrapper variant (incl. ArraySubscript/Reduce/Map) is covered — a new
+/// `RenderExpr` variant fails to compile rather than silently skipping a rewrite.
 fn rewrite_anchor_logical_id_to_physical(
     expr: &mut RenderExpr,
     anchor_alias: &str,
     logical_id: &str,
     physical_id: &str,
 ) {
-    match expr {
-        RenderExpr::PropertyAccessExp(pa) => {
+    let mut f = |e: &RenderExpr| -> crate::render_plan::render_expr::RenderRewrite {
+        use crate::render_plan::render_expr::RenderRewrite;
+        if let RenderExpr::PropertyAccessExp(pa) = e {
             if pa.table_alias.0 == anchor_alias
                 && matches!(&pa.column, PropertyValue::Column(c) if c == logical_id)
             {
-                pa.column = PropertyValue::Column(physical_id.to_string());
+                return RenderRewrite::Replace(RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: pa.table_alias.clone(),
+                    column: PropertyValue::Column(physical_id.to_string()),
+                }));
             }
         }
-        RenderExpr::AggregateFnCall(agg) => {
-            for arg in agg.args.iter_mut() {
-                rewrite_anchor_logical_id_to_physical(arg, anchor_alias, logical_id, physical_id);
-            }
-        }
-        RenderExpr::ScalarFnCall(func) => {
-            for arg in func.args.iter_mut() {
-                rewrite_anchor_logical_id_to_physical(arg, anchor_alias, logical_id, physical_id);
-            }
-        }
-        RenderExpr::OperatorApplicationExp(op) => {
-            for operand in op.operands.iter_mut() {
-                rewrite_anchor_logical_id_to_physical(
-                    operand,
-                    anchor_alias,
-                    logical_id,
-                    physical_id,
-                );
-            }
-        }
-        RenderExpr::Case(case) => {
-            if let Some(scrutinee) = case.expr.as_mut() {
-                rewrite_anchor_logical_id_to_physical(
-                    scrutinee,
-                    anchor_alias,
-                    logical_id,
-                    physical_id,
-                );
-            }
-            for (when_expr, then_expr) in case.when_then.iter_mut() {
-                rewrite_anchor_logical_id_to_physical(
-                    when_expr,
-                    anchor_alias,
-                    logical_id,
-                    physical_id,
-                );
-                rewrite_anchor_logical_id_to_physical(
-                    then_expr,
-                    anchor_alias,
-                    logical_id,
-                    physical_id,
-                );
-            }
-            if let Some(else_expr) = case.else_expr.as_mut() {
-                rewrite_anchor_logical_id_to_physical(
-                    else_expr,
-                    anchor_alias,
-                    logical_id,
-                    physical_id,
-                );
-            }
-        }
-        RenderExpr::List(items) => {
-            for item in items.iter_mut() {
-                rewrite_anchor_logical_id_to_physical(item, anchor_alias, logical_id, physical_id);
-            }
-        }
-        _ => {}
-    }
+        RenderRewrite::Recurse
+    };
+    *expr = crate::render_plan::render_expr::map_render_expr(expr, &mut f);
 }
 
 /// #644 helper: find the single OPTIONAL variable-length GraphRel in `plan`

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1204,3 +1204,5 @@
 {"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*2..3]->(b:Airport) RETURN a.code, count(DISTINCT b) AS c", "name": "test_659_denorm_optional_vlp_count_distinct_endpoint", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport)-[:FLIGHT*2..3]->(b:Airport) RETURN a.code, b.code", "name": "test_659_denorm_vlp_endpoint_id_projection_control", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport)-[:FLIGHT*2..3]->(b:Airport) RETURN a.code, b.city", "name": "test_659_denorm_vlp_endpoint_prop_projection_control", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*2..3]->(b:Airport) RETURN count(a) AS c", "name": "test_683_denorm_optional_vlp_anchor_count", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*2..3]->(b:Airport) RETURN count(DISTINCT a) AS c", "name": "test_683_denorm_optional_vlp_anchor_count_distinct", "schema": "denormalized_flights"}

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
@@ -1,0 +1,49 @@
+WITH RECURSIVE __denorm_scan_a AS (
+SELECT 
+      "Origin" AS "Origin",
+      min("OriginCityName") AS "OriginCityName",
+      min("OriginState") AS "OriginState"
+FROM (
+SELECT 
+      s.Origin AS "Origin",
+      s.OriginCityName AS "OriginCityName",
+      s.OriginState AS "OriginState"
+FROM test_integration.flights AS s
+UNION DISTINCT 
+SELECT 
+      s.Dest AS "Origin",
+      s.DestCityName AS "OriginCityName",
+      s.DestState AS "OriginState"
+FROM test_integration.flights AS s
+)
+GROUP BY "Origin"
+), 
+vlp_a_b_inner AS (
+    SELECT
+        t0.Origin as start_id,
+        t0.Dest as end_id,
+        1 as hop_count,
+        [t0.Origin] as path_edges,
+        [t0.Origin, t0.Dest] as path_nodes,
+        [] as path_relationships
+    FROM test_integration.flights AS t0
+    WHERE 1 <= 3
+    UNION ALL
+    SELECT
+        vp.start_id as start_id,
+        next.Dest as end_id,
+        vp.hop_count + 1,
+        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_nodes, [next.Dest]),
+        [] as path_relationships
+    FROM vlp_a_b_inner vp
+    JOIN test_integration.flights next ON next.Origin = vp.end_id
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      count(a.Origin) AS "c"
+FROM __denorm_scan_a AS a
+LEFT JOIN vlp_a_b AS vt0 ON a.Origin = vt0.start_id

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
@@ -1,0 +1,49 @@
+WITH RECURSIVE __denorm_scan_a AS (
+SELECT 
+      "Origin" AS "Origin",
+      min("OriginCityName") AS "OriginCityName",
+      min("OriginState") AS "OriginState"
+FROM (
+SELECT 
+      s.Origin AS "Origin",
+      s.OriginCityName AS "OriginCityName",
+      s.OriginState AS "OriginState"
+FROM test_integration.flights AS s
+UNION DISTINCT 
+SELECT 
+      s.Dest AS "Origin",
+      s.DestCityName AS "OriginCityName",
+      s.DestState AS "OriginState"
+FROM test_integration.flights AS s
+)
+GROUP BY "Origin"
+), 
+vlp_a_b_inner AS (
+    SELECT
+        t0.Origin as start_id,
+        t0.Dest as end_id,
+        1 as hop_count,
+        array(t0.Origin) as path_edges,
+        array(t0.Origin, t0.Dest) as path_nodes,
+        array() as path_relationships
+    FROM test_integration.flights AS t0
+    WHERE 1 <= 3
+    UNION ALL
+    SELECT
+        vp.start_id as start_id,
+        next.Dest as end_id,
+        vp.hop_count + 1,
+        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_nodes, array(next.Dest)),
+        array() as path_relationships
+    FROM vlp_a_b_inner vp
+    JOIN test_integration.flights next ON next.Origin = vp.end_id
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      count(a.Origin) AS `c`
+FROM __denorm_scan_a AS a
+LEFT JOIN vlp_a_b AS vt0 ON a.Origin = vt0.start_id

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
@@ -1,0 +1,49 @@
+WITH RECURSIVE __denorm_scan_a AS (
+SELECT 
+      "Origin" AS "Origin",
+      min("OriginCityName") AS "OriginCityName",
+      min("OriginState") AS "OriginState"
+FROM (
+SELECT 
+      s.Origin AS "Origin",
+      s.OriginCityName AS "OriginCityName",
+      s.OriginState AS "OriginState"
+FROM test_integration.flights AS s
+UNION DISTINCT 
+SELECT 
+      s.Dest AS "Origin",
+      s.DestCityName AS "OriginCityName",
+      s.DestState AS "OriginState"
+FROM test_integration.flights AS s
+)
+GROUP BY "Origin"
+), 
+vlp_a_b_inner AS (
+    SELECT
+        t0.Origin as start_id,
+        t0.Dest as end_id,
+        1 as hop_count,
+        [t0.Origin] as path_edges,
+        [t0.Origin, t0.Dest] as path_nodes,
+        [] as path_relationships
+    FROM test_integration.flights AS t0
+    WHERE 1 <= 3
+    UNION ALL
+    SELECT
+        vp.start_id as start_id,
+        next.Dest as end_id,
+        vp.hop_count + 1,
+        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_nodes, [next.Dest]),
+        [] as path_relationships
+    FROM vlp_a_b_inner vp
+    JOIN test_integration.flights next ON next.Origin = vp.end_id
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      count(DISTINCT a.Origin) AS "c"
+FROM __denorm_scan_a AS a
+LEFT JOIN vlp_a_b AS vt0 ON a.Origin = vt0.start_id

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
@@ -1,0 +1,49 @@
+WITH RECURSIVE __denorm_scan_a AS (
+SELECT 
+      "Origin" AS "Origin",
+      min("OriginCityName") AS "OriginCityName",
+      min("OriginState") AS "OriginState"
+FROM (
+SELECT 
+      s.Origin AS "Origin",
+      s.OriginCityName AS "OriginCityName",
+      s.OriginState AS "OriginState"
+FROM test_integration.flights AS s
+UNION DISTINCT 
+SELECT 
+      s.Dest AS "Origin",
+      s.DestCityName AS "OriginCityName",
+      s.DestState AS "OriginState"
+FROM test_integration.flights AS s
+)
+GROUP BY "Origin"
+), 
+vlp_a_b_inner AS (
+    SELECT
+        t0.Origin as start_id,
+        t0.Dest as end_id,
+        1 as hop_count,
+        array(t0.Origin) as path_edges,
+        array(t0.Origin, t0.Dest) as path_nodes,
+        array() as path_relationships
+    FROM test_integration.flights AS t0
+    WHERE 1 <= 3
+    UNION ALL
+    SELECT
+        vp.start_id as start_id,
+        next.Dest as end_id,
+        vp.hop_count + 1,
+        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_nodes, array(next.Dest)),
+        array() as path_relationships
+    FROM vlp_a_b_inner vp
+    JOIN test_integration.flights next ON next.Origin = vp.end_id
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      count(DISTINCT a.Origin) AS `c`
+FROM __denorm_scan_a AS a
+LEFT JOIN vlp_a_b AS vt0 ON a.Origin = vt0.start_id

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10203,6 +10203,51 @@ mod vlp_fixed_path_family_496_497_498_499_501 {
              render path (raw edge table + logical `a.code` JOIN key):\n{sql}"
         );
     }
+
+    /// #683 (residual 1 of #659): a bare `count(a)` on the SAME denorm OPTIONAL
+    /// VLP anchor. `count(a)` is normalised (projection_tagging) to
+    /// `count(a.<logical_node_id>)` = `count(a.code)`, but the `__denorm_scan_a`
+    /// CTE exposes the FROM-role physical `origin_code`, not the logical `code` →
+    /// ClickHouse Code 47. The #644 anchor-reroute already knew the physical id
+    /// column (it rewrote the JOIN key); this mirrors that rewrite across the
+    /// SELECT so the anchor's own aggregate resolves. `count(a.code)` explicit and
+    /// `RETURN a.code` already worked (property-mapped upstream); only the bare
+    /// `count(a)` normalisation dangled.
+    #[tokio::test]
+    async fn denorm_optional_vlp_anchor_count_logical_id_683() {
+        let schema = load_schema(SchemaId::Denormalized.yaml_path());
+        let cypher = "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*2..3]->(b:Airport) \
+             RETURN count(a) AS c";
+        let sql = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+
+        // The anchor still reroutes to the scan CTE (the #644 machinery).
+        assert!(
+            sql.contains("FROM __denorm_scan_a AS a"),
+            "#683: the anchor must reroute to the `__denorm_scan_a` scan CTE:\n{sql}"
+        );
+        // The aggregate over the anchor must reference the physical id column the
+        // CTE exposes (origin_code), NOT the logical `a.code` (Code 47).
+        assert!(
+            sql.contains("count(a.origin_code)"),
+            "#683: count(a) must resolve the anchor id to the physical \
+             `a.origin_code` the scan CTE exposes:\n{sql}"
+        );
+        assert!(
+            !sql.contains("count(a.code)"),
+            "#683: count(a) must not reference the logical `a.code` (absent on \
+             the scan CTE — Code 47):\n{sql}"
+        );
+
+        // count(DISTINCT a) too.
+        let cypher_d = "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*2..3]->(b:Airport) \
+             RETURN count(DISTINCT a) AS c";
+        let sql_d = normalize(&render(&schema, cypher_d, SqlDialect::ClickHouse).await);
+        assert!(
+            sql_d.contains("count(DISTINCT a.origin_code)")
+                && !sql_d.contains("a.code"),
+            "#683: count(DISTINCT a) must also resolve to the physical id:\n{sql_d}"
+        );
+    }
 }
 
 mod coupled_anchor_optional_family_504_508_529_530_471 {

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10243,8 +10243,7 @@ mod vlp_fixed_path_family_496_497_498_499_501 {
              RETURN count(DISTINCT a) AS c";
         let sql_d = normalize(&render(&schema, cypher_d, SqlDialect::ClickHouse).await);
         assert!(
-            sql_d.contains("count(DISTINCT a.origin_code)")
-                && !sql_d.contains("a.code"),
+            sql_d.contains("count(DISTINCT a.origin_code)") && !sql_d.contains("a.code"),
             "#683: count(DISTINCT a) must also resolve to the physical id:\n{sql_d}"
         );
     }


### PR DESCRIPTION
## Summary

Fixes residual 1 of #683 (follow-up to #659). `count(a)` on a denormalized OPTIONAL-VLP anchor rendered `count(a.code)`, but the `__denorm_scan_a` node-scan CTE exposes the FROM-role physical `origin_code`, not the logical node_id `code` → **Code 47**.

## Root cause

`count(a)` is normalized (projection_tagging.rs) to `count(a.<node_id.columns().first()>)` = `count(a.code)` using the **logical** id. Unlike explicit `count(a.code)` / `RETURN a.code` (property-mapped upstream before the aggregate), the bare-count normalization arrives un-resolved and the `__denorm_scan_a` CTE never projects `code`.

This is the ANCHOR sibling of #659 (which fixed the VLP-**endpoint** `count(b)` variant); the earlier investigation was blocked because the WITH-path anchor-id helper's traversal excludes VLP.

## Fix — extend the #644 anchor-reroute

`#644`'s `rewrite_denorm_optional_vlp_anchor_scan` already computes the anchor's physical id column (`from_id_col` = `origin_code`) and rewrites the VLP JOIN key `a.code`→`a.origin_code`. This mirrors that rewrite across the SELECT / GROUP BY / HAVING / ORDER BY via a small `(anchor_alias, logical_id) → physical_id` recursive walker, so the anchor's own aggregate resolves against the scan CTE.

**Reuses all of #644's guards** — fires ONLY for the anchor-at-START single-VLP denorm shape:

| shape | behavior |
|---|---|
| `count(a)` forward VLP anchor | `count(a.origin_code)` ✓ (fixed) |
| `count(DISTINCT a)` | `count(DISTINCT a.origin_code)` ✓ |
| end-anchored/reversed (`a)<-[*]-(b`) | stays loud (unchanged) — `left_connection != anchor_alias` |
| composite id | stays loud — `id_cols.len() != 1` |
| anchor-gate WHERE / chained VLP | stays loud (unchanged) |
| `count(a.code)` explicit, `RETURN a.code`, `count(a.city)`, `count(*)` | unchanged (already correct) |

## Gates

- +1 curated byte-golden (`count(a)` + `count(DISTINCT a)`) beside the #644 tests; +2 corpus regression goldens.
- No existing golden flips (the bug was loud). 1611 lib + 223 sql_golden + corpus + ratchet net-zero; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)