### PR TITLE
test(P-0): nightly round 2 — fix unwind-matrix query, re-xfail #689, clear xpass

### DIFF
--- a/tests/integration/matrix/conftest.py
+++ b/tests/integration/matrix/conftest.py
@@ -877,7 +877,12 @@ RETURN a, b, d LIMIT 10"""
     
     def unwind_with_match(self) -> str:
         label = self._get_label()
-        prop, _ = self._get_node_prop(label)
+        # `sample_node_ids` are INTEGERS, so compare against an integer property
+        # (`_get_id_prop`), not an arbitrary `_get_node_prop` which may pick a
+        # String column (e.g. `n.country`/`n.name`) — that made ClickHouse 500 on
+        # a String-vs-Int comparison. The pattern under test is leading-UNWIND
+        # before MATCH (#649), not the property type.
+        prop, _ = self._get_id_prop(label)
         ids = self.schema.sample_node_ids.get(label, [1, 2, 3])
         return f"UNWIND {ids} AS id MATCH (n:{label}) WHERE n.{prop} = id RETURN n"
     

--- a/tests/integration/test_security_graph.py
+++ b/tests/integration/test_security_graph.py
@@ -232,6 +232,7 @@ class TestVariableLengthPaths:
 class TestSecurityQueries:
     """Complex security analysis queries."""
     
+    @pytest.mark.xfail(reason="#689: #659 fixed the end_group_id dangle, but this VLP-then-fixed-hop-to-polymorphic-target shape still generates a malformed recursive CTE (2nd arm joins ds_users on rel.group_id) + triplicated UNION arms — 500 live")
     def test_external_users_with_access(self):
         """Find external users with any access permissions."""
         response = execute_cypher(

--- a/tests/integration/test_vlp_crossfunctional.py
+++ b/tests/integration/test_vlp_crossfunctional.py
@@ -78,7 +78,6 @@ class TestVLPWithClause:
         for row in result["data"]:
             assert row["path_len"] == 2
 
-    @pytest.mark.xfail(reason="Code bug: VLP crossfunctional query generates invalid SQL")
     def test_vlp_with_and_aggregation(self, simple_graph):
         """VLP + WITH + Aggregation: Count distinct endpoints."""
         query = """


### PR DESCRIPTION
## Summary

The manually-dispatched nightly after #687 cleared the 07-24 failures but surfaced 3 more. Round 2 (all test-only):

### 1. `test_unwind_with_match` [social_integration, group_membership] — bad test-generator query
`matrix/conftest.py::unwind_with_match` built `WHERE n.<prop> = id` using `_get_node_prop` (random — may pick a String column like `n.country`) while `sample_node_ids` are **integers** → ClickHouse 500 on String-vs-Int. **Fixed:** use the existing `_get_id_prop` (integer id column). The test targets the leading-UNWIND-before-MATCH pattern (#649), not the property type. Not a ClickGraph bug.

### 2. `test_external_users_with_access` — my over-eager xfail removal, restored
I removed this xfail in #682 because the SQL-gen validated OK, but it **500s live**: #659 fixed the `end_group_id` dangle, yet this VLP-then-fixed-hop-to-polymorphic-target shape still emits a malformed recursive CTE (2nd arm joins `ds_users` on `rel.group_id`) + triplicated UNION arms. **Re-xfailed** with an accurate reason → tracked in **#689**.

> Lesson: `cg validate` (SQL-gen) ≠ live-executable. Don't clear a *live-integration* xfail without exercising the live path.

### 3. `test_vlp_with_and_aggregation` — xpassed, stale marker removed
My #620 fix corrected the `count(DISTINCT t.end_user_id)` → `count(DISTINCT t.end_id)` invalid SQL, so this now passes. Removed the marker.

## Notes
- Test-only. Can't run the live suite locally; grounded in the nightly log + the generator/SQL analysis.
- **Exit:** nightly green + xpass → 0. Will re-dispatch to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)