### PR TITLE
test(P-0): fix nightly — stale disconnected-pattern assertion + 2 xpassed markers

### DIFF
--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -264,10 +264,14 @@ class TestInvalidPatterns:
             RETURN a.name, b.name
             """,
             schema_name=simple_graph["schema_name"], raise_on_error=False)
-        
-        # ClickGraph currently doesn't support comma-separated patterns (Cartesian products)
-        # This is a known limitation - expect error
-        assert response.get("status") == "error"
+
+        # Comma-separated disconnected patterns (Cartesian products) ARE
+        # supported: the two anchors join on `ON 1 = 1`, filtered by WHERE.
+        # (This previously asserted an error under an obsolete "not supported"
+        # limitation — Cartesian support landed since.) Expect the single
+        # Alice × Bob row, no error.
+        assert response.get("status") != "error", response
+        assert response.get("results") == [{"a.name": "Alice", "b.name": "Bob"}], response
     
     def test_invalid_variable_length_range(self, simple_graph):
         """Test invalid variable-length range."""

--- a/tests/integration/test_labels_untyped_nodes.py
+++ b/tests/integration/test_labels_untyped_nodes.py
@@ -71,7 +71,6 @@ def test_labels_in_where_clause(simple_graph):
     assert user_count > 0, "Should have at least one TestUser node"
 
 
-@pytest.mark.xfail(reason="labels() on mixed typed/untyped nodes in same query not fully supported")
 def test_labels_mixed_typed_untyped(simple_graph):
     """Test labels() on both typed and untyped nodes in same query."""
     response = execute_cypher(

--- a/tests/integration/test_shortest_paths.py
+++ b/tests/integration/test_shortest_paths.py
@@ -22,7 +22,6 @@ from conftest import (
 class TestShortestPath:
     """Test shortestPath() function."""
     
-    @pytest.mark.xfail(reason="shortestPath VLP CTE references non-existent table alias")
     def test_shortest_path_basic(self, simple_graph):
         """Test basic shortestPath query."""
         response = execute_cypher(


### PR DESCRIPTION
## Summary

P-0 (PRIORITIES §1.4 nightly-load-bearing + §1.5 xfail hygiene). The **Nightly Full Suite** has been red since ~07-20 on a single stale test plus 2 xpassed markers — cargo/fmt/clippy/build all pass; only the live pytest step fails.

### 1. `test_disconnected_pattern` — obsolete "expect error" assertion

The test asserted `status == 'error'` citing "ClickGraph currently doesn't support comma-separated patterns (Cartesian products)". That limitation is gone — `MATCH (a:TestUser), (b:TestUser) WHERE a.name='Alice' AND b.name='Bob' RETURN a.name, b.name` correctly renders:
```sql
FROM test_integration.users AS a
JOIN test_integration.users AS b ON 1 = 1
WHERE (a.name = 'Alice' AND b.name = 'Bob')
```
and returns the single `{a.name: Alice, b.name: Bob}` row (exactly what the nightly observed: `assert None == 'error'` because status was success). Updated to assert success + that row.

### 2. Two stale `xfail` markers removed (xpassed on the live nightly)

Both underlying bugs are fixed; SQL-gen verified clean locally (`cg validate` → OK):
- `test_shortest_paths.py::test_shortest_path_basic` — "shortestPath VLP CTE references non-existent table alias"
- `test_labels_untyped_nodes.py::test_labels_mixed_typed_untyped` — "labels() on mixed typed/untyped nodes not fully supported"

## Notes

- **Test-only, no source change.** Cartesian/comma-pattern support is independently exercised by the positive tests in `test_spoke_pattern.py`.
- Can't run the live integration suite locally (needs the server + ClickHouse), but the nightly log already pinpointed the exact failure/xpass states, and the SQL translations are verified.
- **Exit:** one green nightly + xpass count → 0 for these (matches PRIORITIES P-0 exit criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)