### PR TITLE
docs(P4 §7.1): record build_chained inner render-loop fully decomposed (#770–#780)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ◐ Phase-4 §7.1 `build_chained` decomposition IN PROGRESS (11 PRs #740–#750, tail done, main-loop teardown started — see §4 + REFACTORING_SAFETY_PLAN §7.1)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ◐ Phase-4 §7.1 `build_chained` decomposition IN PROGRESS (39 PRs #740–#780; tail + main-loop + inner render-loop all decomposed, build_chained 5478 → 850 ln — see §4 + REFACTORING_SAFETY_PLAN §7.1)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -297,6 +297,25 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-28: **Phase-4 §7.1 — `build_chained` inner render-loop FULLY
+  DECOMPOSED** (P-3 lane; PRs #770–#780, 11 more since the earlier 2026-07-28
+  entry). The last hard core — the `for with_plan in with_plans` render-loop —
+  is now a linear pipeline of 14 module-level STEP `fn`s (P1–P14), called
+  top-to-bottom. The anticipated `WithCteBuildState`/`ControlFlow` machinery was
+  **not needed**: only the passthrough-collapse phase owned the labeled
+  `break 'alias_loop`, extracted via a **signal-return** (`try_collapse_passthrough_with
+  → RenderPlanBuilderResult<bool>`; `Ok(true)` → caller `if …? { break 'alias_loop; }`,
+  label binding stays at the call site). The other phases used the standard
+  `&mut`-param + `-> RenderPlanBuilderResult<T>` technique. Notable slices:
+  `apply_with_items_projection` (P9, ~660 ln, 16 params — the largest),
+  `apply_with_order_by_skip_limit_where` (P10+P11), `extract_with_plan_parts`
+  (P2, pure 8-tuple with a borrowed first element). Every slice verified
+  byte-identical-modulo-mechanical by corpus_sweep + sql_golden (no golden
+  regen) and adversarially subagent-reviewed clean. `build_chained` **5478 →
+  850 lines** (84% reduction); the readability half of the exit criterion is met.
+  Remaining to reach ~500: the accumulator-heavy pre-loop setup + `'alias_loop`
+  glue, most of which is the loop's irreducible mutable-state frame. See
+  `REFACTORING_SAFETY_PLAN.md` §7.1.
 - 2026-07-28: **Phase-4 §7.1 — `replace_with_clause_with_cte_reference_v2` DONE
   + `build_chained` clean regions all extracted** (P-3 lane; PRs #749–#768, 20
   more since the 2026-07-27 entry). `replace_v2` (the second §7.1 giant) is fully

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -667,8 +667,8 @@ Exit criterion: no function in the module exceeds ~500 lines; the STEP
 pipeline of the WITH→CTE build is readable top-to-bottom in the entry
 function.
 
-**Progress (2026-07-28):** ◐ **in progress** — 28 byte-identical/behavior-preserving
-PRs merged (#740–#768). A structural correction to the protocol: `build_chained`
+**Progress (2026-07-28):** ◐ **in progress** — 39 byte-identical/behavior-preserving
+PRs merged (#740–#780). A structural correction to the protocol: `build_chained`
 has **no** named nested `fn`s or `RefCell`-capturing closures to hoist (the
 anticipated shape). It is a linear body — setup → a
 `while has_with_clause_in_graph_rel` loop → a **finalization tail** of
@@ -706,13 +706,30 @@ as a param. So the decomposition hoists each self-contained region into a named
   (Projection/GraphJoins/GraphRel/Union/WithClause) are extracted into
   `replace_v2_<variant>_arm` handlers (#764–#768). replace_v2 ~1070 → **212
   lines**; remaining arms are all 12–43 ln.
-- ☐ **Remaining: `build_chained`'s ~1970-line inner `for with_plan in with_plans`
-  render-loop** — the one hard core. Its phases mutate shared locals
-  (`rendered`/`plan_to_render`/`rendered_plans`/`inner_plans_for_id`/
-  `has_optional_match_input`) AND contain `break 'alias_loop`/`continue`/`?` that
-  escape the loop. Needs a `ControlFlow`/action-enum return pattern or the
-  `WithCteBuildState` context struct — a step-change from the byte-identical
-  hoists. Deferred pending an explicit go-ahead.
+- ☑ **`build_chained`'s inner `for with_plan in with_plans` render-loop —
+  fully decomposed** (11 PRs, #770–#780). The one hard core: its phases mutate
+  shared locals (`rendered`/`plan_to_render`/`rendered_plans`/…) AND it owned
+  `break 'alias_loop` + fn-level `?`. The anticipated `WithCteBuildState`
+  context-struct / `ControlFlow` machinery proved **unnecessary** — the standard
+  `&mut`-param + `-> RenderPlanBuilderResult<T>` technique worked, since only the
+  passthrough-collapse phase owned the labeled `break`, extracted via a
+  **signal-return** (`fn … -> RenderPlanBuilderResult<bool>`, `Ok(true)` →
+  caller does `if …? { break 'alias_loop; }`, keeping the label binding at the
+  call site). The 14 STEP phases are now module-level `fn`s called top-to-bottom:
+  `try_collapse_passthrough_with` (P1, signal-return), `extract_with_plan_parts`
+  (P2, pure 8-tuple), `render_with_cte_body` (P4), `reattach_unwind_array_joins`
+  (P5), `extract_nested_cte_schemas` (P6), `register_vlp_cte_schemas` (P7),
+  `compute_pc_skip_aliases` (P8, pure), `apply_with_items_projection` (P9,
+  ~660 ln, 16 params), `apply_with_order_by_skip_limit_where` (P10+P11),
+  `rewrite_cte_join_conditions_and_prune_orphans` (P12),
+  `fix_composite_alias_refs_and_augment_scope` (P13). Every extraction verified
+  byte-identical-modulo-mechanical (dedent, `&mut`-deref, `?`-hoist, borrow-drop)
+  by corpus_sweep + sql_golden with no golden regeneration, and adversarially
+  subagent-reviewed. `build_chained` is 5478 → **850 lines**; the inner-loop body
+  now reads as a linear pipeline of named STEP calls (the readability half of the
+  exit criterion is met). Remaining to reach the ~500-line size half: the
+  accumulator-heavy pre-loop setup + `'alias_loop` glue, most of which is the
+  loop's irreducible mutable-state frame.
 
 
 ### 7.2 Forward resolution through CTE scope (§10)


### PR DESCRIPTION
## Docs update — Phase-4 §7.1 milestone

Records that `build_chained_with_match_cte_plan`'s inner `for with_plan in with_plans`
render-loop — the last hard core of the §7.1 decomposition — is now **fully
decomposed** into 14 module-level STEP functions (P1–P14), across 11 PRs (#770–#780).

### Key facts recorded
- The anticipated `WithCteBuildState` context-struct / `ControlFlow` machinery was **not needed**. Only the passthrough-collapse phase owned the labeled `break 'alias_loop`, extracted via a **signal-return** (`try_collapse_passthrough_with → RenderPlanBuilderResult<bool>`; `Ok(true)` → caller `if …? { break 'alias_loop; }`). All other phases used the standard `&mut`-param + `-> RenderPlanBuilderResult<T>` technique.
- `build_chained`: **5478 → 850 lines** (84% reduction).
- 39 byte-identical/behavior-preserving PRs total (#740–#780), each corpus_sweep + sql_golden clean (no golden regen) and adversarially subagent-reviewed.
- Readability half of the exit criterion (STEP pipeline readable top-to-bottom) is met; remaining to reach the ~500-line size half is the accumulator-heavy loop frame.

Files: `docs/design/REFACTORING_SAFETY_PLAN.md` §7.1, `docs/design/PRIORITIES.md` P-3 log. Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)