### PR TITLE
refactor(P3 §6.2 slice-2): rename is_fk_edge proxy → rel_table_is_end_node; ratchet 4→1

### DIFF
--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -679,14 +679,31 @@ migrated. Per item:
   pin the denorm-endpoint output on this path, so any future slice-4 change that
   altered it flips a golden. Verdict stands (keep the inline predicate) but is
   now **positively covered**, not merely argued.
-- **Slice 2 (`is_fk_edge` proxy, `multi_type_vlp_joins.rs:~764/~1471`) — NOT a
-  clean slice.** (a) The ratchet is a substring counter and the canonical answer
-  is a field literally named `is_fk_edge`, so migration cannot register as
-  progress and risks a spurious bump. (b) The proxy `rel_table == end_table`
-  is a genuinely different predicate than canonical `is_fk_edge`
-  (`from/to_props.is_none() && (from|to_table == edge_table)`). Same
-  investigate-then-decide shape as slice 4; deferred as a divergence check, not a
-  byte-identical migration.
+- **Slice 2 (`is_fk_edge` proxy, `multi_type_vlp_joins.rs:~764/~1471`) —
+  RESOLVED: proxy is CORRECT-and-different, renamed + ratcheted, NOT migrated
+  (#796, 2026-07-28).** A transition-assert over the corpus (site instrumented
+  at both `~764` and `~1471`, `integration corpus_sweep`) hit **13,632×** and —
+  unlike slice 4 — found **14 REAL divergences** vs canonical
+  `RelationshipSchema.is_fk_edge`, in **both** directions:
+  (a) `proxy=true, canon=false` — zeek denormalized coupled self-loops
+  (`ACCESSED`/`CONNECTED_TO` IP→IP, `REQUESTED`/`DNS_REQUESTED` IP→Domain):
+  rel table == node table, but denorm (not FK) → canonical says no, proxy
+  correctly fuses; and
+  (b) `proxy=false, canon=true` — a reversed FK hop (`AUTHORED` Post→User in
+  `FOLLOWS|AUTHORED*1..2`): canonical classifies the edge FK, but on the reversed
+  hop the target `users` is a SEPARATE table, so the proxy correctly emits the
+  two-join (golden `…_test_follows_or_authored_one_to_two_hops` shows
+  `INNER JOIN posts_test … INNER JOIN users_test`). The proxy answers a LOCAL,
+  per-hop, direction-aware question ("does the rel table equal the TARGET node
+  table, so I fuse the joins?"); canonical answers a schema-level classification.
+  Migrating to canonical would emit WRONG SQL (a spurious self-join, or a dropped
+  node join) on real corpus schemas. **Disposition: keep the proxy, but (1) rename
+  the misleadingly-named local `is_fk_edge` → `rel_table_is_end_node` at both
+  sites and document the divergence inline (byte-identical — corpus/golden
+  unchanged), and (2) ratchet the `is_fk_edge` count for this file 4 → 1** (one
+  intentional pointer-to-canonical reference kept in a comment). The existing
+  corpus goldens (the zeek and `AUTHORED`-VLP entries) already byte-lock every
+  divergent case, so a future migration attempt flips a golden.
 - **Slices 1 & 5 (denorm re-derivation cluster) — largely already migrated.**
   The cited sites now read `pattern_ctx.{left,right}_node.is_embedded()`
   (`cte_extraction.rs:~4345`); residual `is_denormalized` tokens are struct field
@@ -1329,13 +1346,17 @@ predicate intentionally divergent from canonical `is_node_denormalized_on_edge`
 POSITIVELY COVERED by a purpose-built denorm self-loop multi-type fixture
 (`denorm_selfloop_multitype`, lib test + 8 corpus goldens) proving inline ==
 canonical on every admissible schema (the only divergent input is
-validator-rejected); slice 2 (`is_fk_edge`
-proxy) is a divergence-check not a clean slice + ratchet-neutral; slices 1/5 are
+validator-rejected); ☑ slice 2 (`is_fk_edge` proxy) RESOLVED — transition-assert
+found 14 REAL divergences (both directions) proving the local proxy is
+correct-and-different from canonical (migrating would emit wrong SQL); kept the
+proxy, renamed `is_fk_edge` → `rel_table_is_end_node` at both sites +
+ratcheted the file's `is_fk_edge` count 4→1 (byte-identical); slices 1/5 are
 legit field-reads/plan-state, not re-derivations · ☑ §6.3 legacy scalar-flag
 path already gone (region recreates `PatternSchemaContext` unconditionally) ·
