### PR TITLE
refactor(P2.10 slice 2): replace plan_builder_utils glob imports with named imports

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -297,6 +297,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.10 import hygiene — slice 2 (`plan_builder_utils` globs → named)**
+  (P-3 refactor lane) — replaced the two `*` globs in
+  `render_plan/plan_builder_utils.rs` with the 6 names the file uses:
+  `denorm_scan_cte_anchor_id_property`, `denorm_scan_cte_anchor_properties`,
+  `extract_parameterized_table_ref`, `extract_table_name`,
+  `get_graph_rel_from_plan` (from `plan_builder_helpers`) + `find_label_for_alias`
+  (from `alias_utils`), plus `get_anchor_alias_from_plan`/`strip_database_prefix`
+  gated `#[cfg(test)]`. **This slice caught the exact shadowing hazard §5.3 warns
+  about**: those last two names *looked* glob-provided but are used only by the
+  file's test module — the glob masked that they weren't part of the production
+  surface. Same compiler-as-enumerator method as slice 1 (grep under-counts the
+  `pub(super) fn` surface). Behavior-identical: `corpus_sweep` + `sql_golden`
+  byte-identical, 1612 lib + 529 integration + ratchet net-zero, fmt/clippy clean,
+  warning-free lib AND `--tests` builds. Remaining target globs live in
+  `filter_builder.rs` + `plan_builder.rs` (3 total) — next slice.
+
 - 2026-07-27: **P2.10 import hygiene — slice 1 (`with_to_cte` globs → named)**
   (P-3 refactor lane) — replaced the two `*` glob imports in
   `render_plan/with_to_cte/mod.rs` (`plan_builder_helpers::*`,

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -518,8 +518,15 @@ One PR per cluster from §1.4's table. Canonical survivors:
   `collect_aliases_from_plan`, `find_cte_reference_alias` from `alias_utils`).
   The compiler was the enumerator — grep under-counted because
   `plan_builder_helpers` exports many `pub(super) fn`. Byte-identical corpus +
-  goldens, ratchet net-zero. `plan_builder_utils.rs`'s twin globs are the next
-  slice.
+  goldens, ratchet net-zero. **Slice 2 done**: `plan_builder_utils.rs`'s twin
+  globs replaced with 6 named imports — 5 from `plan_builder_helpers`
+  (`denorm_scan_cte_anchor_id_property`, `denorm_scan_cte_anchor_properties`,
+  `extract_parameterized_table_ref`, `extract_table_name`,
+  `get_graph_rel_from_plan`) + `find_label_for_alias` from `alias_utils`
+  ungated, plus `get_anchor_alias_from_plan`/`strip_database_prefix` gated
+  `#[cfg(test)]` (they are test-only — a shadowing hazard the glob masked, exactly
+  what §5.3 targets). `filter_builder.rs` + `plan_builder.rs`'s three remaining
+  globs are the next slice.
 - Delete the three files' `#![allow(dead_code)]`; delete what the compiler
   then flags (investigate before deleting, per the late-stage-project rule —
   but the blanket allow has hidden dead surface for months).

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -69,16 +69,19 @@ use crate::render_plan::{
 use crate::utils::cte_column_naming::{cte_column_name, parse_cte_column};
 use crate::utils::cte_naming::is_generated_cte_name;
 
-// Import ALL helper functions from the dedicated helpers module using glob import
-// This allows existing code to call helpers without changes (e.g., extract_table_name())
-// The compiler will use the module functions when available
-#[allow(unused_imports)]
-use super::plan_builder_helpers::*;
-
-// Import ALL alias utility functions from the dedicated module using glob import
-// This consolidates duplicate functions and provides a single source of truth
-#[allow(unused_imports)]
-use super::utils::alias_utils::*;
+// P2.10 import hygiene: this file reaches a handful of `plan_builder_helpers` /
+// `alias_utils` helpers by bare name — previously via two `*` globs. Named
+// imports (the exact set the compiler requires) so shadowing becomes visible;
+// other helpers are reached by explicit `super::…::` paths.
+use super::plan_builder_helpers::{
+    denorm_scan_cte_anchor_id_property, denorm_scan_cte_anchor_properties,
+    extract_parameterized_table_ref, extract_table_name, get_graph_rel_from_plan,
+};
+use super::utils::alias_utils::find_label_for_alias;
+// `get_anchor_alias_from_plan` / `strip_database_prefix` are used only by the
+// `#[cfg(test)]` module below — gate them so the non-test lib build stays clean.
+#[cfg(test)]
+use super::utils::alias_utils::{get_anchor_alias_from_plan, strip_database_prefix};
 
 type RenderPlanBuilderResult<T> = Result<T, RenderBuildError>;
 


### PR DESCRIPTION
## P2.10 import hygiene — slice 2

Per `REFACTORING_SAFETY_PLAN.md` §5.3. Continues slice 1 (#731, `with_to_cte`); this slice does `render_plan/plan_builder_utils.rs` — the biggest, most regression-prone file.

### Change
Replaces the two `*` globs with named imports of the exact set the file references by bare name:

| From | Names | Gating |
|---|---|---|
| `plan_builder_helpers` | `denorm_scan_cte_anchor_id_property`, `denorm_scan_cte_anchor_properties`, `extract_parameterized_table_ref`, `extract_table_name`, `get_graph_rel_from_plan` | production |
| `alias_utils` | `find_label_for_alias` | production |
| `alias_utils` | `get_anchor_alias_from_plan`, `strip_database_prefix` | `#[cfg(test)]` |

### This slice caught real shadowing
The whole point of §5.3 ("named imports so shadowing becomes visible") paid off here: `get_anchor_alias_from_plan` and `strip_database_prefix` *looked* glob-provided, but they're used **only by the file's `#[cfg(test)]` module**. The glob masked that they weren't part of the production surface. A plain named import makes the lib build warn "unused"; gating them `#[cfg(test)]` (matching the existing container-type block already in this file) keeps **both** the lib and `--tests` builds warning-free.

### Method
Same as slice 1: disable the globs, build `--tests`, read the `E0425 cannot find function` list (grep under-counts because `plan_builder_helpers` exports many `pub(super) fn`). 8 names surfaced; 6 production + 2 test-only after checking each call site.

### Why safe
- `corpus_sweep` + `sql_golden` (529 integration) **byte-identical**
- 1612 lib + ratchet **net-zero**, 0 failures
- `fmt --check` clean, `clippy --all-targets` clean, warning-free **lib and `--tests`** builds

### Scope / remaining
Scoped to `plan_builder_utils.rs`. Three target globs remain (`filter_builder.rs` ×1, `plan_builder.rs` ×2) — final slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)