### PR TITLE
fix(#672 part 2): non-self-ref composite FK-edge emits multi-column join

### DIFF
--- a/schemas/test/composite_fk_edge_nonselfref.yaml
+++ b/schemas/test/composite_fk_edge_nonselfref.yaml
@@ -1,0 +1,50 @@
+# Non-self-referencing composite FK-edge fixture (#672 part 2)
+#
+# An FK-edge is a relationship whose edge "table" IS one of the node tables —
+# the relationship is a foreign-key column on that node's row, no separate edge
+# table. Here the FK is a COMPOSITE column set pointing at a DIFFERENT node with
+# a composite node_id, exercising the non-self-ref composite FkEdgeJoin path
+# (join_generation.rs FkEdgeJoin Right branch — edge table == from_node table).
+#
+#   comments_composite
+#   +------------+---------+---------------+----------+
+#   | comment_id | content | forum_region  | forum_id |  <- composite FK to forums_composite
+#   +------------+---------+---------------+----------+
+#
+# Cypher pattern: (c:Comment)-[:IN_FORUM]->(f:Forum)
+# Expected SQL:   c.forum_region = f.region AND c.forum_id = f.forum_id
+
+name: composite_fk_edge_nonselfref
+version: "1.0"
+description: "Non-self-referencing composite FK-edge pattern (#672 part 2 fixture)"
+
+graph_schema:
+  nodes:
+    - label: Comment
+      database: db_composite_fk
+      table: comments_composite
+      node_id: comment_id
+      property_mappings:
+        comment_id: comment_id
+        content: content
+
+    - label: Forum
+      database: db_composite_fk
+      table: forums_composite
+      node_id: [region, forum_id]
+      property_mappings:
+        region: region
+        forum_id: forum_id
+        title: title
+
+  edges:
+    # FK-edge: edge table == Comment (from_node) table; the composite FK columns
+    # [forum_region, forum_id] live on the Comment row and point at Forum's
+    # composite PK [region, forum_id]. Non-self-referencing (Comment != Forum).
+    - type: IN_FORUM
+      database: db_composite_fk
+      table: comments_composite
+      from_id: comment_id
+      to_id: [forum_region, forum_id]
+      from_node: Comment
+      to_node: Forum

--- a/src/query_planner/analyzer/graph_join/join_generation.rs
+++ b/src/query_planner/analyzer/graph_join/join_generation.rs
@@ -346,11 +346,19 @@ pub fn generate_pattern_joins(
                     let left_id = own_table_id(&ctx.left_node, "FkEdgeJoin left")?;
                     let r_left_id =
                         helpers::resolve_identifier(&left_id, t.left_cte_name, plan_ctx);
-                    let r_from_id = Identifier::Single(helpers::resolve_column(
-                        from_id,
+                    // #672: composite-aware (mirrors the Right branch and the
+                    // self-ref path below). The old
+                    // `Identifier::Single(resolve_column(from_id, …))` stringified
+                    // a composite non-self-ref `from_id` into one bogus quoted
+                    // column; wrapping via `from_comma_separated` + per-column
+                    // resolution lets `add_identifier_condition` zip the node_id and
+                    // FK column sets into per-column equalities. Byte-identical for
+                    // single-column FKs.
+                    let r_from_id = helpers::resolve_identifier(
+                        &Identifier::from_comma_separated(from_id),
                         t.right_cte_name,
                         plan_ctx,
-                    ));
+                    );
                     // #632: a SELF-REFERENCING FK-edge (from_node == to_node, one
                     // physical table aliased twice) needs DIFFERENT columns on the
                     // two aliases: the FROM/child row carries the FK column
@@ -442,11 +450,23 @@ pub fn generate_pattern_joins(
                     let right_id = own_table_id(&ctx.right_node, "FkEdgeJoin right")?;
                     let r_right_id =
                         helpers::resolve_identifier(&right_id, t.right_cte_name, plan_ctx);
-                    let r_to_id = Identifier::Single(helpers::resolve_column(
-                        to_id,
+                    // #672: composite-aware. `to_id` is a comma-joined string; wrap
+                    // it as a full Identifier (single OR composite) and resolve each
+                    // column, mirroring the self-ref path above. The old
+                    // `Identifier::Single(resolve_column(to_id, …))` stringified a
+                    // composite `to_id` into one bogus quoted column
+                    // (`c."forum_region, forum_id"`); `add_identifier_condition`
+                    // then zips the node_id and FK column sets positionally into
+                    // per-column equalities (`f.region = c.forum_region AND
+                    // f.forum_id = c.forum_id`). Byte-identical for single-column
+                    // FKs. The author invariant (FK columns declared in the SAME
+                    // order as the target node_id) mirrors the composite self-ref
+                    // and SeparateTable FK-edge contracts.
+                    let r_to_id = helpers::resolve_identifier(
+                        &Identifier::from_comma_separated(to_id),
                         t.left_cte_name,
                         plan_ctx,
-                    ));
+                    );
                     let left_avail = already_available.contains(t.left_alias);
                     let right_avail = already_available.contains(t.right_alias);
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -2106,6 +2106,49 @@ async fn composite_self_referencing_fk_edge_emits_multi_column_join_646() {
     }
 }
 
+/// #672 part 2 regression: a COMPOSITE-id NON-self-referencing FK-edge must emit
+/// a multi-column equality join, not a malformed single quoted identifier.
+///
+/// An FK-edge is a relationship whose edge table IS one of the node tables (the
+/// FK is a column on that node's row). For `(c:Comment)-[:IN_FORUM]->(f:Forum)`
+/// the edge table == Comment (from_node) table, so the join routes the
+/// `FkEdgeJoin` Right branch and resolves the composite `to_id`
+/// (`[forum_region, forum_id]`, the FK on the Comment row) against Forum's
+/// composite `node_id` (`[region, forum_id]`). Before the fix the Right/Left
+/// branches wrapped the comma-joined FK string as `Identifier::Single`, emitting
+/// the bogus `f.region = c."forum_region, forum_id"` (Code 47). The
+/// composite-aware fix (`from_comma_separated` + `resolve_identifier`, mirroring
+/// the #646 self-ref path) zips the sets into `f.region = c.forum_region AND
+/// f.forum_id = c.forum_id`. Byte-identical for single-column FK-edges.
+#[tokio::test]
+async fn composite_non_self_ref_fk_edge_emits_multi_column_join_672() {
+    let schema = load_schema("schemas/test/composite_fk_edge_nonselfref.yaml");
+    // Outgoing routes the Right branch (edge==from_node table, JOIN to_node);
+    // the reversed-written form routes the Left branch — both must be correct.
+    let queries = [
+        "MATCH (c:Comment)-[:IN_FORUM]->(f:Forum) RETURN c.content, f.title",
+        "MATCH (f:Forum)<-[:IN_FORUM]-(c:Comment) RETURN c.content, f.title",
+    ];
+    for cypher in queries {
+        for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+            let sql = render(&schema, cypher, dialect).await;
+            // Both composite columns must be joined (Forum PK cols = Comment FK cols).
+            assert!(
+                sql.contains("f.region = c.forum_region")
+                    && sql.contains("f.forum_id = c.forum_id"),
+                "#672: composite non-self-ref FK-edge join must pair BOTH id \
+                 columns for {dialect:?} / `{cypher}`, got:\n{sql}"
+            );
+            // The malformed comma-joined quoted identifier must be gone.
+            assert!(
+                !sql.contains("forum_region, forum_id"),
+                "#672: must NOT emit the malformed comma-joined identifier for \
+                 {dialect:?} / `{cypher}`:\n{sql}"
+            );
+        }
+    }
+}
+
 /// member's value). The whole-node GROUP BY optimization in `group_by_builder.rs`
 /// now expands to the full `node_id.columns()` set via the schema.
 #[tokio::test]


### PR DESCRIPTION
## Bug (#672 part 2, follow-up to #646)

A non-self-referencing FK-edge (edge table IS one node's table; the FK is a column set on that node's row, pointing at a **different** node) with a **composite** FK emitted a malformed join:

```sql
INNER JOIN forums_composite AS f ON f.region = c."forum_region, forum_id"
```

— the composite `to_id`/`from_id` comma-joined string wrapped as one bogus quoted identifier, only the first node_id column paired → **ClickHouse Code 47**.

## Root cause

In `join_generation.rs`, the `FkEdgeJoin` arm's `NodePosition::Right` branch built `r_to_id = Identifier::Single(resolve_column(to_id, …))` (and `Left`, `from_id`) — single-column paths that stringify a composite. The **self-ref** path in the same arm was already made composite-aware by #646; the non-self-ref path was the remaining gap (filed as #672 part 2 during that review).

## Fix

Resolve the FK via `Identifier::from_comma_separated` + `resolve_identifier` (single OR composite), mirroring the self-ref path. `add_identifier_condition` then zips the node_id and FK column sets positionally into per-column equalities:

```sql
INNER JOIN forums_composite AS f ON f.region = c.forum_region AND f.forum_id = c.forum_id
```

Byte-identical for single-column FK-edges (`from_comma_separated("customer_id")` → `Single`).

## Verification

- Both directions × both dialects render the correct multi-column join.
- **Byte-identical** single-column regression (fk_edge.yaml Order-PLACED_BY-Customer + filesystem_single.yaml self-ref) — confirmed with isolated-build differential testing.
- Self-ref composite path (`composite_self_ref_fk.yaml`) untouched / byte-identical.
- Mixed-arity is safe (`add_identifier_condition` warns + zips `min(len)`, no panic).
- New fixture `schemas/test/composite_fk_edge_nonselfref.yaml` (Comment-IN_FORUM-Forum, composite Forum node_id) + executable-oracle golden (both directions × both dialects).
- Full suite (1611 lib + 520 integration + corpus + ratchet) green; fmt + clippy clean.
- Adversarially reviewed: **0 defects**.

## Scope

The FK-columns-declared-in-node_id-order author invariant is unchanged (shared with the composite self-ref and SeparateTable FK-edge contracts). The loud order/arity guard is **#672 part 1**, still open (needs semantic FK↔PK mapping knowledge — a separate design question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)