-**Phase 3 substantially complete** — mechanical migrations done; what's left is
-divergence investigation (slice 2, same shape as slice 4) + the
-`pattern_schema.rs` dead_code audit. See §6.2/§6.3.
+**Phase 3 substantially complete** — mechanical migrations done; slices 3/4/2 all
+resolved (3 migrated, 4/2 investigated-and-decided with the fixture/transition-
+assert method). Only the low-priority `pattern_schema.rs` dead_code audit remains.
+See §6.2/§6.3.
 
 Phase 4: ◐ early hoists landed OUT OF ORDER 2026-07-14 (low-risk, accepted):
 3 diagnostic helpers (fe968442), 10 self-contained nested fns (b9ce1d94),

--- a/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
+++ b/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
@@ -759,12 +759,23 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
             let end_table = self.get_node_table_with_db(&hop.to_node_type)?;
             let end_id_col = self.get_node_id_column(&hop.to_node_type)?;
 
-            // Check if this is an FK-edge pattern (rel table == target node table)
-            // In this case, the relationship table IS the target node, so we only need one JOIN
-            let is_fk_edge = rel_table == end_table;
+            // Does the relationship table equal the TARGET (end) node table for
+            // THIS hop? If so, the rel row IS the target node row and we fuse the
+            // rel+node joins into one. This is a LOCAL, per-hop, direction-aware
+            // shape test — deliberately NOT the schema-level canonical FK-edge
+            // classification (`RelationshipSchema.is_fk_edge`, `config.rs:1528` =
+            // `no denorm props && edge_table == from_or_to_table`). The two answer
+            // different questions and genuinely diverge on the corpus in BOTH
+            // directions: a denormalized coupled self-loop (zeek `ACCESSED` IP→IP)
+            // has rel==end yet is not FK-edge, and a reversed FK hop (`AUTHORED`
+            // Post→User, whose target `users` is a separate table) has rel!=end
+            // yet IS FK-edge. Migrating this local decision to the canonical field
+            // would emit wrong SQL (a spurious self-join, or a dropped node join),
+            // so it stays a local shape test — just no longer misleadingly named.
+            let rel_table_is_end_node = rel_table == end_table;
 
