### PR TITLE
refactor(P2.5 sub-slice A): move CTE-expression rewriters into render_plan/cte_rewrite.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1–P2.4 merged — P2.5 next)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1–P2.4 merged; P2.5 in progress, sub-sliced)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -169,7 +169,15 @@ byte-identical goldens + corpus, ratchet net-zero. Scoped down from §5.1's
 premise: the private fresh-scan/with-exported alias walkers named there are
 coupled to P2.5's cte_rewrite fns, so they ride with P2.5 (§8.3 no-drive-by); the
 `plan_builder_helpers` `has_with_clause_in_graph_rel` D-cluster copy stays
-untouched. **Next: P2.5 cte_rewrite move.**
+untouched. **P2.5 (cte_rewrite move) in progress — sub-slice A delivered**: the
+CTE-expression-rewriting cluster (`rewrite_operator_application_for_cte`/`_join`
++ `rewrite_render_expr_for_cte_simple`/`_operand`) extracted to
+`render_plan/cte_rewrite.rs`, `pub(crate)` re-exports, byte-identical (one
+`fn`→`pub(crate) fn` visibility widening for the re-export), ratchet net-zero.
+P2.5 is being sub-sliced because its §5.1 home is ~13 fns across 3 scattered
+bands (much larger/entangled than P2.1–P2.4); remaining: `remap_cte_names_*`,
+`rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the deferred P2.4
+alias walkers, D2 dedup. **Next: P2.5 sub-slice B.**
 
 ### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+#662+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
@@ -253,6 +261,24 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.5 sub-slice A — cte_rewrite (expression-rewriting cluster)**
+  (P-3 refactor lane) — the self-contained CTE-expression-rewriting cluster
+  (`rewrite_operator_application_for_cte`, `rewrite_operator_application_for_cte_join`,
+  `rewrite_render_expr_for_cte_simple`, `rewrite_render_expr_for_cte_operand`, old
+  lines 342–453) extracted to a new `render_plan/cte_rewrite.rs`. `pub(crate) use`
+  re-exports for the externally-called `..._for_cte` (join_builder) and the
+  internally-called `..._for_cte_join` (2 sites in plan_builder_utils). The only
+  non-verbatim change is widening `rewrite_operator_application_for_cte_join` from
+  `fn` to `pub(crate) fn` so the re-export can reach it (documented at the site) —
+  same transition-visibility pattern as P2.1/P2.2. **P2.5 is being sub-sliced**
+  because its §5.1 home is ~13 fns across 3 scattered bands (much larger/entangled
+  than P2.1–P2.4, and some listed fns actually belong to P2.6's giant builders);
+  remaining P2.5: `remap_cte_names_*`, `rewrite_logical_expr_cte_refs`,
+  `update_graph_joins_cte_refs`, the P2.4-deferred alias walkers, D2 dedup. Gates:
+  1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7
+  unit, 0 failures; **byte-identical** (moved-fn bodies diff-clean vs main modulo
+  the one visibility line, no golden churn, ratchet net-zero); fmt/clippy clean;
+  warning-free `--tests` build. Next: P2.5 sub-slice B.
 - 2026-07-27: **P2.4 — plan_predicates module move** (P-3 refactor lane) — the
   WITH-detection predicate group (`has_with_clause_in_tree`,
   `has_with_clause_in_graph_rel`, `plan_contains_with_clause`, old lines

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -463,7 +463,7 @@ Split along the audited seams, **pure groups first** (lowest risk):
 | `render_plan/pattern_comprehension_sql.rs` | ✅ **moved (P2.2, Jul 2026)** — the pattern-comprehension SQL *string* emitters (31 fns, ~2,600 lines): emits SQL text, a different layer from the rest | cohesive, separable |
 | `render_plan/clause_extractors.rs` | ✅ **moved (P2.3, Jul 2026)** — the pure clause extractors that remained (`extract_having/order_by/limit/skip` + `extract_sorted_properties`, was 1467–1560). NOTE: `extract_filters/from/group_by/distinct` from the original group had already migrated to `filter_builder.rs`/`group_by_builder.rs` via incremental work | the only externally-consumed group; mostly pure |
 | `render_plan/plan_predicates.rs` | ✅ **WITH-detection group moved (P2.4, Jul 2026)** — `has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`. NOTE: the fresh-scan/with-exported alias walkers (`find_fresh_table_scan_aliases_in_plan`/`collect_fresh_scan_aliases`/`with_exported_aliases_in_branch`) are private helpers coupled to P2.5's cte_rewrite fns, so they ride with P2.5, not here | pure read-only walkers — natural home for the §4 `walk()` rewrites |
-| `render_plan/cte_rewrite.rs` | CTE-ref extraction + CTE/alias rewriting 813–1295, 3323–3849, 6102–6970 | pure-ish (RenderPlan/RenderExpr + maps) |
+| `render_plan/cte_rewrite.rs` | ◐ **in progress (P2.5, sub-sliced)** — CTE-ref extraction + CTE/alias rewriting. Sub-slice A moved the expression-rewriting cluster (`rewrite_operator_application_for_cte`/`_join`, `rewrite_render_expr_for_cte_simple`/`_operand`). Remaining: `remap_cte_names_*`, `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, deferred P2.4 alias walkers, D2 dedup | pure-ish (RenderPlan/RenderExpr + maps) |
 | `render_plan/with_to_cte/` (dir) | 6999–15491: the two giant builders + their orbit | **entangled core** — moved in Phase 2, decomposed in Phase 4 |
 
 Rules for the move slices: `pub(crate)` re-exports from the old path during
