### PR TITLE
refactor(P4 §7.1): hoist apply_from_fallback_to_last_cte out of build_chained

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -2890,6 +2890,57 @@ fn reconcile_stale_cte_name_references(render_plan: &mut RenderPlan, all_ctes: &
     }
 }
 
+/// Post-render fallback (finalization tail of
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// When every table reference in a chained-WITH query has been replaced by a
+/// CTE, the final `render_plan.from` can come back empty. Point it at the last
+/// `with_*` CTE so the query still has a FROM. The alias is the CTE's own
+/// exported-alias part (`with_tag_total_cte_1` → `tag_total`). No-op when there
+/// is no `with_*` CTE.
+///
+/// Caller gates this on `render_plan.from` being `None`, `all_ctes` non-empty,
+/// and no `Union` (each union branch carries its own FROM).
+fn apply_from_fallback_to_last_cte(render_plan: &mut RenderPlan, all_ctes: &[Cte]) {
+    // FALLBACK: If FROM is None but we have CTEs, set FROM to the last CTE
+    // This happens when WITH clauses are chained and all table references have been replaced with CTEs
+    // Skip when Union branches exist — each branch has its own FROM
+    if let Some(last_with_cte) = all_ctes
+        .iter()
+        .rev()
+        .find(|cte| cte.cte_name.starts_with("with_"))
+    {
+        log::debug!(
+            "🔧 build_chained_with_match_cte_plan: FROM clause missing, setting to last CTE: {}",
+            last_with_cte.cte_name
+        );
+
+        // Extract aliases from CTE name: "with_tag_total_cte_1" → "tag_total"
+        let with_alias_part = if let Some(stripped) = last_with_cte.cte_name.strip_prefix("with_") {
+            if let Some(cte_pos) = stripped.rfind("_cte") {
+                &stripped[..cte_pos]
+            } else {
+                stripped
+            }
+        } else {
+            ""
+        };
+
+        render_plan.from = FromTableItem(Some(ViewTableRef {
+            source: std::sync::Arc::new(LogicalPlan::Empty),
+            name: last_with_cte.cte_name.clone(),
+            alias: Some(with_alias_part.to_string()),
+            use_final: false,
+        }));
+
+        log::info!(
+            "🔧 build_chained_with_match_cte_plan: Set FROM to: {} AS '{}'",
+            last_with_cte.cte_name,
+            with_alias_part
+        );
+    }
+}
+
 pub(crate) fn build_chained_with_match_cte_plan(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -7345,41 +7396,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
         && !all_ctes.is_empty()
         && render_plan.union.0.is_none()
     {
-        // FALLBACK: If FROM is None but we have CTEs, set FROM to the last CTE
-        // This happens when WITH clauses are chained and all table references have been replaced with CTEs
-        // Skip when Union branches exist — each branch has its own FROM
-        if let Some(last_with_cte) = all_ctes
-            .iter()
-            .rev()
-            .find(|cte| cte.cte_name.starts_with("with_"))
-        {
-            log::debug!("🔧 build_chained_with_match_cte_plan: FROM clause missing, setting to last CTE: {}", last_with_cte.cte_name);
-
-            // Extract aliases from CTE name: "with_tag_total_cte_1" → "tag_total"
-            let with_alias_part =
-                if let Some(stripped) = last_with_cte.cte_name.strip_prefix("with_") {
-                    if let Some(cte_pos) = stripped.rfind("_cte") {
-                        &stripped[..cte_pos]
-                    } else {
-                        stripped
-                    }
-                } else {
-                    ""
-                };
-
-            render_plan.from = FromTableItem(Some(ViewTableRef {
-                source: std::sync::Arc::new(LogicalPlan::Empty),
-                name: last_with_cte.cte_name.clone(),
-                alias: Some(with_alias_part.to_string()),
-                use_final: false,
-            }));
-
-            log::info!(
-                "🔧 build_chained_with_match_cte_plan: Set FROM to: {} AS '{}'",
-                last_with_cte.cte_name,
-                with_alias_part
-            );
-        }
+        apply_from_fallback_to_last_cte(&mut render_plan, &all_ctes);
     }
 
     // ==========================================================================


### PR DESCRIPTION
## What

Second slice of **Phase-4 §7.1** — decomposing the ~5478-line `build_chained_with_match_cte_plan` into readable sub-500-line units, one hoist per PR (slice 1 was #740).

Extracts the **"FROM fallback to last CTE"** post-pass from the finalization tail into:

```rust
fn apply_from_fallback_to_last_cte(render_plan: &mut RenderPlan, all_ctes: &[Cte])
```

The block was the body of the `else if render_plan.from == None && !all_ctes.is_empty() && no-union` arm. The **guard condition stays inline** at the call site; only the arm body moves.

## Why behavior-preserving

- Body reads exactly one accumulator (`all_ctes`) and mutates exactly one field (`render_plan.from`).
- Types it constructs (`ViewTableRef`, `LogicalPlan::Empty`, `FromTableItem`) are all already module-level imports → no new imports.
- No `return`/`?`/`break`/`continue` crossed the arm boundary, so moving it into a `fn` cannot change control flow.
- Logic byte-for-byte identical modulo the borrow→param substitution. `cargo fmt` reflows the `with_alias_part` let-binding because it now sits one indent level shallower — a whitespace-only change.

## Gate

- `cargo fmt --all` + `cargo clippy --all-targets` clean (0 warnings)
- **1607** lib + **529** integration (incl. `corpus_sweep` + `sql_golden` **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (**net-zero**), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)