-            if is_fk_edge {
-                // FK-edge pattern: relationship table IS the target node table
+            if rel_table_is_end_node {
+                // Fused pattern: the relationship table IS the target node table
                 end_node_alias = format!(
                     "{}{}",
                     if hop.to_node_type == "User" {
@@ -1468,11 +1479,17 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
                             Err(_) => return "'{}'".to_string(), // Empty JSON
                         };
 
-                        let is_fk_edge = rel_table == end_table;
+                        // Same LOCAL per-hop shape test as in the JOIN builder
+                        // above (does the rel table equal the target node table,
+                        // so the rel row IS the target node?) — NOT the canonical
+                        // schema-level FK-edge classification. This MUST match the
+                        // alias choice in the FROM builder so rel_properties
+                        // reference the right alias.
+                        let rel_table_is_end_node = rel_table == end_table;
 
                         // Reconstruct the relationship alias used in FROM clause
-                        let rel_alias = if is_fk_edge {
-                            // FK-edge: alias is the end node alias
+                        let rel_alias = if rel_table_is_end_node {
+                            // Fused: alias is the end node alias
                             // Must match the logic in generate_path_branch_sql (lines 585-595)
                             format!(
                                 "{}{}",

--- a/tests/rust/ratchet/baseline.txt
+++ b/tests/rust/ratchet/baseline.txt
@@ -114,7 +114,7 @@ schema	is_fk_edge	src/render_plan/cte_manager/mod.rs	4
 schema	is_fk_edge	src/render_plan/select_builder.rs	3
 schema	is_fk_edge	src/render_plan/write_plan_builder.rs	1
 schema	is_fk_edge	src/server/bolt_protocol/result_transformer.rs	3
-schema	is_fk_edge	src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs	4
+schema	is_fk_edge	src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs	1
 schema	is_fk_edge	src/sql_generator/emitters/clickhouse/variable_length_cte.rs	7
 schema	to_label_column	src/procedures/apoc_meta_schema.rs	1
 schema	to_label_column	src/query_planner/analyzer/bidirectional_union.rs	1


### PR DESCRIPTION
## What

Resolves Phase-3 §6.2 **slice-2**. A local variable named `is_fk_edge` in the multi-type VLP JOIN emitter (`multi_type_vlp_joins.rs:~764` and `:~1471`, both `let is_fk_edge = rel_table == end_table`) was **misleadingly named** — it invited a "route it through canonical `RelationshipSchema.is_fk_edge`" migration that would produce **wrong SQL**.

## The finding

A transition-assert over the corpus (both sites instrumented, `integration corpus_sweep`, **13,632 hits**) found — unlike slice-4's vacuous agreement — **14 real divergences vs canonical, in BOTH directions**:

- **`proxy=true, canon=false`** — zeek denormalized coupled self-loops (`ACCESSED`/`CONNECTED_TO` IP→IP, `REQUESTED`/`DNS_REQUESTED` IP→Domain): rel table == node table, but it's *denormalized* not FK → canonical says no; the proxy correctly **fuses** the rel+node joins. Migrating would force a spurious self-join.
- **`proxy=false, canon=true`** — a reversed FK hop (`AUTHORED` Post→User inside `FOLLOWS|AUTHORED*1..2`): canonical classifies the edge FK schema-wide, but on the *reversed* hop the target `users` is a **separate** table, so the proxy correctly emits the two-join (golden `…_test_follows_or_authored_one_to_two_hops` shows `INNER JOIN posts_test … INNER JOIN users_test`). Migrating would **drop the User node join**.

The proxy answers a **local, per-hop, direction-aware** question ("does the rel table equal the TARGET node table, so fuse the joins?"); canonical answers a **schema-level** classification. They are legitimately different, and the proxy is the correct one here. **So this is NOT a migration.**

## Disposition (this PR)

1. Rename the misleadingly-named local `is_fk_edge` → `rel_table_is_end_node` at both sites, and document the divergence inline (**byte-identical** — `corpus_sweep` + `sql_golden` unchanged, no `UPDATE_GOLDEN`).
2. Ratchet the file's `is_fk_edge` count **4 → 1** (one intentional pointer-to-canonical reference kept in a comment).

The existing corpus goldens (zeek + `AUTHORED`-VLP entries) already byte-lock every divergent case, so any future migration attempt flips a golden.

## Verification

- fmt clean; clippy `--all-targets` clean; 1608 lib tests pass
- `corpus_sweep` + `sql_golden` **byte-identical** (no `UPDATE_GOLDEN`)
- ratchet passes at the new 4→1 baseline (grep count == baseline == 1)
- Adversarial subagent review in an isolated `CARGO_TARGET_DIR` — **APPROVE, 0 functional defects**; specifically confirmed the divergence is real in both directions (the decision's crux) and byte-identical output

Part of the Phase-3 investigate-then-decide method (same as slice-4's fixture, opposite outcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)