### PR TITLE
refactor(P2.10 slice 3): replace final glob imports with named imports; close §5.3 glob bullet

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -297,6 +297,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.10 import hygiene — slice 3 (final globs; §5.3 glob bullet
+  CLOSED)** (P-3 refactor lane) — replaced the last three `plan_builder_helpers::*`
+  / `alias_utils::*` globs (`filter_builder.rs` ×1, `plan_builder.rs` ×2) with named
+  imports: filter_builder gets 7 from `plan_builder_helpers`
+  (`apply_property_mapping_to_expr`, `collect_graphrel_predicates`,
+  `collect_schema_filters`, `collect_schema_filters_with_alias`, `extract_id_column`,
+  `extract_table_name`, `is_node_denormalized`); plan_builder gets 5 from
+  `plan_builder_helpers` (`apply_property_mapping_to_expr`,
+  `combine_predicates_with_and_logical`, `extract_end_node_id_column`,
+  `references_only_alias_logical`, `split_and_predicates_logical`) +
+  `strip_database_prefix` from `alias_utils`. Also dropped a stale
+  `#[allow(unused_imports)]` on plan_builder's old glob. **No
+  `plan_builder_helpers::*` / `alias_utils::*` glob remains anywhere in `src/`** —
+  §5.3's glob-import bullet is fully closed. Same compiler-as-enumerator method;
+  both files have no test module so all names are production. Behavior-identical:
+  `corpus_sweep` + `sql_golden` byte-identical, 1612 lib + 529 integration + ratchet
+  net-zero, fmt/clippy clean, warning-free lib + `--tests`. Remaining §5.3 items:
+  the utils↔plan_builder cycle note (already mechanical/mostly-satisfied) + stale
+  header docstrings; the `dead_code` allow sweep is P2.10's remaining tail.
+
 - 2026-07-27: **P2.10 import hygiene — slice 2 (`plan_builder_utils` globs → named)**
   (P-3 refactor lane) — replaced the two `*` globs in
   `render_plan/plan_builder_utils.rs` with the 6 names the file uses:

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -525,8 +525,13 @@ One PR per cluster from §1.4's table. Canonical survivors:
   `get_graph_rel_from_plan`) + `find_label_for_alias` from `alias_utils`
   ungated, plus `get_anchor_alias_from_plan`/`strip_database_prefix` gated
   `#[cfg(test)]` (they are test-only — a shadowing hazard the glob masked, exactly
-  what §5.3 targets). `filter_builder.rs` + `plan_builder.rs`'s three remaining
-  globs are the next slice.
+  what §5.3 targets). **Slice 3 done — glob bullet CLOSED**: the last three target
+  globs (`filter_builder.rs` ×1, `plan_builder.rs` ×2) replaced with named imports
+  (filter_builder: 7 from `plan_builder_helpers`; plan_builder: 5 from
+  `plan_builder_helpers` + `strip_database_prefix` from `alias_utils`), stale
+  `#[allow(unused_imports)]` dropped. No `plan_builder_helpers::*` /
+  `alias_utils::*` glob remains anywhere in `src/`. All three slices behavior-identical
+  (corpus + goldens byte-identical, ratchet net-zero).
 - Delete the three files' `#![allow(dead_code)]`; delete what the compiler
   then flags (investigate before deleting, per the late-stage-project rule —
   but the blanket allow has hidden dead surface for months).

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -14,7 +14,12 @@ use crate::render_plan::cte_extraction::{
     extract_relationship_columns, table_to_id_column, RelationshipColumns,
 };
 use crate::render_plan::errors::RenderBuildError;
-use crate::render_plan::plan_builder_helpers::*;
+// P2.10 import hygiene: named imports (the exact set the compiler requires) so
+// shadowing becomes visible; previously a `plan_builder_helpers::*` glob.
+use crate::render_plan::plan_builder_helpers::{
+    apply_property_mapping_to_expr, collect_graphrel_predicates, collect_schema_filters,
+    collect_schema_filters_with_alias, extract_id_column, extract_table_name, is_node_denormalized,
+};
 use crate::render_plan::render_expr::{Operator, OperatorApplication, RenderExpr};
 
 /// Result type for filter builder operations

--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -28,13 +28,14 @@ use super::{
 };
 use crate::render_plan::cte_extraction::extract_ctes_with_context;
 
-// Import ALL helper functions from the dedicated helpers module using glob import
-// This allows existing code to call helpers without changes (e.g., extract_table_name())
-// The compiler will use the module functions when available
-#[allow(unused_imports)]
-use super::plan_builder_helpers::*;
+// P2.10 import hygiene: named imports (the exact set the compiler requires) so
+// shadowing becomes visible; previously two `*` globs.
+use super::plan_builder_helpers::{
+    apply_property_mapping_to_expr, combine_predicates_with_and_logical,
+    extract_end_node_id_column, references_only_alias_logical, split_and_predicates_logical,
+};
 use super::plan_builder_utils::{rewrite_vlp_aggregate_aliases, rewrite_vlp_union_branch_aliases};
-use super::utils::alias_utils::*;
+use super::utils::alias_utils::strip_database_prefix;
 use super::CteGenerationContext;
 
 pub type RenderPlanBuilderResult<T> = Result<T, super::errors::RenderBuildError>;


### PR DESCRIPTION
## P2.10 import hygiene — slice 3 (final; §5.3 glob bullet CLOSED)

Completes the glob→named conversion started in #731 (`with_to_cte`) and #732 (`plan_builder_utils`). This slice does the last two files.

### Change
| File | From | Names |
|---|---|---|
| `filter_builder.rs` | `plan_builder_helpers` | `apply_property_mapping_to_expr`, `collect_graphrel_predicates`, `collect_schema_filters`, `collect_schema_filters_with_alias`, `extract_id_column`, `extract_table_name`, `is_node_denormalized` |
| `plan_builder.rs` | `plan_builder_helpers` | `apply_property_mapping_to_expr`, `combine_predicates_with_and_logical`, `extract_end_node_id_column`, `references_only_alias_logical`, `split_and_predicates_logical` |
| `plan_builder.rs` | `alias_utils` | `strip_database_prefix` |

Also dropped a stale `#[allow(unused_imports)]` that sat on `plan_builder.rs`'s old glob.

### Milestone
**No `plan_builder_helpers::*` / `alias_utils::*` glob remains anywhere in `src/`** — §5.3's *"Replace glob imports with named imports so shadowing becomes visible"* bullet is now fully closed across all four files that carried them.

### Method / safety
Same compiler-as-enumerator approach as slices 1–2: disable the globs, build `--tests`, read the `E0425 cannot find function` list per file, classify by source module. Neither file has a test module, so all imported names are production uses (no `#[cfg(test)]` gating needed here, unlike slice 2).

- `corpus_sweep` + `sql_golden` (529 integration) **byte-identical**
- 1612 lib + ratchet **net-zero**, 0 failures
- `fmt --check` clean, `clippy --all-targets` clean, warning-free **lib and `--tests`**

### Remaining P2.10 tail (not this PR)
§5.3 also lists the utils↔plan_builder cycle note (already mechanical/mostly-satisfied) and stale header docstrings; the `#![allow(dead_code)]` sweep is the remaining tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)