### PR TITLE
test(corpus): characterize composite FK-edge SQL emission (Slice 0 of composite-id refactor)

### DIFF
--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1210,3 +1210,10 @@
 {"cypher": "MATCH (a)-[r]-(b) RETURN a.name, b.name", "name": "denorm_selfloop_multitype__undirected_multitype_expand", "schema": "denorm_selfloop_multitype"}
 {"cypher": "MATCH p=(a)-[]->(b) RETURN p LIMIT 5", "name": "denorm_selfloop_multitype__path_multitype_expand", "schema": "denorm_selfloop_multitype"}
 {"cypher": "MATCH (a)-[r]->(b) RETURN count(*) AS cnt", "name": "denorm_selfloop_multitype__count_multitype_expand", "schema": "denorm_selfloop_multitype"}
+{"cypher": "MATCH (a:Object)-[:PARENT]->(b:Object) RETURN a.name, b.name LIMIT 5", "name": "test_713_composite_self_ref_fk_single_hop", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)-[:PARENT*2..2]->(b:Object) RETURN a.name, b.name", "name": "test_713_composite_self_ref_fk_exact_two_hop", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)-[:PARENT*1..2]->(b:Object) RETURN a.name, b.name", "name": "test_713_composite_self_ref_fk_vlp_one_to_two", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)-[:PARENT*1..3]->(b:Object) RETURN a.name, b.name", "name": "test_713_composite_self_ref_fk_vlp_one_to_three", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)<-[:PARENT]-(b:Object) RETURN a.name, b.name LIMIT 5", "name": "test_713_composite_self_ref_fk_reverse_single_hop", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (c:Comment)-[:IN_FORUM]->(f:Forum) RETURN c.comment_id, f.forum_id LIMIT 5", "name": "test_672_composite_non_self_ref_fk_single_hop", "schema": "composite_fk_edge_nonselfref"}
+{"cypher": "MATCH (c:Comment)<-[:IN_FORUM]-(f:Forum) RETURN c.comment_id, f.forum_id LIMIT 5", "name": "test_672_composite_non_self_ref_fk_reverse_single_hop", "schema": "composite_fk_edge_nonselfref"}

