### PR TITLE
fix(#606): multi-type VLP enforces relationship-uniqueness (was over-counting)

### DIFF
--- a/schemas/test/mt_multitype_uniqueness.yaml
+++ b/schemas/test/mt_multitype_uniqueness.yaml
@@ -1,0 +1,40 @@
+# Multi-type VLP relationship-uniqueness fixture (#606)
+#
+# Two SEPARATE edge tables (MENTORS, HELPS), both Member->Member and
+# self-composable, so `MATCH (a)-[:MENTORS|HELPS*1..N]->(b)` routes through the
+# MULTI-TYPE VLP emitter (src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs)
+# — a flat JOIN + UNION ALL enumeration, distinct from the recursive-CTE path.
+#
+# That emitter enforced NO relationship-uniqueness: it permitted reusing the same
+# physical edge within a path (e.g. a self-loop traversed twice), so it
+# OVER-counted vs Cypher trail semantics (a node MAY be revisited, but an edge
+# may NOT repeat). This fixture is the minimal cyclic case that exposes the
+# over-count. Live oracle (db `mt606`, edges MENTORS{1->2,2->3} HELPS{2->1,3->3}):
+#   *1..2  current 9  vs trail 8   (self-loop 3->3->3 reuses HELPS(3,3))
+#   *1..3  current 15 vs trail 10
+name: mt_multitype_uniqueness
+
+graph_schema:
+  nodes:
+    - label: Member
+      database: mt606
+      table: members
+      node_id: id
+      property_mappings:
+        id: id
+        name: name
+  edges:
+    - type: MENTORS
+      database: mt606
+      table: mentors
+      from_id: from_id
+      to_id: to_id
+      from_node: Member
+      to_node: Member
+    - type: HELPS
+      database: mt606
+      table: helps
+      from_id: from_id
+      to_id: to_id
+      from_node: Member
+      to_node: Member

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4211,6 +4211,7 @@ pub fn extract_ctes_with_context(
                             view_parameter_values,
                             plan_ctx.map(|ctx| std::sync::Arc::new(ctx.clone())),
                             is_undirected,
+                            graph_rel.shortest_path_mode.is_some(),
                         );
 
                         // TODO: Add property projections based on what's needed in RETURN clause

--- a/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
+++ b/src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs
@@ -101,6 +101,12 @@ pub struct MultiTypeVlpJoinGenerator<'a> {
     // Whether the pattern is undirected (includes both incoming and outgoing edges)
     undirected: bool,
 
+    // #606: whether this is a shortestPath pattern. shortestPath keeps
+    // NODE-uniqueness (revisiting a node can never shorten a path), matching the
+    // recursive-CTE gate `uses_edge_uniqueness()`, so the pairwise
+    // relationship-uniqueness guard is NOT emitted for it.
+    is_shortest_path: bool,
+
     // Filter conditions
     start_filters: Option<String>, // WHERE clause for start node
     end_filters: Option<String>,   // WHERE clause for end node
@@ -149,6 +155,7 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         view_parameter_values: HashMap<String, String>,
         plan_ctx: Option<Arc<PlanCtx>>,
         undirected: bool,
+        is_shortest_path: bool,
     ) -> Self {
         let min_hops = spec.min_hops.unwrap_or(1) as usize;
         let max_hops = spec.max_hops.unwrap_or(10) as usize;
@@ -166,6 +173,7 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
             start_alias,
             end_alias,
             undirected,
+            is_shortest_path,
             start_filters,
             end_filters,
             rel_filters,
@@ -731,6 +739,18 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
         // initiated the expand.
         let mut hop_rel_fk_info: Vec<(String, String, String)> = Vec::new();
 
+        // #606: per-hop edge identity for relationship-uniqueness (trail semantics).
+        // Each entry = (rel_type, edge_alias, schema_from_col, schema_to_col). Two
+        // hops traverse the SAME physical edge iff they have the same rel_type
+        // (hence same table) AND the same (from, to) values. We use the
+        // schema-natural from/to columns (NOT the reversed join columns) so a
+        // forward and reverse traversal of one physical edge compare equal.
+        // After the hop loop, we emit `NOT (a.from = b.from AND a.to = b.to)` for
+        // every same-rel-type hop pair — the multi-type flat enumeration otherwise
+        // permits reusing an edge within a path (over-counting vs Cypher trail
+        // semantics, which forbid edge reuse but allow node revisiting).
+        let mut hop_edge_identity: Vec<(String, String, String, String)> = Vec::new();
+
         for (hop_idx, hop) in hops.iter().enumerate() {
             let hop_num = hop_idx + 1;
 
@@ -819,6 +839,17 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
                         ));
                     }
                 }
