### PR TITLE
refactor(P4 §7.1 slice 33): extract compute_pc_skip_aliases (P8)

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -6680,6 +6680,59 @@ fn fix_composite_alias_refs_and_augment_scope(
     }
 }
 
+/// Compute the pattern-comprehension result aliases to skip in WITH-item
+/// projection (a STEP of the main loop's inner render-loop in
+/// `build_chained_with_match_cte_plan`, Phase-4 §7.1 extraction).
+///
+/// Returns `(pc_result_aliases, pc_correlated_aliases)`. For the LEGACY CTE+JOIN
+/// path (no `pattern_hops`), PC result aliases go in the first set so their WITH
+/// items are skipped (results arrive via CTE LEFT JOINs). For the correlated
+/// subquery path (`pattern_hops` populated), they go in the second set so the
+/// items are kept and `count(*)` can be replaced inline. Pure function of the
+/// segment's first WITH plan.
+fn compute_pc_skip_aliases(
+    with_plans: &[LogicalPlan],
+) -> (
+    std::collections::HashSet<String>,
+    std::collections::HashSet<String>,
+) {
+    let (pc_result_aliases, pc_correlated_aliases): (
+        std::collections::HashSet<String>,
+        std::collections::HashSet<String>,
+    ) = with_plans
+        .first()
+        .and_then(|plan| match plan {
+            LogicalPlan::WithClause(wc) if !wc.pattern_comprehensions.is_empty() => {
+                // If any PC has pattern_hops, use correlated subquery path → don't skip
+                let has_pattern_hops = wc
+                    .pattern_comprehensions
+                    .iter()
+                    .any(|pc| !pc.pattern_hops.is_empty());
+                if has_pattern_hops {
+                    // Correlated subquery path: collect aliases that contain count(*)
+                    // placeholders — these will be replaced with scalar subqueries,
+                    // so they should NOT trigger has_aggregation.
+                    let correlated: std::collections::HashSet<String> = wc
+                        .pattern_comprehensions
+                        .iter()
+                        .map(|pc| pc.result_alias.clone())
+                        .collect();
+                    Some((std::collections::HashSet::new(), correlated))
+                } else {
+                    let legacy: std::collections::HashSet<String> = wc
+                        .pattern_comprehensions
+                        .iter()
+                        .map(|pc| pc.result_alias.clone())
+                        .collect();
+                    Some((legacy, std::collections::HashSet::new()))
+                }
+            }
+            _ => None,
+        })
+        .unwrap_or_default();
+    (pc_result_aliases, pc_correlated_aliases)
+}
+
 /// Register schemas for VLP CTEs used by this render segment (a STEP of the main
 /// loop's inner render-loop in `build_chained_with_match_cte_plan`, Phase-4 §7.1
 /// extraction).
@@ -7528,40 +7581,8 @@ pub(crate) fn build_chained_with_match_cte_plan(
                 // (their results come from CTE LEFT JOINs, not from regular WITH item processing)
                 // NOTE: Only skip items for LEGACY CTE+JOIN path. For the new correlated subquery
                 // path (pattern_hops populated), keep items so count(*) can be replaced inline.
-                let (pc_result_aliases, pc_correlated_aliases): (
-                    std::collections::HashSet<String>,
-                    std::collections::HashSet<String>,
-                ) = with_plans
-                    .first()
-                    .and_then(|plan| match plan {
-                        LogicalPlan::WithClause(wc) if !wc.pattern_comprehensions.is_empty() => {
-                            // If any PC has pattern_hops, use correlated subquery path → don't skip
-                            let has_pattern_hops = wc
-                                .pattern_comprehensions
-                                .iter()
-                                .any(|pc| !pc.pattern_hops.is_empty());
-                            if has_pattern_hops {
-                                // Correlated subquery path: collect aliases that contain count(*)
-                                // placeholders — these will be replaced with scalar subqueries,
-                                // so they should NOT trigger has_aggregation.
-                                let correlated: std::collections::HashSet<String> = wc
-                                    .pattern_comprehensions
-                                    .iter()
-                                    .map(|pc| pc.result_alias.clone())
-                                    .collect();
-                                Some((std::collections::HashSet::new(), correlated))
-                            } else {
-                                let legacy: std::collections::HashSet<String> = wc
-                                    .pattern_comprehensions
-                                    .iter()
-                                    .map(|pc| pc.result_alias.clone())
-                                    .collect();
-                                Some((legacy, std::collections::HashSet::new()))
-                            }
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or_default();
+                let (pc_result_aliases, pc_correlated_aliases) =
+                    compute_pc_skip_aliases(&with_plans);
 
                 // Apply WITH items projection if present
                 // This handles cases like `WITH friend.firstName AS name` or `WITH count(friend) AS cnt`


### PR DESCRIPTION
## Phase-4 §7.1 slice 33 — inner render-loop STEP extraction (P8)

Extracts the pattern-comprehension skip-alias computation (P8) from
`build_chained_with_match_cte_plan`'s inner `for with_plan in with_plans` loop
into a pure module-level function.

### What moved
The `let (pc_result_aliases, pc_correlated_aliases) = ...` statement that
inspects the segment's first WITH plan and partitions PC result aliases into:
- **legacy CTE+JOIN path** (no `pattern_hops`) → first set, items skipped
- **correlated subquery path** (`pattern_hops` populated) → second set, items kept so `count(*)` replaces inline

### Signature
```rust
fn compute_pc_skip_aliases(
    with_plans: &[LogicalPlan],
) -> (std::collections::HashSet<String>, std::collections::HashSet<String>)
```
Pure function: single read-only slice input, tuple return, no `&mut`, no control flow. Cleanest possible extraction. Moved statement logic byte-identical modulo fmt reflow.

### Gate
- `cargo test --lib`: 1607 passed, 0 failed
- `cargo test --test integration`: 529 passed (corpus_sweep + sql_golden byte-identical, no UPDATE_GOLDEN)
- `cargo test --test ratchet`: net-zero
- clippy `--all-targets` + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)