### PR TITLE
fix(#606): self-ref FK-edge VLP enforces relationship-uniqueness

### DIFF
--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -1209,6 +1209,30 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
     }
 
+    /// Build the `(from_id, to_id)` edge-identity tuple for ONE FK-edge hop,
+    /// reading the two node-id columns off the given SQL aliases.
+    ///
+    /// FK-edge relationships have no separate edge table and no dedicated
+    /// edge-id column — the edge IS the `from_alias.<from_id> → to_alias.<to_id>`
+    /// node pair (e.g. `child.parent_id → parent.object_id`). So for #606
+    /// relationship-uniqueness the ordered node-id pair uniquely identifies the
+    /// physical edge row. `from_id_col`/`to_id_col` are the node id columns for
+    /// each side (self-referencing FK-edge → same column name on both sides).
+    fn build_fk_edge_tuple(
+        &self,
+        from_alias: &str,
+        from_id_col: &str,
+        to_alias: &str,
+        to_id_col: &str,
+    ) -> String {
+        let tuple_ctor =
+            crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor();
+        format!(
+            "{}({}.{}, {}.{})",
+            tuple_ctor, from_alias, from_id_col, to_alias, to_id_col
+        )
+    }
+
     /// Get the ClickHouse array type for path_edges
     /// Returns type like: `Array(Tuple(UInt32, UInt32))` or `Array(Tuple(String, String, ...))`
     #[allow(dead_code)]
@@ -3092,6 +3116,24 @@ impl<'a> VariableLengthCteGenerator<'a> {
             ))
         ));
 
