### PR TITLE
docs(P4 §7.1): record extracted helpers brought under ~500 ln (#782–#785)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -143,7 +143,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ◐ Phase-4 §7.1 `build_chained` decomposition IN PROGRESS (39 PRs #740–#780; tail + main-loop + inner render-loop all decomposed, build_chained 5478 → 850 ln — see §4 + REFACTORING_SAFETY_PLAN §7.1)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ◐ Phase-4 §7.1 `build_chained` decomposition IN PROGRESS (43 PRs #740–#785; tail + main-loop + inner render-loop decomposed AND every over-budget extracted helper sub-decomposed under ~500 ln — `build_chained` itself 5478 → 850 ln is now the SOLE remaining >500-ln fn in with_to_cte/mod.rs, the deliberately-parked accumulator frame — see §4 + REFACTORING_SAFETY_PLAN §7.1)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -297,6 +297,23 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-28: **Phase-4 §7.1 — over-budget extracted helpers brought under ~500
+  ln** (P-3 lane; PRs #782–#785). The inner-loop decomposition (#770–#780) left
+  several of the helpers it produced still over the module-wide exit target; each
+  is now sub-decomposed one byte-identical slice per PR (scout-verified seam +
+  adversarial review, both agent-driven in parallel). `resolve_cross_table_with_cte_joins`
+  775 → **355** (extracted `generate_vlp_with_cte_join_conditions` #782 + the
+  two-`return Err` `restructure_post_with_optional_or_insert_cte_join` #783);
+  `apply_with_items_projection` 660 → **459** (extracted the pure
+  `build_with_projection_select_items` flat_map builder, #784);
+  `restructure_post_with_optional_match` 529 → **71** (extracted the 445-ln
+  `restructure_optional_cte_bridge` via a borrow-clean pre-clone-`from_name` seam,
+  #785). **`build_chained_with_match_cte_plan` (850 ln) is now the SOLE function
+  in `with_to_cte/mod.rs` over ~500 ln** — the deliberately-parked accumulator
+  frame; every §7.1-extracted helper is at/under target. Module-wide exit
+  criterion met except that one frame. Method note banked: whitespace-free
+  char-multiset identity is a reliable proof that fmt-reflow-heavy dedents added
+  no semantic token. See `REFACTORING_SAFETY_PLAN.md` §7.1.
 - 2026-07-28: **Phase-4 §7.1 — `build_chained` inner render-loop FULLY
   DECOMPOSED** (P-3 lane; PRs #770–#780, 11 more since the earlier 2026-07-28
   entry). The last hard core — the `for with_plan in with_plans` render-loop —

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -730,6 +730,31 @@ as a param. So the decomposition hoists each self-contained region into a named
   exit criterion is met). Remaining to reach the ~500-line size half: the
   accumulator-heavy pre-loop setup + `'alias_loop` glue, most of which is the
   loop's irreducible mutable-state frame.
+- ☑ **Over-budget *extracted helpers* brought under ~500 ln** (4 PRs, #782–#785,
+  2026-07-28). The inner-loop decomposition (#770–#780) left several of the
+  helpers it produced still over the module-wide exit target; each is now
+  sub-decomposed one byte-identical slice per PR, scout-verified seam + adversarial
+  review:
+  - `resolve_cross_table_with_cte_joins` 775 → **355** — extracted
+    `generate_vlp_with_cte_join_conditions` (the VLP `start_id`/`end_id` join-cond
+    generator, #782) and `restructure_post_with_optional_or_insert_cte_join` (the
+    #453 post-WITH OPTIONAL anchor restructure, which owns two `return Err` →
+    `&mut`-param + call-site-`?`, #783).
+  - `apply_with_items_projection` 660 → **459** — extracted
+    `build_with_projection_select_items` (the `items.iter().flat_map(…).collect()`
+    WITH-item → SELECT-column builder; a pure expression with closure-local
+    returns, `rendered` narrowed to `&RenderPlan`, #784).
+  - `restructure_post_with_optional_match` 529 → **71** — extracted
+    `restructure_optional_cte_bridge` (445 ln; the CTE-body bridge restructure).
+    Borrow-clean seam: `from_ref` (shared borrow of `with_cte_render.from`) used in
+    the body only for one log arg → pre-clone `from_name` at the call site so its
+    borrow is dead before the `&mut` helper call (#785).
+  Result: **`build_chained_with_match_cte_plan` (850 ln) is now the ONLY function
+  in `with_to_cte/mod.rs` over ~500 lines** — the deliberately-parked irreducible
+  accumulator frame. Every helper extracted during §7.1 is at/under the target
+  (next-largest: `apply_with_items_projection` 459, `restructure_optional_cte_bridge`
+  445, `apply_pattern_comprehensions` 440). The module-wide exit criterion is met
+  except for that single frame.
 
 
 ### 7.2 Forward resolution through CTE scope (§10)


### PR DESCRIPTION
Docs-only. Updates `REFACTORING_SAFETY_PLAN.md` §7.1 and `PRIORITIES.md` P-3 (header + dated log) to record this session's four §7.1 slices.

The inner render-loop decomposition (#770–#780) produced several helpers that were themselves still over the module-wide ~500-line exit target. Slices 40–43 sub-decompose each:

| Function | Before → After | Slice |
|---|---|---|
| `resolve_cross_table_with_cte_joins` | 775 → 355 | #782 (`generate_vlp_with_cte_join_conditions`) + #783 (`restructure_post_with_optional_or_insert_cte_join`) |
| `apply_with_items_projection` | 660 → 459 | #784 (`build_with_projection_select_items`) |
| `restructure_post_with_optional_match` | 529 → 71 | #785 (`restructure_optional_cte_bridge`, 445 ln) |

**`build_chained_with_match_cte_plan` (850 ln) is now the SOLE function in `with_to_cte/mod.rs` over ~500 ln** — the deliberately-parked irreducible accumulator frame. Every §7.1-extracted helper is at/under the target. The module-wide exit criterion is met except that one frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)