### PR TITLE
refactor(SQL-IR Phase 2): unify the dual Operator enums

### DIFF
--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -1702,33 +1702,13 @@ impl Column {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
-pub enum Operator {
-    Addition,
-    Subtraction,
-    Multiplication,
-    Division,
-    ModuloDivision,
-    Exponentiation,
-    Equal,
-    NotEqual,
-    LessThan,
-    GreaterThan,
-    LessThanEqual,
-    GreaterThanEqual,
-    RegexMatch, // =~ (regex match)
-    And,
-    Or,
-    In,
-    NotIn,
-    StartsWith, // STARTS WITH
-    EndsWith,   // ENDS WITH
-    Contains,   // CONTAINS
-    Not,
-    Distinct,
-    IsNull,
-    IsNotNull,
-}
+// `Operator` is unified with the planner's operator enum: the two were
+// byte-identical 24-variant copies, and maintaining both forced a spurious
+// `TryFrom<LogicalOperator> for Operator` identity conversion plus duplicated
+// operator-render logic. `RenderExpr` (the leaf layer) re-exports the
+// planner's `Operator` so there is a single source of truth. Anything that
+// referred to `render_expr::Operator` still resolves through this re-export.
+pub use crate::query_planner::logical_expr::Operator;
 
 impl Operator {
     /// Returns a numeric precedence level for arithmetic operators.
@@ -2107,7 +2087,9 @@ impl TryFrom<LogicalOperatorApplication> for OperatorApplication {
 
     fn try_from(op: LogicalOperatorApplication) -> Result<Self, Self::Error> {
         let op_app = OperatorApplication {
-            operator: op.operator.try_into()?,
+            // `operator` is now the unified `Operator` (re-exported from the
+            // planner), so no conversion is needed — a plain move.
+            operator: op.operator,
             operands: op
                 .operands
                 .into_iter()
@@ -2115,40 +2097,6 @@ impl TryFrom<LogicalOperatorApplication> for OperatorApplication {
                 .collect::<Result<Vec<RenderExpr>, RenderBuildError>>()?,
         };
         Ok(op_app)
-    }
-}
-
-impl TryFrom<LogicalOperator> for Operator {
-    type Error = RenderBuildError;
-
-    fn try_from(value: LogicalOperator) -> Result<Self, Self::Error> {
-        let operator = match value {
-            LogicalOperator::Addition => Operator::Addition,
-            LogicalOperator::Subtraction => Operator::Subtraction,
-            LogicalOperator::Multiplication => Operator::Multiplication,
-            LogicalOperator::Division => Operator::Division,
-            LogicalOperator::ModuloDivision => Operator::ModuloDivision,
-            LogicalOperator::Exponentiation => Operator::Exponentiation,
-            LogicalOperator::Equal => Operator::Equal,
-            LogicalOperator::NotEqual => Operator::NotEqual,
-            LogicalOperator::LessThan => Operator::LessThan,
-            LogicalOperator::GreaterThan => Operator::GreaterThan,
-            LogicalOperator::LessThanEqual => Operator::LessThanEqual,
-            LogicalOperator::GreaterThanEqual => Operator::GreaterThanEqual,
-            LogicalOperator::RegexMatch => Operator::RegexMatch,
-            LogicalOperator::And => Operator::And,
-            LogicalOperator::Or => Operator::Or,
-            LogicalOperator::In => Operator::In,
-            LogicalOperator::NotIn => Operator::NotIn,
-            LogicalOperator::StartsWith => Operator::StartsWith,
-            LogicalOperator::EndsWith => Operator::EndsWith,
-            LogicalOperator::Contains => Operator::Contains,
-            LogicalOperator::Not => Operator::Not,
-            LogicalOperator::Distinct => Operator::Distinct,
-            LogicalOperator::IsNull => Operator::IsNull,
-            LogicalOperator::IsNotNull => Operator::IsNotNull,
-        };
-        Ok(operator)
     }
 }
 


### PR DESCRIPTION
## What

`render_expr::Operator` and `query_planner::logical_expr::Operator` were **byte-identical 24-variant copies** (same variants, order, comments, and derives). This duplication forced a spurious `TryFrom<LogicalOperator> for Operator` identity conversion, and is the exact root cause both operator-render blocks name in their own TODOs (`to_sql.rs:200`, `to_sql_query.rs:7017`) as the blocker to consolidating the duplicated operator logic.

**Change:** make `render_expr::Operator` a re-export of the planner's enum, delete the duplicate definition and the now-reflexive `TryFrom`, and simplify its one caller (`OperatorApplication::try_from`'s operator field) to a plain move.

The dependency direction is correct: `RenderExpr` is the leaf render layer and already depends on `logical_expr` (it imports `LogicalOperator`, `LogicalCase`, etc.), so re-exporting the planner's `Operator` is not a layering inversion. Every site that referred to `render_expr::Operator` still resolves through the re-export — no call-site churn.

## Why it's safe

Pure type unification — **no output-path change**. Both enums were identical, so no rendering behavior can shift.

- ClickHouse **and** Databricks SQL byte-identical → **0 golden churn** (verified: `git status` shows only `render_expr.rs` modified after both golden suites ran).
- Net −52 lines.

## Gate (run in an isolated `CARGO_TARGET_DIR` due to shared-target lock contention)

- `cargo build -p clickgraph` — Finished ✓
- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets` — no warnings/errors ✓
- `cargo test -p clickgraph --lib` — 1612 passed ✓
- `corpus_sweep` ✓ / `sql_golden` — 238 passed, **0 churn** ✓
- `cargo test --test ratchet` — net-zero ✓

## Context

This is **Phase-2 step 2** from `SQL_IR_DESIGN.md` §3.5 (the grounded path-collapse investigation). It's the structural dedup that unblocks the **step 3** Path D → A collapse (the two operator-render blocks can now share code / D can be retired via the existing `TryFrom<LogicalExpr>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)