--- a/tests/corpus/schema_map.json
+++ b/tests/corpus/schema_map.json
@@ -1,7 +1,15 @@
 {
+  "composite_fk_edge_nonselfref": {
+    "subschema": null,
+    "yaml": "schemas/test/composite_fk_edge_nonselfref.yaml"
+  },
   "composite_id": {
     "subschema": null,
     "yaml": "schemas/examples/composite_node_id_test.yaml"
+  },
+  "composite_self_ref_fk": {
+    "subschema": null,
+    "yaml": "schemas/test/composite_self_ref_fk.yaml"
   },
   "data_security": {
     "subschema": null,

--- a/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_reverse_single_hop.clickhouse.err
+++ b/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_reverse_single_hop.clickhouse.err
@@ -1,0 +1,1 @@
+plan error: AnalyzerError: Invalid relationship pattern: (Forum)-[:IN_FORUM]->(Comment). Schema defines IN_FORUM as (Comment)-[:IN_FORUM]->(Forum). Please add the missing relationship definition to your schema YAML.

--- a/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_reverse_single_hop.databricks.err
+++ b/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_reverse_single_hop.databricks.err
@@ -1,0 +1,1 @@
+plan error: AnalyzerError: Invalid relationship pattern: (Forum)-[:IN_FORUM]->(Comment). Schema defines IN_FORUM as (Comment)-[:IN_FORUM]->(Forum). Please add the missing relationship definition to your schema YAML.

--- a/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_single_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_single_hop.clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      c.comment_id AS "c.comment_id", 
+      f.forum_id AS "f.forum_id"
+FROM db_composite_fk.comments_composite AS c
+INNER JOIN db_composite_fk.forums_composite AS f ON f.region = c.forum_region AND f.forum_id = c.forum_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_single_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_fk_edge_nonselfref/test_672_composite_non_self_ref_fk_single_hop.databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      c.comment_id AS `c.comment_id`, 
+      f.forum_id AS `f.forum_id`
+FROM db_composite_fk.comments_composite AS c
+INNER JOIN db_composite_fk.forums_composite AS f ON f.region = c.forum_region AND f.forum_id = c.forum_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_composite AS b
+INNER JOIN test_integration.fs_objects_composite AS b ON m1."parent_region, parent_id" = b."region, object_id"
+INNER JOIN test_integration.fs_objects_composite AS m1 ON a."parent_region, parent_id" = m1."region, object_id"
+WHERE a.region <> b.region

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_composite AS b
+INNER JOIN test_integration.fs_objects_composite AS b ON m1.`parent_region, parent_id` = b.`region, object_id`
+INNER JOIN test_integration.fs_objects_composite AS m1 ON a.`parent_region, parent_id` = m1.`region, object_id`
+WHERE a.region <> b.region

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_reverse_single_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_reverse_single_hop.clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_composite AS a
+INNER JOIN test_integration.fs_objects_composite AS b ON b.parent_region = a.region AND b.parent_id = a.object_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_reverse_single_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_reverse_single_hop.databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_composite AS a
+INNER JOIN test_integration.fs_objects_composite AS b ON b.parent_region = a.region AND b.parent_id = a.object_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_single_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_single_hop.clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_composite AS b
+INNER JOIN test_integration.fs_objects_composite AS a ON a.parent_region = b.region AND a.parent_id = b.object_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_single_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_single_hop.databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_composite AS b
+INNER JOIN test_integration.fs_objects_composite AS a ON a.parent_region = b.region AND a.parent_id = b.object_id
+LIMIT 5

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_three.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_three.clickhouse.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.region, object_id as start_id,
+        end_node.region, object_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.region, object_id, end_node.region, object_id] as path_nodes,
+        [tuple(start_node.region, object_id, end_node.region, object_id)] as path_edges,
+        start_node.name as start_name,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_composite start_node
+    JOIN test_integration.fs_objects_composite end_node ON start_node.parent_region, parent_id = end_node.region, object_id
+    UNION ALL
+    SELECT
+        new_start.region, object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat([new_start.region, object_id], vp.path_nodes) as path_nodes,
+        arrayConcat([tuple(new_start.region, object_id, current_node.region, object_id)], vp.path_edges) as path_edges,
+        new_start.name as start_name,
+        vp.end_name as end_name
+    FROM vlp_a_b vp
+    JOIN test_integration.fs_objects_composite current_node ON vp.start_id = current_node.region, object_id
+    JOIN test_integration.fs_objects_composite new_start ON new_start.parent_region, parent_id = current_node.region, object_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(new_start.region, object_id, current_node.region, object_id))
+)
+SELECT 
+      t.start_name AS "a.name", 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_three.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_three.databricks.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.region, object_id as start_id,
+        end_node.region, object_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.region, object_id, end_node.region, object_id) as path_nodes,
+        array(struct(start_node.region, object_id, end_node.region, object_id)) as path_edges,
+        start_node.name as start_name,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_composite start_node
+    JOIN test_integration.fs_objects_composite end_node ON start_node.parent_region, parent_id = end_node.region, object_id
+    UNION ALL
+    SELECT
+        new_start.region, object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(array(new_start.region, object_id), vp.path_nodes) as path_nodes,
+        concat(array(struct(new_start.region, object_id, current_node.region, object_id)), vp.path_edges) as path_edges,
+        new_start.name as start_name,
+        vp.end_name as end_name
+    FROM vlp_a_b vp
+    JOIN test_integration.fs_objects_composite current_node ON vp.start_id = current_node.region, object_id
+    JOIN test_integration.fs_objects_composite new_start ON new_start.parent_region, parent_id = current_node.region, object_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(new_start.region, object_id, current_node.region, object_id))
+)
+SELECT 
+      t.start_name AS `a.name`, 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_two.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_two.clickhouse.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.region, object_id as start_id,
+        end_node.region, object_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.region, object_id, end_node.region, object_id] as path_nodes,
+        [tuple(start_node.region, object_id, end_node.region, object_id)] as path_edges,
+        start_node.name as start_name,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_composite start_node
+    JOIN test_integration.fs_objects_composite end_node ON start_node.parent_region, parent_id = end_node.region, object_id
+    UNION ALL
+    SELECT
+        new_start.region, object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat([new_start.region, object_id], vp.path_nodes) as path_nodes,
+        arrayConcat([tuple(new_start.region, object_id, current_node.region, object_id)], vp.path_edges) as path_edges,
+        new_start.name as start_name,
+        vp.end_name as end_name
+    FROM vlp_a_b vp
+    JOIN test_integration.fs_objects_composite current_node ON vp.start_id = current_node.region, object_id
+    JOIN test_integration.fs_objects_composite new_start ON new_start.parent_region, parent_id = current_node.region, object_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, tuple(new_start.region, object_id, current_node.region, object_id))
+)
+SELECT 
+      t.start_name AS "a.name", 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_two.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_vlp_one_to_two.databricks.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.region, object_id as start_id,
+        end_node.region, object_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.region, object_id, end_node.region, object_id) as path_nodes,
+        array(struct(start_node.region, object_id, end_node.region, object_id)) as path_edges,
+        start_node.name as start_name,
+        end_node.name as end_name
+    FROM test_integration.fs_objects_composite start_node
+    JOIN test_integration.fs_objects_composite end_node ON start_node.parent_region, parent_id = end_node.region, object_id
+    UNION ALL
+    SELECT
+        new_start.region, object_id as start_id,
+        vp.end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(array(new_start.region, object_id), vp.path_nodes) as path_nodes,
+        concat(array(struct(new_start.region, object_id, current_node.region, object_id)), vp.path_edges) as path_edges,
+        new_start.name as start_name,
+        vp.end_name as end_name
+    FROM vlp_a_b vp
+    JOIN test_integration.fs_objects_composite current_node ON vp.start_id = current_node.region, object_id
+    JOIN test_integration.fs_objects_composite new_start ON new_start.parent_region, parent_id = current_node.region, object_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, struct(new_start.region, object_id, current_node.region, object_id))
+)
+SELECT 
+      t.start_name AS `a.name`, 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t


