### PR TITLE
refactor(P2.5 sub-slice B): move CTE-name remap pair into render_plan/cte_rewrite.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -175,9 +175,12 @@ CTE-expression-rewriting cluster (`rewrite_operator_application_for_cte`/`_join`
 `render_plan/cte_rewrite.rs`, `pub(crate)` re-exports, byte-identical (one
 `fn`→`pub(crate) fn` visibility widening for the re-export), ratchet net-zero.
 P2.5 is being sub-sliced because its §5.1 home is ~13 fns across 3 scattered
-bands (much larger/entangled than P2.1–P2.4); remaining: `remap_cte_names_*`,
+bands (much larger/entangled than P2.1–P2.4); **sub-slice B delivered**: the
+CTE-name remap pair (`remap_cte_names_in_expr`/`_in_render_plan`) extracted to the
+same `cte_rewrite.rs`, byte-identical, ratchet net-zero. Remaining P2.5:
+`collect_with_cte_table_aliases`, `rewrite_join_conditions_for_cte_aliases`,
 `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the deferred P2.4
-alias walkers, D2 dedup. **Next: P2.5 sub-slice B.**
+alias walkers, D2 dedup. **Next: P2.5 sub-slice C.**
 
 ### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+#662+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
@@ -261,6 +264,20 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.5 sub-slice B — cte_rewrite (CTE-name remap pair)** (P-3
+  refactor lane) — the tightly-coupled CTE-name remap pair
+  (`remap_cte_names_in_expr` + `remap_cte_names_in_render_plan`, old lines
+  1385–1469 and 1513–1567) extracted verbatim into the existing
+  `render_plan/cte_rewrite.rs`. Two non-contiguous deletions (they were separated
+  by the unrelated `rewrite_count_to_conditional` / `quote_qualified_col` helpers,
+  which stay put). `pub(crate) use` re-export for `remap_cte_names_in_render_plan`
+  (2 internal callers); `remap_cte_names_in_expr` has no caller left in
+  plan_builder_utils (it was only invoked by the two moved fns) so it is not
+  re-exported — it lives on as a `pub fn` used internally by `_in_render_plan`.
+  Zero logic edits. Gates: 1612 lib + 529 integration (incl. `corpus_sweep` +
+  sql_golden) + 1 ratchet + 7 unit, 0 failures; **byte-identical** (both fn bodies
+  diff-clean vs main, no golden churn, ratchet net-zero); fmt/clippy clean;
+  warning-free `--tests` build. Next: P2.5 sub-slice C.
 - 2026-07-27: **P2.5 sub-slice A — cte_rewrite (expression-rewriting cluster)**
   (P-3 refactor lane) — the self-contained CTE-expression-rewriting cluster
   (`rewrite_operator_application_for_cte`, `rewrite_operator_application_for_cte_join`,

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -463,7 +463,7 @@ Split along the audited seams, **pure groups first** (lowest risk):
 | `render_plan/pattern_comprehension_sql.rs` | ✅ **moved (P2.2, Jul 2026)** — the pattern-comprehension SQL *string* emitters (31 fns, ~2,600 lines): emits SQL text, a different layer from the rest | cohesive, separable |
 | `render_plan/clause_extractors.rs` | ✅ **moved (P2.3, Jul 2026)** — the pure clause extractors that remained (`extract_having/order_by/limit/skip` + `extract_sorted_properties`, was 1467–1560). NOTE: `extract_filters/from/group_by/distinct` from the original group had already migrated to `filter_builder.rs`/`group_by_builder.rs` via incremental work | the only externally-consumed group; mostly pure |
 | `render_plan/plan_predicates.rs` | ✅ **WITH-detection group moved (P2.4, Jul 2026)** — `has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`. NOTE: the fresh-scan/with-exported alias walkers (`find_fresh_table_scan_aliases_in_plan`/`collect_fresh_scan_aliases`/`with_exported_aliases_in_branch`) are private helpers coupled to P2.5's cte_rewrite fns, so they ride with P2.5, not here | pure read-only walkers — natural home for the §4 `walk()` rewrites |
-| `render_plan/cte_rewrite.rs` | ◐ **in progress (P2.5, sub-sliced)** — CTE-ref extraction + CTE/alias rewriting. Sub-slice A moved the expression-rewriting cluster (`rewrite_operator_application_for_cte`/`_join`, `rewrite_render_expr_for_cte_simple`/`_operand`). Remaining: `remap_cte_names_*`, `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, deferred P2.4 alias walkers, D2 dedup | pure-ish (RenderPlan/RenderExpr + maps) |
+| `render_plan/cte_rewrite.rs` | ◐ **in progress (P2.5, sub-sliced)** — CTE-ref extraction + CTE/alias rewriting. Sub-slice A: expression-rewriting cluster (`rewrite_operator_application_for_cte`/`_join`, `rewrite_render_expr_for_cte_simple`/`_operand`). Sub-slice B: CTE-name remap pair (`remap_cte_names_in_expr`/`_in_render_plan`). Remaining: `collect_with_cte_table_aliases`, `rewrite_join_conditions_for_cte_aliases`, `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, deferred P2.4 alias walkers, D2 dedup | pure-ish (RenderPlan/RenderExpr + maps) |
 | `render_plan/with_to_cte/` (dir) | 6999–15491: the two giant builders + their orbit | **entangled core** — moved in Phase 2, decomposed in Phase 4 |
 
 Rules for the move slices: `pub(crate)` re-exports from the old path during
@@ -1006,9 +1006,12 @@ byte-identical corpus + goldens, ratchet net-zero) ·
 cluster (`rewrite_operator_application_for_cte`/`_for_cte_join` +
 `rewrite_render_expr_for_cte_simple`/`_operand`) → `render_plan/cte_rewrite.rs`,
 `pub(crate)` re-exports, byte-identical (one `fn`→`pub(crate) fn` widening),
-ratchet net-zero. Remaining P2.5: `remap_cte_names_*`,
-`rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the deferred
-P2.4 alias walkers, D2 dedup · ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
+ratchet net-zero. Sub-slice B done: the CTE-name remap pair
+(`remap_cte_names_in_expr`/`_in_render_plan`) → same module, byte-identical,
+ratchet net-zero. Remaining P2.5: `collect_with_cte_table_aliases`,
+`rewrite_join_conditions_for_cte_aliases`, `rewrite_logical_expr_cte_refs`,
+`update_graph_joins_cte_refs`, the deferred P2.4 alias walkers, D2 dedup ·
+☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
 ☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
 
 Phase 3: ◐ Slices 1–2 merged 2026-07-13: GraphNode/ViewScan + query_planner

--- a/src/render_plan/cte_rewrite.rs
+++ b/src/render_plan/cte_rewrite.rs
@@ -9,10 +9,12 @@
 //! keeps resolving.
 //!
 //! Scope note: P2.5's §5.1 home covers the whole CTE-ref extraction + rewriting
-//! group (`remap_cte_names_*`, `rewrite_logical_expr_cte_refs`,
-//! `update_graph_joins_cte_refs`, the alias walkers deferred from P2.4, and the
-//! D2 dedup). Those are landing incrementally; this first sub-slice is the
-//! self-contained 4-function expression-rewriting cluster.
+//! group. Landing incrementally — done so far: the expression-rewriting cluster
+//! (`rewrite_operator_application_for_cte`/`_join`, `rewrite_render_expr_for_cte_*`)
+//! and the CTE-name remap pair (`remap_cte_names_in_expr`/`_in_render_plan`).
+//! Remaining: `collect_with_cte_table_aliases`, `rewrite_join_conditions_for_cte_aliases`,
+//! `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the alias
+//! walkers deferred from P2.4, and the D2 dedup.
 
 use crate::graph_catalog::expression_parser::PropertyValue;
 use crate::render_plan::render_expr::{
@@ -134,5 +136,147 @@ fn rewrite_render_expr_for_cte_operand(
             rewrite_operator_application_for_cte_join(inner_op, cte_alias, cte_references),
         ),
         _ => expr.clone(),
+    }
+}
+
+/// Apply CTE name remapping to RenderExpr recursively
+///
+/// # Arguments
+/// * `expr` - The expression to rewrite
+/// * `cte_name_mapping` - Maps analyzer CTE names to actual CTE names
+pub fn remap_cte_names_in_expr(
+    expr: crate::render_plan::render_expr::RenderExpr,
+    cte_name_mapping: &std::collections::HashMap<String, String>,
+) -> crate::render_plan::render_expr::RenderExpr {
+    use crate::render_plan::render_expr::*;
+
+    match expr {
+        RenderExpr::PropertyAccessExp(pa) => {
+            let table_alias = &pa.table_alias.0;
+
+            // Check if this table_alias is a CTE name that needs remapping
+            if let Some(actual_cte_name) = cte_name_mapping.get(table_alias) {
+                log::debug!("🔧 remap_cte_names: {} → {}", table_alias, actual_cte_name);
+                RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: TableAlias(actual_cte_name.clone()),
+                    column: pa.column,
+                })
+            } else {
+                RenderExpr::PropertyAccessExp(pa)
+            }
+        }
+        RenderExpr::AggregateFnCall(agg) => {
+            let new_args = agg
+                .args
+                .into_iter()
+                .map(|arg| remap_cte_names_in_expr(arg, cte_name_mapping))
+                .collect();
+            RenderExpr::AggregateFnCall(AggregateFnCall {
+                name: agg.name,
+                args: new_args,
+            })
+        }
+        RenderExpr::ScalarFnCall(func) => {
+            let new_args = func
+                .args
+                .into_iter()
+                .map(|arg| remap_cte_names_in_expr(arg, cte_name_mapping))
+                .collect();
+            RenderExpr::ScalarFnCall(ScalarFnCall {
+                name: func.name,
+                args: new_args,
+            })
+        }
+        RenderExpr::OperatorApplicationExp(op) => {
+            let new_operands = op
+                .operands
+                .into_iter()
+                .map(|operand| remap_cte_names_in_expr(operand, cte_name_mapping))
+                .collect();
+            RenderExpr::OperatorApplicationExp(OperatorApplication {
+                operator: op.operator,
+                operands: new_operands,
+            })
+        }
+        RenderExpr::Case(case) => {
+            let new_when_then = case
+                .when_then
+                .into_iter()
+                .map(|(when, then)| {
+                    (
+                        remap_cte_names_in_expr(when, cte_name_mapping),
+                        remap_cte_names_in_expr(then, cte_name_mapping),
+                    )
+                })
+                .collect();
+            let new_expr = case
+                .expr
+                .map(|e| Box::new(remap_cte_names_in_expr(*e, cte_name_mapping)));
+            let new_else = case
+                .else_expr
+                .map(|e| Box::new(remap_cte_names_in_expr(*e, cte_name_mapping)));
+            RenderExpr::Case(RenderCase {
+                expr: new_expr,
+                when_then: new_when_then,
+                else_expr: new_else,
+            })
+        }
+        other => other,
+    }
+}
+
+/// Apply CTE name remapping to all expressions in a RenderPlan
+pub fn remap_cte_names_in_render_plan(
+    plan: &mut crate::render_plan::RenderPlan,
+    cte_name_mapping: &std::collections::HashMap<String, String>,
+) {
+    use crate::render_plan::render_expr::RenderExpr;
+
+    if cte_name_mapping.is_empty() {
+        return;
+    }
+
+    log::info!(
+        "🔧 remap_cte_names_in_render_plan: Applying {} CTE name mappings",
+        cte_name_mapping.len()
+    );
+    for (from, to) in cte_name_mapping {
+        log::debug!("🔧   {} → {}", from, to);
+    }
+
+    // Rewrite SELECT items
+    for item in &mut plan.select.items {
+        item.expression = remap_cte_names_in_expr(item.expression.clone(), cte_name_mapping);
+    }
+
+    // Rewrite JOIN conditions
+    for join in &mut plan.joins.0 {
+        for op in &mut join.joining_on {
+            // Recursively rewrite the OperatorApplication
+            if let RenderExpr::OperatorApplicationExp(new_op) = remap_cte_names_in_expr(
+                RenderExpr::OperatorApplicationExp(op.clone()),
+                cte_name_mapping,
+            ) {
+                *op = new_op;
+            }
+        }
+    }
+
+    // Rewrite WHERE clause
+    if let Some(filter) = &plan.filters.0 {
+        plan.filters.0 = Some(remap_cte_names_in_expr(filter.clone(), cte_name_mapping));
+    }
+
+    // Rewrite GROUP BY
+    plan.group_by.0 = plan
+        .group_by
+        .0
+        .iter()
+        .map(|expr| remap_cte_names_in_expr(expr.clone(), cte_name_mapping))
+        .collect();
+
+    // Rewrite ORDER BY
+    for item in &mut plan.order_by.0 {
+        item.expression = remap_cte_names_in_expr(item.expression.clone(), cte_name_mapping);
     }
 }

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -102,12 +102,15 @@ pub(crate) use super::clause_extractors::{
 // module below uses it, importing it directly — so it is not re-exported.)
 pub(crate) use super::plan_predicates::{has_with_clause_in_graph_rel, plan_contains_with_clause};
 
-// P2.5 (REFACTORING_SAFETY_PLAN.md §5.1, first sub-slice): the CTE-expression
-// rewriting cluster moved to `cte_rewrite.rs`; re-exported here so
-// `join_builder`'s external call and the two internal `_join` call sites resolve
-// during the transition.
+// P2.5 (REFACTORING_SAFETY_PLAN.md §5.1): CTE-rewrite functions moved to
+// `cte_rewrite.rs`; re-exported here so remaining in-module / external call sites
+// resolve during the transition. Sub-slice A: the expression-rewriting cluster
+// (`join_builder`'s external call + the two internal `_join` sites). Sub-slice B:
+// `remap_cte_names_in_render_plan` (2 internal sites; `remap_cte_names_in_expr`
+// has no caller left here so it is not re-exported).
 pub(crate) use super::cte_rewrite::{
-    rewrite_operator_application_for_cte, rewrite_operator_application_for_cte_join,
+    remap_cte_names_in_render_plan, rewrite_operator_application_for_cte,
+    rewrite_operator_application_for_cte_join,
 };
 
 /// Build property mapping from select items for CTE column resolution.
@@ -1382,92 +1385,6 @@ graph_schema:
 // CTE Expression Rewriting Functions
 // ============================================================================
 
-/// Apply CTE name remapping to RenderExpr recursively
-///
-/// # Arguments
-/// * `expr` - The expression to rewrite
-/// * `cte_name_mapping` - Maps analyzer CTE names to actual CTE names
-pub fn remap_cte_names_in_expr(
-    expr: crate::render_plan::render_expr::RenderExpr,
-    cte_name_mapping: &std::collections::HashMap<String, String>,
-) -> crate::render_plan::render_expr::RenderExpr {
-    use crate::render_plan::render_expr::*;
-
-    match expr {
-        RenderExpr::PropertyAccessExp(pa) => {
-            let table_alias = &pa.table_alias.0;
-
-            // Check if this table_alias is a CTE name that needs remapping
-            if let Some(actual_cte_name) = cte_name_mapping.get(table_alias) {
-                log::debug!("🔧 remap_cte_names: {} → {}", table_alias, actual_cte_name);
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(actual_cte_name.clone()),
-                    column: pa.column,
-                })
-            } else {
-                RenderExpr::PropertyAccessExp(pa)
-            }
-        }
-        RenderExpr::AggregateFnCall(agg) => {
-            let new_args = agg
-                .args
-                .into_iter()
-                .map(|arg| remap_cte_names_in_expr(arg, cte_name_mapping))
-                .collect();
-            RenderExpr::AggregateFnCall(AggregateFnCall {
-                name: agg.name,
-                args: new_args,
-            })
-        }
-        RenderExpr::ScalarFnCall(func) => {
-            let new_args = func
-                .args
-                .into_iter()
-                .map(|arg| remap_cte_names_in_expr(arg, cte_name_mapping))
-                .collect();
-            RenderExpr::ScalarFnCall(ScalarFnCall {
-                name: func.name,
-                args: new_args,
-            })
-        }
-        RenderExpr::OperatorApplicationExp(op) => {
-            let new_operands = op
-                .operands
-                .into_iter()
-                .map(|operand| remap_cte_names_in_expr(operand, cte_name_mapping))
-                .collect();
-            RenderExpr::OperatorApplicationExp(OperatorApplication {
-                operator: op.operator,
-                operands: new_operands,
-            })
-        }
-        RenderExpr::Case(case) => {
-            let new_when_then = case
-                .when_then
-                .into_iter()
-                .map(|(when, then)| {
-                    (
-                        remap_cte_names_in_expr(when, cte_name_mapping),
-                        remap_cte_names_in_expr(then, cte_name_mapping),
-                    )
-                })
-                .collect();
-            let new_expr = case
-                .expr
-                .map(|e| Box::new(remap_cte_names_in_expr(*e, cte_name_mapping)));
-            let new_else = case
-                .else_expr
-                .map(|e| Box::new(remap_cte_names_in_expr(*e, cte_name_mapping)));
-            RenderExpr::Case(RenderCase {
-                expr: new_expr,
-                when_then: new_when_then,
-                else_expr: new_else,
-            })
-        }
-        other => other,
-    }
-}
-
 /// Rewrite a `count(x)` aggregate so a WHERE predicate that was hoisted into
 /// the aggregate becomes a conditional count — dialect-aware.
 ///
