### PR TITLE
refactor(SQL-IR Phase 1): route RegexMatch through dialect helper

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1787,7 +1787,10 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 Operator::IsNull => format!("{} IS NULL", operands[0]),
                 Operator::IsNotNull => format!("{} IS NOT NULL", operands[0]),
                 Operator::Distinct => format!("{} IS DISTINCT FROM {}", operands[0], operands[1]),
-                Operator::RegexMatch => format!("match({}, {})", operands[0], operands[1]),
+                Operator::RegexMatch => crate::clickhouse_query_generator::regex_match_predicate(
+                    &operands[0],
+                    &operands[1],
+                ),
             }
         }
         RenderExpr::ScalarFnCall(func) => {

--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -1744,7 +1744,9 @@ fn render_logical_expr_to_sql(
                         // Dialect-aware: Spark's position(substr, str) reverses CH's arg order.
                         crate::clickhouse_query_generator::contains_predicate(&left, &right)
                     }
-                    Op::RegexMatch => format!("match({}, {})", left, right),
+                    Op::RegexMatch => {
+                        crate::clickhouse_query_generator::regex_match_predicate(&left, &right)
+                    }
                     _ => unreachable!(),
                 };
             }

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -24,7 +24,7 @@ mod where_clause_tests;
 
 pub use common::{
     contains_predicate, dialect_function_name, ends_with_predicate, qualified_column,
-    quote_identifier, starts_with_predicate,
+    quote_identifier, regex_match_predicate, starts_with_predicate,
 };
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{


### PR DESCRIPTION
## What

The last two hardcoded `match({}, {})` RegexMatch emission sites now route through the existing `common::regex_match_predicate` dialect helper:

- `src/render_plan/cte_extraction.rs` (Path C)
- `src/render_plan/pattern_comprehension_sql.rs`

This matches the already-routed sites in `to_sql_query.rs` (Path A) and `to_sql.rs` (Path D), and mirrors these two files' own already-routed `StartsWith`/`EndsWith`/`Contains` siblings.

Also adds `regex_match_predicate` to the `clickhouse` module's public re-export so `render_plan/` reaches it via the `clickhouse_query_generator` alias (as the sibling predicates already do).

## Effect

- **ClickHouse:** byte-identical — the helper's default arm is the same `match({}, {})`.
- **Databricks:** now emits `rlike({}, {})` instead of the CH-only `match()` (which is `UNRESOLVED_ROUTINE` on Spark).

## Why no golden churn

Latent correctness-hardening: **0 current Databricks golden reached these two sites** (grep confirms no committed `.databricks.sql` leaked `match(`), so there is nothing to regenerate. The existing `fn_regex_match` golden already covers the WHERE path (Path A). A candidate pattern-comprehension coverage case was explored but the pattern-comprehension inner-`WHERE` is dropped upstream (a separate pre-existing gap), so no golden was added rather than lock in a misleading one.

## Gate

- `cargo fmt --all` ✓
- `cargo clippy --all-targets` ✓ (no new warnings)
- `cargo test -p clickgraph --lib` — 1612 passed ✓
- `corpus_sweep` ✓ / `sql_golden` — 238 passed, **0 churn** ✓
- `cargo test --test ratchet` — net-zero (dialect branch via `get_current_dialect()`, not an axis bump) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)