### PR TITLE
refactor(P4 §7.1): hoist reconcile_stale_cte_name_references out of build_chained

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -2844,6 +2844,52 @@ impl CteNameAllocator {
     }
 }
 
+/// Post-render reconciliation pass (finalization tail of
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// The analyzer assigns CTE names with its own counter (e.g. `_cte_5`) but the
+/// renderer creates CTEs with sequential numbering (`_cte_1`). Scan `render_plan`
+/// for any `with_*_cte_N` table-alias references that don't match a real CTE and
+/// remap each stale reference to the actual CTE that shares its base name (the
+/// portion before `_cte_N`). No-op when every reference already resolves.
+fn reconcile_stale_cte_name_references(render_plan: &mut RenderPlan, all_ctes: &[Cte]) {
+    let actual_cte_names: std::collections::HashSet<String> =
+        all_ctes.iter().map(|c| c.cte_name.clone()).collect();
+    // Build base→actual mapping: strip _cte_N suffix to get base, map to actual name
+    let mut base_to_actual: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for name in &actual_cte_names {
+        if let Some(base) = name.rfind("_cte_").map(|pos| &name[..pos]) {
+            base_to_actual.insert(base.to_string(), name.clone());
+        }
+    }
+    // Collect all table aliases from render plan that look like CTE references
+    let referenced = collect_with_cte_table_aliases(render_plan);
+    let mut auto_remap: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for ref_name in &referenced {
+        if actual_cte_names.contains(ref_name) {
+            continue; // Already correct
+        }
+        if let Some(pos) = ref_name.rfind("_cte_") {
+            let base = &ref_name[..pos];
+            if let Some(actual) = base_to_actual.get(base) {
+                auto_remap.insert(ref_name.clone(), actual.clone());
+            }
+        }
+    }
+    if !auto_remap.is_empty() {
+        log::debug!(
+            "🔧 build_chained: Auto-remapping {} stale CTE references",
+            auto_remap.len()
+        );
+        for (from, to) in &auto_remap {
+            log::debug!("🔧   {} → {}", from, to);
+        }
+        remap_cte_names_in_render_plan(render_plan, &auto_remap);
+    }
+}
+
 pub(crate) fn build_chained_with_match_cte_plan(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -7220,43 +7266,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
     // Comprehensive CTE name fixup: the analyzer assigns CTE names with its own counter
     // (e.g., _cte_5) but the renderer creates CTEs with sequential numbering (_cte_1).
     // Scan render plan for any with_*_cte_N references that don't match actual CTEs.
-    {
-        let actual_cte_names: std::collections::HashSet<String> =
-            all_ctes.iter().map(|c| c.cte_name.clone()).collect();
-        // Build base→actual mapping: strip _cte_N suffix to get base, map to actual name
-        let mut base_to_actual: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        for name in &actual_cte_names {
-            if let Some(base) = name.rfind("_cte_").map(|pos| &name[..pos]) {
-                base_to_actual.insert(base.to_string(), name.clone());
-            }
-        }
-        // Collect all table aliases from render plan that look like CTE references
-        let referenced = collect_with_cte_table_aliases(&render_plan);
-        let mut auto_remap: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
-        for ref_name in &referenced {
-            if actual_cte_names.contains(ref_name) {
-                continue; // Already correct
-            }
-            if let Some(pos) = ref_name.rfind("_cte_") {
-                let base = &ref_name[..pos];
-                if let Some(actual) = base_to_actual.get(base) {
-                    auto_remap.insert(ref_name.clone(), actual.clone());
-                }
-            }
-        }
-        if !auto_remap.is_empty() {
-            log::debug!(
-                "🔧 build_chained: Auto-remapping {} stale CTE references",
-                auto_remap.len()
-            );
-            for (from, to) in &auto_remap {
-                log::debug!("🔧   {} → {}", from, to);
-            }
-            remap_cte_names_in_render_plan(&mut render_plan, &auto_remap);
-        }
-    }
+    reconcile_stale_cte_name_references(&mut render_plan, &all_ctes);
 
     // CRITICAL FIX: If FROM references an alias that's now in a CTE, replace it with the CTE
     // This happens when WITH exports an alias that was originally from a table


### PR DESCRIPTION
## What

First slice of **Phase-4 §7.1** — decomposing the ~5478-line `build_chained_with_match_cte_plan` (the entangled-core giant that P2.6 moved verbatim into `render_plan/with_to_cte/mod.rs`) into readable, sub-500-line units, one hoist per PR.

This slice extracts the self-contained finalization-tail block **"Comprehensive CTE name fixup"** — a lexically-isolated `{ }` scope near the end of the function (~37 lines) — into a named module-level function:

```rust
fn reconcile_stale_cte_name_references(render_plan: &mut RenderPlan, all_ctes: &[Cte])
```

## Why this block first

It's the cleanest possible canary for the extraction mechanic:
- Already lexically isolated in its own `{ }` scope.
- Reads exactly one accumulator (`all_ctes`) and mutates exactly one binding (`render_plan`) — no `RefCell` capture, no `?`, no other locals threaded.
- Both helpers it calls (`collect_with_cte_table_aliases`, `remap_cte_names_in_render_plan`) are already file-level `use super::cte_rewrite::{...}` imports, so the hoisted sibling fn inherits them by bare name — **no new imports, no signature churn.**

The logic is byte-for-byte identical modulo the mechanical `&mut render_plan` / `&render_plan` → parameter substitution.

## §7.1 note

The design doc's hoisting protocol anticipated named nested `fn`s / `RefCell`-capturing closures. In reality the giant has none — it's a long linear body: setup → main iterative loop → a **finalization tail that is a sequence of self-contained post-passes** on the built `RenderPlan`. Those tail blocks are the natural leaves; this is the first. Subsequent slices hoist the remaining tail passes one at a time, then move up into the loop body.

## Gate

- `cargo fmt --all` + `cargo clippy --all-targets` clean (0 warnings)
- **1607** lib + **529** integration (incl. `corpus_sweep` + `sql_golden` **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (**net-zero**), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)