### PR TITLE
refactor(P3 §6.2/§6.3): remove blanket allow(dead_code) from pattern_schema.rs

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -296,8 +296,9 @@ fixed stats fixture.
 - SQL-IR Phases 2–4 (path collapse, structural idioms, Raw shrink) —
   `SQL_IR_DESIGN.md`; Phase-2 A/C unification stays deferred per its own
   investigation.
-- Phase 3 §6.2: mechanical rollout DONE (slices 3/4/2 resolved 2026-07-28,
-  #793/#795/#796); only the low-priority `pattern_schema.rs` dead_code audit remains.
+- Phase 3 §6.2/§6.3: **COMPLETE** (slices 3/4/2 resolved 2026-07-28,
+  #793/#795/#796; `pattern_schema.rs` dead_code audit done #799). No Phase-3
+  items remain.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
@@ -310,6 +311,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-28: **Phase-3 §6.3 — `pattern_schema.rs` `#![allow(dead_code)]`
+  audit** (P-3 lane; PR #799). Lifted the blanket module allow; it surfaced
+  exactly 5 genuinely-dead private/test items (the superseded
+  `node_strategy_for_position` helper — `build_node_strategies` uses an inline
+  `match edge_pattern` instead — plus 4 unused `make_*` test-fixture builders).
+  The module's public API is `pub`-reachable and lint-exempt, so the allow
+  masked nothing there. Deleted the 5 items + 3 now-unused test imports, fixed
+  the stale comment that named the deleted helper, removed the blanket allow;
+  module now builds warning-free. Net −191 lines, no production behavior change,
+  ratchet net-zero (`src/graph_catalog/` is excluded from axis counting).
+  **This closes Phase 3** — no §6.2/§6.3 items remain.
+- 2026-07-28: **corpus_sweep golden normalize() — anonymize
+  `pattern_union_t<n>` counter** (PR #798). The golden normalizer's `\bt\d+\b`
+  remap could not reach the render counter inside a `pattern_union_t<n>` CTE
+  name (the `t` sits after `_`, no word boundary), so that global counter leaked
+  into 2 goldens and made them render-order-dependent — a flaky `corpus_sweep`
+  failure (`denorm_selfloop_multitype/path_multitype_expand`, added #795) that
+  passed alone but failed mid-suite and on main. Added an explicit
+  `pattern_union_t\d+` remap and regenerated the 2 goldens; keeps byte-lock
+  coverage instead of excluding the entry.
 - 2026-07-28: **Phase-3 §6.2 slice-2 — rename `is_fk_edge` proxy →
   `rel_table_is_end_node`; ratchet 4→1** (P-3 lane; PR #796). The multi-type VLP
   JOIN emitter's local `let is_fk_edge = rel_table == end_table`

--- a/docs/design/REFACTORING_SAFETY_PLAN.md
+++ b/docs/design/REFACTORING_SAFETY_PLAN.md
@@ -720,12 +720,17 @@ in, delete the legacy branch (its own PR; goldens are the guard). Then remove
 `#![allow(dead_code)]` from `pattern_schema.rs` and delete whatever is still
 genuinely unused.
 
-**§6.3 status (2026-07-28, scouted):** the legacy scalar-flag branch that ran
-alongside `pattern_ctx` at `cte_extraction.rs:~3591` is **already gone** — that
-region now recreates `PatternSchemaContext` unconditionally and returns an error
-if it can't (`cte_extraction.rs:~4317`); there is no parallel legacy path left to
-delete. Remaining §6.3 work is only the `pattern_schema.rs` `#![allow(dead_code)]`
-audit (separate from the branch deletion, low priority).
+**§6.3 status (2026-07-28, scouted then COMPLETED):** the legacy scalar-flag
+branch that ran alongside `pattern_ctx` at `cte_extraction.rs:~3591` is **already
+gone** — that region now recreates `PatternSchemaContext` unconditionally and
+returns an error if it can't (`cte_extraction.rs:~4317`); there is no parallel
+legacy path left to delete. The `pattern_schema.rs` `#![allow(dead_code)]` audit
+is now **DONE (#799)**: lifting the blanket allow surfaced exactly 5 genuinely-dead
+private/test items (the superseded `node_strategy_for_position` helper + 4 unused
+test-fixture builders; its public API is `pub`-reachable and lint-exempt, so the
+allow masked nothing there). Deleted them + 3 now-unused test imports, fixed the
+stale comment that named the deleted helper, and removed the blanket allow — the
+module now builds warning-free with no suppression. §6.3 is complete.
 
 **Explicit non-goal**: forcing single-hop rendering through `CteStrategy`.
 That's a bigger architectural bet; this phase only consolidates *predicates
@@ -1353,9 +1358,12 @@ proxy, renamed `is_fk_edge` → `rel_table_is_end_node` at both sites +
 ratcheted the file's `is_fk_edge` count 4→1 (byte-identical); slices 1/5 are
 legit field-reads/plan-state, not re-derivations · ☑ §6.3 legacy scalar-flag
 path already gone (region recreates `PatternSchemaContext` unconditionally) ·
-**Phase 3 substantially complete** — mechanical migrations done; slices 3/4/2 all
-resolved (3 migrated, 4/2 investigated-and-decided with the fixture/transition-
-assert method). Only the low-priority `pattern_schema.rs` dead_code audit remains.
+☑ `pattern_schema.rs` `#![allow(dead_code)]` audit DONE (#799, 2026-07-28):
+blanket allow removed, 5 dead private/test items + 3 unused test imports deleted,
+module builds warning-free · **Phase 3 COMPLETE** — mechanical migrations done;
+slices 3/4/2 all resolved (3 migrated, 4/2 investigated-and-decided with the
+fixture/transition-assert method); §6.3 legacy path gone and dead_code audit
+closed. No Phase-3 items remain.
 See §6.2/§6.3.
 
 Phase 4: ◐ early hoists landed OUT OF ORDER 2026-07-14 (low-risk, accepted):

--- a/src/graph_catalog/pattern_schema.rs
+++ b/src/graph_catalog/pattern_schema.rs
@@ -8,9 +8,6 @@
 //!
 //! Previously, schema detection was scattered across 4800+ lines in `graph_join_inference.rs`:
 //! - `is_node_denormalized_on_edge()` - called multiple times
-//!
-//! Note: Some methods and fields are reserved for future pattern optimization features.
-#![allow(dead_code)]
 //! - `edge_has_node_properties()` - called at various points
 //! - `classify_edge_table_pattern()` - computed repeatedly
 //! - `are_edges_coupled()` - checked in nested conditions
@@ -840,8 +837,8 @@ impl PatternSchemaContext {
         // Virtual nodes were previously created based on rel_schema.from_node == "$any",
         // but this ignores the fact that the query specifies concrete types like User, Group.
         //
-        // The fix: Always use node_strategy_for_position() which builds OwnTable/Embedded
-        // strategies based on the actual node schema, not the edge's polymorphic endpoint.
+        // The fix: classify by `edge_pattern` and build OwnTable/EmbeddedInEdge
+        // strategies from the actual node schema, not the edge's polymorphic endpoint.
         //
         // Note: _left_is_polymorphic and _right_is_polymorphic are kept for API compatibility
         // and may be used for edge filtering (type_column filters), but not for node strategies.
@@ -924,48 +921,6 @@ impl PatternSchemaContext {
             }
         };
         Ok(node_strategies)
-    }
-
-    /// Helper to build node strategy for a specific position
-    fn node_strategy_for_position(
-        node_schema: &NodeSchema,
-        rel_schema: &RelationshipSchema,
-        rel_alias: &str,
-        is_from_node: bool,
-        edge_pattern: &EdgeTablePattern,
-    ) -> Result<NodeAccessStrategy, String> {
-        let is_denormalized = match edge_pattern {
-            EdgeTablePattern::FullyDenormalized => true,
-            EdgeTablePattern::Mixed {
-                from_denormalized,
-                to_denormalized,
-            } => {
-                if is_from_node {
-                    *from_denormalized
-                } else {
-                    *to_denormalized
-                }
-            }
-            EdgeTablePattern::Traditional => false,
-        };
-
-        if is_denormalized {
-            Ok(NodeAccessStrategy::EmbeddedInEdge {
-                edge_alias: rel_alias.to_string(),
-                properties: Self::extract_denorm_props(rel_schema, is_from_node),
-                is_from_node,
-            })
-        } else {
-            Ok(NodeAccessStrategy::OwnTable {
-                table: node_schema.full_table_name(),
-                id_column: node_schema.node_id.id.clone(),
-                properties: node_schema
-                    .property_mappings
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.raw_column_name()))
-                    .collect(),
-            })
-        }
     }
 
     /// Extract denormalized properties from relationship schema
@@ -1368,150 +1323,6 @@ pub fn node_denormalized_flag(graph_node: &crate::query_planner::logical_plan::G
 mod tests {
     use super::*;
     use crate::graph_catalog::config::Identifier;
-    use crate::graph_catalog::expression_parser::PropertyValue;
-    use crate::graph_catalog::graph_schema::NodeIdSchema;
-    use crate::graph_catalog::schema_types::SchemaType;
-
-    fn make_test_node(_label: &str, table: &str, id_col: &str) -> NodeSchema {
-        NodeSchema {
-            database: "test_db".to_string(),
-            table_name: table.to_string(),
-            column_names: vec![id_col.to_string(), "name".to_string()],
-            primary_keys: id_col.to_string(),
-            node_id: NodeIdSchema::single(
-                id_col.to_string(),
-                crate::graph_catalog::schema_types::SchemaType::Integer,
-            ),
-            property_mappings: HashMap::from([
-                ("id".to_string(), PropertyValue::Column(id_col.to_string())),
-                (
-                    "name".to_string(),
-                    PropertyValue::Column("name".to_string()),
-                ),
-            ]),
-            view_parameters: None,
-            engine: None,
-            use_final: None,
-            filter: None,
-            is_denormalized: false,
-            from_properties: None,
-            to_properties: None,
-            denormalized_source_table: None,
-            label_column: None,
-            label_value: None,
-            node_id_types: None,
-            source: None,
-            property_types: HashMap::new(),
-            id_generation: None,
-        }
-    }
-
-    fn make_denormalized_node(_label: &str, table: &str, id_col: &str) -> NodeSchema {
-        NodeSchema {
-            database: "test_db".to_string(),
-            table_name: table.to_string(),
-            column_names: vec![id_col.to_string()],
-            primary_keys: id_col.to_string(),
-            node_id: NodeIdSchema::single(
-                id_col.to_string(),
-                crate::graph_catalog::schema_types::SchemaType::String,
-            ),
-            property_mappings: HashMap::new(),
-            view_parameters: None,
-            engine: None,
-            use_final: None,
-            filter: None,
-            is_denormalized: true,
-            denormalized_source_table: Some(format!("test_db.{}", table)),
-            label_column: None,
-            label_value: None,
-            from_properties: Some(HashMap::from([("code".to_string(), "Origin".to_string())])),
-            to_properties: Some(HashMap::from([("code".to_string(), "Dest".to_string())])),
-            node_id_types: None,
-            source: None,
-            property_types: HashMap::new(),
-            id_generation: None,
-        }
-    }
-
-    fn make_test_edge(_type_name: &str, table: &str) -> RelationshipSchema {
-        RelationshipSchema {
-            database: "test_db".to_string(),
-            table_name: table.to_string(),
-            column_names: vec!["from_id".to_string(), "to_id".to_string()],
-            from_node: "User".to_string(),
-            to_node: "User".to_string(),
-            from_node_table: "users".to_string(),
-            to_node_table: "users".to_string(),
-            from_id: Identifier::from("from_id"),
-            to_id: Identifier::from("to_id"),
-            from_node_id_dtype: SchemaType::Integer,
-            to_node_id_dtype: SchemaType::Integer,
-            property_mappings: HashMap::new(),
-            view_parameters: None,
-            engine: None,
-            use_final: None,
-            filter: None,
-            edge_id: None,
-            type_column: None,
-            from_label_column: None,
-            to_label_column: None,
-            from_label_values: None,
-            to_label_values: None,
-            from_node_properties: None,
-            to_node_properties: None,
-            is_fk_edge: false,
-            constraints: None,
-            edge_id_types: None,
-            source: None,
-            property_types: HashMap::new(),
-        }
-    }
-
-    fn make_denormalized_edge(_type_name: &str, table: &str) -> RelationshipSchema {
-        RelationshipSchema {
-            database: "test_db".to_string(),
-            table_name: table.to_string(),
-            column_names: vec![
-                "Origin".to_string(),
-                "Dest".to_string(),
-                "OriginCity".to_string(),
-                "DestCity".to_string(),
-            ],
-            from_node: "Airport".to_string(),
-            to_node: "Airport".to_string(),
-            from_node_table: "airports".to_string(),
-            to_node_table: "airports".to_string(),
-            from_id: Identifier::from("Origin"),
-            to_id: Identifier::from("Dest"),
-            from_node_id_dtype: SchemaType::String,
-            to_node_id_dtype: SchemaType::String,
-            property_mappings: HashMap::new(),
-            view_parameters: None,
-            engine: None,
-            use_final: None,
-            filter: None,
-            edge_id: None,
-            type_column: None,
-            from_label_column: None,
-            to_label_column: None,
-            from_label_values: None,
-            to_label_values: None,
-            from_node_properties: Some(HashMap::from([
-                ("code".to_string(), "Origin".to_string()),
-                ("city".to_string(), "OriginCity".to_string()),
-            ])),
-            to_node_properties: Some(HashMap::from([
-                ("code".to_string(), "Dest".to_string()),
-                ("city".to_string(), "DestCity".to_string()),
-            ])),
-            is_fk_edge: false,
-            constraints: None,
-            edge_id_types: None,
-            source: None,
-            property_types: HashMap::new(),
-        }
-    }
 
     #[test]
     fn test_node_access_strategy_requires_join() {


### PR DESCRIPTION
Closes the last Phase-3 item — the `pattern_schema.rs` `#![allow(dead_code)]` audit (REFACTORING_SAFETY_PLAN §6.3).

## What

The module-level `#![allow(dead_code)]` was a blanket suppressor with a "reserved for future" note. The module is `pub mod`, so its public API surface is lint-exempt anyway — the allow only masked a handful of genuinely-dead **private/test** items. Lifting the allow and building surfaced exactly 5:

- `PatternSchemaContext::node_strategy_for_position` — **superseded**. The live `build_node_strategies` uses an inline `match edge_pattern` that constructs the same `OwnTable`/`EmbeddedInEdge` strategies; only a stale comment still named the helper (fixed). `extract_denorm_props`, which the deleted fn called, stays live (4 call sites in the inline match).
- 4 unused test-fixture builders (`make_test_node`, `make_denormalized_node`, `make_test_edge`, `make_denormalized_edge`) — zero call sites.
- 3 now-unused test-module imports (`PropertyValue`, `NodeIdSchema`, `SchemaType`) that only the deleted fixtures referenced (`Identifier` kept — still used).

Removed the blanket allow so the module builds warning-free with no suppression; future dead code is now caught honestly. **No public item removed; no generated-SQL change.** Net −191 lines.

## Verification

- `cargo build -p clickgraph` and `--tests`: **zero warnings** (confirms nothing else was masked).
- `cargo fmt --all --check`, `cargo clippy --all-targets` (0 warnings).
- `cargo test -p clickgraph --lib`: 1608 passed; the 5 surviving `pattern_schema` unit tests pass.
- `cargo test -p clickgraph --test integration`: 531 passed, `corpus_sweep` + `sql_golden` byte-identical (no `UPDATE_GOLDEN`).
- Ratchet net-zero (`src/graph_catalog/` is excluded from axis counting).
- Adversarial subagent review: **APPROVE — 0 functional defects**, all 10 claims independently verified (single-file scope, dead items confirmed dead repo-wide, no cascading dead code, no public API removed, no hidden `cfg`/macro/trait callers).

Docs: REFACTORING_SAFETY_PLAN §6.3 + §9 marked complete; PRIORITIES backlog + merge-log updated. **This closes Phase 3.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)