### PR TITLE
refactor(P2.10 slice 1): replace with_to_cte glob imports with named imports

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; P2.8 D6 next)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene in progress)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -296,6 +296,28 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-27: **P2.10 import hygiene — slice 1 (`with_to_cte` globs → named)**
+  (P-3 refactor lane) — replaced the two `*` glob imports in
+  `render_plan/with_to_cte/mod.rs` (`plan_builder_helpers::*`,
+  `utils::alias_utils::*`) with the exact 6-name set the moved bodies actually use
+  (`combine_optional_filters_with_and`, `extract_predicates_for_alias_logical`,
+  `has_with_clause_in_graph_rel`, `rewrite_logical_path_functions`;
+  `collect_aliases_from_plan`, `find_cte_reference_alias`), per
+  REFACTORING_SAFETY_PLAN §5.3 ("named imports so shadowing becomes visible").
+  **Method note**: grep under-counted the glob surface (4 vs the real 6) because
+  `plan_builder_helpers` exports many `pub(super) fn` that a `pub fn` grep misses —
+  disabled the globs and let the compiler enumerate the unresolved names (the
+  E0282 "type annotations needed" cascade was fallout from the unresolved calls and
+  vanished once resolved). Pure hygiene, behavior-identical: `corpus_sweep` +
+  `sql_golden` byte-identical, 1612 lib + 529 integration + ratchet net-zero,
+  fmt/clippy clean, warning-free `--tests`. Scoped to `with_to_cte` only (no
+  drive-by); `plan_builder_utils.rs`'s twin globs are the next slice. **Also
+  verified D6/D8 are already resolved by attrition** (documented in §9): D6's inline
+  `expand_table_alias_to_select_items` twin and D8's three named nested twins were
+  already collapsed by prior P2.x moves + dead-code sweeps; remaining same-named
+  fns are legitimately distinct (different modules/signatures/semantics, e.g. the
+  #596 `Union`-boundary divergence). Nothing left to dedup there.
 
 - 2026-07-27: **P2.7 D1 — `with_clause_key` dedup** (P-3 refactor lane) — the three
   near-duplicate WITH-key helpers that P2.6 co-located in

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -510,7 +510,16 @@ One PR per cluster from §1.4's table. Canonical survivors:
   they already thread `plan_ctx` explicitly; entanglement is intra-function
   `RefCell`s, not globals, so this is mechanical).
 - Replace glob imports (`plan_builder_helpers::*`, `alias_utils::*`) with
-  named imports so shadowing becomes visible.
+  named imports so shadowing becomes visible. **◐ in progress (P2.10 slice 1,
+  Jul 2026)**: `with_to_cte/mod.rs`'s two `*` globs replaced with the exact
+  6-name set the compiler requires (`combine_optional_filters_with_and`,
+  `extract_predicates_for_alias_logical`, `has_with_clause_in_graph_rel`,
+  `rewrite_logical_path_functions` from `plan_builder_helpers`;
+  `collect_aliases_from_plan`, `find_cte_reference_alias` from `alias_utils`).
+  The compiler was the enumerator — grep under-counted because
+  `plan_builder_helpers` exports many `pub(super) fn`. Byte-identical corpus +
+  goldens, ratchet net-zero. `plan_builder_utils.rs`'s twin globs are the next
+  slice.
 - Delete the three files' `#![allow(dead_code)]`; delete what the compiler
   then flags (investigate before deleting, per the late-stage-project rule —
   but the blanket allow has hidden dead surface for months).
@@ -1049,7 +1058,25 @@ item-extraction fallback, and it was the one the authoritative
 (`corpus_sweep` + `sql_golden`, 529 tests) is byte-identical, proving the two simple
 copies never actually reached their divergent branch in practice. Ratchet net-zero
 (no axis tokens moved). ·