+        // #606: seed path_edges with this hop's `(from_id, to_id)` edge tuple so
+        // the recursive step can enforce relationship-uniqueness (Cypher default:
+        // an edge may not repeat, but a node MAY be revisited). FK-edge has no
+        // dedicated edge-id column, so the ordered node-id pair is the identity.
+        // Gated by uses_edge_uniqueness() (shortestPath / zero-hop stay
+        // node-unique via path_nodes, keeping base/recursive column shape agreed).
+        if self.uses_edge_uniqueness() {
+            select_items.push(format!(
+                "{} as path_edges",
+                arr(&self.build_fk_edge_tuple(
+                    &self.start_node_alias,
+                    &self.start_node_id_column,
+                    &self.end_node_alias,
+                    &self.end_node_id_column,
+                ))
+            ));
+        }
+
         // Add properties for start and end nodes
         for prop in &self.properties {
             if prop.cypher_alias == self.start_cypher_alias {
@@ -3216,6 +3258,21 @@ impl<'a> VariableLengthCteGenerator<'a> {
             "{ac}(vp.path_nodes, {}) as path_nodes",
             arr(&format!("new_end.{}", self.end_node_id_column))
         ));
+        // #606: APPEND this hop's edge tuple. The hop is current_node -> new_end
+        // (previous end following its FK to its parent), so the edge identity is
+        // (current_node.<end_id>, new_end.<end_id>). Gated by uses_edge_uniqueness()
+        // to agree with the base seed and the cycle check below.
+        if self.uses_edge_uniqueness() {
+            select_items.push(format!(
+                "{ac}(vp.path_edges, {}) as path_edges",
+                arr(&self.build_fk_edge_tuple(
+                    "current_node",
+                    &self.end_node_id_column,
+                    "new_end",
+                    &self.end_node_id_column,
+                ))
+            ));
+        }
 
         // Add properties: start properties from CTE, end properties from new joined node
         for prop in &self.properties {
@@ -3234,7 +3291,17 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         let mut where_conditions = vec![
             format!("vp.hop_count < {}", max_hops),
-            emit_cycle_check(&format!("new_end.{}", self.end_node_id_column)),
+            // #606: edge-unique when uses_edge_uniqueness(), else legacy node-unique.
+            if self.uses_edge_uniqueness() {
+                emit_edge_cycle_check(&self.build_fk_edge_tuple(
+                    "current_node",
+                    &self.end_node_id_column,
+                    "new_end",
+                    &self.end_node_id_column,
+                ))
+            } else {
+                emit_cycle_check(&format!("new_end.{}", self.end_node_id_column))
+            },
         ];
 
         // Add edge constraints if defined in schema
@@ -3302,6 +3369,22 @@ impl<'a> VariableLengthCteGenerator<'a> {
             "{ac}({}, vp.path_nodes) as path_nodes",
             arr(&format!("new_start.{}", self.start_node_id_column))
         ));
+        // #606: PREPEND this hop's edge tuple (path grows at the front here). The
+        // hop is new_start -> current_node (a child pointing via its FK to the
+        // previous start), so the edge identity is
+        // (new_start.<start_id>, current_node.<start_id>). Gated by
+        // uses_edge_uniqueness() to agree with the base seed and cycle check.
+        if self.uses_edge_uniqueness() {
+            select_items.push(format!(
+                "{ac}({}, vp.path_edges) as path_edges",
+                arr(&self.build_fk_edge_tuple(
+                    "new_start",
+                    &self.start_node_id_column,
+                    "current_node",
+                    &self.start_node_id_column,
+                ))
+            ));
+        }
 
         // Add properties: end properties from CTE, start properties from new joined node
         for prop in &self.properties {
@@ -3320,7 +3403,17 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         let mut where_conditions = vec![
             format!("vp.hop_count < {}", max_hops),
-            emit_cycle_check(&format!("new_start.{}", self.start_node_id_column)),
+            // #606: edge-unique when uses_edge_uniqueness(), else legacy node-unique.
+            if self.uses_edge_uniqueness() {
+                emit_edge_cycle_check(&self.build_fk_edge_tuple(
+                    "new_start",
+                    &self.start_node_id_column,
+                    "current_node",
+                    &self.start_node_id_column,
+                ))
+            } else {
+                emit_cycle_check(&format!("new_start.{}", self.start_node_id_column))
+            },
         ];
 
         // Add edge constraints if defined in schema

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.clickhouse.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_c_p_inner AS (
         1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         [start_node.object_id, end_node.object_id] as path_nodes,
+        [tuple(start_node.object_id, end_node.object_id)] as path_edges,
         end_node.name as end_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_c_p_inner AS (
         vp.hop_count + 1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        arrayConcat([tuple(new_start.object_id, current_node.object_id)], vp.path_edges) as path_edges,
         vp.end_name as end_name
     FROM vlp_c_p_inner vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND NOT has(vp.path_edges, tuple(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 ),
 vlp_c_p AS (

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_compound.databricks.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_c_p_inner AS (
         1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         array(start_node.object_id, end_node.object_id) as path_nodes,
+        array(struct(start_node.object_id, end_node.object_id)) as path_edges,
         end_node.name as end_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_c_p_inner AS (
         vp.hop_count + 1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        concat(array(struct(new_start.object_id, current_node.object_id)), vp.path_edges) as path_edges,
         vp.end_name as end_name
     FROM vlp_c_p_inner vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND NOT array_contains(vp.path_edges, struct(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 ),
 vlp_c_p AS (

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.clickhouse.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_p_c AS (
         1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         [start_node.object_id, end_node.object_id] as path_nodes,
+        [tuple(start_node.object_id, end_node.object_id)] as path_edges,
         start_node.name as start_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_p_c AS (
         vp.hop_count + 1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        arrayConcat([tuple(new_start.object_id, current_node.object_id)], vp.path_edges) as path_edges,
         new_start.name as start_name
     FROM vlp_p_c vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND NOT has(vp.path_edges, tuple(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_incoming.databricks.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_p_c AS (
         1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         array(start_node.object_id, end_node.object_id) as path_nodes,
+        array(struct(start_node.object_id, end_node.object_id)) as path_edges,
         start_node.name as start_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_p_c AS (
         vp.hop_count + 1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        concat(array(struct(new_start.object_id, current_node.object_id)), vp.path_edges) as path_edges,
         new_start.name as start_name
     FROM vlp_p_c vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND NOT array_contains(vp.path_edges, struct(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.clickhouse.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_c_p AS (
         1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         [start_node.object_id, end_node.object_id] as path_nodes,
+        [tuple(start_node.object_id, end_node.object_id)] as path_edges,
         end_node.name as end_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_c_p AS (
         vp.hop_count + 1 as hop_count,
         CAST([] AS Array(String)) as path_relationships,
         arrayConcat([new_start.object_id], vp.path_nodes) as path_nodes,
+        arrayConcat([tuple(new_start.object_id, current_node.object_id)], vp.path_edges) as path_edges,
         vp.end_name as end_name
     FROM vlp_c_p vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT has(vp.path_nodes, new_start.object_id)
+      AND NOT has(vp.path_edges, tuple(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_635_self_ref_fk_edge_coupled_rel_var_vlp_where_outgoing.databricks.sql
@@ -5,6 +5,7 @@ WITH RECURSIVE vlp_c_p AS (
         1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         array(start_node.object_id, end_node.object_id) as path_nodes,
+        array(struct(start_node.object_id, end_node.object_id)) as path_edges,
         end_node.name as end_name
     FROM test_integration.fs_objects_single start_node
     JOIN test_integration.fs_objects_single end_node ON start_node.parent_id = end_node.object_id
@@ -16,12 +17,13 @@ WITH RECURSIVE vlp_c_p AS (
         vp.hop_count + 1 as hop_count,
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         concat(array(new_start.object_id), vp.path_nodes) as path_nodes,
+        concat(array(struct(new_start.object_id, current_node.object_id)), vp.path_edges) as path_edges,
         vp.end_name as end_name
     FROM vlp_c_p vp
     JOIN test_integration.fs_objects_single current_node ON vp.start_id = current_node.object_id
     JOIN test_integration.fs_objects_single new_start ON new_start.parent_id = current_node.object_id
     WHERE vp.hop_count < 3
-      AND NOT array_contains(vp.path_nodes, new_start.object_id)
+      AND NOT array_contains(vp.path_edges, struct(new_start.object_id, current_node.object_id))
       AND new_start.parent_id > 0
 )
 SELECT 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8531,6 +8531,66 @@ async fn denormalized_vlp_range_uses_edge_uniqueness_606() {
     );
 }
 
+/// #606 (FK-edge variant): the self-referencing FK-edge VLP generators
+/// (`generate_fk_edge_base_case` + `generate_fk_edge_recursive_append` /
+/// `_recursive_prepend` in `variable_length_cte.rs`) enforced NODE-uniqueness
+/// (`NOT has(vp.path_nodes, <new>.<id>)`) and carried no `path_edges` column at
+/// all, silently dropping valid node-revisiting paths. FK-edge relationships
+/// have no separate edge table / edge-id column — the edge IS the
+/// `(from_id, to_id)` node-id pair — so relationship-uniqueness dedups on that
+/// tuple. This mirrors the #598 / denorm (#709) fix into the FK-edge arms.
+///
+/// Live-verified against a cyclic FK fixture (PARENT edges child→parent
+/// 1→2, 2→3, 3→1, 4→1): the edge-unique walk returns 12 trails over `*1..3`
+/// (including the cycle-closing 1→2→3→1, 2→3→1→2, 3→1→2→3) versus the old
+/// node-unique walk's 9 — exactly the 3 valid paths that were silently dropped,
+/// with no edge reused.
+#[tokio::test]
+async fn fk_edge_vlp_range_uses_edge_uniqueness_606() {
+    let schema = load_schema("schemas/examples/filesystem_single.yaml");
+
+    // Range VLP (min_hops >= 1, not shortestPath): edge-unique in every
+    // expansion form (append when the start is filtered, prepend otherwise).
+    for cypher in [
+        // prepend form (no start filter)
+        "MATCH (a:Object)-[:PARENT*1..3]->(b:Object) RETURN a.object_id, b.object_id",
+        // append form (start filter present)
+        "MATCH (a:Object)-[:PARENT*1..3]->(b:Object) WHERE a.name = 'notes.txt' \
+         RETURN b.object_id",
+        // wrapper form (min_hops > 1)
+        "MATCH (a:Object)-[:PARENT*2..3]->(b:Object) RETURN a.object_id, b.object_id",
+    ] {
+        let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        // Base seeds the (from_id, to_id) edge tuple.
+        assert!(
+            sql.contains("[tuple(start_node.object_id, end_node.object_id)] as path_edges"),
+            "[{cypher}] #606 FK-edge: base must seed path_edges with the \
+             (from_id,to_id) tuple; got:\n{sql}"
+        );
+        // Recursive step extends path_edges and the cycle check is edge-unique
+        // on the tuple — NOT node-unique on the endpoint id.
+        assert!(
+            sql.contains("has(vp.path_edges, tuple(") && !sql.contains("NOT has(vp.path_nodes,"),
+            "[{cypher}] #606 FK-edge: recursive cycle check must test edge-tuple \
+             membership in path_edges, not node membership in path_nodes; got:\n{sql}"
+        );
+    }
+
+    // Zero-hop (*0..N) and shortestPath stay NODE-unique (base carries no edge
+    // to seed the tuple / revisiting a node never shortens a path).
+    for cypher in [
+        "MATCH (a:Object)-[:PARENT*0..3]->(b:Object) RETURN a.object_id, b.object_id",
+        "MATCH p = shortestPath((a:Object)-[:PARENT*1..3]->(b:Object)) RETURN length(p)",
+    ] {
+        let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        assert!(
+            sql.contains("NOT has(vp.path_nodes,") && !sql.contains("has(vp.path_edges, tuple("),
+            "[{cypher}] #606 FK-edge: zero-hop / shortestPath must stay \
+             node-unique; got:\n{sql}"
+        );
+    }
+}
+
 /// #511: a hardcoded `LIMIT 1000` "safety cap" on every `pattern_union` CTE
 /// branch (unlabeled/multi-type relationship scans, e.g.
 /// `MATCH ()-[r]->() RETURN ...`) silently truncated results — with no


### PR DESCRIPTION
## Summary

The self-referencing FK-edge VLP generators (`generate_fk_edge_base_case` + `generate_fk_edge_recursive_append` / `_recursive_prepend` in `variable_length_cte.rs`) enforced **node-uniqueness** and carried no `path_edges` column at all, silently dropping every valid path that legitimately revisits a node. Cypher's default is **relationship-uniqueness** (an edge may not repeat, a node MAY be revisited).

Mirrors the #598 / denormalized (#709) fix into the FK-edge arms. FK-edge relationships have no separate edge table or edge-id column — the edge IS the `from_alias.<from_id> → to_alias.<to_id>` node pair — so the ordered node-id pair is the edge identity. New `build_fk_edge_tuple` helper; `path_edges` seeds `(start_id, end_id)` in the base and extends the per-hop tuple in both append (`current_node → new_end`) and prepend (`new_start → current_node`) arms; cycle check switches to `emit_edge_cycle_check`.

## Scope guard

Gated by the existing `uses_edge_uniqueness()` (`shortest_path_mode.is_none() && effective_min_hops() >= 1`):
- **shortestPath** stays node-unique (revisiting never shortens a path).
- **zero-hop `*0..N`** stays node-unique (its base carries no edge to seed the tuple → base/recursive shape agreement preserved).

## Live verification

Cyclic FK fixture (PARENT edges child→parent: 1→2, 2→3, 3→1, 4→1):

| walk | `*1..3` count | |
|---|---|---|
| edge-unique (this fix) | **12** | matches hand oracle — includes cycle-closing 1→2→3→1, 2→3→1→2, 3→1→2→3 |
| node-unique (old bug) | 9 | silently dropped the 3 cycle-closing trails |

All 12 paths enumerated and checked; no edge reused.

## Tests

- Golden corpus regenerated (`fk_edge_self_ref` VLP only; Databricks maps `tuple`→`struct`, `has`→`array_contains`). Diff confined to base seed / recursive extend / cycle check.
- New golden regression `fk_edge_vlp_range_uses_edge_uniqueness_606` (append + prepend + wrapper edge-unique; zero-hop + shortestPath node-unique).
- Full suite green (1612 unit + 527 integration), clippy clean, ratchet passes.

Follow-up to #598 and #709. Remaining #606 variants (weighted, mixed, heterogeneous-polymorphic, undirected bidirectional, multi-type) stay open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)