### PR TITLE
fix(P2.10): remove orphaned PathFunctionRewriter left dead by #734 (main CI red)

### DIFF
--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -10,7 +10,7 @@
 //! - Polymorphic edge filter generation
 
 use super::render_expr::{
-    AggregateFnCall, Column, Literal, Operator, OperatorApplication, PropertyAccess, RenderExpr,
+    AggregateFnCall, Literal, Operator, OperatorApplication, PropertyAccess, RenderExpr,
     ScalarFnCall, TableAlias,
 };
 use crate::graph_catalog::expression_parser::PropertyValue;
@@ -18,9 +18,7 @@ use crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
 use crate::render_plan::cte_extraction::{
     get_node_label_for_alias, get_relationship_type_for_alias,
 };
-use crate::render_plan::expression_utils::{
-    flatten_addition_operands, has_string_operand, ExprVisitor,
-};
+use crate::render_plan::expression_utils::{flatten_addition_operands, has_string_operand};
 // Note: Direction import commented out until Issue #1 (Undirected Multi-Hop SQL) is fixed
 // use crate::query_planner::logical_expr::Direction;
 use crate::query_planner::logical_plan::LogicalPlan;
@@ -1865,49 +1863,6 @@ pub(super) fn find_anchor_node(
         log::warn!("⚠️ No clear anchor, using fallback: {}", alias);
     }
     fallback
-}
-
-/// Visitor for rewriting path function calls to CTE column references
-/// Converts: length(p) → hop_count, nodes(p) → path_nodes, relationships(p) → path_relationships
-struct PathFunctionRewriter {
-    path_var_name: String,
-    table_alias: String,
-}
-
-impl ExprVisitor for PathFunctionRewriter {
-    fn transform_scalar_fn_call(&mut self, name: &str, args: Vec<RenderExpr>) -> RenderExpr {
-        // Check if this is a path function call with the path variable as argument
-        if args.len() == 1 {
-            if let RenderExpr::TableAlias(TableAlias(alias)) = &args[0] {
-                if alias == &self.path_var_name {
-                    // Convert path functions to CTE column references
-                    let column_name = match name {
-                        "length" => Some("hop_count"),
-                        "nodes" => Some("path_nodes"),
-                        "relationships" => Some("path_relationships"),
-                        _ => None,
-                    };
-
-                    if let Some(col_name) = column_name {
-                        return if self.table_alias.is_empty() {
-                            RenderExpr::Column(Column(PropertyValue::Column(col_name.to_string())))
-                        } else {
-                            RenderExpr::PropertyAccessExp(PropertyAccess {
-                                table_alias: TableAlias(self.table_alias.clone()),
-                                column: PropertyValue::Column(col_name.to_string()),
-                            })
-                        };
-                    }
-                }
-            }
-        }
-
-        // Default: recursively handled args + rebuild call
-        RenderExpr::ScalarFnCall(ScalarFnCall {
-            name: name.to_string(),
-            args,
-        })
-    }
 }
 
 use super::cte_extraction::FixedPathInfo;


### PR DESCRIPTION
## Urgent — main CI is red

The `#734` dead_code sweep turned **main red** at `2641ae61`:
```
error: struct `PathFunctionRewriter` is never constructed
  --> src/render_plan/plan_builder_helpers.rs:1872
note: `-D dead-code` implied by `-D warnings`
```

## Root cause

`#734` deleted the path-function rewriters (`rewrite_path_functions`, `rewrite_fixed_path_functions`, `rewrite_path_functions_with_table`) via a **call-graph reachability closure driven from the compiler's `E0425 cannot find function` list**. That correctly identified the dead *functions* — but their sole consumer, the private `PathFunctionRewriter` visitor struct (+ its `ExprVisitor` impl), became transitively dead. A *never-constructed struct* is not a name-resolution error, so it never appeared in the E0425 list, and local **incremental** clippy reused a cached clean result and masked it. CI's from-clean `cargo clippy --all-targets -- -D warnings` caught it.

**Lesson (banking to memory):** the reachability-closure method finds dead *callables* but not the *types they exclusively construct*; always re-run the gate under a wiped incremental cache before merging a dead-code sweep.

## Fix
- Delete the orphaned `PathFunctionRewriter` struct + `impl ExprVisitor` (−42 lines)
- Drop the two imports it exclusively used: `Column` (from `render_expr`), `ExprVisitor` (from `expression_utils`)
- Preserve the still-live `use super::cte_extraction::FixedPathInfo;` that sat adjacent to the deleted block

## Verification (from-clean, incremental cache wiped)
- `cargo clippy --all-targets -- -D warnings` — **clean** (reproduces + clears the exact CI failure)
- **1612** lib + **529** integration (`corpus_sweep` + `sql_golden` byte-identical, no `UPDATE_GOLDEN`) + **1** ratchet (net-zero) — 0 failures
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)