-☐ P2.8 D6 · ☐ P2.9 D8 · ☐ P2.10 import hygiene + remaining dead_code
+☑ P2.8 D6 (already resolved by attrition — verified Jul 2026): the inline
+`expand_table_alias_to_select_items` twin (`alias_prefix_underscore`/`_dot`
+signature) that §1.4 flagged at old-file :8337–8388 no longer exists; the fn now
+has a single definition and a single call site. Prior P2.x moves + dead-code
+sweeps already collapsed it. The `STEP 2/3/4` markers that remain in the giant are
+an unrelated VLP-CTE-metadata registration block, not the D6 target. The #411
+entanglement note stands but there is no duplication left to consolidate first. ·
+☑ P2.9 D8 (already resolved by attrition — verified Jul 2026): the three named
+nested-redeclaration twins (`extract_alias_from_expr` ×2, `is_cte_reference` ×2,
+`contains_aggregate`/`expr_contains_aggregate` ×2 all *within* the old file) are
+gone. Remaining same-named fns live in *different* modules with *different*
+signatures/semantics and are legitimately distinct — `is_cte_reference` is `bool`
+in `from_builder` vs `Option<String>` in `plan_builder_utils`;
+`collect_live_table_aliases`' vs `collect_exists_scope_aliases`' nested `collect`
+helpers deliberately diverge on `Union` per #596; `with_clause_key`'s
+`extract_alias_from_expr` handles more operators than `logical_plan`'s. Merging any
+pair would change behavior — not a mechanical hoist. ·
+◐ P2.10 import hygiene — slice 1 done (`with_to_cte/mod.rs` globs → named, §5.3);
+`plan_builder_utils.rs` twin globs + remaining dead_code next.
 
 Phase 3: ◐ Slices 1–2 merged 2026-07-13: GraphNode/ViewScan + query_planner
 `is_denormalized` reads routed through canonical wrappers (162f9338/7d0f81bd) ·

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -60,14 +60,16 @@ use std::collections::{HashMap, HashSet};
 // `plan_contains_with_clause` is a `plan_predicates` (P2.4) predicate that
 // `replace_with_clause_with_cte_reference_v2` gates its GraphRel recursion on.
 use super::plan_predicates::plan_contains_with_clause;
-// Reproduce the two glob imports the moved bodies relied on in `plan_builder_utils`
-// (`build_chained_with_match_cte_plan` and the WITH-discovery cluster call e.g.
-// `collect_aliases_from_plan`, `find_cte_reference_alias`,
-// `remap_coupled_rel_vars_in_filter` by bare name).
-#[allow(unused_imports)]
-use super::plan_builder_helpers::*;
-#[allow(unused_imports)]
-use super::utils::alias_utils::*;
+// P2.10 import hygiene: the moved bodies (`build_chained_with_match_cte_plan` +
+// the WITH-discovery cluster) reach a handful of `plan_builder_helpers` /
+// `alias_utils` helpers by bare name — previously via two `*` globs the old file
+// relied on. Named imports (the exact set the compiler requires) so shadowing is
+// visible; other helpers are still reached by explicit `super::…::` paths.
+use super::plan_builder_helpers::{
+    combine_optional_filters_with_and, extract_predicates_for_alias_logical,
+    has_with_clause_in_graph_rel, rewrite_logical_path_functions,
+};
+use super::utils::alias_utils::{collect_aliases_from_plan, find_cte_reference_alias};
 // P2.6 slice 4: `build_chained_with_match_cte_plan` calls these P2.2/P2.5-moved
 // rewriters (in sibling modules) by bare name — the old file reached them via
 // its own re-exports/globs. Mirror of `pattern_comprehension_sql.rs`'s back-import.


### PR DESCRIPTION
## P2.10 import hygiene — slice 1

Per `REFACTORING_SAFETY_PLAN.md` §5.3: *"Replace glob imports (`plan_builder_helpers::*`, `alias_utils::*`) with named imports so shadowing becomes visible."*

### Change
Replaces the two `*` glob imports in `render_plan/with_to_cte/mod.rs` with the exact set of names the moved WITH→CTE bodies actually reference by bare name:

| From | Names |
|---|---|
| `plan_builder_helpers` | `combine_optional_filters_with_and`, `extract_predicates_for_alias_logical`, `has_with_clause_in_graph_rel`, `rewrite_logical_path_functions` |
| `utils::alias_utils` | `collect_aliases_from_plan`, `find_cte_reference_alias` |

Other helpers from those modules are already reached via explicit `super::…::` paths and are unaffected.

### Method (why the compiler, not grep)
A `pub fn` grep under-counts the glob surface — `plan_builder_helpers` exports many `pub(super) fn`, so I initially saw only 4 of the 6 needed names. The reliable enumerator is the compiler: I disabled both globs, built `--tests`, and read the `E0425 cannot find function` list. (The 10 accompanying `E0282 "type annotations needed"` errors were cascade fallout from the unresolved calls — they cleared the moment the names resolved, confirming the 6-name set is complete and exact.)

### Why safe
Pure import hygiene, no logic touched:
- `corpus_sweep` + `sql_golden` (529 integration) **byte-identical**
- 1612 lib + ratchet **net-zero**, 0 failures
- `fmt --check` clean, `clippy --all-targets` clean, warning-free `--tests` build
- Single source file changed (+docs)

### Scope
Scoped to `with_to_cte/mod.rs` only (no drive-by, per §8.3). `plan_builder_utils.rs` carries the same twin globs — that's the next slice.

### Bonus (docs only)
Verified and documented in §9 that **D6 and D8 are already resolved by attrition**: D6's inline `expand_table_alias_to_select_items` twin and D8's three named nested-redeclaration twins were already collapsed by prior P2.x moves + dead-code sweeps. The remaining same-named functions live in different modules with different signatures/semantics (e.g. `collect_live_table_aliases` vs `collect_exists_scope_aliases` deliberately diverge on `Union` per #596) — merging any pair would change behavior, so there's nothing left to dedup there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)