### PR TITLE
fix(#678): denorm VLP WITH endpoint id-property resolves to CTE start_id/end_id

### DIFF
--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1374,11 +1374,26 @@ impl DenormalizedCteStrategy {
         // Build column metadata for denormalized schema
         let mut columns = Vec::new();
 
+        // #678: resolve the endpoint's logical node_id property name (e.g. `code`)
+        // rather than hardcoding the placeholder `"id"`. The shared
+        // `build_vlp_column_metadata` (used by every OTHER strategy) sets the id
+        // column's `cypher_property` to the real logical id name; only the denorm
+        // builder hand-rolled it to `"id"`. That mismatch made the #620/#677 VLP
+        // WITH-item id pre-pass (which fires when `prop_access.column ==
+        // cypher_property`) miss `WITH a.code AS x` over a denorm VLP, so it fell
+        // through to the blind prefix rewriter → `t.start_code` (a column the CTE
+        // never projects; it projects `start_id`/`end_id`) → Code 47.
+        // Composite ids stay `"id"` (loud), per #683-r2 / #605 composite discipline.
+        let start_id_prop = self
+            .denorm_node_id_property_name()
+            .unwrap_or_else(|| "id".to_string());
+        let end_id_prop = start_id_prop.clone();
+
         // Add start node ID column
         columns.push(CteColumnMetadata {
             cte_column_name: VLP_START_ID_COLUMN.to_string(),
             cypher_alias: self.pattern_ctx.left_node_alias.clone(),
-            cypher_property: "id".to_string(),
+            cypher_property: start_id_prop,
             db_column: self.from_col.clone(),
             is_id_column: true,
             vlp_position: Some(VlpColumnPosition::Start),
@@ -1388,7 +1403,7 @@ impl DenormalizedCteStrategy {
         columns.push(CteColumnMetadata {
             cte_column_name: VLP_END_ID_COLUMN.to_string(),
             cypher_alias: self.pattern_ctx.right_node_alias.clone(),
-            cypher_property: "id".to_string(),
+            cypher_property: end_id_prop,
             db_column: self.to_col.clone(),
             is_id_column: true,
             vlp_position: Some(VlpColumnPosition::End),
@@ -1458,6 +1473,58 @@ impl DenormalizedCteStrategy {
                 "DenormalizedCteStrategy requires both nodes to be EmbeddedInEdge".into(),
             )),
         }
+    }
+
+    /// Resolve the endpoint node's **logical** node_id property name (e.g. `code`)
+    /// for a denormalized VLP, mirroring `map_denormalized_property`'s node-schema
+    /// resolution (match the node schema whose table is this edge/denorm table).
+    ///
+    /// This name is used ONLY as a match-key for the #620/#677 WITH-item id
+    /// pre-pass: when the accessed column equals it, the pre-pass rewrites the
+    /// access to the CTE's **position-based** id column (`start_id` = from-role,
+    /// `end_id` = to-role), the position taken from the alias→start/end mapping,
+    /// NOT from this name. So the name only decides *whether* the pre-pass fires,
+    /// never *which* column it targets; a wrong or missing resolution can at worst
+    /// cause a loud Code-47 miss, never a wrong-position value.
+    ///
+    /// Returns `None` (→ caller falls back to the `"id"` placeholder, keeping the
+    /// pre-existing loud behavior) when:
+    /// - the id is composite (#683-r2 / #605 composite discipline), or
+    /// - no node schema matches the table, or
+    /// - **more than one** node schema is hosted on the table with a distinct
+    ///   node_id (e.g. zeek's `dns_log` hosts IP/`ip_address`, Domain/`domain_name`,
+    ///   ResolvedIP/`answers`). Picking one arbitrarily would let a *malformed*
+    ///   query (`WITH a.domain_name` where `a` is an `:IP`) silently match and drop
+    ///   to `start_id` instead of erroring — a loud→silent regression. Staying
+    ///   `None` keeps those loud. Single-label denorm tables (the common case:
+    ///   `flights_denorm` hosts only `Airport`) resolve normally.
+    fn denorm_node_id_property_name(&self) -> Option<String> {
+        let node_schemas = self.schema.all_node_schemas();
+        let rel_table_name = self.table.rsplit('.').next().unwrap_or(&self.table);
+
+        let mut matches = node_schemas.values().filter(|n| {
+            let schema_table = n.table_name.rsplit('.').next().unwrap_or(&n.table_name);
+            schema_table == rel_table_name
+        });
+
+        let node_schema = matches.next()?;
+
+        if node_schema.node_id.is_composite() {
+            return None;
+        }
+        let id_prop = node_schema.node_id.column_or_error().ok()?;
+
+        // If another node schema on the SAME table has a DIFFERENT logical id,
+        // the table is multi-label (heterogeneous endpoints) and we cannot safely
+        // pick one id for both VLP endpoints — stay `None`/loud rather than risk
+        // a loud→silent match on a mislabeled property access.
+        for other in matches {
+            if other.node_id.is_composite() || other.node_id.column_or_error().ok() != Some(id_prop)
+            {
+                return None;
+            }
+        }
+        Some(id_prop.to_string())
     }
 
     /// Map logical property name to physical column name in edge table

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10247,6 +10247,83 @@ mod vlp_fixed_path_family_496_497_498_499_501 {
             "#683: count(DISTINCT a) must also resolve to the physical id:\n{sql_d}"
         );
     }
+
+    /// #678 (residual of #620): `WITH a.code AS x, b.code AS y` over a
+    /// DENORMALIZED VLP resolves each endpoint's logical id property (`code`) to
+    /// the VLP CTE's authoritative id column (`start_id`/`end_id`).
+    ///
+    /// The #620/#677 WITH-item id pre-pass (`rewrite_vlp_id_property_columns`)
+    /// fires when the accessed column equals the CTE metadata's id
+    /// `cypher_property`. Every VLP strategy but the denormalized one builds that
+    /// metadata via the shared `build_vlp_column_metadata`, which sets the id
+    /// column's `cypher_property` to the real logical id name. The denorm builder
+    /// alone hand-rolled it to the placeholder `"id"`, so `a.code`/`b.code` never
+    /// matched → the blind prefix rewriter produced `t.start_code`/`t.end_code`,
+    /// columns the denorm CTE never projects (it projects `start_id`/`end_id`
+    /// holding `origin_code`/`dest_code` values) → ClickHouse Code 47. Fix:
+    /// resolve the endpoint's logical node_id property name in the denorm metadata
+    /// builder (composite ids stay `"id"`/loud per #683-r2 / #605).
+    #[tokio::test]
+    async fn denorm_vlp_with_endpoint_id_property_resolves_to_cte_id_column_678() {
+        let schema = load_schema(SchemaId::Denormalized.yaml_path());
+        let cypher = "MATCH (a:Airport)-[:FLIGHT*1..2]->(b:Airport) \
+                      WITH a.code AS x, b.code AS y RETURN x, y";
+        let sql = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+
+        // Both endpoint id-properties resolve to the CTE's authoritative id
+        // columns, not the blind `start_code`/`end_code` (absent → Code 47).
+        assert!(
+            sql.contains("t.start_id AS \"x\"") && sql.contains("t.end_id AS \"y\""),
+            "#678: denorm VLP WITH endpoint id-property must resolve to \
+             start_id/end_id:\n{sql}"
+        );
+        assert!(
+            !sql.contains("start_code") && !sql.contains("end_code"),
+            "#678: must not reference the dangling start_code/end_code (columns \
+             the denorm CTE never projects):\n{sql}"
+        );
+
+        // Regression guard: a NON-id denorm property must STILL prefix-map to
+        // start_<prop>/end_<prop> (the CTE DOES project those) — the fix is
+        // scoped to the id property only.
+        let cypher_city = "MATCH (a:Airport)-[:FLIGHT*1..2]->(b:Airport) \
+                           WITH a.city AS c1, b.city AS c2 RETURN c1, c2";
+        let sql_city = normalize(&render(&schema, cypher_city, SqlDialect::ClickHouse).await);
+        assert!(
+            sql_city.contains("t.start_city AS \"c1\"")
+                && sql_city.contains("t.end_city AS \"c2\""),
+            "#678: non-id denorm property must still map to start_city/end_city:\n{sql_city}"
+        );
+    }
+
+    /// #678 multi-label guard: when a single denorm table hosts MULTIPLE node
+    /// labels with DIFFERENT logical node_ids (zeek's `dns_log` hosts IP
+    /// /`ip_address`, Domain/`domain_name`, ResolvedIP/`answers`), the id-property
+    /// resolver must return `None` (fall back to the `"id"` placeholder) rather
+    /// than arbitrarily pick one label's id. Picking one would let a mislabeled
+    /// access (`b.domain_name` for a `:Domain` endpoint whose id matched
+    /// BTreeMap-first) silently rewrite to the position-based `end_id`, turning a
+    /// pre-existing loud Code-47 miss into silent output — a ground-rule-1
+    /// violation. Guard keeps these queries byte-identical to pre-#678 main
+    /// (still `t.end_domain_name`, loud). Single-label denorm tables (Airport on
+    /// `flights_denorm`) are unaffected — see the sibling test.
+    #[tokio::test]
+    async fn denorm_vlp_with_endpoint_id_multi_label_table_stays_loud_678() {
+        let schema = load_schema("schemas/examples/zeek_dns_log.yaml");
+        let cypher = "MATCH (a:IP)-[:REQUESTED*1..2]->(b:Domain) \
+                      WITH a.ip_address AS x, b.domain_name AS y RETURN x, y";
+        let sql = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+
+        // The end endpoint's id-property must NOT be rewritten to the CTE's
+        // position id column: `dns_log` is multi-label with distinct node_ids, so
+        // the resolver returns None and the access stays on the pre-existing
+        // (loud) `end_domain_name` prefix form — identical to pre-#678 main.
+        assert!(
+            sql.contains("t.end_domain_name AS \"y\""),
+            "#678: multi-label denorm table must stay loud (end_domain_name), not \
+             silently rewrite to end_id:\n{sql}"
+        );
+    }
 }
 
 mod coupled_anchor_optional_family_504_508_529_530_471 {


### PR DESCRIPTION
## Bug (#678, residual of #620/#677)

`WITH a.code AS x, b.code AS y` over a **denormalized** variable-length path rendered `t.start_code`/`t.end_code` — columns the denorm VLP recursive CTE never projects (it projects `start_id`/`end_id`, holding the physical `origin_code`/`dest_code` values) → **ClickHouse Code 47**. Correct output is `t.start_id`/`t.end_id` (as the standard/FK-edge/etc. VLP paths already produce).

## Root cause

The #620/#677 WITH-item id pre-pass (`rewrite_vlp_id_property_columns`) rewrites `a.<prop>` → `start_id`/`end_id` only when `<prop>` equals the CTE metadata's id **`cypher_property`**. Every VLP strategy but the denormalized one builds that metadata via the shared `build_vlp_column_metadata`, which sets the id column's `cypher_property` to the real logical id name (`code`). `DenormalizedCteStrategy` alone hand-rolled its id-column metadata with the placeholder `cypher_property: "id"`, so `a.code`/`b.code` never matched and fell through to the blind prefix rewriter.

## Fix

New `denorm_node_id_property_name` helper resolves the endpoint's logical node_id property name (mirroring the existing `map_denormalized_property` node-schema-by-table resolution), used for both id columns. **Guards** (each preserves the pre-existing loud Code-47 behavior — ground-rule-1):

- **composite** ids → `None` → stay `"id"`/loud (#683-r2 / #605 discipline);
- **multi-label tables** — a single denorm table hosting several labels with distinct node_ids (zeek `dns_log`: IP/`ip_address`, Domain/`domain_name`, ResolvedIP/`answers`) → `None`. Picking one label's id arbitrarily would let a mislabeled access silently rewrite to the position-based `end_id` — a loud→silent regression. Verified **byte-identical to pre-#678 main** for those tables.

The resolved name is only a match-key; the rewrite target (`start_id`/`end_id`) is position-based, so a wrong/missing resolution can at worst cause a loud miss, never a wrong-position value.

## Scope & verification

- Only the id property changes; non-id denorm props still map to `start_<prop>`/`end_<prop>`.
- Standard / FK-edge / MixedAccess / EdgeToEdge / Coupled paths **byte-identical** (they already used the shared builder).
- 2 regression tests (single-label fix + multi-label stays-loud).
- **Full suite (1611 lib + 518 integration + corpus goldens + ratchet) green; fmt + clippy clean.**
- Adversarially reviewed in a worktree (0 blockers, 0 majors; both MINORs — the loud→silent edge and a misleading comment — addressed in this commit).

Closes #678 (single-label denorm variant). FK-edge self-ref and closed-VLP variants from the original #678 already render correctly on main; the denorm variant was the sole live-remaining shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)