### PR TITLE
docs(P4 §7.1): formally close build_chained decomposition

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -149,7 +149,7 @@ P-3). Latent finding filed in-report: `has_with_clause_in_graph_rel` is
 duplicated (utils + helpers) with a DIFFERENT semantic — a future consolidation
 candidate, not touched here (§8.3 no-drive-by).
 
-### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ◐ Phase-4 §7.1 `build_chained` decomposition IN PROGRESS (43 PRs #740–#785; tail + main-loop + inner render-loop decomposed AND every over-budget extracted helper sub-decomposed under ~500 ln — `build_chained` itself 5478 → 850 ln is now the SOLE remaining >500-ln fn in with_to_cte/mod.rs, the deliberately-parked accumulator frame — see §4 + REFACTORING_SAFETY_PLAN §7.1)
+### P-3 — Phase 2 module moves (P2.1 → P2.6, in order)  ☑ (P2.1–P2.6 + P2.7 D1 done; D6/D8 already resolved; P2.10 import hygiene + dead_code tail COMPLETE — no module-level allow(dead_code) remains under src/render_plan/) · ☑ Phase-4 §7.1 `build_chained` decomposition **DONE / CLOSED** (43 PRs #740–#785; tail + main-loop + inner render-loop decomposed AND every over-budget extracted helper sub-decomposed under ~500 ln; `replace_v2` 1070 → 212 ln; `build_chained` itself 5478 → 850 ln is the SOLE remaining >500-ln fn in with_to_cte/mod.rs — its irreducible accumulator frame, exit criterion met, the ~19-param whole-loop lift explicitly declined — see §4 + REFACTORING_SAFETY_PLAN §7.1)
 The dead-code sweep shrank plan_builder_utils.rs to ~14.5K lines. §5.1 moves are
 now underway. Pure groups first (vlp_rewrite →
 pattern_comprehension_sql → clause_extractors → plan_predicates →
@@ -303,6 +303,20 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-28: **Phase-4 §7.1 — FORMALLY CLOSED** (P-3 lane; docs-only). The
+  entangled-core decomposition is declared complete: across 43 byte-identical/
+  behavior-preserving PRs (#740–#785) `replace_v2` went 1070 → 212 ln and
+  `build_chained_with_match_cte_plan` went 5478 → 850 ln, with every *extractable*
+  helper at/under the ~500-ln target (next-largest 459/445/440). The lone survivor
+  — `build_chained` at 850 ln — is its irreducible mutable-state frame (~10 `let mut`
+  accumulators + the `while`/`'alias_loop` glue between already-extracted STEP
+  helpers + tracing), not an un-decomposed body; the readability half of the exit
+  criterion (STEP pipeline readable top-to-bottom) is met. The only path under 500
+  is lifting the whole `'alias_loop` into one ~19-param signal-return helper, which
+  trades param-plumbing for line count with no readability gain — **explicitly
+  declined**. The remaining substantial refactor work is now **Phase-4 §7.2**
+  (forward resolution / delete `reverse_mapping`), tracked as the **P-4 lane**
+  (`FORWARD_RESOLUTION_PLAN.md`). See `REFACTORING_SAFETY_PLAN.md` §7.1.
 - 2026-07-28: **Phase-4 §7.1 — over-budget extracted helpers brought under ~500
   ln** (P-3 lane; PRs #782–#785). The inner-loop decomposition (#770–#780) left
   several of the helpers it produced still over the module-wide exit target; each

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -667,8 +667,9 @@ Exit criterion: no function in the module exceeds ~500 lines; the STEP
 pipeline of the WITH→CTE build is readable top-to-bottom in the entry
 function.
 
-**Progress (2026-07-28):** ◐ **in progress** — 39 byte-identical/behavior-preserving
-PRs merged (#740–#780). A structural correction to the protocol: `build_chained`
+**Progress (2026-07-28): ☑ COMPLETE — exit criterion met.** 43
+byte-identical/behavior-preserving PRs merged (#740–#785). A structural
+correction to the protocol: `build_chained`
 has **no** named nested `fn`s or `RefCell`-capturing closures to hoist (the
 anticipated shape). It is a linear body — setup → a
 `while has_with_clause_in_graph_rel` loop → a **finalization tail** of
@@ -753,8 +754,22 @@ as a param. So the decomposition hoists each self-contained region into a named
   in `with_to_cte/mod.rs` over ~500 lines** — the deliberately-parked irreducible
   accumulator frame. Every helper extracted during §7.1 is at/under the target
   (next-largest: `apply_with_items_projection` 459, `restructure_optional_cte_bridge`
-  445, `apply_pattern_comprehensions` 440). The module-wide exit criterion is met
-  except for that single frame.
+  445, `apply_pattern_comprehensions` 440).
+
+**§7.1 is CLOSED (2026-07-28, user decision).** The exit criterion — "no function
+exceeds ~500 lines; the STEP pipeline is readable top-to-bottom in the entry
+function" — is met in substance: the entry function reads as a linear pipeline of
+named STEP/finalization calls, and every *extractable* unit is ≤459 ln. The single
+survivor, `build_chained` at 850 ln, is not an un-decomposed god-function but its
+**irreducible mutable-state frame**: ~10 `let mut` accumulators (`current_plan`,
+`all_ctes`, `cte_schemas`, `cte_references`, `cte_name_allocator`, `with_scope`,
+the `flattened_compound_keys` RefCell, …), the `while has_with_clause_in_graph_rel`
+/ `'alias_loop` control glue between already-extracted helpers, and per-phase
+tracing. The only way to force it under 500 is to lift the whole `'alias_loop`
+body into a single ~19-parameter signal-return helper — trading param-plumbing for
+raw line count with **no readability gain** (arguably a loss). That lift is
+explicitly **declined** as not worth the cost; the frame stays as the documented
+terminal state of §7.1.
 
 
 ### 7.2 Forward resolution through CTE scope (§10)
@@ -1243,9 +1258,14 @@ start/end_is_denormalized cluster) · ☐ P3.6 legacy-path deletion
 Phase 4: ◐ early hoists landed OUT OF ORDER 2026-07-14 (low-risk, accepted):
 3 diagnostic helpers (fe968442), 10 self-contained nested fns (b9ce1d94),
 final self-contained batch (c7317091), `WithBarrierScope` extracted (51ea82fe),
-`CteNameAllocator` extracted (1428324a) — the god-function core remains ~5K
-lines · ☐ P4.1..n remaining hoists (RefCell-capturing helpers need the
-`WithCteBuildState` struct) · ☐ P4.x §10 phases 1–3 · ☐ P4.final #411
+`CteNameAllocator` extracted (1428324a) ·
+☑ **§7.1 DONE (2026-07-28)** — `build_chained` 5478 → 850 ln (the irreducible
+accumulator frame, deliberately parked) + `replace_v2` 1070 → 212 ln, across 43
+byte-identical/behavior-preserving PRs (#740–#785); every extracted helper ≤459 ln;
+exit criterion met (see §7.1) ·
+◐ **§7.2 §10 phases 1–3** = the P-4 forward-resolution lane (F0/F1/F1b/F2a/F3/F4
+done; F2b/F5 + F1b residue open — tracked in `FORWARD_RESOLUTION_PLAN.md`) ·
+☐ P4.final #411 (gated on §7.2)
 
 ## 10. Risks / what NOT to do
 


### PR DESCRIPTION
Formally closes **Phase-4 §7.1** (decompose the entangled core) in the tracking docs.

## What §7.1 achieved
Across 43 byte-identical / behavior-preserving PRs (#740–#785):
- `replace_with_clause_with_cte_reference_v2`: **1070 → 212 ln**
- `build_chained_with_match_cte_plan`: **5478 → 850 ln**
- every *extractable* helper is at/under the ~500-ln target (next-largest 459/445/440)

## Why 850 ln is the terminal state
The lone >500-ln survivor, `build_chained`, is not an un-decomposed god-function — it is its **irreducible mutable-state frame**: ~10 `let mut` accumulators (`current_plan`, `all_ctes`, `cte_schemas`, `cte_references`, `cte_name_allocator`, `with_scope`, the `flattened_compound_keys` RefCell, …), the `while has_with_clause_in_graph_rel` / `'alias_loop` control glue *between* already-extracted STEP helpers, and per-phase tracing. The readability half of the exit criterion (STEP pipeline readable top-to-bottom) is met.

The only way under 500 is lifting the whole `'alias_loop` body into one ~19-parameter signal-return helper — trading param-plumbing for raw line count with no readability gain. **Explicitly declined** (user decision).

## Changes (docs-only)
- `REFACTORING_SAFETY_PLAN.md` §7.1 progress ◐→☑ + closing rationale; §9 Phase-4 checklist line updated.
- `PRIORITIES.md` P-3 header ◐→☑; new §4 merge-log entry.

The remaining substantial refactor work is now **Phase-4 §7.2** (forward resolution / delete `reverse_mapping`) — the P-4 lane, tracked in `FORWARD_RESOLUTION_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)