+
+                // #606: record this hop's edge identity (fused arm — the edge row
+                // IS the end-node row, so its alias is `end_node_alias`). Uses the
+                // schema-natural from/to columns so forward/reverse of one physical
+                // edge compare equal.
+                hop_edge_identity.push((
+                    hop.rel_type.clone(),
+                    end_node_alias.clone(),
+                    from_col.columns().join(", "),
+                    to_col.columns().join(", "),
+                ));
             } else {
                 // Standard pattern: separate relationship table and target node table
                 let rel_alias = format!("r{}", hop_num);
@@ -893,11 +924,55 @@ impl<'a> MultiTypeVlpJoinGenerator<'a> {
                         hop_rel_fk_info.push((rel_alias.clone(), f.to_string(), t.to_string()));
                     }
                 }
+
+                // #606: record this hop's edge identity (standard arm — the edge
+                // lives in its own `rel_alias` relationship table).
+                hop_edge_identity.push((
+                    hop.rel_type.clone(),
+                    rel_alias.clone(),
+                    from_col.columns().join(", "),
+                    to_col.columns().join(", "),
+                ));
             }
 
             // Update current_alias for next hop
             current_alias = end_node_alias.clone();
             path_node_aliases.push((end_node_alias.clone(), hop.to_node_type.clone()));
+        }
+
+        // #606: relationship-uniqueness (Cypher trail semantics). The flat
+        // multi-type enumeration above places no constraint against reusing the
+        // same physical edge within a path, so a self-loop or a back-and-forth
+        // over one edge is counted repeatedly (over-count). For every pair of hops
+        // i<j that traverse the SAME relationship type (hence the same table),
+        // forbid both hops being the SAME physical edge:
+        //   NOT (edge_i.from = edge_j.from AND edge_i.to = edge_j.to)
+        // Different rel types live in different tables and can never be the same
+        // physical edge, so only same-type pairs are compared. A node may still be
+        // revisited (we only compare edge identity, never node identity).
+        // shortestPath keeps node-uniqueness (a shortest path never revisits a
+        // node, so it never reuses an edge either) — matching the recursive-CTE
+        // gate `uses_edge_uniqueness()`; skip the guard there.
+        if !self.is_shortest_path {
+            for i in 0..hop_edge_identity.len() {
+                for j in (i + 1)..hop_edge_identity.len() {
+                    let (ref ti, ref ai, ref fi, ref toi) = hop_edge_identity[i];
+                    let (ref tj, ref aj, ref fj, ref toj) = hop_edge_identity[j];
+                    if ti != tj {
+                        continue;
+                    }
+                    let fi_id = crate::graph_catalog::config::Identifier::from_comma_separated(fi);
+                    let toi_id =
+                        crate::graph_catalog::config::Identifier::from_comma_separated(toi);
+                    let fj_id = crate::graph_catalog::config::Identifier::from_comma_separated(fj);
+                    let toj_id =
+                        crate::graph_catalog::config::Identifier::from_comma_separated(toj);
+                    // edge_i.from = edge_j.from AND edge_i.to = edge_j.to
+                    let from_eq = fi_id.to_sql_equality(ai, &fj_id, aj);
+                    let to_eq = toi_id.to_sql_equality(ai, &toj_id, aj);
+                    where_clauses.push(format!("NOT (({from_eq}) AND ({to_eq}))"));
+                }
+            }
         }
 
         // Add start filters — apply after hop loop so end_node alias is available

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1219,3 +1219,6 @@
 {"cypher": "MATCH (c:Comment)<-[:IN_FORUM]-(f:Forum) RETURN c.comment_id, f.forum_id LIMIT 5", "name": "test_672_composite_non_self_ref_fk_reverse_single_hop", "schema": "composite_fk_edge_nonselfref"}
 {"cypher": "MATCH (a:Object)-[:PARENT*1..3]->(b:Object) WHERE a.name = 'doc' RETURN b.name", "name": "test_713_composite_self_ref_fk_vlp_ancestors_append", "schema": "composite_self_ref_fk"}
 {"cypher": "MATCH (a:Account)-[:TRANSFERRED*2..2]->(b:Account) RETURN a.bank_id, b.bank_id", "name": "test_604_composite_normal_exact_two_hop", "schema": "composite_id"}
+{"cypher": "MATCH (a:Member)-[:MENTORS|HELPS*1..2]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_one_to_two", "schema": "mt_multitype_uniqueness"}
+{"cypher": "MATCH (a:Member)-[:MENTORS|HELPS*1..3]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_one_to_three", "schema": "mt_multitype_uniqueness"}
+{"cypher": "MATCH (a:Member)-[:MENTORS|HELPS]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_single_hop", "schema": "mt_multitype_uniqueness"}

--- a/tests/corpus/schema_map.json
+++ b/tests/corpus/schema_map.json
@@ -39,6 +39,10 @@
     "subschema": "ldbc_snb",
     "yaml": "schemas/test/unified_test_multi_schema.yaml"
   },
