### PR TITLE
refactor(P4 §7.1): hoist build_alias_rename_map out of the alias loop

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -5073,6 +5073,72 @@ fn build_cte_column_metadata(
     )
 }
 
+/// Extract the WITH clause's original exported aliases and the renamed→original
+/// alias map (a STEP of the main loop's `'alias_loop` in
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// `original_exported_aliases` are the WithClause's own exported aliases (falling
+/// back to splitting `with_alias` on `_`). The rename map handles `WITH u AS
+/// person`: it maps the renamed alias (`person`) back to the original (`u`) —
+/// derived from each projection item whose expression is a `TableAlias` or
+/// `PropertyAccessExp` and whose output name differs from that source alias — so
+/// downstream lookups can find CTE columns prefixed with the original alias in
+/// `property_mapping`.
+///
+/// Returns `(original_exported_aliases, alias_rename_map)`.
+fn build_alias_rename_map(
+    with_plans: &[LogicalPlan],
+    with_alias: &str,
+) -> (Vec<String>, HashMap<String, String>) {
+    let original_exported_aliases: Vec<String> = with_plans
+        .iter()
+        .find_map(|plan| {
+            if let LogicalPlan::WithClause(wc) = plan {
+                Some(wc.exported_aliases.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| with_alias.split('_').map(|s| s.to_string()).collect());
+
+    // Build rename mapping: renamed_alias → original_alias
+    // For "WITH u AS person", maps "person" → "u" so we can find
+    // CTE columns prefixed with the original alias in property_mapping.
+    let alias_rename_map: HashMap<String, String> = with_plans
+        .iter()
+        .find_map(|plan| {
+            if let LogicalPlan::WithClause(wc) = plan {
+                let mut renames = HashMap::new();
+                for item in &wc.items {
+                    if let Some(ref col_alias) = item.col_alias {
+                        let renamed = &col_alias.0;
+                        // Extract original alias from expression
+                        let original = match &item.expression {
+                            crate::query_planner::logical_expr::LogicalExpr::TableAlias(ta) => {
+                                Some(ta.0.clone())
+                            }
+                            crate::query_planner::logical_expr::LogicalExpr::PropertyAccessExp(
+                                pa,
+                            ) => Some(pa.table_alias.0.clone()),
+                            _ => None,
+                        };
+                        if let Some(orig) = original {
+                            if &orig != renamed {
+                                renames.insert(renamed.clone(), orig);
+                            }
+                        }
+                    }
+                }
+                Some(renames)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    (original_exported_aliases, alias_rename_map)
+}
+
 pub(crate) fn build_chained_with_match_cte_plan(
     plan: &LogicalPlan,
     schema: &GraphSchema,
@@ -7307,48 +7373,11 @@ pub(crate) fn build_chained_with_match_cte_plan(
             let (select_items_for_schema, property_names_for_schema, cte_columns) =
                 build_cte_column_metadata(&with_cte_render, &with_alias, &cte_name);
 
-            // Extract original WITH exported aliases for cte_references mapping
-            let original_exported_aliases: Vec<String> = with_plans
-                .iter()
-                .find_map(|plan| {
-                    if let LogicalPlan::WithClause(wc) = plan {
-                        Some(wc.exported_aliases.clone())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| with_alias.split('_').map(|s| s.to_string()).collect());
-
-            // Build rename mapping: renamed_alias → original_alias
-            // For "WITH u AS person", maps "person" → "u" so we can find
-            // CTE columns prefixed with the original alias in property_mapping.
-            let alias_rename_map: HashMap<String, String> = with_plans
-                .iter()
-                .find_map(|plan| {
-                    if let LogicalPlan::WithClause(wc) = plan {
-                        let mut renames = HashMap::new();
-                        for item in &wc.items {
-                            if let Some(ref col_alias) = item.col_alias {
-                                let renamed = &col_alias.0;
-                                // Extract original alias from expression
-                                let original = match &item.expression {
-                                    crate::query_planner::logical_expr::LogicalExpr::TableAlias(ta) => Some(ta.0.clone()),
-                                    crate::query_planner::logical_expr::LogicalExpr::PropertyAccessExp(pa) => Some(pa.table_alias.0.clone()),
-                                    _ => None,
-                                };
-                                if let Some(orig) = original {
-                                    if &orig != renamed {
-                                        renames.insert(renamed.clone(), orig);
-                                    }
-                                }
-                            }
-                        }
-                        Some(renames)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_default();
+            // Extract original WITH exported aliases + the renamed→original alias
+            // map for cte_references / property_mapping lookups.
+            // See `build_alias_rename_map`.
+            let (original_exported_aliases, alias_rename_map) =
+                build_alias_rename_map(&with_plans, &with_alias);
 
             // ==========================================================================
             // FIX: Post-WITH OPTIONAL MATCH CTE body restructuring


### PR DESCRIPTION
## What

Sixteenth slice of **Phase-4 §7.1**.

Extracts the **"original exported aliases + renamed→original alias map"** phase into:

```rust
fn build_alias_rename_map(
    with_plans: &[LogicalPlan],
    with_alias: &str,
) -> (Vec<String>, HashMap<String, String>)
```

`original_exported_aliases` = the WithClause's exported aliases (else split `with_alias` on `_`); the rename map handles `WITH u AS person` by mapping the renamed alias (`person`) back to the source alias (`u`), derived from each projection item whose expression is a `TableAlias`/`PropertyAccessExp` with a differing output name.

## Why safe

- **Control-flow-clean** (two `.find_map()` chains, no `continue`/`break`/`return`/`?`), **read-only**.
- Both products used downstream: `original_exported_aliases` → `with_cte.with_exported_aliases`; `alias_rename_map` → `property_mapping` lookups.
- Byte-for-byte identical modulo owned→borrowed param.

## Gate

- `cargo fmt --all` + `cargo clippy --all-targets` clean (0 warnings)
- **1607** lib + **529** integration (corpus_sweep + sql_golden **byte-identical**, no `UPDATE_GOLDEN`) + **1** ratchet (**net-zero**), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)