### PR TITLE
fix(render): multi-type VLP non-id endpoint property → native CTE column (#716)

### DIFF
--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -1146,6 +1146,54 @@ impl SelectBuilder for LogicalPlan {
                                         }
                                     }
 
+                                    // #716: a NON-id property of a SINGLE-type VLP
+                                    // endpoint has a native `{position}_{prop}`
+                                    // column in the multi_type_vlp CTE (only
+                                    // multi-type endpoints are JSON-only). Project
+                                    // it directly, byte-identical to the GROUP BY /
+                                    // ORDER BY key `rewrite_expr_for_vlp` produces,
+                                    // so `build_aliased_group_by` unifies them.
+                                    // Otherwise the SELECT's `JSONExtractString(...)`
+                                    // and the GROUP BY's `t.{position}_{prop}` are
+                                    // DIFFERENT expressions → Code 215
+                                    // NOT_AN_AGGREGATE (the non-id sibling of #580;
+                                    // this is #580's documented follow-up). Multi-type
+                                    // / polymorphic / composite-id-`id` cases return
+                                    // None and fall through to the JSON path below.
+                                    if !has_pattern_combinations {
+                                        if let Some(native_col) = native_vlp_endpoint_column(
+                                            gr,
+                                            position == "start",
+                                            col_name,
+                                        ) {
+                                            log::info!(
+                                                "🎯 Multi-type VLP non-id property '{}.{}' -> native CTE column '{}.{}' (#716)",
+                                                cypher_alias, col_name, cte_alias, native_col
+                                            );
+                                            select_items.push(SelectItem {
+                                                expression: RenderExpr::PropertyAccessExp(
+                                                    PropertyAccess {
+                                                        table_alias: RenderTableAlias(
+                                                            cte_alias.clone(),
+                                                        ),
+                                                        column: PropertyValue::Column(native_col),
+                                                    },
+                                                ),
+                                                col_alias: item
+                                                    .col_alias
+                                                    .as_ref()
+                                                    .map(|ca| ColumnAlias(ca.0.clone()))
+                                                    .or_else(|| {
+                                                        Some(ColumnAlias(format!(
+                                                            "{}.{}",
+                                                            cypher_alias, col_name
+                                                        )))
+                                                    }),
+                                            });
+                                            continue;
+                                        }
+                                    }
+
                                     log::info!(
                                         "🎯 Multi-type VLP property access: '{}.{}' -> extracting from {}_properties JSON in CTE '{}'",
                                         cypher_alias, col_name, position, cte_alias
@@ -1897,6 +1945,34 @@ fn single_column_node_id_for_vlp_endpoint(
     gr: &crate::query_planner::logical_plan::GraphRel,
     endpoint_is_start: bool,
 ) -> Option<String> {
+    let label = single_vlp_endpoint_label(gr, endpoint_is_start)?;
+    let schema = crate::server::query_context::get_current_schema_with_fallback()?;
+    let node_schema = schema.node_schema(&label).ok()?;
+    let cols = node_schema.node_id.columns();
+    // Composite ids surface as a concatenated String in the multi-type CTE's
+    // start_id/end_id — not addressable by a single property. Leave to JSON.
+    if cols.len() != 1 {
+        return None;
+    }
+    Some(cols[0].to_string())
+}
+
+/// Resolve the SINGLE concrete node label at a multi-type VLP endpoint, or
+/// `None` when the endpoint is genuinely multi-type. Shared by the #580 id-column
+/// routing (`single_column_node_id_for_vlp_endpoint`) and the #716 non-id native
+/// property routing (`native_vlp_endpoint_column`): both are only valid when the
+/// endpoint collapses to exactly one label, because that is precisely when
+/// `multi_type_vlp_joins` emits native per-property `{start,end}_{prop}` columns
+/// (a genuinely multi-type endpoint carries only the `{start,end}_properties`
+/// JSON blob).
+///
+/// Returns `None` when the endpoint resolves to MORE THAN ONE node type or when
+/// a rel variant is polymorphic (`$any`). The single-column-id check is NOT done
+/// here — id-vs-non-id concerns belong to the callers.
+fn single_vlp_endpoint_label(
+    gr: &crate::query_planner::logical_plan::GraphRel,
+    endpoint_is_start: bool,
+) -> Option<String> {
     use crate::query_planner::logical_expr::Direction;
 
     let schema = crate::server::query_context::get_current_schema_with_fallback()?;
@@ -1967,15 +2043,66 @@ fn single_column_node_id_for_vlp_endpoint(
     if candidate_labels.len() != 1 {
         return None;
     }
-    let label = candidate_labels.into_iter().next()?;
-    let node_schema = schema.node_schema(&label).ok()?;
-    let cols = node_schema.node_id.columns();
-    // Composite ids surface as a concatenated String in the multi-type CTE's
-    // start_id/end_id — not addressable via a single property. Leave to JSON.
-    if cols.len() != 1 {
+    candidate_labels.into_iter().next()
+}
+
+/// #716: for a NON-id property (`u.city`, `u.name`) accessed at a multi-type VLP
+/// endpoint, return the CTE's native `{start,end}_{cypher_prop}` column name when
+/// one exists — i.e. when the endpoint is single-type (`single_vlp_endpoint_label`)
+/// and the property is a genuine schema `Column` mapping that
+/// `multi_type_vlp_joins` emitted as an individual native column.
+///
+/// The returned suffix is derived via [`derive_cypher_property_name`] — the SAME
+/// rewrite the GROUP BY / ORDER BY builder applies (`rewrite_expr_for_vlp`) — so
+/// the projected column is BYTE-IDENTICAL to the grouping key
+/// (`t.{position}_{suffix}`). That identity is the whole point: it lets
+/// `build_aliased_group_by` unify the SELECT expression with the GROUP BY key,
+/// which is what fixes the Code 215 NOT_AN_AGGREGATE crash (the JSON-extract
+/// projection was a DIFFERENT expression from the native grouping key).
+///
+/// Returns `None` (caller keeps the JSONExtract path) when:
+///   - the endpoint is genuinely multi-type / polymorphic (no native columns), or
+///   - the property is the node's `id` (served by the #580 id path, and skipped
+///     by the CTE because `{position}_id` would collide with the reserved
+///     `start_id`/`end_id` columns), or
+///   - the property has no single-`Column` schema mapping (the CTE emits no
+///     native column for computed / multi-column properties).
+///
+/// Composite-id nodes are fine here: compositeness only concatenates the ID
+/// column; non-id properties still get their own native `{position}_{prop}`
+/// column, so — unlike the id path — this does NOT reject composite-id endpoints.
+fn native_vlp_endpoint_column(
+    gr: &crate::query_planner::logical_plan::GraphRel,
+    endpoint_is_start: bool,
+    col_name: &str,
+) -> Option<String> {
+    use crate::graph_catalog::expression_parser::PropertyValue;
+
+    let position = if endpoint_is_start { "start" } else { "end" };
+    let label = single_vlp_endpoint_label(gr, endpoint_is_start)?;
+
+    // Match the GROUP BY builder's suffix derivation exactly (rewrite_expr_for_vlp
+    // → derive_cypher_property_name), so SELECT and GROUP BY reference one column.
+    let suffix =
+        crate::sql_generator::emitters::clickhouse::to_sql_query::derive_cypher_property_name(
+            col_name,
+        );
+
+    // The id property maps to `{position}_id`, which the CTE deliberately skips
+    // (reserved-column collision with `start_id`/`end_id`) and the #580 id path
+    // already serves. Leave it alone.
+    if suffix == "id" {
         return None;
     }
-    Some(cols[0].to_string())
+
+    // Only route when the CTE actually emitted a native column for this property:
+    // it must be a single-`Column` schema mapping on the single candidate label.
+    let schema = crate::server::query_context::get_current_schema_with_fallback()?;
+    let node_schema = schema.node_schema(&label).ok()?;
+    match node_schema.property_mappings.get(&suffix) {
+        Some(PropertyValue::Column(_)) => Some(format!("{}_{}", position, suffix)),
+        _ => None,
+    }
 }
 
 /// #509: build the id-column `PropertyAccess` (or multi-label `coalesce(...)`

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -2062,9 +2062,10 @@ fn single_vlp_endpoint_label(
 ///
 /// Returns `None` (caller keeps the JSONExtract path) when:
 ///   - the endpoint is genuinely multi-type / polymorphic (no native columns), or
-///   - the property is the node's `id` (served by the #580 id path, and skipped
-///     by the CTE because `{position}_id` would collide with the reserved
-///     `start_id`/`end_id` columns), or
+///   - the property is id-shaped (`is_vlp_id_shaped_column`): the genuine
+///     single-column node id is served by the #580 id branch, and any OTHER
+///     id-shaped property maps to the GROUP BY's `{position}_id` sentinel, so it
+///     must stay on the JSON path to avoid a divergent projection (Code 215), or
 ///   - the property has no single-`Column` schema mapping (the CTE emits no
 ///     native column for computed / multi-column properties).
 ///
@@ -2081,19 +2082,27 @@ fn native_vlp_endpoint_column(
     let position = if endpoint_is_start { "start" } else { "end" };
     let label = single_vlp_endpoint_label(gr, endpoint_is_start)?;
 
+    // GROUP BY's `rewrite_expr_for_vlp` treats an id-shaped column as the CTE's
+    // native `{position}_id` sentinel (`col == "id" || starts_with("id.") ||
+    // ends_with("_id") || contains(".orig_"|".resp_")`, to_sql_query.rs). We must
+    // decline EXACTLY those here so the SELECT never routes an id-shaped property
+    // to `{position}_{col}` while the GROUP BY key is `{position}_id` — that
+    // divergence re-creates the very Code 215 this fix removes (e.g. a Post's
+    // non-node-id `author_id` property: GROUP BY → `t.end_id`, so the projection
+    // must NOT become `t.end_author_id`). The genuine single-column node id is
+    // served by the #580 id branch just above; any OTHER id-shaped property (not
+    // the node id) stays on the JSON path unchanged — a pre-existing limitation,
+    // not one this fix introduces.
+    if is_vlp_id_shaped_column(col_name) {
+        return None;
+    }
+
     // Match the GROUP BY builder's suffix derivation exactly (rewrite_expr_for_vlp
     // → derive_cypher_property_name), so SELECT and GROUP BY reference one column.
     let suffix =
         crate::sql_generator::emitters::clickhouse::to_sql_query::derive_cypher_property_name(
             col_name,
         );
-
-    // The id property maps to `{position}_id`, which the CTE deliberately skips
-    // (reserved-column collision with `start_id`/`end_id`) and the #580 id path
-    // already serves. Leave it alone.
-    if suffix == "id" {
-        return None;
-    }
 
     // Only route when the CTE actually emitted a native column for this property:
     // it must be a single-`Column` schema mapping on the single candidate label.
@@ -2103,6 +2112,21 @@ fn native_vlp_endpoint_column(
         Some(PropertyValue::Column(_)) => Some(format!("{}_{}", position, suffix)),
         _ => None,
     }
+}
+
+/// Mirror of `rewrite_expr_for_vlp`'s id-column detection
+/// (`to_sql_query.rs`): a VLP endpoint property whose raw column matches any of
+/// these is rewritten to the CTE's native `{position}_id` sentinel by the
+/// GROUP BY / ORDER BY / WHERE builders. `native_vlp_endpoint_column` consults
+/// this to avoid emitting a divergent `{position}_{col}` projection for the same
+/// property (which would re-introduce Code 215). Kept textually identical to the
+/// predicate at the rewrite site — if that list changes, this must change too.
+fn is_vlp_id_shaped_column(col_raw: &str) -> bool {
+    col_raw == "id"
+        || col_raw.starts_with("id.")
+        || col_raw.ends_with("_id")
+        || col_raw.contains(".orig_")
+        || col_raw.contains(".resp_")
 }
 
 /// #509: build the id-column `PropertyAccess` (or multi-label `coalesce(...)`

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -2462,7 +2462,7 @@ fn is_vlp_path_is_null(expr: &RenderExpr, path_variable: &Option<String>) -> boo
 /// This would allow proper handling of arbitrary schema variations without hardcoding.
 ///
 /// FUTURE: Consider caching property mapping results to improve performance for repeated queries.
-fn derive_cypher_property_name(db_column: &str) -> String {
+pub(crate) fn derive_cypher_property_name(db_column: &str) -> String {
     // Common mappings for various schemas
     // Social benchmark schema
     match db_column {

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14820,3 +14820,96 @@ async fn multi_type_vlp_endpoint_id_scoping_580() {
         );
     }
 }
+
+/// Regression for #716: a NON-id property (`u.city`, `u.name`) of a SINGLE-type
+/// VLP endpoint must project the CTE's native `{start,end}_{prop}` column —
+/// NOT `JSONExtractString({start,end}_properties, ...)`. The non-id sibling of
+/// #580 (which fixed the id-column case and documented this as a follow-up).
+///
+/// The GROUP BY builder (`rewrite_expr_for_vlp` → `derive_cypher_property_name`)
+/// already resolves the same property to the native `t.start_city` column, so
+/// the JSON-extract projection was a DIFFERENT expression from the grouping key
+/// → Code 215 NOT_AN_AGGREGATE (live-verified on the social benchmark). Routing
+/// the SELECT to the identical native column lets `build_aliased_group_by` unify
+/// them. Both start (left_connection) and end (right_connection) endpoints, and
+/// the db→cypher-renamed property (`full_name` → native `start_name`), covered.
+#[tokio::test]
+async fn multi_type_vlp_endpoint_non_id_property_uses_native_column_716() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    // Aggregate over a multi-type VLP grouping by a NON-id START property.
+    let agg = "MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id = 1 \
+               RETURN u.city, count(*)";
+    // A db→cypher-renamed property (`name` maps to `full_name`) — the native
+    // column must use the cypher name (`start_name`), matching the GROUP BY.
+    let renamed = "MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id = 1 \
+                   RETURN u.name, count(*)";
+    // End endpoint non-id property via a reversed pattern (u is right_connection).
+    let end = "MATCH (x)-[:FOLLOWS|AUTHORED*1..2]->(u:User) WHERE u.user_id = 2 \
+               RETURN u.city, count(*)";
+
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(&schema, agg, dialect).await;
+        // START endpoint non-id property → native start_city, not a JSON extract.
+        assert!(
+            sql.contains("t.start_city"),
+            "#716: start endpoint non-id property must project native t.start_city \
+             for {dialect:?}, got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("start_properties, 'city'")
+                && !sql.contains("start_properties, '$.city'"),
+            "#716: start endpoint non-id property must NOT JSON-extract for {dialect:?}, got:\n{sql}"
+        );
+        // SELECT and GROUP BY reference the SAME native column (the unification
+        // that removes Code 215).
+        assert!(
+            sql.contains("GROUP BY `t.start_city`"),
+            "#716: GROUP BY must reference the native start_city column for {dialect:?}, got:\n{sql}"
+        );
+
+        // db→cypher rename: `u.name` (db `full_name`) → native `start_name`,
+        // matching the GROUP BY's derive_cypher_property_name mapping.
+        let renamed_sql = render(&schema, renamed, dialect).await;
+        assert!(
+            renamed_sql.contains("t.start_name") && renamed_sql.contains("GROUP BY `t.start_name`"),
+            "#716: renamed non-id property must project + group by native start_name \
+             for {dialect:?}, got:\n{renamed_sql}"
+        );
+        assert!(
+            !renamed_sql.contains("start_properties, 'full_name'"),
+            "#716: renamed non-id property must NOT JSON-extract for {dialect:?}, got:\n{renamed_sql}"
+        );
+
+        // END endpoint non-id property → native end_city.
+        let end_sql = render(&schema, end, dialect).await;
+        assert!(
+            end_sql.contains("t.end_city") && !end_sql.contains("end_properties, 'city'"),
+            "#716: end endpoint non-id property must project native end_city for {dialect:?}, got:\n{end_sql}"
+        );
+    }
+}
+
+/// #716 boundary coverage: the native-column rewrite must fire ONLY when the VLP
+/// endpoint is genuinely single-type. A genuinely-multi-type far endpoint's
+/// non-id property must STAY on the JSON path (a native `{position}_{prop}`
+/// column does not exist for it — the CTE emits only the properties JSON blob).
+#[tokio::test]
+async fn multi_type_vlp_endpoint_non_id_property_scoping_716() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // OVER-FIRE GUARD: the FAR endpoint `x` of a multi-type VLP is genuinely
+        // User|Post; `x.content` (a Post property) must stay on the JSON path —
+        // no native `end_content` column exists for a multi-type endpoint.
+        let multi_far = "MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id = 1 \
+                         RETURN x.content, count(*)";
+        let far_sql = render(&schema, multi_far, dialect).await;
+        assert!(
+            far_sql.contains("end_properties, 'post_content'")
+                || far_sql.contains("end_properties, '$.post_content'"),
+            "#716: multi-type far endpoint non-id property must stay on the JSON path \
+             for {dialect:?}, got:\n{far_sql}"
+        );
+    }
+}

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14911,5 +14911,24 @@ async fn multi_type_vlp_endpoint_non_id_property_scoping_716() {
             "#716: multi-type far endpoint non-id property must stay on the JSON path \
              for {dialect:?}, got:\n{far_sql}"
         );
+
+        // ID-SHAPED NON-NODE-ID GUARD: a property whose db column ends in `_id`
+        // (e.g. Post's `author_id`, which is NOT the node id `post_id`) is
+        // rewritten by the GROUP BY builder to the CTE's `{position}_id` sentinel
+        // (`rewrite_expr_for_vlp`'s id detection: `ends_with("_id")`). The
+        // projection must therefore NOT route it to a divergent
+        // `t.end_author_id` — that would re-create the Code 215 mismatch this
+        // fix removes. It must stay on the JSON path (matching pre-fix behavior
+        // for this id-shaped shape; native routing is only for non-id-shaped
+        // props).
+        let id_shaped = "MATCH (u:User)-[:AUTHORED|LIKED*1..2]->(p:Post) WHERE u.user_id = 1 \
+                         RETURN p.author_id, count(*)";
+        let id_shaped_sql = render(&schema, id_shaped, dialect).await;
+        assert!(
+            !id_shaped_sql.contains("t.end_author_id"),
+            "#716: an id-shaped non-node-id property (author_id) must NOT route to a \
+             divergent native t.end_author_id (GROUP BY uses t.end_id) for {dialect:?}, \
+             got:\n{id_shaped_sql}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

A multi-type VLP (`[:R1|R2*1..n]`) endpoint's **non-id** property (e.g. `u.city`, `u.name`) in an aggregate crashed ClickHouse with **Code 215 NOT_AN_AGGREGATE**. The outer SELECT projected `JSONExtractString(t.start_properties, 'city')` while the GROUP BY builder independently resolved the same property to the CTE's native `t.start_city` column — two different expressions for one value, so the projected non-aggregate was neither grouped nor aggregated.

The non-id sibling of #580 (which fixed the id-column case and explicitly deferred non-id properties as a follow-up).

**Live-verified** on the social benchmark:
```cypher
MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id=1 RETURN u.city, count(*)
```
Before: `Code: 215 ... 'u.city' is not under aggregate function and not in GROUP BY keys`. After: `New York | 12` (ClickHouse **and** Databricks dialects).

## Root cause & fix

The `multi_type_vlp` CTE already emits native `{start,end}_{cypher_prop}` columns whenever the endpoint is **single-type** (a genuinely multi-type endpoint carries only the properties JSON blob), so the SELECT can project them directly — matching the GROUP BY key byte-for-byte and letting `build_aliased_group_by` unify the two.

- Factor `single_vlp_endpoint_label` out of `single_column_node_id_for_vlp_endpoint` (shared single-candidate-label resolution; `None` for multi-type / polymorphic `$any`).
- Add `native_vlp_endpoint_column`: for a single-type endpoint, return `{position}_{derive_cypher_property_name(col)}` when the property is a single-`Column` schema mapping. The suffix is routed through the **same** `derive_cypher_property_name` the GROUP BY uses (now `pub(crate)`), so **SELECT ≡ GROUP BY by construction**. Excludes the `id` property (served by #580; CTE skips `{position}_id` as a reserved-column collision) and multi-type endpoints (fall through to JSON unchanged). Unlike the id path it does **not** reject composite-id endpoints (compositeness only concatenates the id column).
- Insert the native-column branch after the #580 id branch, before the JSONExtract fallthrough.

## Scope / non-goals

- Genuinely-multi-type endpoints (`x` = User|Post) correctly **stay on JSON** (over-fire guard tested).
- Polymorphic `$any` edges decline (same limitation the #580 id path already has — the polymorphic-schema variant remains a follow-up).
- The "silent-empty ambiguous-JSON-key" half of #716 **does not reproduce** for aliased single-column references (ClickHouse emits a bare `{"city":...}` key); the genuine bug is the Code 215 crash, which this resolves.

## Verification

- **Byte-identical** corpus_sweep + 236 sql_golden (no `UPDATE_GOLDEN`) — **no existing golden changes** (the single-hop data_security / polymorphic `$any` shapes take a different runtime path or decline).
- +2 regression tests: native-column routing for start/end/renamed (`full_name`→`start_name`) props; multi-type-endpoint over-fire guard — both dialects.
- 1607 lib + 531 integration green; `cargo fmt --all --check` clean; `clippy --all-targets` clean; ratchet net-zero.
- Live-verified against ClickHouse (social benchmark): correct city/name + count 12; over-fire guard holds; Databricks dialect routes to native `any_value(t.start_city)`.

Fixes #716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)