### PR TITLE
fix(#606): denormalized VLP enforces relationship-uniqueness

### DIFF
--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1356,6 +1356,43 @@ impl DenormalizedCteStrategy {
         }
     }
 
+    /// Whether this denormalized VLP should enforce Cypher's default
+    /// relationship-uniqueness (an edge may not be reused, but a node MAY be
+    /// revisited) via a `path_edges` array of `(from, to)` edge tuples, instead
+    /// of the stronger node-uniqueness via `path_nodes`.
+    ///
+    /// This is the denormalized-strategy counterpart of the standard emitter's
+    /// [`VariableLengthCteGenerator::uses_edge_uniqueness`] (#598 part 2). It
+    /// mirrors that helper's two shape guards, both of which prevent a
+    /// base/recursive column-shape mismatch (unbound-identifier, cf. #469) and
+    /// preserve intended semantics:
+    ///
+    /// - **shortestPath** stays node-unique: revisiting a node can never
+    ///   shorten a path, and the shortest-path arms have their own base shape.
+    /// - **zero-hop `*0..N`** (`effective_min_hops() == 0`) stays node-unique:
+    ///   its base row is a node paired with itself and carries no edge, so it
+    ///   cannot seed a 1-hop `path_edges` tuple; seeding it only in the
+    ///   ordinary base would diverge from the zero-hop base's column shape.
+    ///
+    /// A denormalized edge has no separate edge-id column, so its edge identity
+    /// is the `(from_col, to_col)` pair — see [`Self::edge_tuple`].
+    fn uses_edge_uniqueness(&self, context: &CteGenerationContext) -> bool {
+        context.shortest_path_mode.is_none() && context.spec.effective_min_hops() >= 1
+    }
+
+    /// The `(from, to)` edge-identity tuple for one hop, read off `rel_alias`
+    /// (base case) or `next` (recursive case). Denormalized edges carry no
+    /// dedicated edge-id column, so the ordered endpoint pair uniquely
+    /// identifies the physical edge row for trail-uniqueness.
+    fn edge_tuple(&self, rel_alias: &str) -> String {
+        let tuple_ctor =
+            crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor();
+        format!(
+            "{}({}.{}, {}.{})",
+            tuple_ctor, rel_alias, self.from_col, rel_alias, self.to_col
+        )
+    }
+
     pub fn generate_sql(
         &self,
         context: &CteGenerationContext,
@@ -1728,10 +1765,22 @@ impl DenormalizedCteStrategy {
             ),
             format!("{}.{} as end_id", self.pattern_ctx.rel_alias, self.to_col),
             "1 as hop_count".to_string(),
-            format!(
-                "{} as path_edges",
-                arr(&format!("{}.{}", self.pattern_ctx.rel_alias, self.from_col))
-            ), // Simplified edge tracking
+            // path_edges seeds the trail-uniqueness array. Under edge-uniqueness
+            // (#606) it holds the `(from, to)` edge-identity tuple so a physical
+            // edge is deduplicated while nodes may still be revisited; otherwise
+            // it keeps the legacy single-`from_col` form (node-uniqueness paths
+            // never consult it — they filter on `path_nodes`).
+            if self.uses_edge_uniqueness(context) {
+                format!(
+                    "{} as path_edges",
+                    arr(&self.edge_tuple(&self.pattern_ctx.rel_alias))
+                )
+            } else {
+                format!(
+                    "{} as path_edges",
+                    arr(&format!("{}.{}", self.pattern_ctx.rel_alias, self.from_col))
+                )
+            },
             format!(
                 "{} as path_nodes",
                 arr(&format!(
@@ -1904,7 +1953,15 @@ impl DenormalizedCteStrategy {
             "vp.start_id as start_id".to_string(),
             format!("next.{} as end_id", self.to_col),
             "vp.hop_count + 1".to_string(),
-            arr_append("vp.path_edges", &format!("next.{}", self.from_col)), // Extend edge path array
+            // Extend path_edges. Under edge-uniqueness (#606) append the new
+            // hop's `(from, to)` edge tuple so the shape matches the base seed
+            // and the recursive cycle check below; otherwise keep the legacy
+            // single-`from_col` append (unused by node-uniqueness filtering).
+            if self.uses_edge_uniqueness(context) {
+                arr_append("vp.path_edges", &self.edge_tuple("next"))
+            } else {
+                arr_append("vp.path_edges", &format!("next.{}", self.from_col))
+            }, // Extend edge path array
             arr_append("vp.path_nodes", &format!("next.{}", self.to_col)), // Extend node path array
             // Extend the relationship-type path array (see base case for why
             // this column is part of the VLP CTE contract). Grows only when a
@@ -1940,11 +1997,25 @@ impl DenormalizedCteStrategy {
             // ⚠️ ClickHouse limitation: NOT IN with array doesn't work in recursive CTEs.
             // Use NOT <array_contains>(array, element) for cycle detection. The membership
             // function is dialect-specific: CH `has`, Spark `array_contains`.
-            format!(
-                "NOT {}(vp.path_nodes, next.{})",
-                cycle_mapper.array_contains(),
-                self.to_col
-            ), // Cycle prevention
+            //
+            // Under edge-uniqueness (#606) test membership of the new hop's
+            // `(from, to)` edge tuple against path_edges — a physical edge may
+            // not repeat, but a node MAY be revisited (Cypher's default
+            // relationship-uniqueness). Otherwise fall back to node-uniqueness
+            // (reject any revisited node) via path_nodes.
+            if self.uses_edge_uniqueness(context) {
+                format!(
+                    "NOT {}(vp.path_edges, {})",
+                    cycle_mapper.array_contains(),
+                    self.edge_tuple("next")
+                )
+            } else {
+                format!(
+                    "NOT {}(vp.path_nodes, next.{})",
+                    cycle_mapper.array_contains(),
+                    self.to_col
+                )
+            }, // Cycle prevention
         ];
 
         // Add additional filters if present
@@ -3550,6 +3621,10 @@ mod tests {
     /// ClickHouse (default) it uses `has`; under Databricks it must use Spark's
     /// `array_contains` (Spark has no `has`). Covers the DenormalizedCteStrategy
     /// recursive builder — the path the server/cg VLP queries route through.
+    ///
+    /// This range VLP (min_hops=1, not shortestPath) enforces #606
+    /// relationship-uniqueness, so the membership test is over `path_edges`
+    /// (the `(from,to)` edge tuple), not `path_nodes`.
     #[test]
     fn test_denormalized_cte_cycle_check_clickhouse_default() {
         let (strategy, context) = denormalized_cycle_check_sql();
@@ -3558,8 +3633,8 @@ mod tests {
             .unwrap()
             .sql;
         assert!(
-            sql.contains("NOT has(vp.path_nodes"),
-            "CH cycle check should use `has`; got:\n{sql}"
+            sql.contains("NOT has(vp.path_edges"),
+            "CH cycle check should use `has` on path_edges (#606); got:\n{sql}"
         );
         assert!(
             !sql.contains("array_contains"),
@@ -3585,11 +3660,12 @@ mod tests {
         })
         .await;
         assert!(
-            sql.contains("array_contains(vp.path_nodes"),
-            "Databricks cycle check should use `array_contains`; got:\n{sql}"
+            sql.contains("array_contains(vp.path_edges"),
+            "Databricks cycle check should use `array_contains` on path_edges \
+             (#606); got:\n{sql}"
         );
         assert!(
-            !sql.contains("has(vp.path_nodes"),
+            !sql.contains("has(vp.path_edges"),
             "Databricks SQL leaked ClickHouse `has(...)` cycle check; got:\n{sql}"
         );
     }

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [f.Origin] as path_edges,
+        [tuple(f.Origin, f.Dest)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         f."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL' AND hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(f.Origin) as path_edges,
+        array(struct(f.Origin, f.Dest)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         f.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL' AND hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [f.Origin] as path_edges,
+        [tuple(f.Origin, f.Dest)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         [] as path_relationships,
         f."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       count(DISTINCT t.end_Dest) AS "dest_count"

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(f.Origin) as path_edges,
+        array(struct(f.Origin, f.Dest)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array() as path_relationships,
         f.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       count(DISTINCT t.end_Dest) AS `dest_count`

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [f.Origin] as path_edges,
+        [tuple(f.Origin, f.Dest)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         [] as path_relationships,
         f."DestCityName" as "end_DestCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."DestCityName" as "end_DestCityName"
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.end_DestCityName AS "dest.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(f.Origin) as path_edges,
+        array(struct(f.Origin, f.Dest)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array() as path_relationships,
         f.`DestCityName` as `end_DestCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.end_DestCityName AS `dest.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [f.Origin] as path_edges,
+        [tuple(f.Origin, f.Dest)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         f."OriginCityName" as "start_OriginCityName",
@@ -16,7 +16,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
@@ -24,7 +24,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL'

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(f.Origin) as path_edges,
+        array(struct(f.Origin, f.Dest)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         f.`OriginCityName` as `start_OriginCityName`,
@@ -16,7 +16,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
@@ -24,7 +24,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL'

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       count(*) AS "paths"

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       count(*) AS `paths`

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -17,7 +17,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
@@ -26,7 +26,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         next."DestState" as "end_DestState"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -17,7 +17,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
@@ -26,7 +26,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         next.`DestState` as `end_DestState`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."DestCityName" as "end_DestCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.end_DestCityName AS "a2.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`DestCityName` as `end_DestCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.end_DestCityName AS `a2.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ), 
 with_a_b_hops_cte_0 AS (SELECT 
       start_city AS "p1_a_city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ), 
 with_a_b_hops_cte_0 AS (SELECT 
       start_city AS `p1_a_city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ), 
 with_a_b_hops_path_nodes_cte_0 AS (SELECT 
       start_city AS "p1_a_city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ), 
 with_a_b_hops_path_nodes_cte_0 AS (SELECT 
       start_city AS `p1_a_city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ), 
 with_dest_dest_state_hops_origin_cte_0 AS (SELECT 
       t.start_city AS "origin", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ), 
 with_dest_dest_state_hops_origin_cte_0 AS (SELECT 
       t.start_city AS `origin`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_airport AS "a.airport", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_airport AS `a.airport`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginState AS "a.state", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginState AS `a.state`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS "a.city", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS `a.city`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_Origin AS "a.code", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_Origin AS `a.code`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS "a.city", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginCityName AS `a.city`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginState AS "a.state", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.start_OriginState AS `a.state`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [t0.Origin] as path_edges,
+        [tuple(t0.Origin, t0.Dest)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."DestCityName" as "end_DestCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.Origin]),
+        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."DestCityName" as "end_DestCityName",
         next."Dest" as "end_Dest"
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
 )
 SELECT DISTINCT 
       t.end_Dest AS "dest.code", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(t0.Origin) as path_edges,
+        array(struct(t0.Origin, t0.Dest)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`DestCityName` as `end_DestCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.Origin)),
+        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`DestCityName` as `end_DestCityName`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.Dest)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
 )
 SELECT DISTINCT 
       t.end_Dest AS `dest.code`, 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [t0.origin_code] as path_edges,
+        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."origin_code" as "start_origin_code",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.origin_code]),
+        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         vp."start_origin_code" as "start_origin_code",
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
 )
 SELECT 
       t.start_origin_code AS "a.code", 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(t0.origin_code) as path_edges,
+        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`origin_code` as `start_origin_code`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.origin_code)),
+        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         vp.`start_origin_code` as `start_origin_code`,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
 )
 SELECT 
       t.start_origin_code AS `a.code`, 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [t0.origin_code] as path_edges,
+        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."dest_city" as "end_dest_city"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.origin_code]),
+        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         next."dest_city" as "end_dest_city"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
 )
 SELECT 
       t.end_dest_city AS "b.city"

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(t0.origin_code) as path_edges,
+        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`dest_city` as `end_dest_city`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.origin_code)),
+        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         next.`dest_city` as `end_dest_city`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
 )
 SELECT 
       t.end_dest_city AS `b.city`

--- a/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [t0.origin_code] as path_edges,
+        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM db_denormalized.flights_denorm AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.origin_code]),
+        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
 )
 SELECT 
       tuple(t.path_nodes, t.path_relationships, t.hop_count) AS "p"

--- a/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(t0.origin_code) as path_edges,
+        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM db_denormalized.flights_denorm AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.origin_code)),
+        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
         concat(vp.path_nodes, array(next.dest_code)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
 )
 SELECT 
       struct(t.path_nodes, t.path_relationships, t.hop_count) AS `p`

--- a/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [t0.origin_code] as path_edges,
+        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."origin_code" as "start_origin_code",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.origin_code]),
+        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         vp."start_origin_code" as "start_origin_code",
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
 )
 SELECT 
       t1.origin_code AS "x.code", 

--- a/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(t0.origin_code) as path_edges,
+        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`origin_code` as `start_origin_code`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.origin_code)),
+        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         vp.`start_origin_code` as `start_origin_code`,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
 )
 SELECT 
       t1.origin_code AS `x.code`, 

--- a/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [t0.origin_code] as path_edges,
+        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."dest_code" as "end_dest_code"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [next.origin_code]),
+        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
 )
 SELECT 
       t.end_dest_code AS "b.code"

--- a/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(t0.origin_code) as path_edges,
+        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`dest_code` as `end_dest_code`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(next.origin_code)),
+        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_nodes, next.dest_code)
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
 )
 SELECT 
       t.end_dest_code AS `b.code`

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8453,6 +8453,84 @@ async fn relationship_uniqueness_guard_skips_unrelated_types_and_optional_518() 
     );
 }
 
+/// #606: the DENORMALIZED VLP strategy (`DenormalizedCteStrategy`, a
+/// single-table / edge-embedded-node schema like `flights_denorm`) enforced
+/// NODE-uniqueness (`NOT has(vp.path_nodes, next.<to>)`) on its range recursive
+/// walk, silently dropping every valid path that legitimately revisits a node.
+/// Cypher's default is RELATIONSHIP-uniqueness: a physical edge may not repeat,
+/// but a node MAY be revisited. This mirrors the standard emitter's #598 part-2
+/// fix into the denormalized strategy: `path_edges` now seeds and extends the
+/// `(from, to)` edge-identity tuple, and the cycle check tests that tuple.
+///
+/// A denormalized edge carries no dedicated edge-id column, so the ordered
+/// endpoint pair IS the edge identity. Live-verified against a cyclic fixture
+/// (edges A→B, B→A, B→C, C→A): the edge-unique walk returns 14 trails over
+/// `*1..3` (including node-revisiting trails like A→B→A and C→A→B→A) versus the
+/// old node-unique walk's 7 — exactly the 7 valid paths that were being
+/// silently dropped, with no edge ever reused.
+#[tokio::test]
+async fn denormalized_vlp_range_uses_edge_uniqueness_606() {
+    let schema = load_schema(SchemaId::Denormalized.yaml_path());
+
+    // Range VLP (min_hops >= 1, not shortestPath): edge-unique.
+    for cypher in [
+        "MATCH (a:Airport)-[:FLIGHT*1..3]->(b:Airport) RETURN a.code, b.code",
+        // Wrapper form (min_hops > 1) must agree on the base/recursive shape.
+        "MATCH (a:Airport)-[:FLIGHT*2..3]->(b:Airport) RETURN a.code, b.code",
+    ] {
+        let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        // Base seed + recursive extend carry the (origin, dest) edge tuple.
+        assert!(
+            sql.contains("[tuple(t")
+                && sql.contains("origin_code")
+                && sql.contains("dest_code")
+                && sql.contains(
+                    "arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)])"
+                ),
+            "[{cypher}] #606: denorm range VLP must seed/extend path_edges with \
+             the (from,to) edge tuple; got:\n{sql}"
+        );
+        // Cycle check is edge-unique on the tuple, NOT node-unique on the endpoint.
+        assert!(
+            sql.contains("NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))"),
+            "[{cypher}] #606: denorm range VLP cycle check must test edge-tuple \
+             membership in path_edges; got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("NOT has(vp.path_nodes, next.dest_code)"),
+            "[{cypher}] #606: denorm range VLP must no longer enforce \
+             node-uniqueness; got:\n{sql}"
+        );
+    }
+
+    // Zero-hop (*0..N) stays NODE-unique: its base row is a node paired with
+    // itself and carries no edge to seed a 1-hop tuple, so switching it would
+    // create a base/recursive column-shape mismatch (#469).
+    let zero = render(
+        &schema,
+        "MATCH (a:Airport)-[:FLIGHT*0..3]->(b:Airport) RETURN a.code, b.code",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        zero.contains("NOT has(vp.path_nodes, next.dest_code)")
+            && !zero.contains("NOT has(vp.path_edges, tuple("),
+        "#606: denorm zero-hop VLP must stay node-unique; got:\n{zero}"
+    );
+
+    // shortestPath stays NODE-unique: revisiting a node can never shorten a path.
+    let sp = render(
+        &schema,
+        "MATCH p = shortestPath((a:Airport)-[:FLIGHT*1..3]->(b:Airport)) RETURN length(p)",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        !sp.contains("NOT has(vp.path_edges, tuple("),
+        "#606: denorm shortestPath VLP must stay node-unique; got:\n{sp}"
+    );
+}
+
 /// #511: a hardcoded `LIMIT 1000` "safety cap" on every `pattern_union` CTE
 /// branch (unlabeled/multi-type relationship scans, e.g.
 /// `MATCH ()-[r]->() RETURN ...`) silently truncated results — with no


### PR DESCRIPTION
## Summary

The denormalized VLP strategy (`DenormalizedCteStrategy` — single-table / edge-embedded-node schemas like `flights_denorm`) enforced **node-uniqueness** on its range recursive walk (`NOT has(vp.path_nodes, next.<to>)`), silently dropping every valid path that legitimately revisits a node. Cypher's default is **relationship-uniqueness**: a physical edge may not repeat, but a node MAY be revisited.

This mirrors the standard emitter's #598 part-2 fix into the denormalized strategy. `path_edges` now seeds and extends the `(from, to)` edge-identity tuple, and the recursive cycle check tests that tuple. A denormalized edge has no dedicated edge-id column, so the ordered endpoint pair IS the edge identity.

## Scope guard

`uses_edge_uniqueness(context)` = `shortest_path_mode.is_none() && effective_min_hops() >= 1` — the denorm counterpart of the standard emitter's guard:
- **shortestPath** stays node-unique (revisiting a node never shortens a path).
- **zero-hop `*0..N`** stays node-unique (base row carries no edge to seed the tuple; flipping it would create a base/recursive column-shape mismatch, cf. #469).

## Live verification

Against a cyclic fixture (edges A→B, B→A, B→C, C→A):

| walk | `*1..3` count | |
|---|---|---|
| edge-unique (this fix) | **14** | matches hand oracle — includes node-revisiting trails A→B→A, C→A→B→A; no edge reused |
| node-unique (old bug) | 7 | silently dropped 7 valid paths |

All 14 paths enumerated and checked by hand.

## Tests

- Golden corpus regenerated (denorm VLP only; Databricks maps `tuple`→`struct`, `has`→`array_contains`). Diff confined to the three intended line forms — verified.
- Updated the two `DenormalizedCteStrategy` dialect-dispatch unit tests (intent preserved: `has` vs `array_contains`; array name `path_nodes`→`path_edges`).
- New golden regression `denormalized_vlp_range_uses_edge_uniqueness_606`.
- Full suite green (1612 unit + 526 integration), clippy clean, ratchet passes.

Follow-up to #598. Closes the denormalized variant of #606; remaining variants (fk-edge / mixed / edge-to-edge / heterogeneous-polymorphic recursive generators) stay open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)