### PR TITLE
refactor(P2.3): move clause extractors into render_plan/clause_extractors.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1, P2.2 merged — P2.3 next)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1, P2.2, P2.3 merged — P2.4 next)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -155,7 +155,14 @@ byte-identical, D3 dedup deferred (follow-up). **P2.2 (pattern_comprehension_sql
 move) MERGED (#660, `3776d0a9`)** — the pattern-comprehension SQL string-emitting
 group (31 fns, `render_plan/pattern_comprehension_sql.rs`, 2,629 lines) extracted
 verbatim, `pub(crate)` re-exports, byte-identical goldens + corpus, ratchet
-net-zero; D7-rest deferred. **Next: P2.3 clause_extractors move.**
+net-zero; D7-rest deferred. **P2.3 (clause_extractors move) delivered** — the
+pure clause extractors that remained (`extract_having/order_by/limit/skip` +
+`extract_sorted_properties`) extracted to `render_plan/clause_extractors.rs`,
+`pub(crate)` re-exports, byte-identical goldens + corpus, ratchet net-zero. NOTE:
+the original §5.1 group also named `extract_filters/from/group_by/distinct`, but
+those had already migrated to `filter_builder.rs`/`group_by_builder.rs` via
+incremental work, so P2.3's real scope was the 5-function remainder. **Next: P2.4
+plan_predicates move.**
 
 ### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+#662+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
@@ -239,6 +246,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.3 — clause_extractors module move** (P-3 refactor lane) — the
+  pure clause extractors remaining in `plan_builder_utils.rs`
+  (`extract_having`/`extract_order_by`/`extract_limit`/`extract_skip` +
+  `extract_sorted_properties`, old lines 1467–1560) extracted verbatim to a new
+  `render_plan/clause_extractors.rs`, `pub(crate) use` re-exports left in
+  `plan_builder_utils` so all `super::plan_builder_utils::extract_*` call sites
+  and `properties_builder`'s direct import keep resolving. Zero logic edits.
+  **Stale-premise correction**: §5.1 named an 8-function group
+  (`filters/from/group_by/having/order_by/limit/skip/distinct`) but
+  `extract_filters/from/group_by/distinct` had already migrated to
+  `filter_builder.rs`/`group_by_builder.rs` via incremental work, so P2.3's real
+  scope was the 5-function remainder (§5.1 table + §9 checklist updated to match).
+  Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1
+  ratchet + 7 unit, 0 failures; **byte-identical** (no golden churn, corpus
+  snapshot unchanged, ratchet net-zero); fmt/clippy clean. Next refactor slice:
+  P2.4 plan_predicates.
 - 2026-07-27: **Doc reconcile + branch prune** (housekeeping, no code) — §2 queue
   status lines brought current after the 07-19..27 batch: P-1 marked
   clean-pool-exhausted with the full shipped list (~20 fixes) + the next picks

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -461,7 +461,7 @@ Split along the audited seams, **pure groups first** (lowest risk):
 |---|---|---|
 | `render_plan/vlp_rewrite.rs` | VLP expr rewriting, 115–812 + `extract_vlp_alias_mappings` :1296 | pure `&mut RenderExpr` transforms — **move first** |
 | `render_plan/pattern_comprehension_sql.rs` | ✅ **moved (P2.2, Jul 2026)** — the pattern-comprehension SQL *string* emitters (31 fns, ~2,600 lines): emits SQL text, a different layer from the rest | cohesive, separable |
-| `render_plan/clause_extractors.rs` | the `extract_*` pipeline 1418–3300 (`extract_filters/from/group_by/having/order_by/limit/skip/distinct` + embedded tests) | the only externally-consumed group; mostly pure |
+| `render_plan/clause_extractors.rs` | ✅ **moved (P2.3, Jul 2026)** — the pure clause extractors that remained (`extract_having/order_by/limit/skip` + `extract_sorted_properties`, was 1467–1560). NOTE: `extract_filters/from/group_by/distinct` from the original group had already migrated to `filter_builder.rs`/`group_by_builder.rs` via incremental work | the only externally-consumed group; mostly pure |
 | `render_plan/plan_predicates.rs` | WITH-detection + alias/table lookups 3850–4247, 4418–4519 | pure read-only walkers — natural home for the §4 `walk()` rewrites |
 | `render_plan/cte_rewrite.rs` | CTE-ref extraction + CTE/alias rewriting 813–1295, 3323–3849, 6102–6970 | pure-ish (RenderPlan/RenderExpr + maps) |
 | `render_plan/with_to_cte/` (dir) | 6999–15491: the two giant builders + their orbit | **entangled core** — moved in Phase 2, decomposed in Phase 4 |
@@ -992,7 +992,11 @@ updated for the pure relocation of schema/dialect axis tokens
 (`from_label_column`/`to_label_column`/`type_column`/`Dialect::`/`databricks`)
 plan_builder_utils → pattern_comprehension_sql, all net-zero. D7-rest deferred (pure move
 this slice). ·
-☐ P2.3 clause_extractors move · ☐ P2.4 plan_predicates move ·
+☑ P2.3 clause_extractors move (`extract_having/order_by/limit/skip` +
+`extract_sorted_properties` → `render_plan/clause_extractors.rs`, `pub(crate)`
+re-exports; `extract_filters/from/group_by/distinct` had already migrated to
+`filter_builder`/`group_by_builder`; byte-identical corpus + goldens, ratchet
+net-zero) · ☐ P2.4 plan_predicates move ·
 ☐ P2.5 cte_rewrite move (+D2) · ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
 ☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
 

--- a/src/render_plan/clause_extractors.rs
+++ b/src/render_plan/clause_extractors.rs
@@ -1,0 +1,116 @@
+//! Clause extractors — pure walkers that pull a single SQL clause out of a
+//! `LogicalPlan` tail (HAVING / ORDER BY / LIMIT / SKIP) plus the
+//! property-sorting helper they share with the whole-node property builders.
+//!
+//! Extracted verbatim from `plan_builder_utils.rs` in P2.3
+//! (`REFACTORING_SAFETY_PLAN.md` §5.1). No logic edits — the functions are
+//! re-exported `pub(crate)` from `plan_builder_utils` during the transition so
+//! existing `super::plan_builder_utils::extract_*` call sites keep resolving.
+//!
+//! Note: `extract_filters` / `extract_from` / `extract_group_by` /
+//! `extract_distinct` from the original §5.1 group already migrated to
+//! `filter_builder.rs` / `group_by_builder.rs` via incremental work, so the
+//! genuinely-pure remainder that lands here is these five.
+
+use crate::query_planner::logical_plan::LogicalPlan;
+use crate::render_plan::errors::RenderBuildError;
+use crate::render_plan::plan_builder_helpers::apply_property_mapping_to_expr;
+use crate::render_plan::render_expr::RenderExpr;
+use crate::render_plan::OrderByItem;
+
+type RenderPlanBuilderResult<T> = Result<T, RenderBuildError>;
+
+pub fn extract_having(plan: &LogicalPlan) -> RenderPlanBuilderResult<Option<RenderExpr>> {
+    let having_clause = match plan {
+        LogicalPlan::Limit(limit) => extract_having(&limit.input)?,
+        LogicalPlan::Skip(skip) => extract_having(&skip.input)?,
+        LogicalPlan::OrderBy(order_by) => extract_having(&order_by.input)?,
+        LogicalPlan::Projection(projection) => extract_having(&projection.input)?,
+        LogicalPlan::GroupBy(group_by) => {
+            if let Some(having) = &group_by.having_clause {
+                let mut render_expr: RenderExpr = having.clone().try_into()?;
+                // Apply property mapping to the HAVING expression
+                apply_property_mapping_to_expr(&mut render_expr, &group_by.input);
+                Some(render_expr)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    Ok(having_clause)
+}
+
+pub fn extract_order_by(plan: &LogicalPlan) -> RenderPlanBuilderResult<Vec<OrderByItem>> {
+    let order_by =
+        match plan {
+            LogicalPlan::Limit(limit) => extract_order_by(&limit.input)?,
+            LogicalPlan::Skip(skip) => extract_order_by(&skip.input)?,
+            LogicalPlan::OrderBy(order_by) => order_by
+                .items
+                .iter()
+                .cloned()
+                .map(|item| {
+                    // #484: id()/elementId() in ORDER BY position must route through
+                    // the same pattern_union-aware / schema-driven ID resolution as
+                    // GROUP BY and SELECT (see `resolve_id_function_for_group_order`
+                    // doc comment in group_by_builder.rs) — otherwise it falls
+                    // through to the generic function-registry `toInt64(0)`
+                    // placeholder, making `ORDER BY id(o)` a silent no-op.
+                    if let Some(resolved) =
+                        super::group_by_builder::resolve_id_function_for_group_order(
+                            &order_by.input,
+                            &item.expression,
+                        )
+                    {
+                        return Ok(OrderByItem {
+                            expression: resolved,
+                            order: match item.order {
+                                crate::query_planner::logical_plan::OrderByOrder::Asc => {
+                                    crate::render_plan::OrderByOrder::Asc
+                                }
+                                crate::query_planner::logical_plan::OrderByOrder::Desc => {
+                                    crate::render_plan::OrderByOrder::Desc
+                                }
+                            },
+                        });
+                    }
+                    let mut order_item: OrderByItem = item.try_into()?;
+                    // Apply property mapping to the order by expression
+                    apply_property_mapping_to_expr(&mut order_item.expression, &order_by.input);
+                    Ok(order_item)
+                })
+                .collect::<Result<Vec<OrderByItem>, RenderBuildError>>()?,
+            _ => vec![],
+        };
+    Ok(order_by)
+}
+
+pub fn extract_limit(plan: &LogicalPlan) -> Option<i64> {
+    match plan {
+        LogicalPlan::Limit(limit) => Some(limit.count),
+        _ => None,
+    }
+}
+
+pub fn extract_skip(plan: &LogicalPlan) -> Option<i64> {
+    match plan {
+        LogicalPlan::Limit(limit) => extract_skip(&limit.input),
+        LogicalPlan::Skip(skip) => Some(skip.count),
+        _ => None,
+    }
+}
+
+pub fn extract_sorted_properties(
+    property_map: &std::collections::HashMap<
+        String,
+        crate::graph_catalog::expression_parser::PropertyValue,
+    >,
+) -> Vec<(String, String)> {
+    let mut properties: Vec<(String, String)> = property_map
+        .iter()
+        .map(|(prop_name, prop_value)| (prop_name.clone(), prop_value.raw().to_string()))
+        .collect();
+    properties.sort_by(|a, b| a.0.cmp(&b.0));
+    properties
+}

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod clause_extractors;
 pub mod cte_extraction;
 pub mod cte_generation;
 pub mod cte_manager;

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -87,6 +87,14 @@ pub(crate) use super::vlp_rewrite::{
     translate_db_columns_to_cypher_properties,
 };
 
+// P2.3 (REFACTORING_SAFETY_PLAN.md §5.1): the clause-extractor group moved to
+// `clause_extractors.rs`; re-exported here so existing
+// `super::plan_builder_utils::extract_*` call sites resolve during the
+// transition.
+pub(crate) use super::clause_extractors::{
+    extract_having, extract_limit, extract_order_by, extract_skip, extract_sorted_properties,
+};
+
 /// Build property mapping from select items for CTE column resolution.
 /// Maps (alias, property) -> column_name for property access resolution.
 ///
@@ -1464,101 +1472,6 @@ graph_schema:
         }
     }
 }
-pub fn extract_having(plan: &LogicalPlan) -> RenderPlanBuilderResult<Option<RenderExpr>> {
-    let having_clause = match plan {
-        LogicalPlan::Limit(limit) => extract_having(&limit.input)?,
-        LogicalPlan::Skip(skip) => extract_having(&skip.input)?,
-        LogicalPlan::OrderBy(order_by) => extract_having(&order_by.input)?,
-        LogicalPlan::Projection(projection) => extract_having(&projection.input)?,
-        LogicalPlan::GroupBy(group_by) => {
-            if let Some(having) = &group_by.having_clause {
-                let mut render_expr: RenderExpr = having.clone().try_into()?;
-                // Apply property mapping to the HAVING expression
-                apply_property_mapping_to_expr(&mut render_expr, &group_by.input);
-                Some(render_expr)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    };
-    Ok(having_clause)
-}
-
-pub fn extract_order_by(plan: &LogicalPlan) -> RenderPlanBuilderResult<Vec<OrderByItem>> {
-    let order_by =
-        match plan {
-            LogicalPlan::Limit(limit) => extract_order_by(&limit.input)?,
-            LogicalPlan::Skip(skip) => extract_order_by(&skip.input)?,
-            LogicalPlan::OrderBy(order_by) => order_by
-                .items
-                .iter()
-                .cloned()
-                .map(|item| {
-                    // #484: id()/elementId() in ORDER BY position must route through
-                    // the same pattern_union-aware / schema-driven ID resolution as
-                    // GROUP BY and SELECT (see `resolve_id_function_for_group_order`
-                    // doc comment in group_by_builder.rs) — otherwise it falls
-                    // through to the generic function-registry `toInt64(0)`
-                    // placeholder, making `ORDER BY id(o)` a silent no-op.
-                    if let Some(resolved) =
-                        super::group_by_builder::resolve_id_function_for_group_order(
-                            &order_by.input,
-                            &item.expression,
-                        )
-                    {
-                        return Ok(OrderByItem {
-                            expression: resolved,
-                            order: match item.order {
-                                crate::query_planner::logical_plan::OrderByOrder::Asc => {
-                                    crate::render_plan::OrderByOrder::Asc
-                                }
-                                crate::query_planner::logical_plan::OrderByOrder::Desc => {
-                                    crate::render_plan::OrderByOrder::Desc
-                                }
-                            },
-                        });
-                    }
-                    let mut order_item: OrderByItem = item.try_into()?;
-                    // Apply property mapping to the order by expression
-                    apply_property_mapping_to_expr(&mut order_item.expression, &order_by.input);
-                    Ok(order_item)
-                })
-                .collect::<Result<Vec<OrderByItem>, RenderBuildError>>()?,
-            _ => vec![],
-        };
-    Ok(order_by)
-}
-
-pub fn extract_limit(plan: &LogicalPlan) -> Option<i64> {
-    match plan {
-        LogicalPlan::Limit(limit) => Some(limit.count),
-        _ => None,
-    }
-}
-
-pub fn extract_skip(plan: &LogicalPlan) -> Option<i64> {
-    match plan {
-        LogicalPlan::Limit(limit) => extract_skip(&limit.input),
-        LogicalPlan::Skip(skip) => Some(skip.count),
-        _ => None,
-    }
-}
-
-pub fn extract_sorted_properties(
-    property_map: &std::collections::HashMap<
-        String,
-        crate::graph_catalog::expression_parser::PropertyValue,
-    >,
-) -> Vec<(String, String)> {
-    let mut properties: Vec<(String, String)> = property_map
-        .iter()
-        .map(|(prop_name, prop_value)| (prop_name.clone(), prop_value.raw().to_string()))
-        .collect();
-    properties.sort_by(|a, b| a.0.cmp(&b.0));
-    properties
-}
-
 // ============================================================================
 // CTE Expression Rewriting Functions
 // ============================================================================


### PR DESCRIPTION
## What

Phase-2 §5.1 module move (P-3 refactor lane). Extracts the pure clause
extractors remaining in `plan_builder_utils.rs` verbatim to a new
`render_plan/clause_extractors.rs`:

- `extract_having`, `extract_order_by`, `extract_limit`, `extract_skip`
- `extract_sorted_properties`

`pub(crate) use` re-exports left in `plan_builder_utils` so all
`super::plan_builder_utils::extract_*` call sites and `properties_builder`'s
direct import keep resolving during the transition. **Zero logic edits.**

### Stale-premise correction
§5.1 named an 8-function group
(`filters/from/group_by/having/order_by/limit/skip/distinct`), but
`extract_filters/from/group_by/distinct` had already migrated to
`filter_builder.rs`/`group_by_builder.rs` via incremental work — so P2.3's real
scope was the 5-function remainder. §5.1 table + §9 checklist + PRIORITIES P-3
updated to match.

## Verification
- Moved-fn bodies verified **byte-identical** vs `main` (code content diff empty).
- **Byte-identical**: no golden churn, `corpus_sweep` snapshot unchanged, ratchet net-zero.
- Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; fmt/clippy clean.
- Worktree-isolated review: VERDICT MERGE (0 blocker/major/minor).

Next refactor slice: P2.4 plan_predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)