### PR TITLE
refactor(P2.10): dead_code sweep of cte_generation.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -297,6 +297,31 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-27: **P2.10 dead_code tail — `cte_generation`** (P-3 refactor lane) —
+  third slice of the §5.3 tail. Removed the blanket `#![allow(dead_code)]` and
+  deleted two fully-dead sub-features on `CteGenerationContext`: the
+  `variable_length_properties` field + `get_properties`/`with_properties`, and the
+  `start_cypher_alias`/`end_cypher_alias` fields + getters + test-only setters
+  (whose only callers were 7 `.with_*_cypher_alias(…)` builder chains in
+  `cte_manager` tests — removed with them, as the values were set-but-never-read).
+  Also deleted 7 genuinely-dead free fns (`extract_node_label_from_plan`,
+  `analyze_property_requirements`, `extract_var_len_properties`,
+  `extract_alias_from_plan`, `get_variable_length_info`,
+  `map_property_to_column_with_schema_context`, `get_node_schema_by_table` — some
+  formed an internal *mutually-dead* cluster reachable only from each other, which
+  the reachability closure catches but grep does not). **Scope decision (user):**
+  the two half-dead getters `get_filter` / `get_fixed_length_joins` were KEPT
+  behind a scoped `#[allow(dead_code)]` with an explanatory comment — their sibling
+  setters (`with_filter`, `set_fixed_length_joins`) are live-called from
+  `cte_extraction`, so deleting the getters would make the fields write-only and
+  cascade a dead-code warning onto production code; that write-path pruning is a
+  separate, deferred decision. `with_schema` was gated `#[cfg(test)]`
+  (test-only-live — flagged dead by the clean lib compile since its callers are all
+  `#[cfg(test)]`). −302 lines. Verified from a WIPED incremental cache (#736
+  lesson). Behavior-identical: `corpus_sweep` + `sql_golden` byte-identical, 1607
+  lib + 529 integration + ratchet net-zero, fmt/clippy clean, warning-free
+  lib + `--tests`. Remaining tail: `cte_extraction.rs` (large central file).
+
 - 2026-07-27: **P2.10 dead_code tail — delete `expression_utils` + `filter_pipeline`
   dead cluster** (P-3 refactor lane) — second slice of the §5.3 tail. The two
   files were a single cross-referencing dead cluster: `filter_pipeline`'s 5 unused

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -563,11 +563,25 @@ One PR per cluster from §1.4's table. Canonical survivors:
   deleted `VLPExprRewriter` (−458 lines). Applied the #736 lesson (verified from a
   wiped incremental cache). Ratchet: −10 `is_denormalized` schema-axis tokens
   (a genuine reduction, baseline regenerated to lock it). Corpus + goldens
-  byte-identical. The remaining blanket allows (`plan_builder_utils` already lost
-  its module-level one in an earlier phase; `cte_generation` — dead methods/fields
-  on the LIVE `CteGenerationContext`, whose test-only setters in `cte_manager`
-  tests make it a more delicate standalone slice; `cte_extraction` — a large
-  central file warranting its own pass) are the last follow-up slices.
+  byte-identical. **`cte_generation` dead-code swept (Jul 2026)**: removed its
+  blanket allow and deleted two fully-dead sub-features on `CteGenerationContext`
+  — the `variable_length_properties` field + `get_properties`/`with_properties`,
+  and the `start_cypher_alias`/`end_cypher_alias` fields + their getters + their
+  test-only setters (whose only callers were 7 `.with_*_cypher_alias(…)` chains in
+  `cte_manager` unit tests, removed with them since the values were set-but-never-
+  read) — plus 7 genuinely-dead free fns (`extract_node_label_from_plan`,
+  `analyze_property_requirements`, `extract_var_len_properties`,
+  `extract_alias_from_plan`, `get_variable_length_info`,
+  `map_property_to_column_with_schema_context`, `get_node_schema_by_table`, several
+  of which formed an internal mutually-dead cluster that fools naive grep). Two
+  half-dead getters (`get_filter`, `get_fixed_length_joins`) were KEPT behind a
+  scoped `#[allow(dead_code)]` — their sibling setters (`with_filter`,
+  `set_fixed_length_joins`) are live-called from `cte_extraction`, so deleting the
+  getters would make the fields write-only and cascade a warning onto production
+  code (a separate decision, deliberately deferred). `with_schema` was gated
+  `#[cfg(test)]` (test-only-live). −302 lines, ratchet net-zero. **The remaining
+  blanket allow (`cte_extraction` — a large central file warranting its own pass)
+  is the last follow-up slice.**
 - Fix the stale header docstrings; update `render_plan/AGENTS.md`'s module
   diagram in the same PRs.
 

