### PR TITLE
fix(#604): composite-aware relationship-uniqueness guard (Site A) — closes #604

### DIFF
--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -498,15 +498,6 @@ impl FilterBuilder for LogicalPlan {
                                         )
                                     })
                                     .unwrap_or(false);
-                            let (rel_from_id_str, rel_to_id_str) = if undirected_doubled {
-                                use crate::sql_generator::emitters::clickhouse::variable_length_cte as vlc;
-                                (
-                                    vlc::DOUBLED_EDGES_ORIG_FROM.to_string(),
-                                    vlc::DOUBLED_EDGES_ORIG_TO.to_string(),
-                                )
-                            } else {
-                                (rel_cols.from_id.to_string(), rel_cols.to_id.to_string())
-                            };
                             // The pairwise relationship-uniqueness guard references
                             // the r1..rN edge-table aliases of the single-type flat
                             // self-join. Two paths reach here WITHOUT those aliases
@@ -531,13 +522,52 @@ impl FilterBuilder for LogicalPlan {
                             let use_legacy_start_end_guard = vlp_schema_type
                                 == crate::render_plan::cte_extraction::VlpSchemaType::FkEdge
                                 || is_multi_type;
+                            // #604 Site A: the relationship-uniqueness edge
+                            // columns (from_id/to_id) may be COMPOSITE. Pass the
+                            // full per-column vectors to the composite-aware
+                            // generator instead of stringifying the Identifier
+                            // (which collapsed a composite to one bogus quoted
+                            // column `r1."from_bank_id, from_account_number"`).
+                            // Single-column ids yield one-element vectors — the
+                            // exact input the old single-column wrapper produced,
+                            // so single-key schemas are byte-identical.
+                            let (from_cols, to_cols): (Vec<String>, Vec<String>) =
+                                if undirected_doubled {
+                                    use crate::sql_generator::emitters::clickhouse::variable_length_cte as vlc;
+                                    (
+                                        vec![vlc::DOUBLED_EDGES_ORIG_FROM.to_string()],
+                                        vec![vlc::DOUBLED_EDGES_ORIG_TO.to_string()],
+                                    )
+                                } else {
+                                    (
+                                        rel_cols
+                                            .from_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| c.to_string())
+                                            .collect(),
+                                        rel_cols
+                                            .to_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| c.to_string())
+                                            .collect(),
+                                    )
+                                };
+                            // `start_id_col`/`end_id_col` feed only the legacy
+                            // start != end guard (FkEdge / multi-type), which is
+                            // addressed separately; keep them single here.
+                            let from_col_refs: Vec<&str> =
+                                from_cols.iter().map(String::as_str).collect();
+                            let to_col_refs: Vec<&str> =
+                                to_cols.iter().map(String::as_str).collect();
                             // Generate relationship-uniqueness filters
