### PR TITLE
refactor(SQL-IR Phase 1): route STARTS WITH / ENDS WITH through dialect helpers

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1769,8 +1769,14 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                         format!("{} NOT IN {}", operands[0], operands[1])
                     }
                 }
-                Operator::StartsWith => format!("startsWith({}, {})", operands[0], operands[1]),
-                Operator::EndsWith => format!("endsWith({}, {})", operands[0], operands[1]),
+                Operator::StartsWith => crate::clickhouse_query_generator::starts_with_predicate(
+                    &operands[0],
+                    &operands[1],
+                ),
+                Operator::EndsWith => crate::clickhouse_query_generator::ends_with_predicate(
+                    &operands[0],
+                    &operands[1],
+                ),
                 Operator::Contains => {
                     // Dialect-aware: Spark's position(substr, str) reverses CH's arg order.
                     crate::clickhouse_query_generator::contains_predicate(

--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -1734,8 +1734,12 @@ fn render_logical_expr_to_sql(
                     node_joins_added,
                 );
                 return match op.operator {
-                    Op::StartsWith => format!("startsWith({}, {})", left, right),
-                    Op::EndsWith => format!("endsWith({}, {})", left, right),
+                    Op::StartsWith => {
+                        crate::clickhouse_query_generator::starts_with_predicate(&left, &right)
+                    }
+                    Op::EndsWith => {
+                        crate::clickhouse_query_generator::ends_with_predicate(&left, &right)
+                    }
                     Op::Contains => {
                         // Dialect-aware: Spark's position(substr, str) reverses CH's arg order.
                         crate::clickhouse_query_generator::contains_predicate(&left, &right)

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -72,6 +72,36 @@ pub fn contains_predicate(haystack: &str, needle: &str) -> String {
     }
 }
 
+/// Emit a prefix-match predicate for Cypher `haystack STARTS WITH needle`,
+/// dialect-aware.
+///
+/// ClickHouse spells it `startsWith(haystack, needle)` (camelCase);
+/// Spark/Databricks has the builtin `startswith(str, prefix)` (lowercase, same
+/// argument order). Pure name-case swap — both return a boolean. Emitted from
+/// every `StartsWith` render site so the two dialects stay in sync.
+pub fn starts_with_predicate(haystack: &str, needle: &str) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        SqlDialect::Databricks => format!("startswith({}, {})", haystack, needle),
+        _ => format!("startsWith({}, {})", haystack, needle),
+    }
+}
+
+/// Emit a suffix-match predicate for Cypher `haystack ENDS WITH needle`,
+/// dialect-aware.
+///
+/// ClickHouse spells it `endsWith(haystack, needle)` (camelCase);
+/// Spark/Databricks has the builtin `endswith(str, suffix)` (lowercase, same
+/// argument order). Pure name-case swap — both return a boolean. Emitted from
+/// every `EndsWith` render site so the two dialects stay in sync.
+pub fn ends_with_predicate(haystack: &str, needle: &str) -> String {
+    use crate::sql_generator::SqlDialect;
+    match crate::server::query_context::get_current_dialect() {
+        SqlDialect::Databricks => format!("endswith({}, {})", haystack, needle),
+        _ => format!("endsWith({}, {})", haystack, needle),
+    }
+}
+
 /// Render a Cypher `=~` regex match (`RegexMatch` operator) for the active dialect.
 ///
 /// ClickHouse spells it `match(haystack, pattern)`; Spark/Databricks has no
@@ -326,5 +356,44 @@ mod simple_case_sql_tests {
             sql,
             "CASE n.name WHEN 'Alice' THEN 'Admin' WHEN 'Bob' THEN 'User' ELSE 'Guest' END"
         );
+    }
+}
+
+#[cfg(test)]
+mod string_predicate_tests {
+    use super::{ends_with_predicate, starts_with_predicate};
+    use crate::server::query_context::{with_query_context, QueryContext};
+    use crate::sql_generator::SqlDialect;
+
+    #[test]
+    fn clickhouse_default_uses_camelcase_functions() {
+        // Default (no scope) = ClickHouse: the historical camelCase spelling,
+        // byte-identical to what the pipeline emitted before these helpers.
+        assert_eq!(
+            starts_with_predicate("n.name", "'Al'"),
+            "startsWith(n.name, 'Al')"
+        );
+        assert_eq!(
+            ends_with_predicate("n.name", "'ce'"),
+            "endsWith(n.name, 'ce')"
+        );
+    }
+
+    #[tokio::test]
+    async fn databricks_uses_lowercase_builtins() {
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let (starts, ends) = with_query_context(ctx, async {
+            (
+                starts_with_predicate("n.name", "'Al'"),
+                ends_with_predicate("n.name", "'ce'"),
+            )
+        })
+        .await;
+        // Spark builtins are lowercase, same arg order.
+        assert_eq!(starts, "startswith(n.name, 'Al')");
+        assert_eq!(ends, "endswith(n.name, 'ce')");
     }
 }

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -22,7 +22,10 @@ mod view_scan;
 #[cfg(test)]
 mod where_clause_tests;
 
