### PR TITLE
refactor(SQL-IR Phase 1): route simple-CASE through a dialect-aware helper

### DIFF
--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -112,6 +112,45 @@ pub fn reduce_fold_sql(
     }
 }
 
+/// Render a Cypher *simple* CASE (`CASE expr WHEN v1 THEN r1 ... ELSE d END`)
+/// for the active dialect, from its already-rendered component strings.
+///
+/// ClickHouse spells the simple form as a function,
+/// `caseWithExpression(expr, v1, r1, v2, r2, ..., default)`; Spark/Databricks
+/// has no such function and uses the standard `CASE expr WHEN v THEN r ... ELSE
+/// d END` syntax (which ClickHouse also accepts, but the function form is what
+/// this pipeline has historically emitted for CH, so it is preserved
+/// byte-identically here). Emitted from the `RenderExpr::Case` render site so
+/// the two dialects stay in sync.
+///
+/// `case_expr` is the rendered subject expression, `when_then` the rendered
+/// `(value, result)` branch pairs, and `default` the rendered ELSE result
+/// (callers pass the fallback — `NULL` or an empty array — when the Cypher CASE
+/// omits ELSE).
+pub fn simple_case_sql(case_expr: &str, when_then: &[(String, String)], default: &str) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        SqlDialect::Databricks => {
+            let mut sql = format!("CASE {}", case_expr);
+            for (value, result) in when_then {
+                sql.push_str(&format!(" WHEN {} THEN {}", value, result));
+            }
+            sql.push_str(&format!(" ELSE {} END", default));
+            sql
+        }
+        // ClickHouse: caseWithExpression(expr, v1, r1, ..., default).
+        _ => {
+            let mut args = vec![case_expr.to_string()];
+            for (value, result) in when_then {
+                args.push(value.clone());
+                args.push(result.clone());
+            }
+            args.push(default.to_string());
+            format!("caseWithExpression({})", args.join(", "))
+        }
+    }
+}
+
 /// Resolve a SQL function name to its active-dialect spelling via the function
 /// registry, falling back to `name` unchanged when it has no registry entry.
 ///
@@ -245,6 +284,47 @@ mod try_render_percentile_tests {
                 &["t.x".into(), "0.9".into(), "extra".into()]
             ),
             None
+        );
+    }
+}
+
+#[cfg(test)]
+mod simple_case_sql_tests {
+    use super::simple_case_sql;
+    use crate::server::query_context::{with_query_context, QueryContext};
+    use crate::sql_generator::SqlDialect;
+
+    fn branches() -> Vec<(String, String)> {
+        vec![
+            ("'Alice'".into(), "'Admin'".into()),
+            ("'Bob'".into(), "'User'".into()),
+        ]
+    }
+
+    #[test]
+    fn clickhouse_default_uses_case_with_expression() {
+        // Default (no scope) = ClickHouse: the historical function form,
+        // byte-identical to what the pipeline emitted before this helper.
+        assert_eq!(
+            simple_case_sql("n.name", &branches(), "'Guest'"),
+            "caseWithExpression(n.name, 'Alice', 'Admin', 'Bob', 'User', 'Guest')"
+        );
+    }
+
+    #[tokio::test]
+    async fn databricks_uses_standard_case_syntax() {
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async {
+            simple_case_sql("n.name", &branches(), "'Guest'")
+        })
+        .await;
+        // Spark has no caseWithExpression; standard CASE-expr syntax instead.
+        assert_eq!(
+            sql,
+            "CASE n.name WHEN 'Alice' THEN 'Admin' WHEN 'Bob' THEN 'User' ELSE 'Guest' END"
         );
     }
 }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7337,15 +7337,17 @@ impl RenderExpr {
                     }
                 };
 
-                // For ClickHouse, use caseWithExpression for simple CASE expressions
+                // Simple CASE (`CASE expr WHEN v THEN r ...`): dialect-aware.
+                // CH spells it caseWithExpression(...); Spark uses standard
+                // CASE-expr syntax. See common::simple_case_sql.
                 if let Some(case_expr) = &case.expr {
-                    // caseWithExpression(expr, val1, res1, val2, res2, ..., default)
-                    let mut args = vec![case_expr.to_sql()];
-
-                    for (when_expr, then_expr) in &case.when_then {
-                        args.push(when_expr.to_sql());
-                        args.push(render_result(then_expr));
-                    }
+                    let when_then: Vec<(String, String)> = case
+                        .when_then
+                        .iter()
+                        .map(|(when_expr, then_expr)| {
+                            (when_expr.to_sql(), render_result(then_expr))
+                        })
+                        .collect();
 
                     let else_expr = case
                         .else_expr
@@ -7359,9 +7361,8 @@ impl RenderExpr {
                                 "NULL".to_string()
                             }
                         });
-                    args.push(else_expr);
 
