### PR TITLE
fix(corpus): anonymize pattern_union_t<n> counter in golden normalize()

### DIFF
--- a/tests/rust/integration/golden/corpus/denorm_selfloop_multitype/denorm_selfloop_multitype__path_multitype_expand.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denorm_selfloop_multitype/denorm_selfloop_multitype__path_multitype_expand.clickhouse.sql
@@ -1,4 +1,4 @@
-WITH pattern_union_t1599 AS (
+WITH pattern_union_t0 AS (
 SELECT 'Actor' AS start_type, toString(db_denorm_selfloop.events.src_actor) as start_id, toString(db_denorm_selfloop.events.dst_actor) as end_id, 'Actor' AS end_type, ['RECEIVED'] as path_relationships, [formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.channel AS channel, db_denorm_selfloop.events.evt_id AS evt_id)] as rel_properties, formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.src_actor, db_denorm_selfloop.events.src_name) as start_properties, formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.dst_actor, db_denorm_selfloop.events.dst_name) as end_properties, db_denorm_selfloop.events.channel AS channel, db_denorm_selfloop.events.evt_id AS evt_id, NULL AS weight FROM db_denorm_selfloop.events
 UNION ALL
 SELECT 'Actor' AS start_type, toString(db_denorm_selfloop.events.src_actor) as start_id, toString(db_denorm_selfloop.events.dst_actor) as end_id, 'Actor' AS end_type, ['SENT'] as path_relationships, [formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.evt_id AS evt_id, db_denorm_selfloop.events.weight AS weight)] as rel_properties, formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.src_actor, db_denorm_selfloop.events.src_name) as start_properties, formatRowNoNewline('JSONEachRow', db_denorm_selfloop.events.dst_actor, db_denorm_selfloop.events.dst_name) as end_properties, NULL AS channel, db_denorm_selfloop.events.evt_id AS evt_id, db_denorm_selfloop.events.weight AS weight FROM db_denorm_selfloop.events
@@ -12,5 +12,5 @@ SELECT
       t0.end_id AS "__end_id__", 
       t0.start_type AS "__start_label__", 
       t0.end_type AS "__end_label__"
-FROM pattern_union_t1599 AS t0
+FROM pattern_union_t0 AS t0
 LIMIT 5

--- a/tests/rust/integration/golden/corpus/denorm_selfloop_multitype/denorm_selfloop_multitype__path_multitype_expand.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denorm_selfloop_multitype/denorm_selfloop_multitype__path_multitype_expand.databricks.sql
@@ -1,4 +1,4 @@
-WITH pattern_union_t1600 AS (
+WITH pattern_union_t0 AS (
 (SELECT 'Actor' AS start_type, string(db_denorm_selfloop.events.src_actor) as start_id, string(db_denorm_selfloop.events.dst_actor) as end_id, 'Actor' AS end_type, array('RECEIVED') as path_relationships, array(to_json(struct(db_denorm_selfloop.events.channel AS channel, db_denorm_selfloop.events.evt_id AS evt_id))) as rel_properties, to_json(struct(db_denorm_selfloop.events.src_actor, db_denorm_selfloop.events.src_name)) as start_properties, to_json(struct(db_denorm_selfloop.events.dst_actor, db_denorm_selfloop.events.dst_name)) as end_properties, db_denorm_selfloop.events.channel AS channel, db_denorm_selfloop.events.evt_id AS evt_id, NULL AS weight FROM db_denorm_selfloop.events)
 UNION ALL
 (SELECT 'Actor' AS start_type, string(db_denorm_selfloop.events.src_actor) as start_id, string(db_denorm_selfloop.events.dst_actor) as end_id, 'Actor' AS end_type, array('SENT') as path_relationships, array(to_json(struct(db_denorm_selfloop.events.evt_id AS evt_id, db_denorm_selfloop.events.weight AS weight))) as rel_properties, to_json(struct(db_denorm_selfloop.events.src_actor, db_denorm_selfloop.events.src_name)) as start_properties, to_json(struct(db_denorm_selfloop.events.dst_actor, db_denorm_selfloop.events.dst_name)) as end_properties, NULL AS channel, db_denorm_selfloop.events.evt_id AS evt_id, db_denorm_selfloop.events.weight AS weight FROM db_denorm_selfloop.events)
@@ -12,5 +12,5 @@ SELECT
       t0.end_id AS `__end_id__`, 
       t0.start_type AS `__start_label__`, 
       t0.end_type AS `__end_label__`
-FROM pattern_union_t1600 AS t0
+FROM pattern_union_t0 AS t0
 LIMIT 5

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -1632,7 +1632,13 @@ pub(crate) fn normalize(sql: &str) -> String {
             .into_owned()
     }
     let s = remap(sql, r"\bt\d+\b", "t");
-    remap(&s, r"\bcte\d+\b", "cte")
+    let s = remap(&s, r"\bcte\d+\b", "cte");
+    // The generic `\bt\d+\b` remap above cannot reach the `t<n>` render counter
+    // inside a `pattern_union_t<n>` CTE name: the `t` is preceded by `_` (a word
+    // char), so there is no word boundary before it. Left un-anonymized, that
+    // global counter leaks into the golden and makes the render order-dependent
+    // (byte-stable alone, but not across a full sweep). Anonymize it explicitly.
+    remap(&s, r"pattern_union_t\d+", "pattern_union_t")
 }
 
 fn golden_path(schema_dir: &str, name: &str, dialect: &str) -> String {


### PR DESCRIPTION
## Problem

`corpus_sweep`'s golden `normalize()` (`sql_golden_tests.rs`) anonymizes render counters via `\bt\d+\b`, but that regex cannot reach the `t<n>` inside a `pattern_union_t<n>` CTE name — the `t` sits after `_` (a word char), so there is no word boundary before it. The global monotonic counter therefore leaks un-anonymized into the golden, making the render **order-dependent**: byte-stable when the entry renders in isolation, but not across a full sweep (the counter reflects how many queries rendered earlier in the same process).

This showed up as a flaky `corpus_sweep` failure on the two `denorm_selfloop_multitype/path_multitype_expand` goldens (added in #795). They pass alone but fail mid-suite — and fail on `main` too — with the **only** diff being a `pattern_union_t1599` vs `t2962` CTE name.

## Fix

Add an explicit `pattern_union_t\d+ → pattern_union_t<seq>` remap to `normalize()`, and regenerate the 2 affected goldens (now `pattern_union_t0`, order-independent).

- Only **2 goldens** carry this token (confirmed by grep); the 52 stable `pattern_union_r<alias>` CTEs are alias-based and unaffected.
- Keeps byte-lock coverage rather than dropping the entry to `nondeterministic.txt`.

## Verification

- `cargo test -p clickgraph --test integration` — **531 passed, 0 failed** (previously 1 failed mid-suite).
- `corpus_sweep` in isolation and in full-suite position both green.
- `cargo fmt --all --check`, `cargo clippy --all-targets` (0 warnings), ratchet net-zero, 1608 lib tests pass.
- `UPDATE_GOLDEN` diff scope: exactly the 2 goldens + the harness edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)