@@ -1002,7 +1002,13 @@ net-zero) · ☑ P2.4 plan_predicates move (WITH-detection group
 fresh-scan/with-exported alias walkers ride with P2.5 cte_rewrite, and the
 `plan_builder_helpers` `has_with_clause_in_graph_rel` D-cluster copy is untouched;
 byte-identical corpus + goldens, ratchet net-zero) ·
-☐ P2.5 cte_rewrite move (+D2) · ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
+◐ P2.5 cte_rewrite move (+D2) — sub-slice A done: the CTE-expression-rewriting
+cluster (`rewrite_operator_application_for_cte`/`_for_cte_join` +
+`rewrite_render_expr_for_cte_simple`/`_operand`) → `render_plan/cte_rewrite.rs`,
+`pub(crate)` re-exports, byte-identical (one `fn`→`pub(crate) fn` widening),
+ratchet net-zero. Remaining P2.5: `remap_cte_names_*`,
+`rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the deferred
+P2.4 alias walkers, D2 dedup · ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
 ☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
 
 Phase 3: ◐ Slices 1–2 merged 2026-07-13: GraphNode/ViewScan + query_planner

--- a/src/render_plan/cte_rewrite.rs
+++ b/src/render_plan/cte_rewrite.rs
@@ -1,0 +1,138 @@
+//! CTE-reference rewriting — transforms `RenderExpr`/`OperatorApplication`
+//! property accesses to CTE column naming when the referenced alias is a CTE.
+//!
+//! Extracted verbatim from `plan_builder_utils.rs` in P2.5 (first sub-slice,
+//! `REFACTORING_SAFETY_PLAN.md` §5.1). No logic edits — the one externally-called
+//! function (`rewrite_operator_application_for_cte`) is re-exported `pub(crate)`
+//! from `plan_builder_utils` during the transition so `join_builder`'s
+//! `super::plan_builder_utils::rewrite_operator_application_for_cte` call site
+//! keeps resolving.
+//!
+//! Scope note: P2.5's §5.1 home covers the whole CTE-ref extraction + rewriting
+//! group (`remap_cte_names_*`, `rewrite_logical_expr_cte_refs`,
+//! `update_graph_joins_cte_refs`, the alias walkers deferred from P2.4, and the
+//! D2 dedup). Those are landing incrementally; this first sub-slice is the
+//! self-contained 4-function expression-rewriting cluster.
+
+use crate::graph_catalog::expression_parser::PropertyValue;
+use crate::render_plan::render_expr::{
+    OperatorApplication, PropertyAccess, RenderExpr, TableAlias,
+};
+use crate::utils::cte_column_naming::cte_column_name;
+use std::collections::HashMap;
+
+/// Rewrite a RenderExpr to use CTE column names where applicable.
+/// Converts property access expressions to use CTE column naming convention.
+/// E.g., a.user_id becomes a_b.a_user_id (where a_b is the CTE alias)
+// P2.5: widened `fn` → `pub(crate) fn` (the sole change vs the original) so the
+// two remaining call sites in plan_builder_utils resolve via the transition
+// re-export; body is verbatim.
+pub(crate) fn rewrite_operator_application_for_cte_join(
+    op_app: &OperatorApplication,
+    cte_alias: &str,
+    cte_references: &HashMap<String, String>,
+) -> OperatorApplication {
+    // Rewrite operands to use CTE column names
+    let rewritten_operands: Vec<RenderExpr> = op_app
+        .operands
+        .iter()
+        .map(|operand| rewrite_render_expr_for_cte_operand(operand, cte_alias, cte_references))
+        .collect();
+
+    OperatorApplication {
+        operator: op_app.operator,
+        operands: rewritten_operands,
+    }
+}
+
+/// Public version for use by join_builder
+/// Rewrites operator application to use CTE column names.
+/// The table alias is kept (e.g., "o" stays "o") but column becomes "o_user_id".
+pub fn rewrite_operator_application_for_cte(
+    op_app: &OperatorApplication,
+    cte_references: &HashMap<String, String>,
+) -> OperatorApplication {
+    // Rewrite operands to use CTE column names
+    let rewritten_operands: Vec<RenderExpr> = op_app
+        .operands
+        .iter()
+        .map(|operand| rewrite_render_expr_for_cte_simple(operand, cte_references))
+        .collect();
+
+    OperatorApplication {
+        operator: op_app.operator,
+        operands: rewritten_operands,
+    }
+}
+
+/// Simple CTE expression rewriting - just prefixes column names, keeps table alias the same.
+/// E.g., o.user_id -> o.o_user_id (when "o" is in cte_references)
+fn rewrite_render_expr_for_cte_simple(
+    expr: &RenderExpr,
+    cte_references: &HashMap<String, String>,
+) -> RenderExpr {
+    match expr {
+        RenderExpr::PropertyAccessExp(pa) => {
+            // Check if this alias is from a CTE
+            if cte_references.contains_key(&pa.table_alias.0) {
+                // Rewrite column to use CTE naming: alias_column
+                // Keep the same table alias (e.g., "o" stays "o")
+                let cte_column = cte_column_name(&pa.table_alias.0, pa.column.raw());
+                RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: pa.table_alias.clone(), // Keep same table alias
+                    column: PropertyValue::Column(cte_column),
+                })
+            } else {
+                // Not a CTE reference, keep as-is
+                expr.clone()
+            }
+        }
+        RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
+            rewrite_operator_application_for_cte(inner_op, cte_references),
+        ),
+        _ => expr.clone(),
+    }
+}
+
+/// Rewrite a RenderExpr operand to use CTE column names where applicable.
+/// Helper function that avoids needing cte_schemas parameter.
+fn rewrite_render_expr_for_cte_operand(
+    expr: &RenderExpr,
+    cte_alias: &str,
+    cte_references: &HashMap<String, String>,
+) -> RenderExpr {
+    match expr {
+        RenderExpr::PropertyAccessExp(pa) => {
+            // Check if this alias is from a CTE
+            if cte_references.contains_key(&pa.table_alias.0) {
+                // Rewrite to use CTE alias and column naming.
+                // Skip re-encoding if the column is already a CTE-encoded name (p{N}_...)
+                // to avoid double-encoding like p20_a_allNeighboursCount_p1_a_user_id
+                let raw_col = pa.column.raw();
+                let cte_column = if crate::utils::cte_column_naming::is_cte_column(raw_col) {
+                    raw_col.to_string()
+                } else {
+                    cte_column_name(&pa.table_alias.0, raw_col)
+                };
+                log::info!(
+                    "🔧 Rewriting property access: {}.{} -> {}.{}",
+                    pa.table_alias.0,
+                    pa.column.raw(),
+                    cte_alias,
+                    cte_column
+                );
+                RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: TableAlias(cte_alias.to_string()),
+                    column: PropertyValue::Column(cte_column),
+                })
+            } else {
+                // Not a CTE reference, keep as-is
+                expr.clone()
+            }
+        }
+        RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
+            rewrite_operator_application_for_cte_join(inner_op, cte_alias, cte_references),
+        ),
+        _ => expr.clone(),
+    }
+}

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod clause_extractors;
 pub mod cte_extraction;
 pub mod cte_generation;
 pub mod cte_manager;
+pub(crate) mod cte_rewrite;
 pub(crate) mod expression_utils;
 mod feature_flags;
 mod filter_builder;

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -102,6 +102,14 @@ pub(crate) use super::clause_extractors::{
 // module below uses it, importing it directly — so it is not re-exported.)
 pub(crate) use super::plan_predicates::{has_with_clause_in_graph_rel, plan_contains_with_clause};
 
+// P2.5 (REFACTORING_SAFETY_PLAN.md §5.1, first sub-slice): the CTE-expression
+// rewriting cluster moved to `cte_rewrite.rs`; re-exported here so
+// `join_builder`'s external call and the two internal `_join` call sites resolve
+// during the transition.
+pub(crate) use super::cte_rewrite::{
+    rewrite_operator_application_for_cte, rewrite_operator_application_for_cte_join,
+};
+
 /// Build property mapping from select items for CTE column resolution.
 /// Maps (alias, property) -> column_name for property access resolution.
 ///
@@ -337,119 +345,6 @@ fn find_id_column_in_cte(cte_name: &str, cte_alias: &str, ctes: &super::CteItems
     }
     // Ultimate fallback
     format!("{}_user_id", cte_alias)
-}
-
-/// Rewrite a RenderExpr to use CTE column names where applicable.
-/// Converts property access expressions to use CTE column naming convention.
-/// E.g., a.user_id becomes a_b.a_user_id (where a_b is the CTE alias)
-fn rewrite_operator_application_for_cte_join(
-    op_app: &OperatorApplication,
-    cte_alias: &str,
-    cte_references: &HashMap<String, String>,
-) -> OperatorApplication {
-    // Rewrite operands to use CTE column names
-    let rewritten_operands: Vec<RenderExpr> = op_app
-        .operands
-        .iter()
-        .map(|operand| rewrite_render_expr_for_cte_operand(operand, cte_alias, cte_references))
-        .collect();
-
-    OperatorApplication {
-        operator: op_app.operator,
-        operands: rewritten_operands,
-    }
-}
-
-/// Public version for use by join_builder
-/// Rewrites operator application to use CTE column names.
-/// The table alias is kept (e.g., "o" stays "o") but column becomes "o_user_id".
-pub fn rewrite_operator_application_for_cte(
-    op_app: &OperatorApplication,
-    cte_references: &HashMap<String, String>,
-) -> OperatorApplication {
-    // Rewrite operands to use CTE column names
-    let rewritten_operands: Vec<RenderExpr> = op_app
-        .operands
-        .iter()
-        .map(|operand| rewrite_render_expr_for_cte_simple(operand, cte_references))
-        .collect();
-
-    OperatorApplication {
-        operator: op_app.operator,
-        operands: rewritten_operands,
-    }
-}
-
-/// Simple CTE expression rewriting - just prefixes column names, keeps table alias the same.
-/// E.g., o.user_id -> o.o_user_id (when "o" is in cte_references)
-fn rewrite_render_expr_for_cte_simple(
-    expr: &RenderExpr,
-    cte_references: &HashMap<String, String>,
-) -> RenderExpr {
-    match expr {
-        RenderExpr::PropertyAccessExp(pa) => {
-            // Check if this alias is from a CTE
-            if cte_references.contains_key(&pa.table_alias.0) {
-                // Rewrite column to use CTE naming: alias_column
-                // Keep the same table alias (e.g., "o" stays "o")
-                let cte_column = cte_column_name(&pa.table_alias.0, pa.column.raw());
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: pa.table_alias.clone(), // Keep same table alias
-                    column: PropertyValue::Column(cte_column),
-                })
-            } else {
-                // Not a CTE reference, keep as-is
-                expr.clone()
-            }
-        }
-        RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
-            rewrite_operator_application_for_cte(inner_op, cte_references),
-        ),
-        _ => expr.clone(),
-    }
-}
-
-/// Rewrite a RenderExpr operand to use CTE column names where applicable.
-/// Helper function that avoids needing cte_schemas parameter.
-fn rewrite_render_expr_for_cte_operand(
-    expr: &RenderExpr,
-    cte_alias: &str,
-    cte_references: &HashMap<String, String>,
-) -> RenderExpr {
-    match expr {
-        RenderExpr::PropertyAccessExp(pa) => {
-            // Check if this alias is from a CTE
-            if cte_references.contains_key(&pa.table_alias.0) {
-                // Rewrite to use CTE alias and column naming.
-                // Skip re-encoding if the column is already a CTE-encoded name (p{N}_...)
-                // to avoid double-encoding like p20_a_allNeighboursCount_p1_a_user_id
-                let raw_col = pa.column.raw();
-                let cte_column = if crate::utils::cte_column_naming::is_cte_column(raw_col) {
-                    raw_col.to_string()
-                } else {
-                    cte_column_name(&pa.table_alias.0, raw_col)
-                };
-                log::info!(
-                    "🔧 Rewriting property access: {}.{} -> {}.{}",
-                    pa.table_alias.0,
-                    pa.column.raw(),
-                    cte_alias,
-                    cte_column
-                );
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(cte_alias.to_string()),
-                    column: PropertyValue::Column(cte_column),
-                })
-            } else {
-                // Not a CTE reference, keep as-is
-                expr.clone()
-            }
-        }
-        RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
-            rewrite_operator_application_for_cte_join(inner_op, cte_alias, cte_references),
-        ),
-        _ => expr.clone(),
-    }
 }
 
 /// Extract a JOIN condition from a filter expression.


### PR DESCRIPTION
## What

Phase-2 §5.1 module move — **first sub-slice** of the (large) `cte_rewrite`
group. Extracts the self-contained CTE-expression-rewriting cluster verbatim
from `plan_builder_utils.rs` to a new `render_plan/cte_rewrite.rs`:

- `rewrite_operator_application_for_cte` (external caller: join_builder)
- `rewrite_operator_application_for_cte_join`
- `rewrite_render_expr_for_cte_simple`, `rewrite_render_expr_for_cte_operand`

`pub(crate) use` re-exports left behind. The **only** non-verbatim change:
`rewrite_operator_application_for_cte_join` widened `fn` → `pub(crate) fn` so the
re-export reaches it for its 2 internal callers (documented at the site) — same
transition-visibility pattern as P2.1/P2.2.

### Why sub-sliced
P2.5's §5.1 home is ~13 fns across 3 scattered bands (much larger/entangled than
P2.1–P2.4, and some listed fns actually belong to P2.6's giant builders), so it's
being landed incrementally. Remaining P2.5: `remap_cte_names_*`,
`rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the P2.4-deferred
alias walkers, D2 dedup.

## Verification
- Moved-fn bodies **byte-identical** vs `main` (modulo the one visibility line).
- **Byte-identical**: no golden churn, `corpus_sweep` unchanged, ratchet net-zero.
- Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; fmt/clippy clean; warning-free `--tests` build.
- Worktree-isolated review: VERDICT MERGE (0 findings).

Next: P2.5 sub-slice B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)