+  "mt_multitype_uniqueness": {
+    "subschema": null,
+    "yaml": "schemas/test/mt_multitype_uniqueness.yaml"
+  },
   "ontime_flights": {
     "subschema": null,
     "yaml": "schemas/examples/ontime_denormalized.yaml"

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.clickhouse.sql
@@ -10,6 +10,7 @@ INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'HELPS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -19,6 +20,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -28,6 +30,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
 FROM mt606.members a_1
@@ -44,6 +47,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -53,6 +57,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['MENTORS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
 FROM mt606.members a_1
@@ -74,6 +79,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -83,6 +89,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
 FROM mt606.members a_1
@@ -90,6 +97,7 @@ INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'MENTORS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -99,6 +107,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
 FROM mt606.members a_1
@@ -108,6 +117,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       t.start_id AS "a.id", 

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.clickhouse.sql
@@ -1,0 +1,115 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['HELPS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'HELPS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'HELPS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'MENTORS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['HELPS', 'MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['MENTORS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['MENTORS', 'HELPS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'HELPS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'MENTORS', 'HELPS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n4.id, n4.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 3 AS hop_count, ['MENTORS', 'MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id), toString(n4.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+)
+SELECT 
+      t.start_id AS "a.id", 
+      t.end_id AS "b.id"
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.databricks.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.databricks.sql
@@ -1,0 +1,115 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('HELPS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'HELPS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'HELPS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'HELPS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'MENTORS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('MENTORS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('MENTORS', 'HELPS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'HELPS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'HELPS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'MENTORS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+UNION ALL
+SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
+INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+)
+SELECT 
+      t.start_id AS `a.id`, 
+      t.end_id AS `b.id`
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.databricks.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_three.databricks.sql
@@ -10,6 +10,7 @@ INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'HELPS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -19,6 +20,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'HELPS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -28,6 +30,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
 FROM mt606.members a_1
@@ -44,6 +47,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('HELPS', 'MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -53,6 +57,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('MENTORS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
 FROM mt606.members a_1
@@ -74,6 +79,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'HELPS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -83,6 +89,7 @@ INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
 FROM mt606.members a_1
@@ -90,6 +97,7 @@ INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'MENTORS', 'HELPS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -99,6 +107,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.helps r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n4.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n4.id, n4.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 3 AS hop_count, array('MENTORS', 'MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id), string(n4.id)) AS path_nodes
 FROM mt606.members a_1
@@ -108,6 +117,7 @@ INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
 INNER JOIN mt606.mentors r3 ON n3.id = r3.from_id
 INNER JOIN mt606.members n4 ON r3.to_id = n4.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       t.start_id AS `a.id`, 

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.clickhouse.sql
@@ -10,6 +10,7 @@ INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
 FROM mt606.members a_1
@@ -36,6 +37,7 @@ INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       t.start_id AS "a.id", 

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.clickhouse.sql
@@ -1,0 +1,43 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['HELPS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'HELPS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['HELPS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['MENTORS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['MENTORS', 'HELPS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, formatRowNoNewline('JSONEachRow', n3.id, n3.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 2 AS hop_count, ['MENTORS', 'MENTORS'] AS path_relationships, ['{}', '{}'] AS rel_properties, [toString(a_1.id), toString(n2.id), toString(n3.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+)
+SELECT 
+      t.start_id AS "a.id", 
+      t.end_id AS "b.id"
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.databricks.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.databricks.sql
@@ -1,0 +1,43 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('HELPS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'HELPS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('MENTORS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('MENTORS', 'HELPS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+UNION ALL
+SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('MENTORS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
+INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+)
+SELECT 
+      t.start_id AS `a.id`, 
+      t.end_id AS `b.id`
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.databricks.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_one_to_two.databricks.sql
@@ -10,6 +10,7 @@ INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.helps r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'Member' AS end_type, n3.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, to_json(struct(n3.id, n3.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 2 AS hop_count, array('HELPS', 'MENTORS') AS path_relationships, array('{}', '{}') AS rel_properties, array(string(a_1.id), string(n2.id), string(n3.id)) AS path_nodes
 FROM mt606.members a_1
@@ -36,6 +37,7 @@ INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
 INNER JOIN mt606.members n2 ON r1.to_id = n2.id
 INNER JOIN mt606.mentors r2 ON n2.id = r2.from_id
 INNER JOIN mt606.members n3 ON r2.to_id = n3.id
+WHERE NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       t.start_id AS `a.id`, 

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_single_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_single_hop.clickhouse.sql
@@ -1,0 +1,15 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, toString(r1.from_id) AS r_from_id, toString(r1.to_id) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['HELPS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, toString(r1.from_id) AS r_from_id, toString(r1.to_id) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.id, n2.name) AS end_properties, formatRowNoNewline('JSONEachRow', a_1.id, a_1.name) AS start_properties, 1 AS hop_count, ['MENTORS'] AS path_relationships, ['{}'] AS rel_properties, [toString(a_1.id), toString(n2.id)] AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+)
+SELECT 
+      t.start_id AS "a.id", 
+      t.end_id AS "b.id"
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_single_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/mt_multitype_uniqueness/test_606_multitype_vlp_uniqueness_single_hop.databricks.sql
@@ -1,0 +1,15 @@
+WITH vlp_multi_type_a_b AS (
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, string(r1.from_id) AS r_from_id, string(r1.to_id) AS r_to_id, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('HELPS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.helps r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+UNION ALL
+SELECT 'Member' AS end_type, n2.id AS end_id, a_1.id AS start_id, 'Member' AS start_type, string(r1.from_id) AS r_from_id, string(r1.to_id) AS r_to_id, to_json(struct(n2.id, n2.name)) AS end_properties, to_json(struct(a_1.id, a_1.name)) AS start_properties, 1 AS hop_count, array('MENTORS') AS path_relationships, array('{}') AS rel_properties, array(string(a_1.id), string(n2.id)) AS path_nodes
+FROM mt606.members a_1
+INNER JOIN mt606.mentors r1 ON a_1.id = r1.from_id
+INNER JOIN mt606.members n2 ON r1.to_id = n2.id
+)
+SELECT 
+      t.start_id AS `a.id`, 
+      t.end_id AS `b.id`
+FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_graphrag_expansion.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_graphrag_expansion.clickhouse.sql
@@ -11,7 +11,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -19,7 +19,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', p3.content AS content, p3.created_at AS created, p3.post_id AS post_id, p3.content AS title) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(p2.post_id), toString(p3.post_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -49,7 +49,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -57,7 +57,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', p3.content AS content, p3.created_at AS created, p3.post_id AS post_id, p3.content AS title) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(u2.user_id), toString(p3.post_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -103,7 +103,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -111,7 +111,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 1 AS hop_count, ['LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -141,7 +141,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, formatRowNoNewline('JSONEachRow', u_1.email_address, u_1.full_name, u_1.user_id) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(u_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench u_1
@@ -149,7 +149,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 )
 SELECT 
       t.end_properties AS "target.properties", 

--- a/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_graphrag_expansion.databricks.sql
+++ b/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_graphrag_expansion.databricks.sql
@@ -11,7 +11,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -19,7 +19,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(p3.content AS content, p3.created_at AS created, p3.post_id AS post_id, p3.content AS title)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(p2.post_id), string(p3.post_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -49,7 +49,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -57,7 +57,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(p3.content AS content, p3.created_at AS created, p3.post_id AS post_id, p3.content AS title)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(u2.user_id), string(p3.post_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -103,7 +103,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -111,7 +111,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 1 AS hop_count, array('LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -141,7 +141,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, u_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, to_json(struct(u_1.email_address, u_1.full_name, u_1.user_id)) AS start_properties, u_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(u_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench u_1
@@ -149,7 +149,7 @@ INNER JOIN brahmand.interactions r1 ON u_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND (u_1.user_id = 1)
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND (u_1.user_id = 1)
 )
 SELECT 
       t.end_properties AS `target.properties`, 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_all_users.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_all_users.clickhouse.sql
@@ -21,6 +21,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 )
 SELECT count(*) AS "total_paths" FROM (
 SELECT 1 AS __dummy

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_all_users.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_all_users.databricks.sql
@@ -21,6 +21,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 )
 SELECT count(*) AS `total_paths` FROM (
 SELECT 1 AS __dummy

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_with_limit.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_with_limit.clickhouse.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `x.properties` AS `x.properties`, `x.id` AS `x.id`, `x.__label__` AS `x.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_with_limit.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypePerformance_test_multi_type_with_limit.databricks.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `x.properties` AS `x.properties`, `x.id` AS `x.id`, `x.__label__` AS `x.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_follows_or_authored_one_to_two_hops.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_follows_or_authored_one_to_two_hops.clickhouse.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT DISTINCT 
       `node_type` AS "node_type", count(*) AS "cnt" FROM (

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_follows_or_authored_one_to_two_hops.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_follows_or_authored_one_to_two_hops.databricks.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT DISTINCT 
       `node_type` AS `node_type`, count(*) AS `cnt` FROM (

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_two_hops_only.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_two_hops_only.clickhouse.sql
@@ -13,7 +13,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT DISTINCT 
       `node_type` AS "node_type", count(*) AS "cnt" FROM (

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_two_hops_only.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_two_hops_only.databricks.sql
@@ -13,7 +13,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT DISTINCT 
       `node_type` AS `node_type`, count(*) AS `cnt` FROM (

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_with_sql_only.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_with_sql_only.clickhouse.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `x.properties` AS `x.properties`, `x.id` AS `x.id`, `x.__label__` AS `x.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_with_sql_only.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeRecursivePatterns_test_multi_type_with_sql_only.databricks.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `x.properties` AS `x.properties`, `x.id` AS `x.id`, `x.__label__` AS `x.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeWithPathFunctions_test_length_with_multi_type.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeWithPathFunctions_test_length_with_multi_type.clickhouse.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `path_length` AS "path_length", count(*) AS "cnt" FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeWithPathFunctions_test_length_with_multi_type.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMultiTypeWithPathFunctions_test_length_with_multi_type.databricks.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `path_length` AS `path_length`, count(*) AS `cnt` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestLabelInference_test_inference_variable_length_path_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestLabelInference_test_inference_variable_length_path_endpoint.clickhouse.sql
@@ -20,6 +20,7 @@ INNER JOIN test_integration.user_follows_test r1 ON a_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', p3.author_id AS author_id, p3.post_content AS content, p3.post_date AS created_at, p3.post_id AS post_id, p3.post_title AS title) AS end_properties, 2 AS hop_count, ['FOLLOWS', 'LIKED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.follow_date), formatRowNoNewline('JSONEachRow', r2.like_date)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id)] AS path_nodes
 FROM test_integration.users_test a_1

--- a/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestLabelInference_test_inference_variable_length_path_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestLabelInference_test_inference_variable_length_path_endpoint.databricks.sql
@@ -20,6 +20,7 @@ INNER JOIN test_integration.user_follows_test r1 ON a_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 UNION ALL
 SELECT 'Post' AS end_type, p3.post_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(p3.author_id AS author_id, p3.post_content AS content, p3.post_date AS created_at, p3.post_id AS post_id, p3.post_title AS title)) AS end_properties, 2 AS hop_count, array('FOLLOWS', 'LIKED') AS path_relationships, array(to_json(struct(r1.follow_date)), to_json(struct(r2.like_date))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id)) AS path_nodes
 FROM test_integration.users_test a_1

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_0.clickhouse.sql
@@ -5,7 +5,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -45,7 +45,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -93,7 +93,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -133,7 +133,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -181,7 +181,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -221,7 +221,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -269,7 +269,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -309,7 +309,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -357,7 +357,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -397,7 +397,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       JSONExtractString(t.start_properties, 'email_address') AS "a.email", 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_0.databricks.sql
@@ -5,7 +5,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -45,7 +45,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -93,7 +93,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -133,7 +133,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -181,7 +181,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -221,7 +221,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -269,7 +269,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -309,7 +309,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -357,7 +357,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -397,7 +397,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       get_json_object(t.start_properties, '$.email_address') AS `a.email`, 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_2.clickhouse.sql
@@ -5,7 +5,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -45,7 +45,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -93,7 +93,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -133,7 +133,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -181,7 +181,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -221,7 +221,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -269,7 +269,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -309,7 +309,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -357,7 +357,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -397,7 +397,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       JSONExtractString(t.start_properties, 'user_id') AS "a.user_id", 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_exact_2.databricks.sql
@@ -5,7 +5,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -45,7 +45,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -93,7 +93,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -133,7 +133,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -181,7 +181,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -221,7 +221,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -269,7 +269,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -309,7 +309,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -357,7 +357,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -397,7 +397,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 )
 SELECT 
       get_json_object(t.start_properties, '$.user_id') AS `a.user_id`, 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_path_var_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_path_var_0.clickhouse.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_path_var_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_path_var_0.databricks.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_0.clickhouse.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address, u2.full_name, u2.user_id) AS end_properties, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, ['AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address, u2.full_name, u2.user_id) AS end_properties, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, ['COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address, u2.full_name, u2.user_id) AS end_properties, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, ['FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address, u2.full_name, u2.user_id) AS end_properties, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, ['LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address, u2.full_name, u2.user_id) AS end_properties, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, ['SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address, u3.full_name, u3.user_id) AS end_properties, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address, u4.full_name, u4.user_id) AS end_properties, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       JSONExtractString(t.start_properties, 'user_id') AS "a.user_id", 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_0.databricks.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address, u2.full_name, u2.user_id)) AS end_properties, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, array('AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address, u2.full_name, u2.user_id)) AS end_properties, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, array('COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address, u2.full_name, u2.user_id)) AS end_properties, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, array('FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address, u2.full_name, u2.user_id)) AS end_properties, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, array('LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address, u2.full_name, u2.user_id)) AS end_properties, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 1 AS hop_count, array('SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address, u3.full_name, u3.user_id)) AS end_properties, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address, u4.full_name, u4.user_id)) AS end_properties, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       get_json_object(t.start_properties, '$.user_id') AS `a.user_id`, 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_1.clickhouse.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['AUTHORED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'AUTHORED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['COMMENTED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'AUTHORED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'COMMENTED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['FOLLOWS', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'AUTHORED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'COMMENTED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'FOLLOWS', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['LIKES', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(p2.post_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, ['SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'AUTHORED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'COMMENTED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'FOLLOWS', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'LIKES', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(p3.post_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, ['SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'AUTHORED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'COMMENTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'FOLLOWS'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'LIKES'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, formatRowNoNewline('JSONEachRow', u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, formatRowNoNewline('JSONEachRow', a_1.email_address, a_1.full_name, a_1.user_id) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, ['SHARED', 'SHARED', 'SHARED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', r1.timestamp, r1.interaction_weight), formatRowNoNewline('JSONEachRow', r2.timestamp, r2.interaction_weight), formatRowNoNewline('JSONEachRow', r3.timestamp, r3.interaction_weight)] AS rel_properties, [toString(a_1.user_id), toString(u2.user_id), toString(u3.user_id), toString(u4.user_id)] AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       JSONExtractString(t.start_properties, 'full_name') AS "a.name", 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_schema_matrix__TestPolymorphicSchema_test_vlp_range_1.databricks.sql
@@ -7,7 +7,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -17,7 +17,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -27,7 +27,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -37,7 +37,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -47,7 +47,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -55,7 +55,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -65,7 +65,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -75,7 +75,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -85,7 +85,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -95,7 +95,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -105,7 +105,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -115,7 +115,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -125,7 +125,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -173,7 +173,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -183,7 +183,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -223,7 +223,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -243,7 +243,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -281,7 +281,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -301,7 +301,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -331,7 +331,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -361,7 +361,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -389,7 +389,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -419,7 +419,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -439,7 +439,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -479,7 +479,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -497,7 +497,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -537,7 +537,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -553,7 +553,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -563,7 +563,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -573,7 +573,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -583,7 +583,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -593,7 +593,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -601,7 +601,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -611,7 +611,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -621,7 +621,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -631,7 +631,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -641,7 +641,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -651,7 +651,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -661,7 +661,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -671,7 +671,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -719,7 +719,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -729,7 +729,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -769,7 +769,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -789,7 +789,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -827,7 +827,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -847,7 +847,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -877,7 +877,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -907,7 +907,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -935,7 +935,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -965,7 +965,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -985,7 +985,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1025,7 +1025,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1043,7 +1043,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('AUTHORED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1083,7 +1083,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'AUTHORED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1093,7 +1093,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1103,7 +1103,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1151,7 +1151,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1161,7 +1161,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1201,7 +1201,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1211,7 +1211,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1221,7 +1221,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1231,7 +1231,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1241,7 +1241,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1249,7 +1249,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1259,7 +1259,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1269,7 +1269,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1279,7 +1279,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1289,7 +1289,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1299,7 +1299,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1319,7 +1319,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1329,7 +1329,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1377,7 +1377,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1387,7 +1387,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1427,7 +1427,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1447,7 +1447,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1485,7 +1485,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1505,7 +1505,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1535,7 +1535,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1565,7 +1565,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1593,7 +1593,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1623,7 +1623,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1639,7 +1639,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1649,7 +1649,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1697,7 +1697,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1707,7 +1707,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'AUTHORED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1747,7 +1747,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1757,7 +1757,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1767,7 +1767,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1777,7 +1777,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1787,7 +1787,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1795,7 +1795,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1805,7 +1805,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1815,7 +1815,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1825,7 +1825,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1835,7 +1835,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1845,7 +1845,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1865,7 +1865,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1875,7 +1875,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1923,7 +1923,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1933,7 +1933,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1973,7 +1973,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -1993,7 +1993,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2031,7 +2031,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2051,7 +2051,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2081,7 +2081,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2111,7 +2111,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2139,7 +2139,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('COMMENTED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2169,7 +2169,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'COMMENTED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2179,7 +2179,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2199,7 +2199,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2237,7 +2237,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2257,7 +2257,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2297,7 +2297,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2307,7 +2307,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2355,7 +2355,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2365,7 +2365,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2395,7 +2395,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2405,7 +2405,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2415,7 +2415,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2425,7 +2425,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2435,7 +2435,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2443,7 +2443,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2453,7 +2453,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2463,7 +2463,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2473,7 +2473,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2483,7 +2483,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2493,7 +2493,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2523,7 +2523,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2533,7 +2533,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2581,7 +2581,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2591,7 +2591,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2631,7 +2631,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2651,7 +2651,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2689,7 +2689,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2709,7 +2709,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2725,7 +2725,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2745,7 +2745,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2783,7 +2783,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2803,7 +2803,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'AUTHORED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2843,7 +2843,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2853,7 +2853,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2901,7 +2901,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2911,7 +2911,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'COMMENTED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2941,7 +2941,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2951,7 +2951,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2961,7 +2961,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2971,7 +2971,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2981,7 +2981,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2989,7 +2989,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -2999,7 +2999,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3009,7 +3009,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3019,7 +3019,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3029,7 +3029,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3039,7 +3039,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3069,7 +3069,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3079,7 +3079,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3127,7 +3127,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3137,7 +3137,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3177,7 +3177,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3197,7 +3197,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3235,7 +3235,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('FOLLOWS', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3255,7 +3255,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3265,7 +3265,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3295,7 +3295,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3323,7 +3323,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3353,7 +3353,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3383,7 +3383,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3403,7 +3403,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3441,7 +3441,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3461,7 +3461,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3501,7 +3501,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3511,7 +3511,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3559,7 +3559,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3569,7 +3569,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3589,7 +3589,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3599,7 +3599,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3609,7 +3609,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3619,7 +3619,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3629,7 +3629,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3637,7 +3637,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3647,7 +3647,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3657,7 +3657,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3667,7 +3667,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3677,7 +3677,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3687,7 +3687,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3727,7 +3727,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3737,7 +3737,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3785,7 +3785,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3795,7 +3795,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3811,7 +3811,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3841,7 +3841,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3869,7 +3869,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3899,7 +3899,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'AUTHORED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3929,7 +3929,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3949,7 +3949,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -3987,7 +3987,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4007,7 +4007,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'COMMENTED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4047,7 +4047,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4057,7 +4057,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4105,7 +4105,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4115,7 +4115,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'FOLLOWS', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4135,7 +4135,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4145,7 +4145,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4155,7 +4155,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4165,7 +4165,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4175,7 +4175,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4183,7 +4183,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4193,7 +4193,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4203,7 +4203,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4213,7 +4213,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4223,7 +4223,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4233,7 +4233,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4273,7 +4273,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4283,7 +4283,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4331,7 +4331,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('LIKES', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4341,7 +4341,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4351,7 +4351,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4391,7 +4391,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4409,7 +4409,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4449,7 +4449,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4469,7 +4469,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4499,7 +4499,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4527,7 +4527,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4557,7 +4557,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4587,7 +4587,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4607,7 +4607,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4645,7 +4645,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4665,7 +4665,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4705,7 +4705,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4715,7 +4715,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4763,7 +4763,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4773,7 +4773,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4783,7 +4783,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4793,7 +4793,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4803,7 +4803,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4813,7 +4813,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4823,7 +4823,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4831,7 +4831,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.posts_bench p2 ON r1.to_id = p2.post_id
 INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4841,7 +4841,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4851,7 +4851,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4861,7 +4861,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4871,7 +4871,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(p2.post_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4881,7 +4881,7 @@ INNER JOIN brahmand.interactions r2 ON p2.post_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'Post' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'Post' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u2.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u2.email_address AS email, u2.full_name AS name, u2.user_id AS user_id)) AS end_properties, u2.email_address AS end_email, u2.full_name AS end_name, u2.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 1 AS hop_count, array('SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4897,7 +4897,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4937,7 +4937,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4955,7 +4955,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'AUTHORED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -4995,7 +4995,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'AUTHORED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5015,7 +5015,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5045,7 +5045,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5073,7 +5073,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'COMMENTED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5103,7 +5103,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'COMMENTED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5133,7 +5133,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5153,7 +5153,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5191,7 +5191,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'FOLLOWS', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5211,7 +5211,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'FOLLOWS' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5251,7 +5251,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5261,7 +5261,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5309,7 +5309,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'LIKES', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5319,7 +5319,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'LIKES' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5329,7 +5329,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5339,7 +5339,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5349,7 +5349,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5359,7 +5359,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(p3.post_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5369,7 +5369,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.posts_bench p3 ON r2.to_id = p3.post_id
 INNER JOIN brahmand.interactions r3 ON p3.post_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'Post' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'Post' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u3.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u3.email_address AS email, u3.full_name AS name, u3.user_id AS user_id)) AS end_properties, u3.email_address AS end_email, u3.full_name AS end_name, u3.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 2 AS hop_count, array('SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5377,7 +5377,7 @@ INNER JOIN brahmand.interactions r1 ON a_1.user_id = r1.from_id
 INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'AUTHORED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5387,7 +5387,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'AUTHORED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'COMMENTED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5397,7 +5397,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'COMMENTED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'FOLLOWS') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5407,7 +5407,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'FOLLOWS' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'LIKES') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5417,7 +5417,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'LIKES' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id))
 UNION ALL
 SELECT 'User' AS end_type, u4.user_id AS end_id, a_1.user_id AS start_id, 'User' AS start_type, to_json(struct(u4.email_address AS email, u4.full_name AS name, u4.user_id AS user_id)) AS end_properties, u4.email_address AS end_email, u4.full_name AS end_name, u4.user_id AS end_user_id, to_json(struct(a_1.email_address, a_1.full_name, a_1.user_id)) AS start_properties, a_1.email_address AS start_email, a_1.full_name AS start_name, a_1.user_id AS start_user_id, 3 AS hop_count, array('SHARED', 'SHARED', 'SHARED') AS path_relationships, array(to_json(struct(r1.timestamp, r1.interaction_weight)), to_json(struct(r2.timestamp, r2.interaction_weight)), to_json(struct(r3.timestamp, r3.interaction_weight))) AS rel_properties, array(string(a_1.user_id), string(u2.user_id), string(u3.user_id), string(u4.user_id)) AS path_nodes
 FROM brahmand.users_bench a_1
@@ -5427,7 +5427,7 @@ INNER JOIN brahmand.interactions r2 ON u2.user_id = r2.from_id
 INNER JOIN brahmand.users_bench u3 ON r2.to_id = u3.user_id
 INNER JOIN brahmand.interactions r3 ON u3.user_id = r3.from_id
 INNER JOIN brahmand.users_bench u4 ON r3.to_id = u4.user_id
-WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User'
+WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND r2.interaction_type = 'SHARED' AND r2.from_type = 'User' AND r2.to_type = 'User' AND r3.interaction_type = 'SHARED' AND r3.from_type = 'User' AND r3.to_type = 'User' AND NOT ((r1.from_id = r2.from_id) AND (r1.to_id = r2.to_id)) AND NOT ((r1.from_id = r3.from_id) AND (r1.to_id = r3.to_id)) AND NOT ((r2.from_id = r3.from_id) AND (r2.to_id = r3.to_id))
 )
 SELECT 
       get_json_object(t.start_properties, '$.full_name') AS `a.name`, 

--- a/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_graphrag_expansion.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_graphrag_expansion.clickhouse.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `target.properties` AS `target.properties`, `target.id` AS `target.id`, `target.__label__` AS `target.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_graphrag_expansion.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_graphrag_expansion.databricks.sql
@@ -24,7 +24,7 @@ INNER JOIN test_integration.user_follows_test r1 ON u_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 INNER JOIN test_integration.user_follows_test r2 ON u2.user_id = r2.follower_id
 INNER JOIN test_integration.users_test u3 ON r2.followed_id = u3.user_id
-WHERE (u_1.user_id = 1)
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id)) AND (u_1.user_id = 1)
 )
 SELECT `target.properties` AS `target.properties`, `target.id` AS `target.id`, `target.__label__` AS `target.__label__` FROM (
 SELECT 

--- a/tests/rust/integration/golden/sql_ir/standard/vlp_multi_type__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/vlp_multi_type__clickhouse.sql
@@ -23,6 +23,7 @@ INNER JOIN social.user_follows_bench r1 ON a_1.user_id = r1.follower_id
 INNER JOIN social.users_bench u2 ON r1.followed_id = u2.user_id
 INNER JOIN social.user_follows_bench r2 ON u2.user_id = r2.follower_id
 INNER JOIN social.users_bench u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 )
 SELECT 
       t.end_properties AS "b.properties", 

--- a/tests/rust/integration/golden/sql_ir/standard/vlp_multi_type__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/vlp_multi_type__databricks.sql
@@ -23,6 +23,7 @@ INNER JOIN social.user_follows_bench r1 ON a_1.user_id = r1.follower_id
 INNER JOIN social.users_bench u2 ON r1.followed_id = u2.user_id
 INNER JOIN social.user_follows_bench r2 ON u2.user_id = r2.follower_id
 INNER JOIN social.users_bench u3 ON r2.followed_id = u3.user_id
+WHERE NOT ((r1.follower_id = r2.follower_id) AND (r1.followed_id = r2.followed_id))
 )
 SELECT 
       t.end_properties AS `b.properties`, 


### PR DESCRIPTION
**Slice 1 of the #606 remaining-VLP-arms work** (relationship-uniqueness). This arm has the *opposite* failure mode from the recursive generators fixed in #598/#709/#712.

## Problem

The multi-type VLP emitter (`multi_type_vlp_joins.rs`) is a flat JOIN + UNION enumeration. It emitted **no uniqueness predicate at all** — `path_nodes` was built only for `nodes(p)` display, never filtered — so a path could reuse the **same physical edge** (a self-loop twice, or a back-and-forth). That **over-counts** vs Cypher trail semantics (node revisiting OK, edge reuse NOT).

## Fix

In `generate_path_branch_sql`, record each hop's edge identity `(rel_type, edge_alias, from_col, to_col)` — schema-natural columns so forward/reverse of one physical edge compare equal — then for every same-rel-type hop pair i<j emit `NOT (edge_i.from = edge_j.from AND edge_i.to = edge_j.to)` via `Identifier::to_sql_equality` (composite-aware). Different rel types live in different tables (and each hop carries a `type_column = 'X'` filter), so they can never alias the same physical edge — only same-type pairs are compared; node revisiting stays allowed.

shortestPath keeps node-uniqueness (a shortest path never revisits a node, so never reuses an edge) — threaded `is_shortest_path` to skip the guard there, matching the recursive-CTE `uses_edge_uniqueness()` gate.

## Verification

- **Live oracle** (cyclic fixture, MENTORS{1→2,2→3} + HELPS{2→1,3→3-selfloop}): counts now match the hand-computed trail exactly — `*1..2` 9→**8**, `*1..3` 15→**10**.
- New `mt_multitype_uniqueness` corpus fixture characterizes the transition.
- Corpus churn: 34 goldens (social_integration/polymorphic/social_polymorphic/standard) + 2 snapshots — **every change is the added same-type pairwise guard** (verified: no non-guard semantic change; single-hop gets none; no shortestPath/non-multi-type golden changed).
- 1608 lib + 531 integration + ratchet net-zero; fmt/clippy clean.
- **Adversarial review: APPROVE — 0 functional defects**, with live confirmation of the same-table-polymorphic safety (per-hop type filter → cross-type hops are disjoint rows; branch=12 vs main=14, correct=12) and reversed-hop identity.

## Follow-up (not a regression)

Filed **#806**: flat-path edge identity uses `(from,to)` only, collapsing parallel edges (under-count) — pre-existing, affects single-type flat identically; the recursive path already uses the full composite `edge_id`. This PR keeps multi-type flat *consistent* with single-type flat.

Partially addresses #606 (multi-type arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)