### PR DESCRIPTION
**Slice 0 of the composite-id emission refactor** (abstracts open issues #604/#713/#672/#627 — composite `Identifier` stringified/truncated at SQL emission instead of threaded as a column vector). This slice adds no source change — it establishes the characterization net so the subsequent fixes are byte-guarded.

## Why

The two composite FK-edge schemas (`composite_self_ref_fk` #646, `composite_fk_edge_nonselfref` #672) had **zero corpus goldens** — nothing locked their (malformed) SQL, so a byte-identical-guarded refactor of the emission path was impossible. This adds them to the corpus sweep.

## What

- `tests/corpus/schema_map.json`: +2 schemas (alphabetical insert).
- `tests/corpus/queries.jsonl`: +7 entries — self-ref single-hop / exact `*2..2` / VLP `*1..2` / VLP `*1..3` / reverse; non-self-ref single-hop / reverse.
- +22 golden files under `tests/rust/integration/golden/corpus/`.

The goldens **intentionally capture the CURRENTLY-MALFORMED output** (composite ids collapsed to one quoted identifier, e.g. `start_node.region, object_id as start_id`, `ON ... = c.\"forum_region, forum_id\"`, duplicate-alias exact-hop join). This is characterization — locking today's behavior so the #713/#604 fixes show up as a clean malformed→correct diff with zero single-column collateral. The reverse non-self-ref hop legitimately fails loud (schema defines only Comment→Forum) and is locked as an `.err` golden.

## Verification

- `UPDATE_GOLDEN=1 ... corpus_sweep`: +22 goldens, **zero churn** to existing goldens (verified via `git status`).
- Full `cargo test -p clickgraph --test integration`: 531 passed, `corpus_sweep` green with the new goldens locked.
- `cargo fmt --all --check` clean, ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)