### PR TITLE
refactor(P2.10): dead_code sweep of cte_extraction.rs (§5.3 bullet complete)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene in progress)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -296,6 +296,21 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-27: **P2.10 dead_code tail — `cte_extraction` (§5.3 bullet COMPLETE)**
+  (P-3 refactor lane) — final slice. Despite being the largest tail file (~8.5K
+  lines), `cte_extraction.rs` carried only **4 dead private free fns**:
+  `extract_node_alias` (recursive — its self-calls fool naive grep, dead by
+  reachability closure), `table_to_id_column_for_label`,
+  `get_relationship_columns_from_schema`, `get_node_info_from_schema`. The live
+  sibling `get_relationship_columns_by_table` sat *between* the last three and was
+  preserved. Removed them + the blanket `#![allow(dead_code)]`; no orphaned imports
+  (the deleted fns called only live shared helpers). Verified from a WIPED
+  incremental cache (#736 lesson). **No module-level `#![allow(dead_code)]` remains
+  anywhere under `src/render_plan/` — the §5.3 dead_code bullet is closed.**
+  Behavior-identical: `corpus_sweep` + `sql_golden` byte-identical, 1607 lib + 529
+  integration + ratchet net-zero (deleted fns carried no axis tokens), fmt/clippy
+  clean, warning-free lib + `--tests`.
 
 - 2026-07-27: **P2.10 dead_code tail — `cte_generation`** (P-3 refactor lane) —
   third slice of the §5.3 tail. Removed the blanket `#![allow(dead_code)]` and

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -579,9 +579,17 @@ One PR per cluster from §1.4's table. Canonical survivors:
   `set_fixed_length_joins`) are live-called from `cte_extraction`, so deleting the
   getters would make the fields write-only and cascade a warning onto production
   code (a separate decision, deliberately deferred). `with_schema` was gated
-  `#[cfg(test)]` (test-only-live). −302 lines, ratchet net-zero. **The remaining
-  blanket allow (`cte_extraction` — a large central file warranting its own pass)
-  is the last follow-up slice.**
+  `#[cfg(test)]` (test-only-live). −302 lines, ratchet net-zero. **`cte_extraction`
+  swept (Jul 2026) — §5.3 dead_code bullet now COMPLETE.** Despite being the
+  largest tail file (~8.5K lines), it carried only 4 dead private free fns:
+  `extract_node_alias` (recursive — self-calls fool grep, dead by reachability
+  closure), `table_to_id_column_for_label`, `get_relationship_columns_from_schema`,
+  `get_node_info_from_schema` (the live sibling `get_relationship_columns_by_table`
+  sat between the last three and was preserved). Removed them + the blanket allow;
+  no orphaned imports (all called only live shared helpers). −~30 lines, ratchet
+  net-zero (deleted fns carried no axis tokens), verified from a wiped incremental
+  cache. **No module-level `#![allow(dead_code)]` remains anywhere under
+  `src/render_plan/`.**
 - Fix the stale header docstrings; update `render_plan/AGENTS.md`'s module
   diagram in the same PRs.
 

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1,8 +1,4 @@
 //! CTE extraction utilities for variable-length path handling
-//!
-//! Some functions in this module are reserved for future use or used only in specific code paths.
-// Note: Helper functions for VLP CTE generation are kept for complex path patterns
-#![allow(dead_code)]
 
 use crate::clickhouse_query_generator::quote_identifier;
 use crate::clickhouse_query_generator::variable_length_cte::NodeProperty;
@@ -774,17 +770,6 @@ fn collect_parameters_recursive(expr: &RenderExpr, params: &mut Vec<String>) {
         | RenderExpr::ExistsSubquery(_)
         | RenderExpr::PatternCount(_)
         | RenderExpr::CteEntityRef(_) => {}
-    }
-}
-
-/// Helper function to extract the node alias from a GraphNode
-fn extract_node_alias(plan: &LogicalPlan) -> Option<String> {
-    match plan {
-        LogicalPlan::GraphNode(node) => Some(node.alias.clone()),
-        LogicalPlan::Filter(filter) => extract_node_alias(&filter.input),
-        LogicalPlan::Projection(proj) => extract_node_alias(&proj.input),
-        LogicalPlan::WithClause(wc) => extract_node_alias(&wc.input),
-        _ => None,
     }
 }
 
@@ -2260,29 +2245,10 @@ pub fn table_to_id_column(table: &str) -> String {
     "id".to_string()
 }
 
-/// Get ID column for a label
-fn table_to_id_column_for_label(label: &str) -> String {
-    table_to_id_column(&label_to_table_name(label))
-}
-
-/// Get relationship columns from schema
-fn get_relationship_columns_from_schema(rel_type: &str) -> Option<(String, String)> {
-    let table = rel_type_to_table_name(rel_type);
-    let cols = extract_relationship_columns_from_table(&table);
-    Some((cols.from_id.to_string(), cols.to_id.to_string()))
-}
-
 /// Get relationship columns by table name
 fn get_relationship_columns_by_table(table_name: &str) -> Option<(String, String)> {
     let cols = extract_relationship_columns_from_table(table_name);
     Some((cols.from_id.to_string(), cols.to_id.to_string()))
-}
-
-/// Get node info from schema
-fn get_node_info_from_schema(node_label: &str) -> Option<(String, String)> {
-    let table = label_to_table_name(node_label);
-    let id_col = table_to_id_column(&table);
-    Some((table, id_col))
 }
 
 /// Apply property mapping to an expression


### PR DESCRIPTION
## Summary

**Final slice of the §5.3 `dead_code` tail** — completes the bullet. After this, **no module-level `#![allow(dead_code)]` remains anywhere under `src/render_plan/`.**

Despite being the largest tail file (~8.5K lines), `cte_extraction.rs` carried only **4 dead private free fns**:
- `extract_node_alias` — recursive; its self-calls fool naive grep, but it's unreachable from any live root (dead by reachability closure)
- `table_to_id_column_for_label`
- `get_relationship_columns_from_schema`
- `get_node_info_from_schema`

The live sibling `get_relationship_columns_by_table` sat **between** the last three (name-adjacent, easy to over-delete) and was **preserved** — it's called from `cte_extraction.rs:5543`.

## Change
- Delete the 4 dead fns + the module-level `#![allow(dead_code)]`
- No orphaned imports: the deleted fns called only live shared helpers (`table_to_id_column`, `label_to_table_name`, `rel_type_to_table_name`, `extract_relationship_columns_from_table`)
- Docs: §5.3 marked complete in `REFACTORING_SAFETY_PLAN.md` + `PRIORITIES.md` (P-3 header + merge log)

## Verification (from wiped incremental cache — #736 lesson)
- `cargo clippy --all-targets -- -D warnings` clean
- **1607** lib + **529** integration (`corpus_sweep` + `sql_golden` **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (net-zero — deleted fns carried no axis tokens; `is_denormalized` occurrence count unchanged at 32) — 0 failures
- `cargo fmt --all --check` clean

## Series recap (P2.10 dead_code tail)
`plan_builder_helpers` (#734) → `feature_flags` (#735) → *hotfix* (#736) → `expression_utils`+`filter_pipeline` (#737) → `cte_generation` (#738) → **`cte_extraction` (this PR)**. §5.3 dead_code bullet closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)