### PR TITLE
fix(#642): rename derived VLP sub-CTE family on union-arm dedup

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -121,7 +121,108 @@ pub(crate) fn rewrite_cte_self_name_in_raw_sql(content: &mut CteContent, old: &s
     let CteContent::RawSql(sql) = content else {
         return;
     };
+    // #642: a VLP CTE's RawSql can bundle a whole FAMILY of derived sub-CTEs —
+    // `<old>_inner`, `<old>_to_target`, `<old>_bfs`, `<old>_recon`,
+    // `<old>_reachable` (shortestPath/BFS/min-hops wrappers) — all defined inside
+    // this ONE blob and cross-referencing each other. Renaming only `<old>`→`<new>`
+    // (the #618 single-CTE case) leaves those derived names intact, so a second
+    // union arm with the same aliases re-defines e.g. `<old>_inner` → Code 179.
+    //
+    // Discover the derived names actually present as `<old>_<suffix> AS (` headers
+    // in this blob and rename each `<old>_<suffix>`→`<new>_<suffix>` FIRST (longest
+    // first, so `<old>_inner` is handled before the bare `<old>` — otherwise the
+    // whole-identifier boundary would already have stopped `<old>` from matching
+    // inside `<old>_inner`, but doing the derived names first is clearest and
+    // order-independent since each rewrite targets a distinct whole identifier).
+    let mut derived = discover_derived_cte_names(sql, old);
+    // Longest suffix first for determinism (no nesting among siblings, but stable).
+    derived.sort_by_key(|b| std::cmp::Reverse(b.len()));
+    for derived_old in derived {
+        let derived_new = format!("{}{}", new, &derived_old[old.len()..]);
+        *sql = rewrite_cte_name_structural(sql, &derived_old, &derived_new);
+    }
     *sql = rewrite_cte_name_structural(sql, old, new);
+}
+
+/// #642: find the derived sub-CTE names (`<base>_<suffix>`) DEFINED as headers
+/// (`<base>_<suffix> AS (`) inside a VLP RawSql blob. Only names that appear as an
+/// actual CTE definition header are returned, so we never rename a coincidental
+/// identifier.
+///
+/// TWO-LAYER SAFETY: this discovery gate is deliberately NOT the safety boundary —
+/// even if it over-includes a name, the actual rewrite goes through
+/// `rewrite_cte_name_structural`, which only touches header / post-`FROM` /
+/// post-`JOIN` positions and is string-literal-aware. So an over-detected name at
+/// worst re-confirms a rename that is already correct; it can never corrupt a
+/// column, alias, or literal. The gate requires `AS (` (a real definition, not an
+/// `AS <alias>` reference) to keep discovery tight regardless. String-literal spans are skipped (a literal containing
+/// `foo_inner AS (` must not be mistaken for a header).
+fn discover_derived_cte_names(sql: &str, base: &str) -> Vec<String> {
+    if base.is_empty() {
+        return Vec::new();
+    }
+    let bytes = sql.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let prefix = format!("{}_", base);
+    let mut names = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut i = 0;
+    let mut in_string = false;
+    while i < sql.len() {
+        let b = bytes[i];
+        if in_string {
+            if b == b'\'' {
+                if i + 1 < sql.len() && bytes[i + 1] == b'\'' {
+                    i += 2;
+                    continue;
+                }
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'\'' {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        // Match `<base>_<suffix>` as a whole identifier at a header position.
+        if sql[i..].starts_with(&prefix) {
+            let before_ok = i == 0 || !is_ident(bytes[i - 1]);
+            if before_ok {
+                // Consume the full identifier `<base>_<ident-chars>`.
+                let mut end = i + prefix.len();
+                while end < sql.len() && is_ident(bytes[end]) {
+                    end += 1;
+                }
+                let candidate = &sql[i..end];
+                // Only accept it if this occurrence is a DEFINITION header:
+                // `<name> AS (` — `AS` followed (after optional whitespace) by `(`.
+                // A CTE definition is ALWAYS `AS (`; an aliased table reference is
+                // `AS <alias>` (no paren) or a bare `<name> <alias>` — neither of
+                // which we rename. Requiring the `(` avoids mistaking an aliased
+                // reference for a definition (defense-in-depth: no VLP template
+                // currently emits `<derived> AS <alias>`, but this keeps discovery
+                // strictly limited to real definitions).
+                let rest = sql[end..].trim_start();
+                let is_header = {
+                    let low = rest.to_ascii_lowercase();
+                    low.strip_prefix("as")
+                        .map(|after| after.trim_start())
+                        .is_some_and(|after| after.starts_with('('))
+                };
+                if is_header && candidate.len() > prefix.len() && seen.insert(candidate.to_string())
+                {
+                    names.push(candidate.to_string());
+                }
+                i = end;
+                continue;
+            }
+        }
+        let ch_len = sql[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        i += ch_len;
+    }
+    names
 }
 
 /// Rewrite `old`→`new` only where `old` is a CTE reference: the definition
@@ -8174,6 +8275,50 @@ mod tests {
             ),
             "WHERE n = 'a''vlp_a_b' AND FROM vlp_a_b_2 vp"
         );
+    }
+
+    /// #642: the derived sub-CTE family (`<base>_inner`/`_to_target`/…) bundled in
+    /// a VLP RawSql blob must be discovered (only at `AS (` definition headers) and
+    /// renamed together with the base, so a second union arm with the same aliases
+    /// doesn't re-define e.g. `vlp_a_b_inner` (Code 179).
+    #[test]
+    fn discover_and_rewrite_derived_cte_family_642() {
+        // Discovery: only names defined as `<base>_<suffix> AS (` headers.
+        let sql = "vlp_a_b_inner AS (\n  FROM vlp_a_b_inner vp\n),\nvlp_a_b_to_target AS (\n  SELECT * FROM vlp_a_b_inner\n),\nvlp_a_b AS (\n  SELECT * FROM vlp_a_b_to_target\n)";
+        let mut found = discover_derived_cte_names(sql, "vlp_a_b");
+        found.sort();
+        assert_eq!(found, vec!["vlp_a_b_inner", "vlp_a_b_to_target"]);
+
+        // A `<base>_<suffix>` that is only REFERENCED (never a header) is NOT
+        // discovered — e.g. a bare `FROM foo_inner` with no `foo_inner AS (`.
+        assert_eq!(
+            discover_derived_cte_names("SELECT * FROM vlp_a_b_inner", "vlp_a_b"),
+            Vec::<String>::new()
+        );
+
+        // A string literal that looks like a header must NOT be discovered.
+        assert_eq!(
+            discover_derived_cte_names("WHERE x = 'vlp_a_b_inner AS ('", "vlp_a_b"),
+            Vec::<String>::new()
+        );
+
+        // Full family rewrite (base + derived) via rewrite_cte_self_name_in_raw_sql.
+        let mut content = CteContent::RawSql(sql.to_string());
+        rewrite_cte_self_name_in_raw_sql(&mut content, "vlp_a_b", "vlp_a_b_2");
+        let CteContent::RawSql(rewritten) = &content else {
+            panic!("expected RawSql");
+        };
+        // Every header and cross-reference of the family is renamed.
+        assert!(rewritten.contains("vlp_a_b_2_inner AS ("));
+        assert!(rewritten.contains("FROM vlp_a_b_2_inner vp"));
+        assert!(rewritten.contains("vlp_a_b_2_to_target AS ("));
+        assert!(rewritten.contains("SELECT * FROM vlp_a_b_2_inner")); // to_target's ref
+        assert!(rewritten.contains("vlp_a_b_2 AS ("));
+        assert!(rewritten.contains("SELECT * FROM vlp_a_b_2_to_target")); // outer's ref
+                                                                          // The un-suffixed base must NOT leak (no bare `vlp_a_b_inner`/`vlp_a_b AS`).
+        assert!(!rewritten.contains("vlp_a_b_inner"));
+        assert!(!rewritten.contains("vlp_a_b_to_target"));
+        assert!(!rewritten.contains("\nvlp_a_b AS ("));
     }
 
     /// Wrap `inner` in a `Cte` node — the shape the Phase 1 Slice 2 gap-fix

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -13991,9 +13991,8 @@ mod vlp_multi_table_label_family_557_558_559 {
     /// self-consistent `vlp_a_b_2` CTE.
     ///
     /// Scope: this covers the single-CTE recursive-VLP shape (#618's repro).
-    /// Multi-sub-CTE VLP shapes (shortestPath/BFS `_bfs`/`_recon`/`_inner`) still
-    /// collide on the DERIVED sub-names in both arms — pre-existing on main,
-    /// tracked in #642.
+    /// Multi-sub-CTE VLP shapes (shortestPath/BFS `_inner`/`_bfs`/`_recon`) are
+    /// handled by #642 (the sibling test below), which renames the derived family.
     #[tokio::test]
     async fn vlp_in_both_union_arms_renames_second_cte_definition_and_selfref_618() {
         let schema = load_schema(SchemaId::Standard.yaml_path());
@@ -14042,6 +14041,60 @@ mod vlp_multi_table_label_family_557_558_559 {
         assert!(
             sql.contains("start_node.user_id = 6") && sql.contains("start_node.user_id = 5"),
             "#618: both per-arm start filters (user 6 and user 5) must survive: {sql}"
+        );
+    }
+
+    /// #642: a top-level Cypher UNION with a MULTI-SUB-CTE VLP (shortestPath, whose
+    /// CTE is built from a `vlp_a_b_inner` recursive body + a `vlp_a_b` ROW_NUMBER
+    /// dedup wrapper, all in ONE RawSql blob) in BOTH arms reusing aliases `a`/`b`.
+    /// #618 renamed only the OUTER `vlp_a_b`→`vlp_a_b_2` and its FROM/self-refs; the
+    /// DERIVED `vlp_a_b_inner` stayed, so the second arm re-defined it → Code 179.
+    /// The dedup now discovers the derived family (`vlp_a_b_inner`) and renames it
+    /// with the base (`vlp_a_b_2_inner`), rewriting its header, self-ref, and the
+    /// wrapper's cross-reference.
+    #[tokio::test]
+    async fn vlp_multi_sub_cte_in_both_union_arms_renames_derived_family_642() {
+        let schema = load_schema(SchemaId::Standard.yaml_path());
+        let sql = render(
+            &schema,
+            "MATCH p = shortestPath((a:User)-[:FOLLOWS*1..3]->(b:User)) WHERE a.user_id = 6 \
+             RETURN length(p) AS l \
+             UNION ALL \
+             MATCH p = shortestPath((a:User)-[:FOLLOWS*1..3]->(b:User)) WHERE a.user_id = 5 \
+             RETURN length(p) AS l",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+
+        // The derived sub-CTE must be defined exactly once per name — no duplicate
+        // `vlp_a_b_inner AS (` (the Code 179 trigger).
+        assert_eq!(
+            sql.matches("vlp_a_b_inner AS (").count(),
+            1,
+            "#642: the derived sub-CTE `vlp_a_b_inner` must be defined exactly once \
+             (no duplicate → Code 179): {sql}"
+        );
+        // The second arm's derived family is renamed in lock-step with its base.
+        assert!(
+            sql.contains("vlp_a_b_2_inner AS (") && sql.contains("vlp_a_b_2 AS ("),
+            "#642: the second arm's derived sub-CTE must be renamed to \
+             `vlp_a_b_2_inner` alongside `vlp_a_b_2`: {sql}"
+        );
+        // The renamed inner's recursive self-ref points at ITSELF, and the renamed
+        // outer wrapper references the renamed inner (no cross-arm dangling ref).
+        assert!(
+            sql.contains("FROM vlp_a_b_2_inner vp"),
+            "#642: renamed inner's self-reference must be rewritten: {sql}"
+        );
+        assert!(
+            sql.matches("FROM vlp_a_b_inner").count() >= 1
+                && sql.matches("FROM vlp_a_b_2_inner").count() >= 1,
+            "#642: each arm's wrapper must reference its OWN inner CTE: {sql}"
+        );
+        // Both per-arm start filters survive.
+        assert!(
+            sql.contains("start_node.user_id = 6") && sql.contains("start_node.user_id = 5"),
+            "#642: both per-arm start filters must survive the family rename: {sql}"
         );
     }
 }


### PR DESCRIPTION
## Bug (#642, follow-up to #618)

A top-level Cypher UNION with a **multi-sub-CTE VLP** (shortestPath/BFS/min-hops — whose recursive CTE is a `{name}_inner` body + a `{name}` dedup/wrapper, bundled in ONE RawSql blob) in **both** arms with the same aliases emitted:

```
Code: 179. CTE with name vlp_a_b_inner already exists
```

#618 renamed only the outer `vlp_a_b`→`vlp_a_b_2` and its FROM/self-refs on union-arm dedup; the **derived** `vlp_a_b_inner` stayed → duplicate definition + arm-2's `vlp_a_b_2` wrapper wrongly referencing arm-1's inner. Pre-existing on main, not a #618 regression.

## Fix (all in `cte_extraction.rs`)

1. New `discover_derived_cte_names(sql, base)` — scans the blob for `{base}_{suffix} AS (` **definition headers** (string-literal-aware; skips literals), returns the derived family.
2. `rewrite_cte_self_name_in_raw_sql` now discovers the family and renames each `{base}_{suffix}`→`{new}_{suffix}` (via the existing structural rewriter — header + FROM/JOIN positions, whole-identifier + string-literal gated) **before** renaming the bare base.

**Two-layer safety**: discovery is not the safety boundary — even an over-detected name only re-confirms a rewrite the structural rewriter would make correctly; it can never corrupt a column, alias, or literal. The gate requires `AS (` regardless.

## Scope

Covers the common multi-sub-CTE shapes (shortestPath/min-hops `_inner`, `_to_target`) whose cross-refs are all FROM/JOIN positions. The conservative #618 column-qualifier contract (`SELECT vlp_a_b.x` left alone) is unchanged — a rare denorm-end-filter `{name}_inner.col` position is not rewritten (would need the qualifier position #618 deliberately excludes); such a both-arms shape, if reachable, stays as-is rather than risk the #618 silent-corruption hazard.

## Verification

- shortestPath + min-hops both-arms: exactly one `vlp_a_b_inner AS (`, arm-2 renamed to `vlp_a_b_2_inner` (header + self-ref + wrapper cross-ref), no dangling arm-1 refs.
- String-literal `'vlp_a_b_inner'` byte-preserved.
- Byte-identical: #618 single-CTE both-arms, single-arm shortestPath, non-VLP union.
- +unit test (discovery + family rewrite + string-literal/reference-only safety) +integration test.
- Full suite (1612 lib + 521 integration + corpus + ratchet) green; fmt + clippy clean.
- Adversarially reviewed with isolated-build differential testing: **0 defects** (the one flagged over-match confirmed provably benign via the two-layer design; the reviewer's NIT — tighten discovery to `AS (` — is applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)