### PR TITLE
refactor(P2.4): move WITH-detection predicates into render_plan/plan_predicates.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1, P2.2, P2.3 merged — P2.4 next)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1–P2.4 merged — P2.5 next)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -161,8 +161,15 @@ pure clause extractors that remained (`extract_having/order_by/limit/skip` +
 `pub(crate)` re-exports, byte-identical goldens + corpus, ratchet net-zero. NOTE:
 the original §5.1 group also named `extract_filters/from/group_by/distinct`, but
 those had already migrated to `filter_builder.rs`/`group_by_builder.rs` via
-incremental work, so P2.3's real scope was the 5-function remainder. **Next: P2.4
-plan_predicates move.**
+incremental work, so P2.3's real scope was the 5-function remainder. **P2.4
+(plan_predicates move) delivered** — the WITH-detection predicate group
+(`has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`)
+extracted to `render_plan/plan_predicates.rs`, `pub(crate)` re-exports,
+byte-identical goldens + corpus, ratchet net-zero. Scoped down from §5.1's
+premise: the private fresh-scan/with-exported alias walkers named there are
+coupled to P2.5's cte_rewrite fns, so they ride with P2.5 (§8.3 no-drive-by); the
+`plan_builder_helpers` `has_with_clause_in_graph_rel` D-cluster copy stays
+untouched. **Next: P2.5 cte_rewrite move.**
 
 ### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+#662+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
@@ -246,6 +253,25 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.4 — plan_predicates module move** (P-3 refactor lane) — the
+  WITH-detection predicate group (`has_with_clause_in_tree`,
+  `has_with_clause_in_graph_rel`, `plan_contains_with_clause`, old lines
+  2008–2098) extracted verbatim to a new `render_plan/plan_predicates.rs`.
+  `pub(crate) use` re-exports for the two production-called names left in
+  `plan_builder_utils`; `has_with_clause_in_tree` has no production caller (only
+  the P1.2 characterization tests use it) so it is imported directly by the test
+  module instead of re-exported (keeps the lib build warning-free). Zero logic
+  edits. **Scoped down from §5.1's premise**: the band also listed the private
+  fresh-scan / with-exported alias walkers, but those are coupled to P2.5's
+  cte_rewrite fns (`update_graph_joins_cte_refs`/`rewrite_logical_expr_cte_refs`),
+  so they ride with P2.5 rather than churn visibility ahead of their callers
+  (§8.3 no-drive-by); the `plan_builder_helpers` second copy of
+  `has_with_clause_in_graph_rel` (`pub(super)`, different semantics) is the
+  flagged D-cluster duplicate and is left untouched (separate dedup). §5.1 table
+  + §9 checklist + P-3 updated. Gates: 1612 lib + 529 integration (incl.
+  `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; **byte-identical**
+  (moved-fn bodies diff-clean vs main, no golden churn, ratchet net-zero);
+  fmt/clippy clean. Next refactor slice: P2.5 cte_rewrite.
 - 2026-07-27: **P2.3 — clause_extractors module move** (P-3 refactor lane) — the
   pure clause extractors remaining in `plan_builder_utils.rs`
   (`extract_having`/`extract_order_by`/`extract_limit`/`extract_skip` +

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -462,7 +462,7 @@ Split along the audited seams, **pure groups first** (lowest risk):
 | `render_plan/vlp_rewrite.rs` | VLP expr rewriting, 115–812 + `extract_vlp_alias_mappings` :1296 | pure `&mut RenderExpr` transforms — **move first** |
 | `render_plan/pattern_comprehension_sql.rs` | ✅ **moved (P2.2, Jul 2026)** — the pattern-comprehension SQL *string* emitters (31 fns, ~2,600 lines): emits SQL text, a different layer from the rest | cohesive, separable |
 | `render_plan/clause_extractors.rs` | ✅ **moved (P2.3, Jul 2026)** — the pure clause extractors that remained (`extract_having/order_by/limit/skip` + `extract_sorted_properties`, was 1467–1560). NOTE: `extract_filters/from/group_by/distinct` from the original group had already migrated to `filter_builder.rs`/`group_by_builder.rs` via incremental work | the only externally-consumed group; mostly pure |
-| `render_plan/plan_predicates.rs` | WITH-detection + alias/table lookups 3850–4247, 4418–4519 | pure read-only walkers — natural home for the §4 `walk()` rewrites |
+| `render_plan/plan_predicates.rs` | ✅ **WITH-detection group moved (P2.4, Jul 2026)** — `has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`. NOTE: the fresh-scan/with-exported alias walkers (`find_fresh_table_scan_aliases_in_plan`/`collect_fresh_scan_aliases`/`with_exported_aliases_in_branch`) are private helpers coupled to P2.5's cte_rewrite fns, so they ride with P2.5, not here | pure read-only walkers — natural home for the §4 `walk()` rewrites |
 | `render_plan/cte_rewrite.rs` | CTE-ref extraction + CTE/alias rewriting 813–1295, 3323–3849, 6102–6970 | pure-ish (RenderPlan/RenderExpr + maps) |
 | `render_plan/with_to_cte/` (dir) | 6999–15491: the two giant builders + their orbit | **entangled core** — moved in Phase 2, decomposed in Phase 4 |
 
@@ -996,7 +996,12 @@ this slice). ·
 `extract_sorted_properties` → `render_plan/clause_extractors.rs`, `pub(crate)`
 re-exports; `extract_filters/from/group_by/distinct` had already migrated to
 `filter_builder`/`group_by_builder`; byte-identical corpus + goldens, ratchet
-net-zero) · ☐ P2.4 plan_predicates move ·
+net-zero) · ☑ P2.4 plan_predicates move (WITH-detection group
+`has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`
+→ `render_plan/plan_predicates.rs`, `pub(crate)` re-exports; the private
+fresh-scan/with-exported alias walkers ride with P2.5 cte_rewrite, and the
+`plan_builder_helpers` `has_with_clause_in_graph_rel` D-cluster copy is untouched;
+byte-identical corpus + goldens, ratchet net-zero) ·
 ☐ P2.5 cte_rewrite move (+D2) · ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
 ☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
 

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod pattern_comprehension_sql;
 pub mod plan_builder_helpers; // Made public for JOIN dependency sorting in SQL generation
 mod plan_builder_utils;
 pub mod plan_optimizer;
+pub(crate) mod plan_predicates;
 mod properties_builder;
 pub mod property_expansion;
 mod select_builder;

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -95,6 +95,13 @@ pub(crate) use super::clause_extractors::{
     extract_having, extract_limit, extract_order_by, extract_skip, extract_sorted_properties,
 };
 
+// P2.4 (REFACTORING_SAFETY_PLAN.md §5.1): the WITH-detection predicate group
+// moved to `plan_predicates.rs`; re-exported here so existing
+// `super::plan_builder_utils::*` call sites resolve during the transition.
+// (`has_with_clause_in_tree` has no production caller here — only the test
+// module below uses it, importing it directly — so it is not re-exported.)
+pub(crate) use super::plan_predicates::{has_with_clause_in_graph_rel, plan_contains_with_clause};
+
 /// Build property mapping from select items for CTE column resolution.
 /// Maps (alias, property) -> column_name for property access resolution.
 ///
@@ -542,6 +549,10 @@ pub fn collect_aliases_from_single_render_expr(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // P2.4: `has_with_clause_in_tree` moved to `plan_predicates` and is not
+    // re-exported (no production caller); the characterization tests below use
+    // it directly.
+    use super::super::plan_predicates::has_with_clause_in_tree;
 
     #[test]
     fn test_placeholder_functions() {
@@ -2003,98 +2014,6 @@ pub fn hoist_nested_ctes(from: &mut RenderPlan, to: &mut Vec<Cte>) {
         );
         to.extend(nested_ctes);
     }
-}
-
-/// Check if there's a `WithClause` anywhere in the logical plan tree.
-///
-/// This is the single canonical WITH-existence predicate (§4.2 unify). It is
-/// built on the exhaustive [`LogicalPlan::any_node`] walk, so it reaches EVERY
-/// child edge — `GraphRel.center`, `Cte.input`, `ViewScan.input`, and the
-/// write-op inputs — and can never drift out of sync with the plan structure.
-/// The walk is iterative (explicit stack), so it cannot overflow on deep plans;
-/// the old manual `depth`-guard recursion is therefore gone.
-///
-/// [`plan_contains_with_clause`] is a synonym that delegates here — they were
-/// two hand-rolled copies that had historically drifted (the §6 bug class);
-/// they are now one implementation with two names kept for call-site clarity.
-pub fn has_with_clause_in_tree(plan: &LogicalPlan) -> bool {
-    plan.any_node(|node| matches!(node, LogicalPlan::WithClause(_)))
-}
-
-/// Check if plan has WITH clause in GraphRel.right (WITH+MATCH pattern)
-pub fn has_with_clause_in_graph_rel(plan: &LogicalPlan) -> bool {
-    log::debug!(
-        "🔍 has_with_clause_in_graph_rel: Called with plan type: {:?}",
-        std::mem::discriminant(plan)
-    );
-    fn check_graph_rel_right(plan: &LogicalPlan) -> bool {
-        log::debug!(
-            "🔍 check_graph_rel_right: Checking plan type: {:?}",
-            std::mem::discriminant(plan)
-        );
-        match plan {
-            LogicalPlan::GraphRel(gr) => {
-                log::debug!(
-                    "🔍 check_graph_rel: Found GraphRel, checking left: {:?}, right: {:?}",
-                    std::mem::discriminant(&*gr.left),
-                    std::mem::discriminant(&*gr.right)
-                );
-                // Check BOTH left and right sides for WITH clauses
-                let has_in_left = has_with_clause_in_tree(&gr.left);
-                let has_in_right = has_with_clause_in_tree(&gr.right);
-                let recursive_left = check_graph_rel_right(&gr.left);
-                let recursive_right = check_graph_rel_right(&gr.right);
-                log::debug!(
-            "🔍 check_graph_rel: has_in_left: {}, has_in_right: {}, recursive_left: {}, recursive_right: {}",
-                    has_in_left, has_in_right, recursive_left, recursive_right
-                );
-                has_in_left || has_in_right || recursive_left || recursive_right
-            }
-            LogicalPlan::GraphJoins(gj) => {
-                log::debug!(
-                    "🔍 check_graph_rel_right: Found GraphJoins, checking input: {:?}",
-                    std::mem::discriminant(&*gj.input)
-                );
-                check_graph_rel_right(&gj.input)
-            }
-            LogicalPlan::Projection(p) => {
-                log::debug!(
-                    "🔍 check_graph_rel_right: Found Projection, checking input: {:?}",
-                    std::mem::discriminant(&*p.input)
-                );
-                check_graph_rel_right(&p.input)
-            }
-            LogicalPlan::Filter(f) => {
-                log::debug!(
-                    "🔍 check_graph_rel_right: Found Filter, checking input: {:?}",
-                    std::mem::discriminant(&*f.input)
-                );
-                check_graph_rel_right(&f.input)
-            }
-            // Handle the unknown Discriminant(7) case - assume it might contain WITH clauses
-            _ => {
-                log::debug!("🔍 check_graph_rel_right: Unknown plan type {:?}, checking with has_with_clause_in_tree", std::mem::discriminant(plan));
-                has_with_clause_in_tree(plan)
-            }
-        }
-    }
-    let result = check_graph_rel_right(plan);
-    log::debug!("🔍 has_with_clause_in_graph_rel: Final result: {}", result);
-    result
-}
-
-/// Check if plan contains a `WithClause` node — synonym for
-/// [`has_with_clause_in_tree`].
-///
-/// These were two independently hand-rolled walkers that drifted apart (the §6
-/// infinite-iteration / lost-WITH bug class: `plan_contains_with_clause` had at
-/// one point missed `GraphRel.center`, `Cte`, and `ViewScan.input`). They are
-/// now the SAME implementation — this one delegates — so the CLAUDE.md rule-5
-/// "these must agree" invariant is structural, not a convention to police. The
-/// name is retained because call sites in the WITH→CTE builder read more
-/// clearly as "does this sub-tree still contain a WITH to process?".
-pub fn plan_contains_with_clause(plan: &LogicalPlan) -> bool {
-    has_with_clause_in_tree(plan)
 }
 
 pub(crate) fn generate_swapped_joins_for_optional_match(

--- a/src/render_plan/plan_predicates.rs
+++ b/src/render_plan/plan_predicates.rs
@@ -1,0 +1,109 @@
+//! Plan predicates — pure, read-only walkers that answer structural questions
+//! about a `LogicalPlan` (currently: WITH-clause existence).
+//!
+//! Extracted verbatim from `plan_builder_utils.rs` in P2.4
+//! (`REFACTORING_SAFETY_PLAN.md` §5.1). No logic edits — the functions are
+//! re-exported `pub(crate)` from `plan_builder_utils` during the transition so
+//! existing `super::plan_builder_utils::*` call sites keep resolving.
+//!
+//! Scope note: §5.1 also grouped the fresh-scan / with-exported alias walkers
+//! here, but those are private helpers tightly coupled to the P2.5 `cte_rewrite`
+//! functions (`update_graph_joins_cte_refs` / `rewrite_logical_expr_cte_refs`),
+//! so they ride with P2.5 rather than churn visibility ahead of their callers
+//! (§8.3 no-drive-by). The second `has_with_clause_in_graph_rel` copy in
+//! `plan_builder_helpers.rs` (`pub(super)`, different semantics) is the flagged
+//! D-cluster duplicate — a separate dedup, left untouched here.
+
+use crate::query_planner::logical_plan::LogicalPlan;
+
+/// Check if there's a `WithClause` anywhere in the logical plan tree.
+///
+/// This is the single canonical WITH-existence predicate (§4.2 unify). It is
+/// built on the exhaustive [`LogicalPlan::any_node`] walk, so it reaches EVERY
+/// child edge — `GraphRel.center`, `Cte.input`, `ViewScan.input`, and the
+/// write-op inputs — and can never drift out of sync with the plan structure.
+/// The walk is iterative (explicit stack), so it cannot overflow on deep plans;
+/// the old manual `depth`-guard recursion is therefore gone.
+///
+/// [`plan_contains_with_clause`] is a synonym that delegates here — they were
+/// two hand-rolled copies that had historically drifted (the §6 bug class);
+/// they are now one implementation with two names kept for call-site clarity.
+pub fn has_with_clause_in_tree(plan: &LogicalPlan) -> bool {
+    plan.any_node(|node| matches!(node, LogicalPlan::WithClause(_)))
+}
+
+/// Check if plan has WITH clause in GraphRel.right (WITH+MATCH pattern)
+pub fn has_with_clause_in_graph_rel(plan: &LogicalPlan) -> bool {
+    log::debug!(
+        "🔍 has_with_clause_in_graph_rel: Called with plan type: {:?}",
+        std::mem::discriminant(plan)
+    );
+    fn check_graph_rel_right(plan: &LogicalPlan) -> bool {
+        log::debug!(
+            "🔍 check_graph_rel_right: Checking plan type: {:?}",
+            std::mem::discriminant(plan)
+        );
+        match plan {
+            LogicalPlan::GraphRel(gr) => {
+                log::debug!(
+                    "🔍 check_graph_rel: Found GraphRel, checking left: {:?}, right: {:?}",
+                    std::mem::discriminant(&*gr.left),
+                    std::mem::discriminant(&*gr.right)
+                );
+                // Check BOTH left and right sides for WITH clauses
+                let has_in_left = has_with_clause_in_tree(&gr.left);
+                let has_in_right = has_with_clause_in_tree(&gr.right);
+                let recursive_left = check_graph_rel_right(&gr.left);
+                let recursive_right = check_graph_rel_right(&gr.right);
+                log::debug!(
+            "🔍 check_graph_rel: has_in_left: {}, has_in_right: {}, recursive_left: {}, recursive_right: {}",
+                    has_in_left, has_in_right, recursive_left, recursive_right
+                );
+                has_in_left || has_in_right || recursive_left || recursive_right
+            }
+            LogicalPlan::GraphJoins(gj) => {
+                log::debug!(
+                    "🔍 check_graph_rel_right: Found GraphJoins, checking input: {:?}",
+                    std::mem::discriminant(&*gj.input)
+                );
+                check_graph_rel_right(&gj.input)
+            }
+            LogicalPlan::Projection(p) => {
+                log::debug!(
+                    "🔍 check_graph_rel_right: Found Projection, checking input: {:?}",
+                    std::mem::discriminant(&*p.input)
+                );
+                check_graph_rel_right(&p.input)
+            }
+            LogicalPlan::Filter(f) => {
+                log::debug!(
+                    "🔍 check_graph_rel_right: Found Filter, checking input: {:?}",
+                    std::mem::discriminant(&*f.input)
+                );
+                check_graph_rel_right(&f.input)
+            }
+            // Handle the unknown Discriminant(7) case - assume it might contain WITH clauses
+            _ => {
+                log::debug!("🔍 check_graph_rel_right: Unknown plan type {:?}, checking with has_with_clause_in_tree", std::mem::discriminant(plan));
+                has_with_clause_in_tree(plan)
+            }
+        }
+    }
+    let result = check_graph_rel_right(plan);
+    log::debug!("🔍 has_with_clause_in_graph_rel: Final result: {}", result);
+    result
+}
+
+/// Check if plan contains a `WithClause` node — synonym for
+/// [`has_with_clause_in_tree`].
+///
+/// These were two independently hand-rolled walkers that drifted apart (the §6
+/// infinite-iteration / lost-WITH bug class: `plan_contains_with_clause` had at
+/// one point missed `GraphRel.center`, `Cte`, and `ViewScan.input`). They are
+/// now the SAME implementation — this one delegates — so the CLAUDE.md rule-5
+/// "these must agree" invariant is structural, not a convention to police. The
+/// name is retained because call sites in the WITH→CTE builder read more
+/// clearly as "does this sub-tree still contain a WITH to process?".
+pub fn plan_contains_with_clause(plan: &LogicalPlan) -> bool {
+    has_with_clause_in_tree(plan)
+}


### PR DESCRIPTION
## What

Phase-2 §5.1 module move (P-3 refactor lane). Extracts the WITH-detection
predicate group verbatim from `plan_builder_utils.rs` to a new
`render_plan/plan_predicates.rs`:

- `has_with_clause_in_tree`, `has_with_clause_in_graph_rel`, `plan_contains_with_clause`

`pub(crate) use` re-exports left for the two production-called names.
`has_with_clause_in_tree` has no production caller (only the P1.2
characterization tests), so the test module imports it directly rather than via
a re-export the lib build would flag unused. **Zero logic edits.**

### Scoped down from §5.1's premise
The band also listed the private fresh-scan / with-exported alias walkers, but
those are coupled to P2.5's cte_rewrite fns
(`update_graph_joins_cte_refs`/`rewrite_logical_expr_cte_refs`), so they ride
with P2.5 rather than churn visibility ahead of their callers (§8.3
no-drive-by). The `plan_builder_helpers` second copy of
`has_with_clause_in_graph_rel` (`pub(super)`, different semantics) is the
flagged D-cluster duplicate — a separate dedup, left untouched.

## Verification
- Moved-fn bodies verified **byte-identical** vs `main`.
- **Byte-identical**: no golden churn, `corpus_sweep` snapshot unchanged, ratchet net-zero.
- Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; fmt/clippy clean; warning-free `--tests` build.
- Worktree-isolated review: VERDICT MERGE (0 findings).

Next refactor slice: P2.5 cte_rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)