### PR TITLE
refactor(P4 §7.1): hoist apply_passthrough_cte_name_remappings out of build_chained

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -2941,6 +2941,26 @@ fn apply_from_fallback_to_last_cte(render_plan: &mut RenderPlan, all_ctes: &[Cte
     }
 }
 
+/// Post-render remapping pass (finalization tail of
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// When passthrough WITH clauses are skipped, expressions in `render_plan` may
+/// still reference the analyzer's original CTE names. Rewrite them to the actual
+/// names the renderer created, using the allocator's analyzer→actual remapping.
+/// No-op when the allocator recorded no remappings.
+fn apply_passthrough_cte_name_remappings(
+    render_plan: &mut RenderPlan,
+    cte_name_allocator: &CteNameAllocator,
+) {
+    if cte_name_allocator.has_remappings() {
+        log::info!(
+            "🔧 build_chained_with_match_cte_plan: Applying CTE name remapping ({} entries)",
+            cte_name_allocator.remapping().len()
+        );
+        remap_cte_names_in_render_plan(render_plan, cte_name_allocator.remapping());
+    }
+}
+
 pub(crate) fn build_chained_with_match_cte_plan(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -7306,13 +7326,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
     // CRITICAL FIX: Apply CTE name remapping for passthrough WITHs
     // When WITHs are skipped, expressions may still reference the analyzer's CTE names.
     // Remap them to the actual CTE names that were created.
-    if cte_name_allocator.has_remappings() {
-        log::info!(
-            "🔧 build_chained_with_match_cte_plan: Applying CTE name remapping ({} entries)",
-            cte_name_allocator.remapping().len()
-        );
-        remap_cte_names_in_render_plan(&mut render_plan, cte_name_allocator.remapping());
-    }
+    apply_passthrough_cte_name_remappings(&mut render_plan, &cte_name_allocator);
 
     // Comprehensive CTE name fixup: the analyzer assigns CTE names with its own counter
     // (e.g., _cte_5) but the renderer creates CTEs with sequential numbering (_cte_1).


### PR DESCRIPTION
## What

Third slice of **Phase-4 §7.1** — decomposing the ~5478-line `build_chained_with_match_cte_plan`, one hoist per PR (slices 1–2 were #740, #741).

Extracts the **"Apply CTE name remapping for passthrough WITHs"** post-pass from the finalization tail into:

```rust
fn apply_passthrough_cte_name_remappings(render_plan: &mut RenderPlan, cte_name_allocator: &CteNameAllocator)
```

The `if cte_name_allocator.has_remappings()` guard moves into the fn — the block already early-outs on that condition, so a no-op-when-empty free fn is exactly equivalent.

## Why behavior-preserving

- Block reads `cte_name_allocator` and mutates `render_plan`.
- Both allocator methods (`has_remappings`, `remapping`) are private methods on the module-level `CteNameAllocator` struct → reachable from a sibling free fn; `remap_cte_names_in_render_plan` is an existing file-level import → no new imports.
- No `return`/`?`/`break`/`continue`, so moving into a `fn` can't change flow.
- Logic byte-for-byte identical modulo the borrow→param substitution.

## Gate

- `cargo fmt --all` + `cargo clippy --all-targets` clean (0 warnings)
- **1607** lib + **529** integration (incl. `corpus_sweep` + `sql_golden` **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (**net-zero**), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)