@@ -1508,62 +1425,6 @@ fn rewrite_count_to_conditional(agg: &mut AggregateFnCall, cond: RenderExpr) {
 /// variables that lack the `p{N}_{alias}_{prop}` column shape.
 pub(crate) fn quote_qualified_col(alias: &str, col: &str) -> String {
     format!("{}.{}", alias, current_function_mapper().quote_alias(col))
-}
-
-/// Apply CTE name remapping to all expressions in a RenderPlan
-pub fn remap_cte_names_in_render_plan(
-    plan: &mut crate::render_plan::RenderPlan,
-    cte_name_mapping: &std::collections::HashMap<String, String>,
-) {
-    use crate::render_plan::render_expr::RenderExpr;
-
-    if cte_name_mapping.is_empty() {
-        return;
-    }
-
-    log::info!(
-        "🔧 remap_cte_names_in_render_plan: Applying {} CTE name mappings",
-        cte_name_mapping.len()
-    );
-    for (from, to) in cte_name_mapping {
-        log::debug!("🔧   {} → {}", from, to);
-    }
-
-    // Rewrite SELECT items
-    for item in &mut plan.select.items {
-        item.expression = remap_cte_names_in_expr(item.expression.clone(), cte_name_mapping);
-    }
-
-    // Rewrite JOIN conditions
-    for join in &mut plan.joins.0 {
-        for op in &mut join.joining_on {
-            // Recursively rewrite the OperatorApplication
-            if let RenderExpr::OperatorApplicationExp(new_op) = remap_cte_names_in_expr(
-                RenderExpr::OperatorApplicationExp(op.clone()),
-                cte_name_mapping,
-            ) {
-                *op = new_op;
-            }
-        }
-    }
-
-    // Rewrite WHERE clause
-    if let Some(filter) = &plan.filters.0 {
-        plan.filters.0 = Some(remap_cte_names_in_expr(filter.clone(), cte_name_mapping));
-    }
-
-    // Rewrite GROUP BY
-    plan.group_by.0 = plan
-        .group_by
-        .0
-        .iter()
-        .map(|expr| remap_cte_names_in_expr(expr.clone(), cte_name_mapping))
-        .collect();
-
-    // Rewrite ORDER BY
-    for item in &mut plan.order_by.0 {
-        item.expression = remap_cte_names_in_expr(item.expression.clone(), cte_name_mapping);
-    }
 }
 
 /// Collect all `with_*_cte_*` table aliases referenced in a RenderPlan's expressions.


### PR DESCRIPTION
## What

Phase-2 §5.1 module move — **second sub-slice** of the `cte_rewrite` group.
Extracts the tightly-coupled CTE-name remap pair verbatim from
`plan_builder_utils.rs` into the existing `render_plan/cte_rewrite.rs`:

- `remap_cte_names_in_expr` (old 1385–1469)
- `remap_cte_names_in_render_plan` (old 1513–1567)

**Non-contiguous move**: the two fns were separated in source by the unrelated
`rewrite_count_to_conditional` / `quote_qualified_col` helpers, which stay put.

`pub(crate) use` re-export for `remap_cte_names_in_render_plan` (2 internal
callers). `remap_cte_names_in_expr` has no caller left in plan_builder_utils (it
was only invoked by the two moved fns), so it is intentionally not re-exported —
it lives on as a `pub fn` used internally by `_in_render_plan`. **Zero logic edits.**

## Verification
- Both moved-fn bodies **byte-identical** vs `main`.
- **Byte-identical**: no golden churn, `corpus_sweep` unchanged, ratchet net-zero.
- Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; fmt/clippy clean; warning-free `--tests` build (no dead-code/unused-re-export warnings).
- Worktree-isolated review: VERDICT MERGE (0 findings).

Next: P2.5 sub-slice C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)