### PR TITLE
refactor(P2.5 D2): dedup the CTE property-rewriter family via CteAliasPolicy

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1–P2.4 merged; P2.5 nearly done — only D2 dedup left)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ◐ (P2.1–P2.5 done; P2.6 with_to_cte next)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -186,8 +186,15 @@ CTE-ref rewriters (`rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs
 and the 3 alias walkers deferred from P2.4) extracted to a new
 `render_plan/cte_graph_joins_rewrite.rs` (the LogicalPlan companion to
 `cte_rewrite.rs`), fully byte-identical (no visibility changes needed), ratchet
-net-zero. Remaining P2.5: **D2 dedup only**. **Next: P2.5 D2 dedup, or P2.6
-with_to_cte.**
+net-zero. Remaining P2.5: **D2 dedup only**. **D2 dedup delivered**: the
+four-function CTE property-rewriter family collapsed to one operator core +
+`rewrite_render_expr_for_cte` + a `CteAliasPolicy` (`Keep`/`Rewrite`) enum,
+byte-identical (corpus + goldens unchanged) as a behavior-preserving dedup — the
+double-encoding guard still fires only under `Rewrite`; the plan's universal-guard
+idea is left as an open transition-assert follow-up (would change `Keep`
+semantics). **P2.5 COMPLETE. Next: P2.6 with_to_cte** — the "entangled core" (the
+two giant WITH→CTE builders + orbit); larger and higher-risk than P2.1–P2.5, moved
+in Phase 2 and decomposed in Phase 4.
 
 ### P-4 — Phase 4 §7.2: forward resolution through CTE scope  ◐ (F0+F1+F1b/#602+#662+F2a+F3+F4 done; F2b/F5 and F1b residue open)
 **Concrete staged plan written: `docs/design/FORWARD_RESOLUTION_PLAN.md`.** It
@@ -271,6 +278,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.5 D2 dedup — CTE property-rewriter family** (P-3 refactor lane)
+  — the four near-identical CTE property-rewriters (two operator wrappers
+  `rewrite_operator_application_for_cte`/`_join` + two `RenderExpr` helpers
+  `_simple`/`_operand`, all colocated in `cte_rewrite.rs` after sub-slices A–C)
+  collapsed into: the two public wrappers (unchanged signatures) → one shared
+  `rewrite_operator_application` core → one `rewrite_render_expr_for_cte` core,
+  parameterized by a `Copy` `CteAliasPolicy` enum (`Keep` = keep the property's
+  alias + unconditional encode; `Rewrite(cte_alias)` = rewrite alias + the
+  double-encode `is_cte_column` guard + the info log). **Byte-identical**: this is
+  a behavior-preserving dedup — each policy reproduces exactly one former
+  function's behavior, so corpus + goldens are unchanged (the equivalence proof,
+  since source structure changed and byte-diff-vs-main does not apply to a dedup).
+  The plan's §5.2 idea of applying the double-encode guard *universally* (under
+  `Keep` too) is the still-open transition-assert question — deliberately NOT
+  folded in, since it would change `Keep` semantics (ground rule: no semantic
+  change in a consolidation). Left as a separate follow-up. Net: −2 functions,
+  −~35 lines. **This completes P2.5.** Gates: 1612 lib + 529 integration (incl.
+  `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; no golden churn;
+  ratchet net-zero; fmt/clippy clean; warning-free `--tests` build. Next: P2.6
+  with_to_cte.
 - 2026-07-27: **P2.5 sub-slice D — cte_graph_joins_rewrite (LogicalPlan-level CTE
   rewriters)** (P-3 refactor lane) — the contiguous LogicalPlan-level CTE-ref
   rewrite block (`rewrite_logical_expr_cte_refs`, the 3 alias walkers deferred

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -463,7 +463,7 @@ Split along the audited seams, **pure groups first** (lowest risk):
 | `render_plan/pattern_comprehension_sql.rs` | ✅ **moved (P2.2, Jul 2026)** — the pattern-comprehension SQL *string* emitters (31 fns, ~2,600 lines): emits SQL text, a different layer from the rest | cohesive, separable |
 | `render_plan/clause_extractors.rs` | ✅ **moved (P2.3, Jul 2026)** — the pure clause extractors that remained (`extract_having/order_by/limit/skip` + `extract_sorted_properties`, was 1467–1560). NOTE: `extract_filters/from/group_by/distinct` from the original group had already migrated to `filter_builder.rs`/`group_by_builder.rs` via incremental work | the only externally-consumed group; mostly pure |
 | `render_plan/plan_predicates.rs` | ✅ **WITH-detection group moved (P2.4, Jul 2026)** — `has_with_clause_in_tree`/`has_with_clause_in_graph_rel`/`plan_contains_with_clause`. NOTE: the fresh-scan/with-exported alias walkers (`find_fresh_table_scan_aliases_in_plan`/`collect_fresh_scan_aliases`/`with_exported_aliases_in_branch`) are private helpers coupled to P2.5's cte_rewrite fns, so they ride with P2.5, not here | pure read-only walkers — natural home for the §4 `walk()` rewrites |
-| `render_plan/cte_rewrite.rs` (+ `cte_graph_joins_rewrite.rs`) | ◐ **in progress (P2.5, sub-sliced)** — CTE-ref extraction + rewriting. RenderExpr/RenderPlan level in `cte_rewrite.rs` (sub-slices A–C: expression-rewriting cluster, CTE-name remap pair, join-condition rewrite group). LogicalPlan level in `cte_graph_joins_rewrite.rs` (sub-slice D: `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the 3 fresh-scan/with-exported alias walkers). Remaining: D2 dedup only | pure-ish (RenderPlan/RenderExpr + maps) |
+| `render_plan/cte_rewrite.rs` (+ `cte_graph_joins_rewrite.rs`) | ☑ **done (P2.5)** — CTE-ref extraction + rewriting. RenderExpr/RenderPlan level in `cte_rewrite.rs` (sub-slices A–C + the D2 dedup: expression-rewriting core via `CteAliasPolicy`, CTE-name remap pair, join-condition rewrite group). LogicalPlan level in `cte_graph_joins_rewrite.rs` (sub-slice D). All byte-identical | pure-ish (RenderPlan/RenderExpr + maps) |
 | `render_plan/with_to_cte/` (dir) | 6999–15491: the two giant builders + their orbit | **entangled core** — moved in Phase 2, decomposed in Phase 4 |
 
 Rules for the move slices: `pub(crate)` re-exports from the old path during
@@ -474,11 +474,16 @@ transition; no logic edits in a move PR; corpus sweep byte-identical.
 One PR per cluster from §1.4's table. Canonical survivors:
 - **D1**: keep one `with_clause_key()` in `utils/` next to `cte_naming`;
   delete the other two.
-- **D2**: one `rewrite_render_expr_for_cte(expr, ctx)` where `ctx` carries the
-  alias-writing policy (keep-alias / cte-alias / cte-name) and the
-  double-encoding guard from `_operand` (:1141-1147) — the guard is the only
-  semantic difference; verify it's safe to apply universally (transition-assert
-  per §2.5).
+- **D2**: ✅ **done (Jul 2026, in `render_plan/cte_rewrite.rs`)** — collapsed to
+  one `rewrite_render_expr_for_cte(expr, cte_references, policy)` + a shared
+  operator core, where `policy` is a `CteAliasPolicy` enum (`Keep` = keep alias,
+  unconditional encode; `Rewrite(cte_alias)` = rewrite alias + double-encode
+  guard + log). Done as a **behavior-preserving** dedup (byte-identical corpus +
+  goldens): the guard still fires only under `Rewrite`, exactly as the original
+  `_operand` did. The plan's original idea of applying the guard *universally*
+  (under `Keep` too) is the still-open transition-assert question — deliberately
+  NOT folded in, since it would change semantics under `Keep`. Left as a separate
+  follow-up.
 - **D3**: keep `_with_endpoint_info`, express the other three as thin
   wrappers, delete `_legacy` after a corpus-verified switch.
 - **D6**: the inline STEP 2/3/4 copy inside the giant fn calls
@@ -1002,7 +1007,7 @@ net-zero) · ☑ P2.4 plan_predicates move (WITH-detection group
 fresh-scan/with-exported alias walkers ride with P2.5 cte_rewrite, and the
 `plan_builder_helpers` `has_with_clause_in_graph_rel` D-cluster copy is untouched;
 byte-identical corpus + goldens, ratchet net-zero) ·
-◐ P2.5 cte_rewrite move (+D2) — sub-slice A done: the CTE-expression-rewriting
+☑ P2.5 cte_rewrite move (+D2) — sub-slice A done: the CTE-expression-rewriting
 cluster (`rewrite_operator_application_for_cte`/`_for_cte_join` +
 `rewrite_render_expr_for_cte_simple`/`_operand`) → `render_plan/cte_rewrite.rs`,
 `pub(crate)` re-exports, byte-identical (one `fn`→`pub(crate) fn` widening),
@@ -1017,7 +1022,12 @@ LogicalPlan-level CTE-ref rewriters (`rewrite_logical_expr_cte_refs`,
 `find_fresh_table_scan_aliases_in_plan`/`collect_fresh_scan_aliases`/`with_exported_aliases_in_branch`)
 → new `render_plan/cte_graph_joins_rewrite.rs` (LogicalPlan companion to
 `cte_rewrite.rs`), fully byte-identical (no visibility changes needed), ratchet
-net-zero. Remaining P2.5: D2 dedup only ·
+net-zero. D2 dedup done: the four-function CTE property-rewriter family collapsed
+to one operator core + `rewrite_render_expr_for_cte` + a `CteAliasPolicy`
+(`Keep`/`Rewrite`) enum. **Byte-identical** (corpus + goldens unchanged) — done as
+a behavior-preserving dedup: the double-encoding guard still fires only under
+`Rewrite`, exactly as before; whether it is safe universally under `Keep` is left
+as the plan's open transition-assert follow-up (not folded in). **P2.5 COMPLETE.** ·
 ☐ P2.6 with_to_cte move · ☐ P2.7 D1 ·
 ☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
 

--- a/src/render_plan/cte_rewrite.rs
+++ b/src/render_plan/cte_rewrite.rs
@@ -10,12 +10,13 @@
 //!
 //! Scope note: P2.5's §5.1 home covers the whole CTE-ref extraction + rewriting
 //! group. Landing incrementally — done so far: the expression-rewriting cluster
-//! (`rewrite_operator_application_for_cte`/`_join`, `rewrite_render_expr_for_cte_*`),
-//! the CTE-name remap pair (`remap_cte_names_in_expr`/`_in_render_plan`), and the
-//! join-condition rewrite group (`collect_with_cte_table_aliases`,
-//! `strip_table_alias_from_resolved`, `rewrite_join_conditions_for_cte_aliases`).
-//! Remaining: `rewrite_logical_expr_cte_refs`, `update_graph_joins_cte_refs`, the
-//! alias walkers deferred from P2.4, and the D2 dedup.
+//! (`rewrite_operator_application_for_cte`/`_join`), the CTE-name remap pair
+//! (`remap_cte_names_in_expr`/`_in_render_plan`), and the join-condition rewrite
+//! group (`collect_with_cte_table_aliases`, `strip_table_alias_from_resolved`,
+//! `rewrite_join_conditions_for_cte_aliases`). The D2 dedup (§5.2) collapsed the
+//! four-function property-rewriter family into one operator core +
+//! `rewrite_render_expr_for_cte` + the `CteAliasPolicy` enum. The LogicalPlan-level
+//! rewriters live in the sibling `cte_graph_joins_rewrite.rs` (P2.5 sub-slice D).
 
 use crate::graph_catalog::expression_parser::PropertyValue;
 use crate::render_plan::render_expr::{
@@ -35,17 +36,7 @@ pub(crate) fn rewrite_operator_application_for_cte_join(
     cte_alias: &str,
     cte_references: &HashMap<String, String>,
 ) -> OperatorApplication {
-    // Rewrite operands to use CTE column names
-    let rewritten_operands: Vec<RenderExpr> = op_app
-        .operands
-        .iter()
-        .map(|operand| rewrite_render_expr_for_cte_operand(operand, cte_alias, cte_references))
-        .collect();
-
-    OperatorApplication {
-        operator: op_app.operator,
-        operands: rewritten_operands,
-    }
+    rewrite_operator_application(op_app, cte_references, CteAliasPolicy::Rewrite(cte_alias))
 }
 
 /// Public version for use by join_builder
@@ -55,11 +46,44 @@ pub fn rewrite_operator_application_for_cte(
     op_app: &OperatorApplication,
     cte_references: &HashMap<String, String>,
 ) -> OperatorApplication {
-    // Rewrite operands to use CTE column names
+    rewrite_operator_application(op_app, cte_references, CteAliasPolicy::Keep)
+}
+
+/// D2 (`REFACTORING_SAFETY_PLAN.md` §5.2): the CTE property-rewriter family was
+/// four near-identical functions (two operator wrappers + two `RenderExpr`
+/// helpers) differing only in **alias policy**. This enum carries that policy so
+/// the family collapses to one operator core + one expression core.
+///
+/// The two policies are *behaviorally distinct* and both live callers depend on
+/// their exact behavior, so this dedup is **byte-identical** — it does NOT unify
+/// the double-encoding guard (that guard fires only under `Rewrite`, exactly as
+/// before). Whether the guard is safe to apply universally under `Keep` is the
+/// plan's open transition-assert question, deliberately left as a separate
+/// follow-up rather than folded in here (ground rule: never change semantics in
+/// a consolidation slice).
+#[derive(Clone, Copy)]
+enum CteAliasPolicy<'a> {
+    /// Keep the property's existing table alias; encode the column as
+    /// `cte_column_name(alias, col)` unconditionally. (`..._for_cte` /
+    /// `..._simple` behavior.)
+    Keep,
+    /// Rewrite the property's table alias to `cte_alias`; skip re-encoding a
+    /// column that is already CTE-encoded (the double-encode guard) and log the
+    /// rewrite. (`..._for_cte_join` / `..._operand` behavior.)
+    Rewrite(&'a str),
+}
+
+/// Operator-application core shared by both public entry points: rewrite each
+/// operand under `policy`, preserving the operator.
+fn rewrite_operator_application(
+    op_app: &OperatorApplication,
+    cte_references: &HashMap<String, String>,
+    policy: CteAliasPolicy,
+) -> OperatorApplication {
     let rewritten_operands: Vec<RenderExpr> = op_app
         .operands
         .iter()
-        .map(|operand| rewrite_render_expr_for_cte_simple(operand, cte_references))
+        .map(|operand| rewrite_render_expr_for_cte(operand, cte_references, policy))
         .collect();
 
     OperatorApplication {
@@ -68,73 +92,59 @@ pub fn rewrite_operator_application_for_cte(
     }
 }
 
-/// Simple CTE expression rewriting - just prefixes column names, keeps table alias the same.
-/// E.g., o.user_id -> o.o_user_id (when "o" is in cte_references)
-fn rewrite_render_expr_for_cte_simple(
+/// Expression core shared by both policies. A `PropertyAccessExp` whose alias is
+/// a CTE reference is rewritten per `policy`; an `OperatorApplicationExp` recurses
+/// (carrying the same policy); everything else is cloned as-is.
+fn rewrite_render_expr_for_cte(
     expr: &RenderExpr,
     cte_references: &HashMap<String, String>,
+    policy: CteAliasPolicy,
 ) -> RenderExpr {
     match expr {
         RenderExpr::PropertyAccessExp(pa) => {
             // Check if this alias is from a CTE
             if cte_references.contains_key(&pa.table_alias.0) {
-                // Rewrite column to use CTE naming: alias_column
-                // Keep the same table alias (e.g., "o" stays "o")
-                let cte_column = cte_column_name(&pa.table_alias.0, pa.column.raw());
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: pa.table_alias.clone(), // Keep same table alias
-                    column: PropertyValue::Column(cte_column),
-                })
+                match policy {
+                    CteAliasPolicy::Keep => {
+                        // Rewrite column to use CTE naming: alias_column
+                        // Keep the same table alias (e.g., "o" stays "o")
+                        let cte_column = cte_column_name(&pa.table_alias.0, pa.column.raw());
+                        RenderExpr::PropertyAccessExp(PropertyAccess {
+                            table_alias: pa.table_alias.clone(), // Keep same table alias
+                            column: PropertyValue::Column(cte_column),
+                        })
+                    }
+                    CteAliasPolicy::Rewrite(cte_alias) => {
+                        // Rewrite to use CTE alias and column naming.
+                        // Skip re-encoding if the column is already a CTE-encoded name (p{N}_...)
+                        // to avoid double-encoding like p20_a_allNeighboursCount_p1_a_user_id
+                        let raw_col = pa.column.raw();
+                        let cte_column = if crate::utils::cte_column_naming::is_cte_column(raw_col)
+                        {
+                            raw_col.to_string()
+                        } else {
+                            cte_column_name(&pa.table_alias.0, raw_col)
+                        };
+                        log::info!(
+                            "🔧 Rewriting property access: {}.{} -> {}.{}",
+                            pa.table_alias.0,
+                            pa.column.raw(),
+                            cte_alias,
+                            cte_column
+                        );
+                        RenderExpr::PropertyAccessExp(PropertyAccess {
+                            table_alias: TableAlias(cte_alias.to_string()),
+                            column: PropertyValue::Column(cte_column),
+                        })
+                    }
+                }
             } else {
                 // Not a CTE reference, keep as-is
                 expr.clone()
             }
         }
         RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
-            rewrite_operator_application_for_cte(inner_op, cte_references),
-        ),
-        _ => expr.clone(),
-    }
-}
-
-/// Rewrite a RenderExpr operand to use CTE column names where applicable.
-/// Helper function that avoids needing cte_schemas parameter.
-fn rewrite_render_expr_for_cte_operand(
-    expr: &RenderExpr,
-    cte_alias: &str,
-    cte_references: &HashMap<String, String>,
-) -> RenderExpr {
-    match expr {
-        RenderExpr::PropertyAccessExp(pa) => {
-            // Check if this alias is from a CTE
-            if cte_references.contains_key(&pa.table_alias.0) {
-                // Rewrite to use CTE alias and column naming.
-                // Skip re-encoding if the column is already a CTE-encoded name (p{N}_...)
-                // to avoid double-encoding like p20_a_allNeighboursCount_p1_a_user_id
-                let raw_col = pa.column.raw();
-                let cte_column = if crate::utils::cte_column_naming::is_cte_column(raw_col) {
-                    raw_col.to_string()
-                } else {
-                    cte_column_name(&pa.table_alias.0, raw_col)
-                };
-                log::info!(
-                    "🔧 Rewriting property access: {}.{} -> {}.{}",
-                    pa.table_alias.0,
-                    pa.column.raw(),
-                    cte_alias,
-                    cte_column
-                );
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(cte_alias.to_string()),
-                    column: PropertyValue::Column(cte_column),
-                })
-            } else {
-                // Not a CTE reference, keep as-is
-                expr.clone()
-            }
-        }
-        RenderExpr::OperatorApplicationExp(inner_op) => RenderExpr::OperatorApplicationExp(
-            rewrite_operator_application_for_cte_join(inner_op, cte_alias, cte_references),
+            rewrite_operator_application(inner_op, cte_references, policy),
         ),
         _ => expr.clone(),
     }


### PR DESCRIPTION
## What

Phase-2 §5.2 **D2 dedup** — completes P2.5. The four near-identical CTE
property-rewriters in `cte_rewrite.rs` collapse into a shared core parameterized
by a `Copy` `CteAliasPolicy` enum:

- `rewrite_operator_application_for_cte(op_app, cte_references)` → core with `Keep`
- `rewrite_operator_application_for_cte_join(op_app, cte_alias, cte_references)` → core with `Rewrite(cte_alias)`
- the two private `RenderExpr` helpers (`_simple`/`_operand`) → one `rewrite_render_expr_for_cte(expr, cte_references, policy)`

`Keep` = keep the property's alias + unconditional `cte_column_name`.
`Rewrite(alias)` = rewrite alias + the double-encode `is_cte_column` guard + the info log.

**Behavior-preserving**: each policy reproduces exactly one former function.
Public signatures unchanged. The plan's §5.2 idea of applying the double-encode
guard *universally* (under `Keep` too) would change `Keep` semantics, so it is
**deliberately NOT folded in** — left as the open transition-assert follow-up
(ground rule: no semantic change in a consolidation).

## Verification
- Equivalence proof = **corpus + goldens byte-identical** (source structure
  changed, so diff-vs-main doesn't apply to a dedup).
- Gates: 1612 lib + 529 integration (incl. `corpus_sweep` + sql_golden) + 1 ratchet + 7 unit, 0 failures; no golden churn; ratchet net-zero; fmt/clippy clean; warning-free `--tests` build.
- Worktree-isolated review: VERDICT MERGE — reviewer independently traced both recursion paths and confirmed **crossover is structurally impossible**; equivalence holds even on untested shapes.

Net: −2 functions. **This completes P2.5.** Next: P2.6 with_to_cte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)