--- a/src/render_plan/cte_generation.rs
+++ b/src/render_plan/cte_generation.rs
@@ -1,8 +1,4 @@
 //! CTE generation utilities for variable-length path queries
-//!
-//! Some structures and methods in this module are reserved for future use.
-// Note: NodeRole enum and some helper methods are intentionally kept for future CTE enhancements
-#![allow(dead_code)]
 
 use std::collections::HashMap;
 
@@ -11,23 +7,16 @@ use crate::clickhouse_query_generator::NodeProperty;
 use crate::graph_catalog::config::Identifier;
 use crate::graph_catalog::expression_parser::PropertyValue;
 use crate::graph_catalog::graph_schema::GraphSchema;
-use crate::query_planner::logical_expr::LogicalExpr;
 use crate::query_planner::logical_plan::LogicalPlan;
 use crate::query_planner::logical_plan::ShortestPathMode;
 use crate::query_planner::logical_plan::VariableLengthSpec;
-use crate::render_plan::cte_extraction::extract_node_label_from_viewscan;
 use crate::render_plan::render_expr::RenderExpr;
 
 /// Context for CTE generation - holds property requirements and other metadata
 #[derive(Debug, Clone, Default)]
 pub struct CteGenerationContext {
-    /// Properties needed for variable-length paths, keyed by "left_alias-right_alias"
-    variable_length_properties: HashMap<String, Vec<NodeProperty>>,
     /// WHERE filter expression to apply to variable-length CTEs
     filter_expr: Option<RenderExpr>,
-    /// Cypher aliases for start and end nodes (for filter rewriting)
-    start_cypher_alias: Option<String>,
-    end_cypher_alias: Option<String>,
     /// Graph schema for this query (enables multi-schema support)
     schema: Option<GraphSchema>,
     /// Fixed-length path inline JOINs (from_table, from_alias, joins)
@@ -85,12 +74,13 @@ impl CteGenerationContext {
         Self::default()
     }
 
+    /// Construct a context seeded with a schema. Test-only-live: exercised
+    /// solely by the `cte_manager` unit tests (production code builds contexts
+    /// via `new()` + `with_schema_owned()`).
+    #[cfg(test)]
     pub(crate) fn with_schema(schema: GraphSchema) -> Self {
         Self {
-            variable_length_properties: HashMap::new(),
             filter_expr: None,
-            start_cypher_alias: None,
-            end_cypher_alias: None,
             schema: Some(schema),
             fixed_length_joins: HashMap::new(),
             spec: VariableLengthSpec::default(),
@@ -180,50 +170,16 @@ impl CteGenerationContext {
         self.schema.as_ref()
     }
 
-    pub(crate) fn get_properties(&self, left_alias: &str, right_alias: &str) -> Vec<NodeProperty> {
-        let key = format!("{}-{}", left_alias, right_alias);
-        self.variable_length_properties
-            .get(&key)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    // 🆕 IMMUTABLE BUILDER PATTERN: Returns new context instead of mutating
-    pub(crate) fn with_properties(
-        mut self,
-        left_alias: &str,
-        right_alias: &str,
-        properties: Vec<NodeProperty>,
-    ) -> Self {
-        let key = format!("{}-{}", left_alias, right_alias);
-        self.variable_length_properties.insert(key, properties);
-        self
-    }
-
+    /// Read accessor for the WHERE filter. Currently unused: `with_filter`
+    /// (live, called from `cte_extraction`) populates `filter_expr`, but no
+    /// consumer reads it back yet. Kept as the paired getter for that field.
+    #[allow(dead_code)]
     pub(crate) fn get_filter(&self) -> Option<&RenderExpr> {
         self.filter_expr.as_ref()
     }
 
     pub(crate) fn with_filter(mut self, filter: RenderExpr) -> Self {
         self.filter_expr = Some(filter);
-        self
-    }
-
-    pub(crate) fn get_start_cypher_alias(&self) -> Option<&str> {
-        self.start_cypher_alias.as_deref()
-    }
-
-    pub(crate) fn with_start_cypher_alias(mut self, alias: String) -> Self {
-        self.start_cypher_alias = Some(alias);
-        self
-    }
-
-    pub(crate) fn get_end_cypher_alias(&self) -> Option<&str> {
-        self.end_cypher_alias.as_deref()
-    }
-
-    pub(crate) fn with_end_cypher_alias(mut self, alias: String) -> Self {
-        self.end_cypher_alias = Some(alias);
         self
     }
 
@@ -246,7 +202,11 @@ impl CteGenerationContext {
             .insert(key, (from_table, from_alias, joins));
     }
 
-    /// Retrieve fixed-length path inline JOINs if available
+    /// Retrieve fixed-length path inline JOINs if available. Currently unused:
+    /// `set_fixed_length_joins` (live, called from `cte_extraction`) populates
+    /// `fixed_length_joins`, but no consumer reads it back yet. Kept as the
+    /// paired getter for that field.
+    #[allow(dead_code)]
     pub(crate) fn get_fixed_length_joins(
         &self,
         start_alias: &str,
@@ -255,47 +215,6 @@ impl CteGenerationContext {
         let key = format!("{}-{}", start_alias, end_alias);
         self.fixed_length_joins.get(&key)
     }
-}
-
-/// Extract node label from a GraphNode plan
-fn extract_node_label_from_plan(plan: &LogicalPlan) -> String {
-    match plan {
-        LogicalPlan::GraphNode(node) => {
-            // Look for ViewScan in the input
-            if let Some(label) = extract_node_label_from_viewscan(&node.input) {
-                return label;
-            }
-            // Fallback to alias if no label found
-            node.alias.clone()
-        }
-        _ => "User".to_string(), // fallback
-    }
-}
-
-/// Analyze the plan to determine what properties are needed for variable-length CTEs
-pub(crate) fn analyze_property_requirements(
-    plan: &LogicalPlan,
-    schema: &GraphSchema,
-) -> CteGenerationContext {
-    let context = CteGenerationContext::with_schema(schema.clone());
-
-    // Find variable-length relationships and their required properties
-    if let Some((left_alias, right_alias, left_label, right_label, rel_type)) =
-        get_variable_length_info(plan)
-    {
-        let properties = extract_var_len_properties(
-            plan,
-            &left_alias,
-            &right_alias,
-            &left_label,
-            &right_label,
-            Some(&rel_type),
-        );
-        // 🆕 IMMUTABLE PATTERN: Chain the builder method
-        return context.with_properties(&left_alias, &right_alias, properties);
-    }
-
-    context
 }
 
 /// Extract properties referenced in a RenderExpr (e.g., from filters)
@@ -385,185 +304,6 @@ fn extract_properties_from_expr_recursive(
     }
 }
 
-/// Extract property requirements from projection for variable-length paths
-/// Returns a vector of properties that need to be included in the CTE
-/// Recursively searches through the plan to find the Projection node
-///
-/// # Denormalized Property Access
-/// If `relationship_type` is provided, properties are checked against denormalized
-/// edge tables first before falling back to node tables. This enables 10-100x faster
-/// queries by eliminating JOINs in variable-length path traversals.
-pub(crate) fn extract_var_len_properties(
-    plan: &LogicalPlan,
-    left_alias: &str,
-    right_alias: &str,
-    left_label: &str,
-    right_label: &str,
-    relationship_type: Option<&str>,
-) -> Vec<NodeProperty> {
-    let mut properties = Vec::new();
-
-    // Find the projection in the plan (recursively)
-    match plan {
-        LogicalPlan::Projection(proj) => {
-            for item in &proj.items {
-                // Check if this is a property access expression
-                if let LogicalExpr::PropertyAccessExp(prop_acc) = &item.expression {
-                    let node_alias = prop_acc.table_alias.0.as_str();
-                    let property_name = prop_acc.column.raw();
-
-                    // Determine if this is for the left or right node
-                    if node_alias == left_alias || node_alias == right_alias {
-                        // Determine which node label to use
-                        let node_label = if node_alias == left_alias {
-                            left_label
-                        } else {
-                            right_label
-                        };
-
-                        // Handle wildcard property selection
-                        if property_name == "*" {
-                            // Expand * to all properties for this node type
-                            if let Some(schema) =
-                                crate::server::query_context::get_current_schema_with_fallback()
-                            {
-                                if let Some(node_schema) = schema.all_node_schemas().get(node_label)
-                                {
-                                    // Create a property for each mapping (sorted for deterministic ordering)
-                                    let mut sorted_props: Vec<_> =
-                                        node_schema.property_mappings.iter().collect();
-                                    sorted_props.sort_by_key(|(k, _)| k.as_str());
-                                    for (prop_name, prop_value) in sorted_props {
-                                        properties.push(NodeProperty {
-                                            cypher_alias: node_alias.to_string(),
-                                            column_name: prop_value.raw().to_string(),
-                                            alias: prop_name.clone(),
-                                        });
-                                    }
-                                }
-                            }
-                        } else {
-                            // Regular property - use denormalized-aware mapping
-                            let column_name = map_property_to_column_with_relationship_context(
-                                property_name,
-                                node_label,
-                                relationship_type,
-                                None,
-                                None,
-                            )
-                            .unwrap_or_else(|_| property_name.to_string());
-                            let alias = property_name.to_string();
-
-                            properties.push(NodeProperty {
-                                cypher_alias: node_alias.to_string(),
-                                column_name,
-                                alias,
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        // Recursively search in child plans
-        LogicalPlan::Filter(filter) => {
-            return extract_var_len_properties(
-                &filter.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        LogicalPlan::OrderBy(order_by) => {
-            return extract_var_len_properties(
-                &order_by.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        LogicalPlan::Skip(skip) => {
-            return extract_var_len_properties(
-                &skip.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        LogicalPlan::Limit(limit) => {
-            return extract_var_len_properties(
-                &limit.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        LogicalPlan::GroupBy(group_by) => {
-            return extract_var_len_properties(
-                &group_by.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        LogicalPlan::GraphJoins(joins) => {
-            return extract_var_len_properties(
-                &joins.input,
-                left_alias,
-                right_alias,
-                left_label,
-                right_label,
-                relationship_type,
-            );
-        }
-        _ => {}
-    }
-
-    properties
-}
-
-/// Extract alias from a plan node
-fn extract_alias_from_plan(plan: &LogicalPlan) -> Option<String> {
-    match plan {
-        LogicalPlan::GraphNode(node) => Some(node.alias.clone()),
-        LogicalPlan::ViewScan(_) => None, // ViewScan doesn't have an alias field
-        _ => None,
-    }
-}
-
-/// Get variable length info from plan
-fn get_variable_length_info(
-    plan: &LogicalPlan,
-) -> Option<(String, String, String, String, String)> {
-    match plan {
-        LogicalPlan::GraphRel(graph_rel) => {
-            if graph_rel.variable_length.is_some() {
-                let left_alias = extract_alias_from_plan(&graph_rel.left)?;
-                let right_alias = extract_alias_from_plan(&graph_rel.right)?;
-                let left_label = extract_node_label_from_viewscan(&graph_rel.left)?;
-                let right_label = extract_node_label_from_viewscan(&graph_rel.right)?;
-                let rel_type = graph_rel.labels.as_ref()?.first()?.clone();
-                Some((left_alias, right_alias, left_label, right_label, rel_type))
-            } else {
-                None
-            }
-        }
-        LogicalPlan::GraphNode(node) => get_variable_length_info(&node.input),
-        LogicalPlan::Filter(filter) => get_variable_length_info(&filter.input),
-        LogicalPlan::Projection(proj) => get_variable_length_info(&proj.input),
-        _ => None,
-    }
-}
-
 /// Schema-aware property mapping using GraphSchema
 /// Map a property to column with schema awareness
 /// Returns an error if the schema is not available or the property mapping is not found
@@ -577,17 +317,6 @@ pub(crate) fn map_property_to_column_with_schema(
     node_label: &str,
 ) -> Result<String, String> {
     map_property_to_column_with_relationship_context(property, node_label, None, None, None)
-}
-
-/// Map property to column with explicit schema context (preferred)
-/// When schema_name is provided, it searches ONLY that schema (deterministic)
-/// When schema_name is None, it searches all schemas (legacy behavior)
-pub(crate) fn map_property_to_column_with_schema_context(
-    property: &str,
-    node_label: &str,
-    schema_name: Option<&str>,
-) -> Result<String, String> {
-    map_property_to_column_with_relationship_context(property, node_label, None, None, schema_name)
 }
 
 /// Schema-aware property mapping with relationship context
@@ -906,17 +635,4 @@ pub fn map_relationship_property_to_column(
     })?;
 
     Ok(column.raw().to_string())
-}
-
-/// Get node schema by table name
-fn get_node_schema_by_table<'a>(
-    schema: &'a GraphSchema,
-    table_name: &str,
-) -> Option<(&'a str, &'a crate::graph_catalog::graph_schema::NodeSchema)> {
-    for (label, node_schema) in schema.all_node_schemas() {
-        if node_schema.table_name == table_name {
-            return Some((label.as_str(), node_schema));
-        }
-    }
-    None
 }

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -3518,9 +3518,7 @@ mod tests {
         .with_spec(VariableLengthSpec {
             min_hops: Some(1),
             max_hops: Some(3),
-        })
-        .with_start_cypher_alias("u1".to_string())
-        .with_end_cypher_alias("u2".to_string());
+        });
 
         // Test with empty properties and filters
         let properties = vec![];
@@ -3595,13 +3593,10 @@ mod tests {
             HashMap::new(),
         ));
         let strategy = DenormalizedCteStrategy::new(&pattern_ctx, schema).unwrap();
-        let context = CteGenerationContext::new()
-            .with_spec(VariableLengthSpec {
-                min_hops: Some(1),
-                max_hops: Some(3),
-            })
-            .with_start_cypher_alias("f1".to_string())
-            .with_end_cypher_alias("f2".to_string());
+        let context = CteGenerationContext::new().with_spec(VariableLengthSpec {
+            min_hops: Some(1),
+            max_hops: Some(3),
+        });
         (strategy, context)
     }
 
@@ -3717,13 +3712,10 @@ mod tests {
         let strategy = strategy.unwrap();
 
         // Create context
-        let context = CteGenerationContext::new()
-            .with_spec(VariableLengthSpec {
-                min_hops: Some(1),
-                max_hops: Some(3),
-            })
-            .with_start_cypher_alias("f1".to_string())
-            .with_end_cypher_alias("f2".to_string());
+        let context = CteGenerationContext::new().with_spec(VariableLengthSpec {
+            min_hops: Some(1),
+            max_hops: Some(3),
+        });
 
         // Test with empty properties and filters
         let properties = vec![];
@@ -3836,13 +3828,10 @@ mod tests {
         let strategy = strategy_result.unwrap();
 
         // Create context
-        let context = CteGenerationContext::new()
-            .with_spec(VariableLengthSpec {
-                min_hops: Some(1),
-                max_hops: Some(3),
-            })
-            .with_start_cypher_alias("parent".to_string())
-            .with_end_cypher_alias("child".to_string());
+        let context = CteGenerationContext::new().with_spec(VariableLengthSpec {
+            min_hops: Some(1),
+            max_hops: Some(3),
+        });
 
         // Test with empty properties and filters
         let properties = vec![];
@@ -3914,13 +3903,10 @@ mod tests {
         assert!(strategy.validate(&pattern_ctx).is_ok());
 
         // Test SQL generation
-        let context = CteGenerationContext::new()
-            .with_spec(VariableLengthSpec {
-                min_hops: Some(1),
-                max_hops: Some(3),
-            })
-            .with_start_cypher_alias("u".to_string())
-            .with_end_cypher_alias("p".to_string());
+        let context = CteGenerationContext::new().with_spec(VariableLengthSpec {
+            min_hops: Some(1),
+            max_hops: Some(3),
+        });
 
         let properties = vec![
             NodeProperty {
@@ -4012,9 +3998,7 @@ mod tests {
         .with_spec(VariableLengthSpec {
             min_hops: Some(1),
             max_hops: Some(3),
-        })
-        .with_start_cypher_alias("f1".to_string())
-        .with_end_cypher_alias("f2".to_string());
+        });
 
         // Test with empty properties and filters
         let properties = vec![];
@@ -4090,9 +4074,7 @@ mod tests {
         .with_spec(VariableLengthSpec {
             min_hops: Some(1),
             max_hops: Some(1), // Coupled edges typically represent single hops
-        })
-        .with_start_cypher_alias("n1".to_string())
-        .with_end_cypher_alias("n2".to_string());
+        });
 
         // Test with empty properties and filters
         let properties = vec![];


### PR DESCRIPTION
## Summary

Third slice of the §5.3 `dead_code` tail (after `plan_builder_helpers` #734, `feature_flags` #735, `expression_utils`+`filter_pipeline` #737). Removed `cte_generation.rs`'s blanket `#![allow(dead_code)]` and triaged the exposed surface by **call-graph reachability closure**.

## Deleted — two fully-dead sub-features on `CteGenerationContext`
Both accessor sides **and** the backing field dead, with no live reader anywhere in the workspace:
- `variable_length_properties` field + `get_properties` + `with_properties`
- `start_cypher_alias` / `end_cypher_alias` fields + their getters + their setters. The setters were **test-only-live** — their only callers were **7 `.with_*_cypher_alias(…)` builder chains in `cte_manager` unit tests**, setting values nothing ever read. Removed those chains too (a set-but-never-read no-op).

## Deleted — 7 genuinely-dead free fns
`extract_node_label_from_plan`, `analyze_property_requirements`, `extract_var_len_properties`, `extract_alias_from_plan`, `get_variable_length_info`, `map_property_to_column_with_schema_context`, `get_node_schema_by_table`.

Several formed an **internal mutually-dead cluster** (`analyze_property_requirements` → `get_variable_length_info` → `extract_alias_from_plan` / `extract_var_len_properties`, none reachable from a live root) — the kind naive grep marks "used" but reachability closure correctly kills.

## Kept — scope decision
The two half-dead getters `get_filter` / `get_fixed_length_joins` **stay**, behind a scoped `#[allow(dead_code)]` + explanatory comment. Their sibling setters (`with_filter`, `set_fixed_length_joins`) are **live-called from `cte_extraction`**, so deleting the getters would make the fields write-only and cascade a dead-code warning onto production code. That write-path pruning is a separate, deferred decision.

## Gated `#[cfg(test)]`
`with_schema` — test-only-live. The clean non-test lib compile flags it dead (all 3 callers live in `cte_manager`'s `#[cfg(test)] mod`); a plain `cargo build --tests` masks this, so it was caught by `clippy --all-targets` **from a wiped incremental cache** (the #736 lesson).

## Housekeeping
Removed 2 orphaned imports (`LogicalExpr`, `extract_node_label_from_viewscan`); `cargo fmt` reflowed the shortened test builder chains. **−302 lines net.**

## Verification (from wiped incremental cache)
- `cargo clippy --all-targets -- -D warnings` clean
- **1607** lib + **529** integration (`corpus_sweep` + `sql_golden` **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (net-zero — `cte_generation` `is_denormalized` count unchanged at 1) — 0 failures
- `cargo fmt --all --check` clean

## Remaining tail
`cte_extraction.rs` (large central file) — the last §5.3 blanket allow, its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)