-                    format!("caseWithExpression({})", args.join(", "))
+                    super::common::simple_case_sql(&case_expr.to_sql(), &when_then, &else_expr)
                 } else {
                     // Searched CASE - use standard CASE syntax
                     let mut sql = String::from("CASE");

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_case_expression.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestRandomQueries_test_case_expression.databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       u.name AS `u.name`, 
-      caseWithExpression(u.exposure, 'external', 'RISK', 'OK') AS `risk_level`
+      CASE u.exposure WHEN 'external' THEN 'RISK' ELSE 'OK' END AS `risk_level`
 FROM data_security.ds_users AS u
 ORDER BY u.name ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestCaseInWhere_test_case_in_where_simple.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestCaseInWhere_test_case_in_where_simple.databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       n.name AS `n.name`
 FROM test_integration.users AS n
-WHERE caseWithExpression(n.name, 'Alice', 1, 'Bob', 1, 0) = 1
+WHERE CASE n.name WHEN 'Alice' THEN 1 WHEN 'Bob' THEN 1 ELSE 0 END = 1
 ORDER BY n.name ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestCaseWithNull_test_case_with_null_input.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestCaseWithNull_test_case_with_null_input.databricks.sql
@@ -1,6 +1,6 @@
 SELECT 
       a.name AS `a.name`, 
-      caseWithExpression(b.name, NULL, 'No follow', b.name) AS `followed`
+      CASE b.name WHEN NULL THEN 'No follow' ELSE b.name END AS `followed`
 FROM test_integration.users AS a
 LEFT JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id
 LEFT JOIN test_integration.users AS b ON b.user_id = t0.followed_id

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestNestedCase_test_nested_case_complex.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestNestedCase_test_nested_case_complex.databricks.sql
@@ -1,6 +1,6 @@
 SELECT 
       n.name AS `n.name`, 
       n.age AS `n.age`, 
-      CASE WHEN n.age >= 30 THEN caseWithExpression(n.name, 'Alice', 'Senior Admin', 'Senior User') ELSE CASE WHEN n.age >= 25 THEN 'Regular User' ELSE 'Junior User' END END AS `role`
+      CASE WHEN n.age >= 30 THEN CASE n.name WHEN 'Alice' THEN 'Senior Admin' ELSE 'Senior User' END ELSE CASE WHEN n.age >= 25 THEN 'Regular User' ELSE 'Junior User' END END AS `role`
 FROM test_integration.users AS n
 ORDER BY n.name ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_multiple_values.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_multiple_values.databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       n.name AS `n.name`, 
-      caseWithExpression(n.name, 'Alice', 'Level 3', 'Bob', 'Level 2', 'Charlie', 'Level 2', 'Level 1') AS `level`
+      CASE n.name WHEN 'Alice' THEN 'Level 3' WHEN 'Bob' THEN 'Level 2' WHEN 'Charlie' THEN 'Level 2' ELSE 'Level 1' END AS `level`
 FROM test_integration.users AS n
 ORDER BY n.name ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_no_else.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_no_else.databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       n.name AS `n.name`, 
-      caseWithExpression(n.name, 'Alice', 'VIP', NULL) AS `status`
+      CASE n.name WHEN 'Alice' THEN 'VIP' ELSE NULL END AS `status`
 FROM test_integration.users AS n
 ORDER BY n.name ASC

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_single_value.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_case_expressions__TestSimpleCaseInReturn_test_simple_case_single_value.databricks.sql
@@ -1,5 +1,5 @@
 SELECT 
       n.name AS `n.name`, 
-      caseWithExpression(n.name, 'Alice', 'Admin', 'User') AS `role`
+      CASE n.name WHEN 'Alice' THEN 'Admin' ELSE 'User' END AS `role`
 FROM test_integration.users AS n
 ORDER BY n.name ASC


### PR DESCRIPTION
## Summary

Resumes the **SQL-IR / dialect-neutral rendering** track (Phase 1: migrate Path A's remaining hardcoded ClickHouse leaves through the dialect layer, one leaf per PR, CH byte-identical).

`RenderExpr::Case` with a subject expression (Cypher *simple* CASE, `CASE expr WHEN v THEN r … END`) was hardcoded to ClickHouse's `caseWithExpression(expr, v1, r1, …, default)` function at its sole emission site (`to_sql_query.rs:7364`). That function **does not exist in Spark/Databricks**, so it leaked verbatim into **7 committed `.databricks.sql` goldens** — a latent Spark-dialect bug of the exact class the 2026-06-28 dual-dialect sweep targeted (a CH-only function inlined at a hardcoded site instead of routed through the dialect layer).

## Change

Add `common::simple_case_sql(case_expr, when_then, default)`, mirroring the existing dialect-aware `reduce_fold_sql` / `contains_predicate` / `regex_match_predicate` helpers:
- **ClickHouse** keeps the historical `caseWithExpression(...)` spelling — byte-identical.
- **Databricks** emits standard `CASE expr WHEN v THEN r … ELSE d END` (Spark requires it; ClickHouse also accepts it).

The searched-CASE arm (no subject) was already standard `CASE WHEN … END` and is untouched. The `has_list_branch` NULL→`[]` handling and empty-ELSE fallback logic are preserved unchanged.

## Verification

- **CH byte-identical**: 0 `.clickhouse.sql` goldens changed; `corpus_sweep` + `sql_golden` pass unchanged.
- **7 `.databricks.sql` goldens** regenerated to correct standard CASE — including the nested-CASE (inner simple-CASE embedded in an outer searched-CASE) and empty-ELSE (`ELSE NULL`) forms.
- **New unit tests** lock both dialect spellings (`simple_case_sql_tests`).
- **Gate**: `cargo fmt --all --check`, `cargo clippy --all-targets` clean, 1610 lib + 531 integration pass, ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)