### PR TITLE
fix(#802): FK-edge exact-bound VLP no longer emits duplicate endpoint alias (Code 179)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -300,9 +300,9 @@ fixed stats fixture.
   #793/#795/#796; `pattern_schema.rs` dead_code audit done #799). No Phase-3
   items remain.
 - Composite-id emission: #604/#713 **DONE** (2026-07-28, #800–#804). Remaining
-  composite-id follow-ups are bug-driven / design-cycle: #802 (FK-edge
-  exact-bound dup-alias Code 179), #627 (composed/adjacent VLP CTE per-column
-  exposure), #672 part-1 (wrong-order silent zip).
+  composite-id follow-ups are bug-driven / design-cycle: ~~#802 (FK-edge
+  exact-bound dup-alias Code 179)~~ **DONE 2026-07-29 (#810)**, #627 (composed/
+  adjacent VLP CTE per-column exposure), #672 part-1 (wrong-order silent zip).
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
@@ -315,6 +315,28 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-07-29: **#802 — FK-edge exact-bound VLP duplicate endpoint alias (Code
+  179)** (composite-id follow-up). `(a)-[:PARENT*2..2]->(b)` on a self-ref
+  FK-edge table emitted `FROM t AS b JOIN t AS b` (endpoint alias twice) + start
+  alias `a` undefined → Code 179. **Root:** `extract_joins` roots the expander
+  chain at the START node, but `select_anchor`'s alphabetical tie-break picks the
+  END node as `anchor_table` for a self-ref table (both endpoints = same table),
+  and `extract_from` used it — FROM disagreed with the joins. **Fix**
+  (`from_builder.rs`): a flat exact VLP (N≥2) derives FROM from the same
+  `expand_fixed_length_joins_with_context` that builds its joins, so they agree
+  by construction. Normal/Polymorphic already root at start → byte-identical
+  (zero corpus churn). **Un-masked** a composite-key defect in the FK-edge/
+  multi-type legacy `start != end` guard (`filter_builder.rs`): `start_id`/
+  `end_id` came from the single-`String` `ViewScan.id_column`, truncating
+  composite keys to `a.region <> b.region` — live-verified to drop a valid
+  grandparent path (0 rows vs 1). Made composite-aware via `node_id.columns()`;
+  single-col yields one-element vectors → byte-identical. **Known residual**
+  (documented): the legacy start!=end guard is stricter than Cypher trail
+  semantics on CYCLIC self-ref data — pre-existing, shared single/composite,
+  tracked with the #598-followup rel-uniqueness rewrite. Live-verified on
+  ClickHouse (single + composite fixtures); adversarial review before merge.
+  Goldens: regenerated `composite_self_ref_fk` exact-two-hop (was locking the
+  buggy form); added single-col `fk_edge_self_ref` exact two/three-hop.
 - 2026-07-28: **#606 VLP relationship-uniqueness — remaining live arms** (USER:
   "finish bug-driven refactoring if more exist"). After #598/#709/#712, three
   Explore passes mapped the residual arms. **Only one was a live bug:**

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -8195,6 +8195,19 @@ pub fn generate_cycle_prevention_filters_composite(
         // Emitting `r{i}` aliases here would be a LOUD SQL error. Until a
         // path-specific rule is written we PRESERVE the previous behaviour
         // (start != end guard over the aliases those paths actually expose).
+        //
+        // #802: `start_id_cols`/`end_id_cols` are now full per-column vectors,
+        // so this guard is composite-correct — a composite-keyed Fk-edge emits
+        // `NOT (a.k1 = b.k1 AND a.k2 = b.k2 ...)` instead of the old truncated
+        // `a.k1 <> b.k1` (which silently dropped valid grandparent paths whose
+        // endpoints happened to share the first key column). KNOWN RESIDUAL:
+        // this `start != end` guard is stricter than Cypher trail semantics on
+        // CYCLIC self-ref data — a valid cycle-closing trail (e.g. `n1→n2→n3→n1`
+        // over three distinct edges) is dropped because it returns to its start.
+        // Acyclic hierarchies (the designed FK-edge self-ref domain: filesystems,
+        // org charts, category trees) are unaffected — a path there can never
+        // revisit a node. Pre-existing and shared by single- and composite-key
+        // FkEdge; tracked with the #598-followup rel-uniqueness rewrite above.
         filters.push(generate_composite_not_equal(
             start_alias,
             start_id_cols,

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -462,27 +462,86 @@ impl FilterBuilder for LogicalPlan {
                             // For denormalized, use relationship columns directly (nodes
                             // have no separate table — extract_table_name would fail).
                             // For normal schemas, use node ID columns from node tables.
-                            let (start_id_col, end_id_col) = if is_denormalized {
-                                (rel_cols.from_id.to_string(), rel_cols.to_id.to_string())
-                            } else {
-                                let start_table =
-                                    extract_table_name(&graph_rel.left).ok_or_else(|| {
-                                        RenderBuildError::MissingTableInfo(
-                                            "start node in cycle prevention".to_string(),
-                                        )
-                                    })?;
-                                let end_table =
-                                    extract_table_name(&graph_rel.right).ok_or_else(|| {
-                                        RenderBuildError::MissingTableInfo(
-                                            "end node in cycle prevention".to_string(),
-                                        )
-                                    })?;
-                                let start = extract_id_column(&graph_rel.left)
-                                    .unwrap_or_else(|| table_to_id_column(&start_table));
-                                let end = extract_id_column(&graph_rel.right)
-                                    .unwrap_or_else(|| table_to_id_column(&end_table));
-                                (start, end)
+                            //
+                            // #802: `start_id_cols`/`end_id_cols` are per-column
+                            // vectors so the legacy FkEdge / multi-type `start !=
+                            // end` node guard stays correct for COMPOSITE node
+                            // keys. Previously these were single strings sourced
+                            // from `ViewScan.id_column`, which silently drops
+                            // every column past the first for a composite key —
+                            // emitting `a.region <> b.region` for a
+                            // `[region, object_id]` key (an under-constrained
+                            // guard that admits distinct nodes sharing a region).
+                            // That defect was masked while the FK-edge exact VLP
+                            // errored Code 179 (dup FROM/JOIN alias, #802 FROM
+                            // fix); un-masking it here keeps the guard honest.
+                            // Single-column keys yield one-element vectors →
+                            // byte-identical to the old single-string path.
+                            let schema_for_ids =
+                                crate::server::query_context::get_current_schema_with_fallback();
+                            let composite_node_id_cols = |node_plan: &LogicalPlan| -> Option<Vec<String>> {
+                                let schema = schema_for_ids.as_ref()?;
+                                let label =
+                                    crate::render_plan::cte_extraction::extract_node_label_from_viewscan_with_schema(
+                                        node_plan, schema,
+                                    )?;
+                                let node_schema = schema.node_schema_opt(&label)?;
+                                if node_schema.node_id.is_composite() {
+                                    Some(
+                                        node_schema
+                                            .node_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| c.to_string())
+                                            .collect(),
+                                    )
+                                } else {
+                                    None
+                                }
                             };
+                            let (start_id_cols, end_id_cols): (Vec<String>, Vec<String>) =
+                                if is_denormalized {
+                                    (
+                                        rel_cols
+                                            .from_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| c.to_string())
+                                            .collect(),
+                                        rel_cols
+                                            .to_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| c.to_string())
+                                            .collect(),
+                                    )
+                                } else {
+                                    let start_table =
+                                        extract_table_name(&graph_rel.left).ok_or_else(|| {
+                                            RenderBuildError::MissingTableInfo(
+                                                "start node in cycle prevention".to_string(),
+                                            )
+                                        })?;
+                                    let end_table =
+                                        extract_table_name(&graph_rel.right).ok_or_else(|| {
+                                            RenderBuildError::MissingTableInfo(
+                                                "end node in cycle prevention".to_string(),
+                                            )
+                                        })?;
+                                    // Prefer the node schema's full composite key;
+                                    // else the lossy-but-correct single column.
+                                    let start = composite_node_id_cols(&graph_rel.left)
+                                        .unwrap_or_else(|| {
+                                            vec![extract_id_column(&graph_rel.left)
+                                                .unwrap_or_else(|| table_to_id_column(&start_table))]
+                                        });
+                                    let end = composite_node_id_cols(&graph_rel.right)
+                                        .unwrap_or_else(|| {
+                                            vec![extract_id_column(&graph_rel.right)
+                                                .unwrap_or_else(|| table_to_id_column(&end_table))]
+                                        });
+                                    (start, end)
+                                };
 
                             // #617: single-walk undirected exact-bound chains hop
                             // over the doubled-edge CTE; the pairwise uniqueness
@@ -554,20 +613,24 @@ impl FilterBuilder for LogicalPlan {
                                             .collect(),
                                     )
                                 };
-                            // `start_id_col`/`end_id_col` feed only the legacy
-                            // start != end guard (FkEdge / multi-type), which is
-                            // addressed separately; keep them single here.
+                            // `start_id_cols`/`end_id_cols` feed only the legacy
+                            // start != end node guard (FkEdge / multi-type),
+                            // which is now composite-aware (#802).
                             let from_col_refs: Vec<&str> =
                                 from_cols.iter().map(String::as_str).collect();
                             let to_col_refs: Vec<&str> =
                                 to_cols.iter().map(String::as_str).collect();
+                            let start_id_refs: Vec<&str> =
+                                start_id_cols.iter().map(String::as_str).collect();
+                            let end_id_refs: Vec<&str> =
+                                end_id_cols.iter().map(String::as_str).collect();
                             // Generate relationship-uniqueness filters
                             if let Some(cycle_filter) = crate::render_plan::cte_extraction::generate_cycle_prevention_filters_composite(
                                 exact_hops,
-                                &[start_id_col.as_str()],
+                                &start_id_refs,
                                 &to_col_refs,
                                 &from_col_refs,
-                                &[end_id_col.as_str()],
+                                &end_id_refs,
                                 &graph_rel.left_connection,
                                 &graph_rel.right_connection,
                                 use_legacy_start_end_guard,

--- a/src/render_plan/from_builder.rs
+++ b/src/render_plan/from_builder.rs
@@ -993,6 +993,65 @@ impl LogicalPlan {
 
         log::info!("🔍 No VLP found, proceeding with FROM marker...");
 
+        // #802: A flat exact-bound VLP (`*N..N`, N≥2) expands into a chained
+        // self-join rooted at the START node — `extract_joins` returns the
+        // `expand_fixed_length_joins_with_context` output whose `from_alias` is
+        // `start_alias`. The analyzer, however, may pick the END node as
+        // `anchor_table`: for a self-referencing FK-edge table both endpoints
+        // resolve to the SAME table name, so `select_anchor`'s alphabetical
+        // tie-break ranks the endpoint alias first. That makes the FROM clause
+        // (endpoint `b`) disagree with the expander's join chain (rooted at
+        // start `a`): the endpoint alias then appears BOTH as FROM and as the
+        // final hop's JOIN target (Code 179 MULTIPLE_EXPRESSIONS_FOR_ALIAS)
+        // while the start alias is referenced but never defined. Derive FROM
+        // from the SAME expander that produced the joins so the two agree by
+        // construction. Normal/Polymorphic already root at the start node, so
+        // this is byte-identical for them; it only corrects the FK-edge
+        // endpoint-anchor case. (A later endpoint-selective-predicate reorder,
+        // `reorder_from_for_selective_predicate`, still re-roots to the endpoint
+        // when a WHERE filter warrants it — it rewrites the join conditions to
+        // stay consistent, which is exactly what this arm was missing.)
+        if let Some(graph_rel) = find_vlp_graph_rel(&graph_joins.input) {
+            if is_fixed_length_vlp(graph_rel) {
+                let exact = graph_rel
+                    .variable_length
+                    .as_ref()
+                    .and_then(|s| s.exact_hop_count())
+                    .unwrap_or(0);
+                if exact > 1 {
+                    if let Some(schema) = crate::server::query_context::get_current_schema() {
+                        if let Some(vlp_ctx) = crate::render_plan::cte_extraction::build_vlp_context(
+                            graph_rel, &schema,
+                        ) {
+                            let (from_table, from_alias, _joins) =
+                                crate::render_plan::cte_extraction::expand_fixed_length_joins_with_context(
+                                    &vlp_ctx,
+                                );
+                            // Honor parameterized-view table refs when present
+                            // (matches the sibling anchor/FROM-marker branches);
+                            // the expander already prefers the parameterized
+                            // start table, so `from_table` is the fallback.
+                            let table_name = parameterized_tables
+                                .get(&from_alias)
+                                .cloned()
+                                .unwrap_or(from_table);
+                            log::info!(
+                                "✅ #802: flat exact VLP FROM from expander: table='{}' alias='{}'",
+                                table_name,
+                                from_alias
+                            );
+                            return Ok(Some(ViewTableRef {
+                                source: Arc::new(LogicalPlan::Empty),
+                                name: table_name,
+                                alias: Some(from_alias),
+                                use_final: false,
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+
         // If an anchor_table is set, prefer it as FROM (ensures OPTIONAL MATCH
         // with incoming direction uses the required-MATCH anchor, not the optional node)
         if let Some(ref anchor) = graph_joins.anchor_table {

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1187,6 +1187,9 @@
 {"cypher": "MATCH (c:Object)-[:PARENT]->(p:Object) RETURN c.name, p.name", "name": "test_632_self_ref_fk_edge_child_parent_join", "schema": "fk_edge_self_ref"}
 {"cypher": "MATCH (a:Object)-[:PARENT*2..2]->(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_two_hop", "schema": "fk_edge_self_ref"}
 {"cypher": "MATCH (a:Object)-[:PARENT*3..3]->(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_three_hop", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (a:Object)<-[:PARENT*2..2]-(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_two_hop_reverse", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (a:Object)-[:PARENT*2..2]->(b:Object) WHERE b.name = 'x' RETURN a.name", "name": "test_802_self_ref_fk_edge_exact_two_hop_endpoint_where", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (a:Object)-[:PARENT*2..2]-(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_two_hop_undirected", "schema": "fk_edge_self_ref"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (b:User)<-[:FOLLOWS*1..2]-(a) WHERE a.is_active = true RETURN a.name, count(b) AS c", "name": "test_645_reversed_optional_vlp_anchor_gate", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (b:User)<-[:FOLLOWS*1..3]-(a) WHERE a.is_active = true AND a.country = 'USA' RETURN a.name, count(b) AS c", "name": "test_645_reversed_optional_vlp_anchor_gate_compound", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b:User) RETURN a.name, count(b) AS c ORDER BY a.name", "name": "test_647_end_anchored_optional_vlp_incoming", "schema": "standard"}

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1185,6 +1185,8 @@
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS*1..2]->(b:User) WHERE a.is_active = true RETURN a.name, count(b) AS c", "name": "test_621_optional_vlp_anchor_gate_directed", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS*1..3]->(b:User) WHERE a.is_active = true AND a.country = 'USA' RETURN a.name, count(b) AS c", "name": "test_621_optional_vlp_anchor_gate_compound_range", "schema": "standard"}
 {"cypher": "MATCH (c:Object)-[:PARENT]->(p:Object) RETURN c.name, p.name", "name": "test_632_self_ref_fk_edge_child_parent_join", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (a:Object)-[:PARENT*2..2]->(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_two_hop", "schema": "fk_edge_self_ref"}
+{"cypher": "MATCH (a:Object)-[:PARENT*3..3]->(b:Object) RETURN a.name, b.name", "name": "test_802_self_ref_fk_edge_exact_three_hop", "schema": "fk_edge_self_ref"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (b:User)<-[:FOLLOWS*1..2]-(a) WHERE a.is_active = true RETURN a.name, count(b) AS c", "name": "test_645_reversed_optional_vlp_anchor_gate", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (b:User)<-[:FOLLOWS*1..3]-(a) WHERE a.is_active = true AND a.country = 'USA' RETURN a.name, count(b) AS c", "name": "test_645_reversed_optional_vlp_anchor_gate_compound", "schema": "standard"}
 {"cypher": "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b:User) RETURN a.name, count(b) AS c ORDER BY a.name", "name": "test_647_end_anchored_optional_vlp_incoming", "schema": "standard"}

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.clickhouse.sql
@@ -1,7 +1,7 @@
 SELECT 
       a.name AS "a.name", 
       b.name AS "b.name"
-FROM test_integration.fs_objects_composite AS b
-INNER JOIN test_integration.fs_objects_composite AS b ON m1.parent_region = b.region AND m1.parent_id = b.object_id
+FROM test_integration.fs_objects_composite AS a
 INNER JOIN test_integration.fs_objects_composite AS m1 ON a.parent_region = m1.region AND a.parent_id = m1.object_id
-WHERE a.region <> b.region
+INNER JOIN test_integration.fs_objects_composite AS b ON m1.parent_region = b.region AND m1.parent_id = b.object_id
+WHERE NOT (a.region = b.region AND a.object_id = b.object_id)

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_713_composite_self_ref_fk_exact_two_hop.databricks.sql
@@ -1,7 +1,7 @@
 SELECT 
       a.name AS `a.name`, 
       b.name AS `b.name`
-FROM test_integration.fs_objects_composite AS b
-INNER JOIN test_integration.fs_objects_composite AS b ON m1.parent_region = b.region AND m1.parent_id = b.object_id
+FROM test_integration.fs_objects_composite AS a
 INNER JOIN test_integration.fs_objects_composite AS m1 ON a.parent_region = m1.region AND a.parent_id = m1.object_id
-WHERE a.region <> b.region
+INNER JOIN test_integration.fs_objects_composite AS b ON m1.parent_region = b.region AND m1.parent_id = b.object_id
+WHERE NOT (a.region = b.region AND a.object_id = b.object_id)

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_three_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_three_hop.clickhouse.sql
@@ -1,0 +1,8 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS m2 ON m1.parent_id = m2.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m2.parent_id = b.object_id
+WHERE a.object_id <> b.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_three_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_three_hop.databricks.sql
@@ -1,0 +1,8 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS m2 ON m1.parent_id = m2.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m2.parent_id = b.object_id
+WHERE a.object_id <> b.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop.clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m1.parent_id = b.object_id
+WHERE a.object_id <> b.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop.databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m1.parent_id = b.object_id
+WHERE a.object_id <> b.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_endpoint_where.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_endpoint_where.clickhouse.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS "a.name"
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON m1.parent_id = b.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON a.parent_id = m1.object_id
+WHERE (b.name = 'x' AND a.object_id <> b.object_id)

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_endpoint_where.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_endpoint_where.databricks.sql
@@ -1,0 +1,6 @@
+SELECT 
+      a.name AS `a.name`
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON m1.parent_id = b.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON a.parent_id = m1.object_id
+WHERE (b.name = 'x' AND a.object_id <> b.object_id)

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_reverse.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_reverse.clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON b.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON m1.parent_id = a.object_id
+WHERE b.object_id <> a.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_reverse.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_reverse.databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON b.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON m1.parent_id = a.object_id
+WHERE b.object_id <> a.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_undirected.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_undirected.clickhouse.sql
@@ -1,0 +1,15 @@
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m1.parent_id = b.object_id
+WHERE a.object_id <> b.object_id
+UNION ALL 
+SELECT 
+      a.name AS "a.name", 
+      b.name AS "b.name"
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON b.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON m1.parent_id = a.object_id
+WHERE b.object_id <> a.object_id

--- a/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_undirected.databricks.sql
+++ b/tests/rust/integration/golden/corpus/fk_edge_self_ref/test_802_self_ref_fk_edge_exact_two_hop_undirected.databricks.sql
@@ -1,0 +1,15 @@
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_single AS a
+INNER JOIN test_integration.fs_objects_single AS m1 ON a.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS b ON m1.parent_id = b.object_id
+WHERE a.object_id <> b.object_id
+UNION ALL 
+SELECT 
+      a.name AS `a.name`, 
+      b.name AS `b.name`
+FROM test_integration.fs_objects_single AS b
+INNER JOIN test_integration.fs_objects_single AS m1 ON b.parent_id = m1.object_id
+INNER JOIN test_integration.fs_objects_single AS a ON m1.parent_id = a.object_id
+WHERE b.object_id <> a.object_id


### PR DESCRIPTION
## Summary

Fixes #802. An exact-bound FK-edge VLP like `MATCH (a:Object)-[:PARENT*2..2]->(b:Object)` emitted SQL with the endpoint alias `b` used **twice** (once as `FROM`, once as the final hop's JOIN target) → ClickHouse **Code 179 MULTIPLE_EXPRESSIONS_FOR_ALIAS**, with the start alias `a` referenced but never defined.

**Before:**
```sql
FROM fs_objects_single AS b
INNER JOIN fs_objects_single AS b ON m1.parent_id = b.object_id   -- dup alias b
INNER JOIN fs_objects_single AS m1 ON a.parent_id = m1.object_id  -- a undefined
```
**After:**
```sql
FROM fs_objects_single AS a
INNER JOIN fs_objects_single AS m1 ON a.parent_id = m1.object_id
INNER JOIN fs_objects_single AS b ON m1.parent_id = b.object_id
WHERE a.object_id <> b.object_id
```

## Root cause

A **FROM/joins inconsistency**, not the expander reusing `b`. `extract_joins` returns the `expand_fixed_length_joins_with_context` chain, always rooted at the START node (`from_alias = start_alias`). For a self-referencing FK-edge table both endpoints resolve to the SAME table name, so the analyzer's `select_anchor` alphabetical tie-break picks the END node as `anchor_table`, and `extract_from` used that — FROM (`b`) disagreed with the join chain (rooted at `a`).

## Fix

For a flat exact VLP (N≥2), derive FROM from the **same expander** that produces the joins, so they agree by construction. Normal/Polymorphic already root at the start node → **byte-identical**; only the FK-edge endpoint-anchor case changes. The later endpoint-selective-predicate reorder still re-roots to the endpoint when a WHERE filter warrants it.

## Un-masked composite-key defect (loud → silent-wrong trap)

Turning the Code 179 crash into an executable query exposed a latent composite-key bug in the FK-edge / multi-type legacy `start != end` cycle-prevention guard: `start_id`/`end_id` came from `ViewScan.id_column` (single `String`), silently dropping every column past the first — emitting `a.region <> b.region` for a `[region, object_id]` key. **Live-verified**: a 3-node acyclic composite chain returned **0 rows instead of 1** (both endpoints shared a region). Made the guard composite-aware via the node schema's full `node_id.columns()`; single-column keys yield one-element vectors → the exact old output (**zero corpus churn** outside the one intended query).

## Known residual (documented, pre-existing)

The legacy `start != end` guard is stricter than Cypher trail semantics on **cyclic** self-ref data — a cycle-closing trail over distinct edges (`n1→n2→n3→n1`) is dropped. Acyclic hierarchies (the designed FK-edge self-ref domain: filesystems, org charts, category trees) are unaffected. Pre-existing, shared by single/composite, tracked with the #598-followup rel-uniqueness rewrite.

## Verification

- Live-verified against ClickHouse with single + composite self-ref fixtures: `*2..2`/`*3..3` on acyclic trees return correct rows; composite guard fix confirmed to restore a valid grandparent path the truncated guard dropped.
- `cargo fmt --all --check` ✅ · `cargo clippy --all-targets` clean ✅
- Full workspace `cargo test` ✅ (1608 lib + 531 integration) · ratchet net-zero ✅
- corpus_sweep: only the one intended `composite_self_ref_fk` exact-two-hop golden changed (both dialects, was locking the buggy form); added single-col `fk_edge_self_ref` exact two/three-hop characterization goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)