### PR TITLE
refactor(P4 §7.1): hoist prepare_with_plans_and_pre_aliases out of the alias loop

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -4254,6 +4254,66 @@ fn build_iteration_worklist(
     )
 }
 
+/// Prepare a WITH alias group's plans for rendering and collect its pre-WITH
+/// aliases (a STEP of the main loop's `'alias_loop` in
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// Refreshes every plan's `GraphJoins.cte_references` from the
+/// previous-iterations-only snapshot (so GraphRel nodes see the CTEs available
+/// before this alias's own CTE is built), then collects the table aliases
+/// defined INSIDE the WITH clauses (`Projection(With)` input) that must be
+/// filtered out of the outer query's joins — excluding the WITH boundary
+/// variable itself and any alias that is already a CTE reference from an earlier
+/// iteration (`processed_cte_aliases`).
+///
+/// Returns `(refreshed_with_plans, pre_with_aliases)`.
+fn prepare_with_plans_and_pre_aliases(
+    with_plans: Vec<LogicalPlan>,
+    cte_references_for_rendering: &HashMap<String, String>,
+    with_alias: &str,
+    processed_cte_aliases: &std::collections::HashSet<String>,
+) -> RenderPlanBuilderResult<(Vec<LogicalPlan>, std::collections::HashSet<String>)> {
+    let with_plans: Vec<LogicalPlan> = with_plans
+        .into_iter()
+        .map(|plan| {
+            update_graph_joins_cte_refs(
+                &plan,
+                cte_references_for_rendering,
+                &std::collections::HashMap::new(),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Collect aliases from the pre-WITH scope (inside the WITH clauses)
+    // These aliases should be filtered out from the outer query's joins
+    let mut pre_with_aliases = std::collections::HashSet::new();
+    for with_plan in with_plans.iter() {
+        // For Projection(With), the input contains the pre-WITH pattern
+        if let LogicalPlan::Projection(proj) = with_plan {
+            let inner_aliases = collect_aliases_from_plan(&proj.input);
+            pre_with_aliases.extend(inner_aliases);
+        }
+    }
+    // Don't filter out the WITH variable itself - it's the boundary variable
+    pre_with_aliases.remove(with_alias);
+    // Don't filter out aliases that are already CTEs (processed in earlier iterations)
+    // These are now references to CTEs, not original tables
+    for cte_alias in processed_cte_aliases {
+        if pre_with_aliases.remove(cte_alias) {
+            log::debug!(
+                "🔧 build_chained_with_match_cte_plan: Keeping '{}' (already a CTE reference)",
+                cte_alias
+            );
+        }
+    }
+    log::info!(
+        "🔧 build_chained_with_match_cte_plan: Pre-WITH aliases to filter: {:?}",
+        pre_with_aliases
+    );
+
+    Ok((with_plans, pre_with_aliases))
+}
+
 pub(crate) fn build_chained_with_match_cte_plan(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -4457,40 +4517,12 @@ pub(crate) fn build_chained_with_match_cte_plan(
             // Use the snapshot from PREVIOUS iterations only (not including current alias)
             log::debug!("🔧 build_chained_with_match_cte_plan: Updating cte_references for {} plans before rendering. Using previous CTEs: {:?}", with_plans.len(), cte_references_for_rendering);
 
-            let with_plans: Vec<LogicalPlan> = with_plans
-                .into_iter()
-                .map(|plan| {
-                    update_graph_joins_cte_refs(
-                        &plan,
-                        &cte_references_for_rendering,
-                        &std::collections::HashMap::new(),
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            // Collect aliases from the pre-WITH scope (inside the WITH clauses)
-            // These aliases should be filtered out from the outer query's joins
-            let mut pre_with_aliases = std::collections::HashSet::new();
-            for with_plan in with_plans.iter() {
-                // For Projection(With), the input contains the pre-WITH pattern
-                if let LogicalPlan::Projection(proj) = with_plan {
-                    let inner_aliases = collect_aliases_from_plan(&proj.input);
-                    pre_with_aliases.extend(inner_aliases);
-                }
-            }
-            // Don't filter out the WITH variable itself - it's the boundary variable
-            pre_with_aliases.remove(&with_alias);
-            // Don't filter out aliases that are already CTEs (processed in earlier iterations)
-            // These are now references to CTEs, not original tables
-            for cte_alias in &processed_cte_aliases {
-                if pre_with_aliases.remove(cte_alias) {
-                    log::debug!("🔧 build_chained_with_match_cte_plan: Keeping '{}' (already a CTE reference)", cte_alias);
-                }
-            }
-            log::info!(
-                "🔧 build_chained_with_match_cte_plan: Pre-WITH aliases to filter: {:?}",
-                pre_with_aliases
-            );
+            let (with_plans, pre_with_aliases) = prepare_with_plans_and_pre_aliases(
+                with_plans,
+                &cte_references_for_rendering,
+                &with_alias,
+                &processed_cte_aliases,
+            )?;
 
             // Render each WITH clause plan
             let mut rendered_plans: Vec<RenderPlan> = Vec::new();


### PR DESCRIPTION
## What

Eleventh slice of **Phase-4 §7.1** — the second into the main `while` loop, and the **first from inside the `'alias_loop`** (the per-alias-group for-loop).

Extracts the control-flow-clean sub-region that (a) refreshes each WITH plan's `GraphJoins.cte_references` from the previous-iterations-only snapshot and (b) collects the pre-WITH aliases to filter from the outer joins, into:

```rust
fn prepare_with_plans_and_pre_aliases(
    with_plans: Vec<LogicalPlan>,
    cte_references_for_rendering: &HashMap<String, String>,
    with_alias: &str,
    processed_cte_aliases: &HashSet<String>,
) -> RenderPlanBuilderResult<(Vec<LogicalPlan>, HashSet<String>)>
```

## Why safe

- The extracted region sits **after** the `filtered_grouped_withs.get(&with_alias)` match whose `None`-arm does `continue` — so the region itself has **no loop-control flow** (no `continue`/`break`), only the fn-level `?` on the `update_graph_joins_cte_refs` map, which the call site re-propagates with `?` (same `Err`, same point).
- It reads the previous-CTE snapshot + the loop-level `processed_cte_aliases` (**read-only**) and produces the rebound `with_plans` + `pre_with_aliases` the rest of the alias-loop consumes.

## Deltas from byte-identical

- `pre_with_aliases.remove(&with_alias)` → `.remove(with_alias)` (param is `&str`; `HashSet<String>::remove` takes a `Borrow`).
- `&cte_references_for_rendering` → `cte_references_for_rendering` (already a ref).
- `update_graph_joins_cte_refs` / `collect_aliases_from_plan` are module-level imports → no new imports.

## Gate

- `cargo fmt --all` + `cargo clippy --all-targets` clean (0 warnings)
- **1607** lib + **529** integration (corpus_sweep + sql_golden **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (**net-zero**), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)