-pub use common::{contains_predicate, dialect_function_name, qualified_column, quote_identifier};
+pub use common::{
+    contains_predicate, dialect_function_name, ends_with_predicate, qualified_column,
+    quote_identifier, starts_with_predicate,
+};
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{
     get_supported_functions, is_ch_aggregate_function, is_function_supported,

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -317,17 +317,17 @@ impl ToSql for LogicalExpr {
                         }
                     }
                     Operator::StartsWith => {
-                        // ClickHouse: startsWith(haystack, prefix)
-                        Ok(format!(
-                            "startsWith({}, {})",
-                            operands_sql[0], operands_sql[1]
+                        // Dialect-aware: CH startsWith vs Spark startswith.
+                        Ok(super::common::starts_with_predicate(
+                            &operands_sql[0],
+                            &operands_sql[1],
                         ))
                     }
                     Operator::EndsWith => {
-                        // ClickHouse: endsWith(haystack, suffix)
-                        Ok(format!(
-                            "endsWith({}, {})",
-                            operands_sql[0], operands_sql[1]
+                        // Dialect-aware: CH endsWith vs Spark endswith.
+                        Ok(super::common::ends_with_predicate(
+                            &operands_sql[0],
+                            &operands_sql[1],
                         ))
                     }
                     Operator::Contains => {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7249,10 +7249,10 @@ impl RenderExpr {
 
                 // Special handling for string predicates - ClickHouse uses functions
                 if op.operator == Operator::StartsWith && rendered.len() == 2 {
-                    return format!("startsWith({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::starts_with_predicate(&rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::EndsWith && rendered.len() == 2 {
-                    return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::ends_with_predicate(&rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::Contains && rendered.len() == 2 {
                     return super::common::contains_predicate(&rendered[0], &rendered[1]);
@@ -7707,10 +7707,10 @@ impl RenderExpr {
 
                 // Special handling for string predicates - ClickHouse uses functions
                 if op.operator == Operator::StartsWith && rendered.len() == 2 {
-                    return format!("startsWith({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::starts_with_predicate(&rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::EndsWith && rendered.len() == 2 {
-                    return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
+                    return super::common::ends_with_predicate(&rendered[0], &rendered[1]);
                 }
                 if op.operator == Operator::Contains && rendered.len() == 2 {
                     return super::common::contains_predicate(&rendered[0], &rendered[1]);
@@ -8043,10 +8043,10 @@ impl ToSql for OperatorApplication {
 
         // Special handling for string predicates - ClickHouse uses functions
         if self.operator == Operator::StartsWith && rendered.len() == 2 {
-            return format!("startsWith({}, {})", &rendered[0], &rendered[1]);
+            return super::common::starts_with_predicate(&rendered[0], &rendered[1]);
         }
         if self.operator == Operator::EndsWith && rendered.len() == 2 {
-            return format!("endsWith({}, {})", &rendered[0], &rendered[1]);
+            return super::common::ends_with_predicate(&rendered[0], &rendered[1]);
         }
         if self.operator == Operator::Contains && rendered.len() == 2 {
             return super::common::contains_predicate(&rendered[0], &rendered[1]);

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_aggregate_with_where.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_aggregate_with_where.databricks.sql
@@ -4,5 +4,5 @@ SELECT
 FROM data_security.ds_groups AS g
 INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'User'
 INNER JOIN data_security.ds_users AS u ON t0.member_id = u.user_id
-WHERE startsWith(g.name, 'E')
+WHERE startswith(g.name, 'E')
 GROUP BY g.name


### PR DESCRIPTION
## Summary

Second Phase-1 SQL-IR slice. Cypher `STARTS WITH` / `ENDS WITH` were hardcoded to ClickHouse's `startsWith(...)` / `endsWith(...)` **camelCase** functions at **6 emission sites** across all four render paths. Spark/Databricks spells these builtins **lowercase** (`startswith` / `endswith`, DBR 11.3 LTS+, [same arg order](https://docs.databricks.com/aws/en/sql/language-manual/functions/startswith)), so the CH camelCase leaked into Databricks output — a latent Spark-dialect leak of the class the 2026-06-28 sweep fixed.

## Change

Add `common::starts_with_predicate` / `ends_with_predicate`, siblings of the existing dialect-aware `contains_predicate` / `regex_match_predicate` (which already sit right beside these sites in every path). CH keeps camelCase (byte-identical); Databricks emits the lowercase builtin. Routed all **6** sites:
- **Path A** (`to_sql_query.rs`): 3 `OperatorApplication` render sites.
- **Path C** (`cte_extraction.rs`): the VLP-CTE `render_expr_to_sql_string`.
- **Path D** (`to_sql.rs`): the `LogicalExpr::to_sql` operator arm (view-filter + EXISTS/IN-subquery path) — its `Contains` sibling was already routed via `contains_predicate` (#364), so this closes that inconsistency. *(Caught by adversarial review — initial pass counted 5.)*
- `pattern_comprehension_sql.rs`: the pattern-comprehension predicate arm.

Re-exported both from the `clickhouse` emitter module for the Path C / pattern-comp call sites.

The neighboring RegexMatch `match(...)` sites in Path C / pattern-comp remain hardcoded (a `regex_match_predicate` helper exists but isn't used there) — left for a separate leaf slice.

## Correctness

Databricks `startswith(str, prefix)` / `endswith(str, suffix)` are lowercase builtins with the **same argument order** as CH's — a pure name-case swap. Spark resolves builtin function names case-insensitively, so the previously-leaked camelCase still resolved at runtime; this closes the consistency gap rather than a hard runtime break.

## Verification

- **CH byte-identical**: 0 `.clickhouse.sql` goldens changed.
- **1 `.databricks.sql` golden** regenerated (`startsWith` → `startswith`).
- New unit tests lock both dialect spellings.
- **Gate**: fmt, clippy --all-targets, 1612 lib + 531 integration, ratchet net-zero.
- **Adversarial worktree review**: found the 6th (Path D) site + doc-comment overclaim (both now fixed); confirmed CH byte-identical, spelling, re-export wiring, and all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)