### PR TITLE
fix(#640 shape 1): undirected EXISTS with inner WHERE renders OR-of-both-orientations

### DIFF
--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -371,12 +371,13 @@ fn generate_exists_filtered_graph_rel_sql(
         get_current_schema, is_correlation_cte_alias, is_exists_outer_alias,
     };
 
-    // Only directed single-hop is covered by v1. Undirected needs OR-of-both-
-    // orientations join logic; defer (loud fallback).
-    let outgoing = match graph_rel.direction {
-        Direction::Outgoing => true,
-        Direction::Incoming => false,
-        Direction::Either => return Ok(None),
+    // Directed single-hop and undirected single-hop are covered. Undirected
+    // (`Either`) emits an OR-of-both-orientations correlation/join (#640 shape 1);
+    // `outgoing` is `None` for it (no fixed source/target role).
+    let outgoing: Option<bool> = match graph_rel.direction {
+        Direction::Outgoing => Some(true),
+        Direction::Incoming => Some(false),
+        Direction::Either => None,
     };
 
     // Defer variable-length and shortestPath EXISTS — those carry path semantics
@@ -427,14 +428,22 @@ fn generate_exists_filtered_graph_rel_sql(
     // Fall back to the relationship-schema role for an unlabeled inner node.
     let inner_type = match inner_label {
         Some(l) => l,
-        None => {
+        None => match outgoing {
             // inner endpoint is the target for Outgoing (a->b), source for Incoming.
-            if outgoing {
-                rel_schema.to_node.clone()
-            } else {
-                rel_schema.from_node.clone()
+            Some(true) => rel_schema.to_node.clone(),
+            Some(false) => rel_schema.from_node.clone(),
+            // Undirected + unlabeled: the inner endpoint could be either role, so
+            // the role is ambiguous UNLESS both roles are the same node type
+            // (the common self-referential case, e.g. User-FOLLOWS-User). Defer
+            // when they differ rather than guess (loud fallback).
+            None => {
+                if rel_schema.from_node == rel_schema.to_node {
+                    rel_schema.to_node.clone()
+                } else {
+                    return Ok(None);
+                }
             }
-        }
+        },
     };
     let Some(inner_node_schema) = schema.node_schema_opt(&inner_type) else {
         return Ok(None);
@@ -477,15 +486,6 @@ fn generate_exists_filtered_graph_rel_sql(
     let to_col = rel_schema.to_id.to_string();
     let edge_table = format!("{}.{}", rel_schema.database, rel_schema.table_name);
     let edge_alias = "e";
-    // Correlation column (edge column facing the OUTER anchor) and inner-join
-    // column (edge column facing the INNER endpoint).
-    let (corr_edge_col, inner_edge_col) = if outgoing {
-        // a (source) -> b (target): correlate on from_id, join b on to_id.
-        (from_col.clone(), to_col.clone())
-    } else {
-        // a (target) <- b (source): correlate on to_id, join b on from_id.
-        (to_col.clone(), from_col.clone())
-    };
 
     // Resolve the OUTER anchor's id SQL (CTE-aware, mirrors generate_exists_graph_rel_sql).
     let outer_node = if outer_conn == left_conn {
@@ -499,13 +499,20 @@ fn generate_exists_filtered_graph_rel_sql(
     };
     let outer_type = match outer_label {
         Some(l) => l,
-        None => {
-            if outgoing {
-                rel_schema.from_node.clone()
-            } else {
-                rel_schema.to_node.clone()
+        None => match outgoing {
+            Some(true) => rel_schema.from_node.clone(),
+            Some(false) => rel_schema.to_node.clone(),
+            // Undirected + unlabeled outer: same ambiguity as the inner endpoint;
+            // safe only when both roles share a node type (deferred otherwise above,
+            // but re-check here since the outer node is resolved independently).
+            None => {
+                if rel_schema.from_node == rel_schema.to_node {
+                    rel_schema.from_node.clone()
+                } else {
+                    return Ok(None);
+                }
             }
-        }
+        },
     };
     let Some(outer_node_schema) = schema.node_schema_opt(&outer_type) else {
         return Ok(None);
@@ -523,12 +530,39 @@ fn generate_exists_filtered_graph_rel_sql(
         map_exists_inner_predicate(predicate, inner_conn, &inner_type, inner_node_schema);
     let pred_sql = RenderExpr::try_from(mapped_pred)?.to_sql();
 
-    // Assemble: SELECT 1 FROM edge AS e JOIN inner AS <inner_conn> ON ... WHERE corr AND pred
-    let sql = format!(
-        "SELECT 1 FROM {edge_table} AS {edge_alias} \
-         INNER JOIN {inner_table} AS {inner_conn} ON {inner_conn}.{inner_id_col} = {edge_alias}.{inner_edge_col} \
-         WHERE {edge_alias}.{corr_edge_col} = {outer_id_sql} AND {pred_sql}"
-    );
+    // Assemble the correlation + inner-join, then the shared predicate.
+    let join_and_corr = match outgoing {
+        // Directed: correlate on the edge column facing the OUTER anchor, join the
+        // inner endpoint on the opposite column.
+        Some(true) => {
+            // a (source) -> b (target): correlate on from_id, join b on to_id.
+            format!(
+                "INNER JOIN {inner_table} AS {inner_conn} ON {inner_conn}.{inner_id_col} = {edge_alias}.{to_col} \
+                 WHERE {edge_alias}.{from_col} = {outer_id_sql}"
+            )
+        }
+        Some(false) => {
+            // a (target) <- b (source): correlate on to_id, join b on from_id.
+            format!(
+                "INNER JOIN {inner_table} AS {inner_conn} ON {inner_conn}.{inner_id_col} = {edge_alias}.{from_col} \
+                 WHERE {edge_alias}.{to_col} = {outer_id_sql}"
+            )
+        }
+        // Undirected: the edge may run either way. Fuse correlation + inner binding
+        // per orientation into the JOIN ON so a single OR covers both:
+        //   (a = e.from AND b = e.to) OR (a = e.to AND b = e.from)
+        // #640 shape 1. The predicate then filters the joined inner node.
+        None => {
+            format!(
+                "INNER JOIN {inner_table} AS {inner_conn} ON \
+                 ({edge_alias}.{from_col} = {outer_id_sql} AND {inner_conn}.{inner_id_col} = {edge_alias}.{to_col}) OR \
+                 ({edge_alias}.{to_col} = {outer_id_sql} AND {inner_conn}.{inner_id_col} = {edge_alias}.{from_col}) \
+                 WHERE 1 = 1"
+            )
+        }
+    };
+
+    let sql = format!("SELECT 1 FROM {edge_table} AS {edge_alias} {join_and_corr} AND {pred_sql}");
 
     Ok(Some((sql, vec![outer_conn.clone()])))
 }

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -6092,6 +6092,68 @@ async fn shortest_path_exists_where_clause_errors_cleanly_not_silently_dropped()
     );
 }
 
+/// #640 shape 1: `EXISTS { (a)-[:R]-(b) WHERE b.p }` — UNDIRECTED single-hop with
+/// an inner WHERE. #587 covered directed single-hop and deliberately kept
+/// undirected loud. This extends `generate_exists_filtered_graph_rel_sql` to emit
+/// the OR-of-both-orientations correlation, fusing correlation + inner binding per
+/// orientation into the JOIN ON so a single OR covers both edge directions.
+#[tokio::test]
+async fn undirected_exists_with_inner_where_renders_or_of_both_orientations_640() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    // Labeled AND unlabeled inner node both render the same OR join (the inner
+    // type resolves via the relationship's from/to role — here both are User).
+    for cypher in [
+        "MATCH (a:User) WHERE EXISTS { MATCH (a)-[:FOLLOWS]-(b:User) \
+         WHERE b.name = 'Alice' } RETURN a.name",
+        "MATCH (a:User) WHERE EXISTS { MATCH (a)-[:FOLLOWS]-(b) \
+         WHERE b.name = 'Alice' } RETURN a.name",
+    ] {
+        let sql = normalize(&render(&schema, cypher, SqlDialect::ClickHouse).await);
+        assert!(
+            sql.contains("EXISTS (SELECT 1 FROM social.user_follows_bench AS e")
+                && sql.contains("INNER JOIN social.users_bench AS b"),
+            "[{cypher}] #640: undirected EXISTS must render the correlated edge \
+             subquery with the inner-node join; got:\n{sql}"
+        );
+        // OR-of-both-orientations: a may sit on either edge column, and b binds
+        // the opposite one per orientation.
+        assert!(
+            sql.contains(
+                "(e.follower_id = a.user_id AND b.user_id = e.followed_id) OR \
+                 (e.followed_id = a.user_id AND b.user_id = e.follower_id)"
+            ),
+            "[{cypher}] #640: undirected EXISTS must emit the OR-of-both-orientations \
+             correlation/join; got:\n{sql}"
+        );
+        // The inner predicate is still mapped (b.name -> b.full_name) and applied.
+        assert!(
+            sql.contains("b.full_name = 'Alice'"),
+            "[{cypher}] #640: the inner WHERE must be mapped and folded in; got:\n{sql}"
+        );
+    }
+
+    // Regression: directed single-hop (the #587 shape) must stay byte-identical —
+    // correlate on the anchor's edge column, join the inner on the opposite, with
+    // NO OR-of-orientations.
+    let directed = normalize(
+        &render(
+            &schema,
+            "MATCH (a:User) WHERE EXISTS { MATCH (a)-[:FOLLOWS]->(b:User) \
+             WHERE b.name = 'Alice' } RETURN a.name",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        directed.contains(
+            "INNER JOIN social.users_bench AS b ON b.user_id = e.followed_id \
+             WHERE e.follower_id = a.user_id AND b.full_name = 'Alice'"
+        ),
+        "#640: directed single-hop EXISTS must stay on the #587 form (no OR); got:\n{directed}"
+    );
+}
+
 /// Regression test: `EXISTS { pattern }` whose correlated variable was bound
 /// BEFORE a `WITH` barrier — i.e. the variable lives in a CTE by the time the
 /// EXISTS subquery is rendered — must correlate against the variable's


### PR DESCRIPTION
## Bug (#640 shape 1, follow-up to #587)

`MATCH (a) WHERE EXISTS { (a)-[:R]-(b) WHERE b.p }` — an **undirected** single-hop EXISTS with an inner WHERE — failed loud (`Unsupported feature: EXISTS pattern with non-GraphRel subplan`). #587 added the directed single-hop path and deliberately kept undirected on the loud fallback.

## Fix

Extends `generate_exists_filtered_graph_rel_sql` (`render_expr.rs`) to handle `Direction::Either`, emitting the OR-of-both-orientations correlation — fusing the correlation and the inner-node binding per orientation into the JOIN ON so one OR covers both edge directions:

```sql
INNER JOIN inner AS b ON
  (e.from = a AND b.id = e.to) OR (e.to = a AND b.id = e.from)
WHERE 1 = 1 AND <mapped-predicate>
```

This mirrors the established undirected idiom already used in `join_builder.rs` and reuses #587's inner-predicate mapping (`b.name` → `b.full_name`, keyed by the resolved inner type so unlabeled inner nodes work too). EXISTS only needs ≥1 surviving row, so the row-duplication an OR can cause (edge present both ways) is immaterial.

## Loud-fallback discipline (unchanged shapes stay loud — ground-rule-1)

- **Heterogeneous undirected** (`from_node != to_node`, e.g. `(a:User)-[:AUTHORED]-(b:Post)`): the outer anchor is unlabeled in the EXISTS subplan, so the role is ambiguous → defer (`Ok(None)`), keeping the loud error rather than emitting type-crossed SQL. Verified loud, no wrong SQL.
- **composite id / composite edge FK / denormalized inner / polymorphic**: still deferred (the #587 guards, untouched).
- **directed single-hop**: byte-identical to the #587 form (no OR).

## Verification

- Two regression tests (undirected labeled + unlabeled emit the OR; directed stays on the #587 form).
- Full suite (1611 lib + 519 integration + corpus goldens + ratchet) green; fmt + clippy clean.
- Adversarially reviewed in a worktree: **0 defects** — undirected OR semantics confirmed correct (matches `join_builder.rs:3988`), heterogeneous/composite/polymorphic defer loud, directed byte-identical (Outgoing + Incoming + heterogeneous), no false positives from the JOIN-ON correlation.

Addresses #640 shape 1 (undirected). Shapes 2–5 (multi-hop/VLP, both-endpoints-outer, composite, denorm) remain deferred/loud per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)