-                            if let Some(cycle_filter) = crate::render_plan::cte_extraction::generate_cycle_prevention_filters(
+                            if let Some(cycle_filter) = crate::render_plan::cte_extraction::generate_cycle_prevention_filters_composite(
                                 exact_hops,
-                                &start_id_col,
-                                &rel_to_id_str,
-                                &rel_from_id_str,
-                                &end_id_col,
+                                &[start_id_col.as_str()],
+                                &to_col_refs,
+                                &from_col_refs,
+                                &[end_id_col.as_str()],
                                 &graph_rel.left_connection,
                                 &graph_rel.right_connection,
                                 use_legacy_start_end_guard,

--- a/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.clickhouse.sql
@@ -5,4 +5,4 @@ FROM db_composite_id.accounts AS a
 INNER JOIN db_composite_id.transfers AS r1 ON a.bank_id = r1.from_bank_id AND a.account_number = r1.from_account_number
 INNER JOIN db_composite_id.transfers AS r2 ON r1.to_bank_id = r2.from_bank_id AND r1.to_account_number = r2.from_account_number
 INNER JOIN db_composite_id.accounts AS b ON r2.to_bank_id = b.bank_id AND r2.to_account_number = b.account_number
-WHERE NOT (r1."from_bank_id, from_account_number" = r2."from_bank_id, from_account_number" AND r1."to_bank_id, to_account_number" = r2."to_bank_id, to_account_number")
+WHERE NOT (((r1.from_bank_id = r2.from_bank_id AND r1.from_account_number = r2.from_account_number) AND r1.to_bank_id = r2.to_bank_id) AND r1.to_account_number = r2.to_account_number)

--- a/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.databricks.sql
@@ -5,4 +5,4 @@ FROM db_composite_id.accounts AS a
 INNER JOIN db_composite_id.transfers AS r1 ON a.bank_id = r1.from_bank_id AND a.account_number = r1.from_account_number
 INNER JOIN db_composite_id.transfers AS r2 ON r1.to_bank_id = r2.from_bank_id AND r1.to_account_number = r2.from_account_number
 INNER JOIN db_composite_id.accounts AS b ON r2.to_bank_id = b.bank_id AND r2.to_account_number = b.account_number
-WHERE NOT (r1.`from_bank_id, from_account_number` = r2.`from_bank_id, from_account_number` AND r1.`to_bank_id, to_account_number` = r2.`to_bank_id, to_account_number`)
+WHERE NOT (((r1.from_bank_id = r2.from_bank_id AND r1.from_account_number = r2.from_account_number) AND r1.to_bank_id = r2.to_bank_id) AND r1.to_account_number = r2.to_account_number)


### PR DESCRIPTION
**Slice 3 (final) of the composite-id emission refactor.** Completes #604: the JOIN-ON half was Slice 2 (#803); this is the uniqueness-guard half (Site A).

## Problem

The exact-bound VLP relationship-uniqueness WHERE guard in `filter_builder.rs` stringified the composite edge id `Identifier` (`rel_cols.from_id.to_string()` → `"from_bank_id, from_account_number"`) and passed it through the single-column `generate_cycle_prevention_filters` wrapper, which re-wraps each arg in a 1-element slice. So the composite key reached `_composite` as ONE bogus column:
```sql
WHERE NOT (r1."from_bank_id, from_account_number" = r2."from_bank_id, from_account_number" AND ...)
```
→ ClickHouse Code 47 (the guard half that survived Slice 2's JOIN-ON fix).

## Fix

Build the per-column `Vec<&str>` from `rel_cols.from_id.columns()` / `to_id.columns()` and call `generate_cycle_prevention_filters_composite` directly:
```sql
WHERE NOT (r1.from_bank_id = r2.from_bank_id AND r1.from_account_number = r2.from_account_number
           AND r1.to_bank_id = r2.to_bank_id AND r1.to_account_number = r2.to_account_number)
```
The `undirected_doubled` branch keeps its single-name constants (one-element vectors). `start_id_col`/`end_id_col` feed only the legacy `start != end` guard (FkEdge / multi-type) and stay single. Single-column schemas → one-element vectors → byte-identical to the old wrapper. Operand order (to 3rd, from 4th) preserved exactly.

## Result

With Slice 2 (JOIN-ON) + this, the composite Normal-arm exact-bound VLP is **fully correct and executable**. Verified end-to-end on live ClickHouse: loaded a 2-hop chain A1→A2→A3; `(:Account)-[:TRANSFERRED*2..2]->(:Account)` returns exactly `A1 → A3` (was Code 47 on main), with the uniqueness guard correctly forbidding edge reuse.

## Verification

- Live: correct rows on real data; single-hop + guard both correct.
- Corpus: only `test_604_composite_normal_exact_two_hop` WHERE changes (malformed→correct); **zero single-col collateral** (all standard/#617-undirected/fixture uniqueness goldens byte-identical).
- 1608 lib + 531 integration + ratchet net-zero; fmt/clippy clean.
- Adversarial review: **APPROVE — 0 functional defects** (operand order, byte-identity, undirected-doubled preservation all confirmed).

Closes #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)