### PR TITLE
docs(SQL-IR): refresh stale operator-consolidation TODOs + log #818

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -334,13 +334,15 @@ fixed stats fixture.
   (`cte_extraction`, ~8 CTE/filter callers) is the one live second path and its
   separateness is FUNDAMENTAL (runs at CTE-build stage before A's `query_context`
   task-locals exist; its `alias_mapping` p1→start_node rewrite has no equivalent
-  in A). Recommended shippable Phase-2 order: (1) retire B, (2) unify the dual
-  `Operator` enums (`logical_expr` vs `render_expr`, ~100 dup lines, both files'
-  own TODOs, best first CODE slice), (3) collapse D→A via the existing
-  `TryFrom<LogicalExpr>` (`render_expr.rs:1825`). (4) C full-collapse is a separate
-  DESIGN CYCLE (stage/timing constraint), NOT a mechanical step — its drift items
-  (backtick-vs-doublequote quoting, latent-unreached hardcoded `POWER`/`arrayFold`/
-  map/CASE arms — verified 0 Databricks golden leak) can be reconciled as small
+  in A). Recommended shippable Phase-2 order: (1) retire B, **(2) unify the dual
+  `Operator` enums — DONE #818 (`188e4507`): were byte-identical 24-variant copies,
+  render now re-exports the planner enum; deleted the identity `TryFrom` + its one
+  caller; 0 golden churn, review APPROVE-0; unblocks step 3**, (3) collapse D→A via
+  the existing `TryFrom<LogicalExpr>` (`render_expr.rs:1825`) — NEXT. (4) C
+  full-collapse is a separate DESIGN CYCLE (stage/timing constraint), NOT a
+  mechanical step — its drift items (backtick-vs-doublequote quoting,
+  latent-unreached hardcoded `POWER`/`arrayFold`/map/CASE arms — verified 0
+  Databricks golden leak) can be reconciled as small
   independent correctness slices without full collapse.
   Phase 3 (structural idioms) / 4 (Raw shrink) stay deferred behind Phase 2.
 - Phase 3 §6.2/§6.3: **COMPLETE** (slices 3/4/2 resolved 2026-07-28,
@@ -361,6 +363,24 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-29: **SQL-IR Phase 2 step 2 — unify the dual `Operator` enums** (#818,
+  `188e4507`). `render_expr::Operator` and `query_planner::logical_expr::Operator`
+  were byte-identical 24-variant copies (same variants/order/comments/derives).
+  Made render's a `pub use` re-export of the planner enum (correct layering —
+  render is the leaf that already depends on logical_expr), deleted the duplicate
+  definition + the now-reflexive `TryFrom<LogicalOperator> for Operator` + its one
+  caller (a plain move). Pure type unification, no output-path change: CH **and**
+  Databricks byte-identical, **0 golden churn**; net −52 lines. Review APPROVE-0
+  (derive-list identity, `Copy`/serde/name-resolution all verified). Refreshed the
+  two now-stale `to_sql.rs`/`to_sql_query.rs` operator-consolidation TODOs (they
+  cited the just-removed "two Operator types" blocker) to point at the real
+  remaining step-3 work (bake LogicalExpr→RenderExpr, retire Path D). Ran in an
+  isolated `CARGO_TARGET_DIR` (shared `/data/cargo-target-shared` was lock-contended
+  by another project's build fleet). **Next SQL-IR: Phase-2 step 3** — collapse
+  Path D→A via the existing `TryFrom<LogicalExpr>` (`render_expr.rs:1825`);
+  re-plumb `function_translator` to bake scalar-fn args first, retire the dead
+  ViewScan renderer. Or step 1 (retire near-dead Path B) as a smaller warm-up.
 
 - 2026-07-29: **SQL-IR Phase 1 — RegexMatch routed through dialect helper**
   (#815, `1a57e817`). The last two hardcoded `match({}, {})` RegexMatch emission

--- a/src/sql_generator/emitters/clickhouse/to_sql.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql.rs
@@ -197,16 +197,16 @@ impl ToSql for LogicalExpr {
                 Ok(prop.column.to_sql(&prop.table_alias.0))
             }
             LogicalExpr::OperatorApplicationExp(op) => {
-                // ⚠️ TODO: Operator rendering consolidation (Phase 3)
-                // This code is duplicated in to_sql_query.rs with very similar operator handling.
-                // Root cause: Two different Operator types (logical_expr::Operator vs render_expr::Operator)
-                // prevent simple consolidation. Phase 3 strategy:
-                // 1. Create OperatorRenderer trait with operator_symbol() and render_special_cases()
-                // 2. Implement trait for LogicalExpr operators (in this module)
-                // 3. Implement trait for RenderExpr operators (in to_sql_query.rs)
-                // 4. Create unified render_operator() function in common.rs
-                // See notes/OPERATOR_RENDERING_ANALYSIS.md for detailed analysis.
-                // Estimated effort: 4-6 hours for full consolidation
+                // ⚠️ TODO: Operator rendering consolidation (SQL-IR Phase 2 step 3).
+                // This block duplicates the operator handling in to_sql_query.rs.
+                // The former blocker — two distinct `Operator` types — is GONE: the
+                // enums were unified (render_expr::Operator now re-exports
+                // logical_expr::Operator, PR #818). What remains: this block walks
+                // `LogicalExpr` operands and returns `Result`, while the render-side
+                // block walks `RenderExpr` operands and returns `String`. Collapsing
+                // is now the Path D -> A retirement (SQL_IR_DESIGN.md §3.5 step 3):
+                // bake LogicalExpr -> RenderExpr at this block's callers (the existing
+                // `TryFrom<LogicalExpr>`), then render via the one RenderExpr path.
                 let operands_sql: Vec<String> = op
                     .operands
                     .iter()

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7014,17 +7014,17 @@ impl RenderExpr {
                 column.to_sql(&table_alias.0)
             }
             RenderExpr::OperatorApplicationExp(op) => {
-                // ⚠️ TODO: Operator rendering consolidation (Phase 3)
-                // This code is duplicated in to_sql.rs (~70 lines of similar operator handling).
-                // Both implementations handle Operator enums with identical variants but different types:
-                // - to_sql.rs: crate::query_planner::logical_expr::Operator
-                // - to_sql_query.rs: crate::render_plan::render_expr::Operator
-                // Phase 3 consolidation strategy: Create OperatorRenderer trait (see notes/OPERATOR_RENDERING_ANALYSIS.md)
-                // Benefits:
-                // - Eliminate duplication without type system complexity
-                // - Preserve context-specific behavior (error handling, special cases)
-                // - Enable future operator extensions
-                // Estimated effort: 4-6 hours, should be 100% backward compatible
+                // ⚠️ TODO: Operator rendering consolidation (SQL-IR Phase 2 step 3).
+                // This block duplicates the operator handling in to_sql.rs (~70 lines).
+                // The former blocker — two distinct `Operator` types — is GONE: the
+                // enums were unified (render_expr::Operator now re-exports
+                // logical_expr::Operator, PR #818), so both blocks match on the SAME
+                // enum. What remains: to_sql.rs walks `LogicalExpr` operands and
+                // returns `Result`; this block walks `RenderExpr` operands and returns
+                // `String`. Collapsing is now the Path D -> A retirement
+                // (SQL_IR_DESIGN.md §3.5 step 3): bake LogicalExpr -> RenderExpr via
+                // the existing `TryFrom<LogicalExpr>` at to_sql.rs's callers, then
+                // render everything through this RenderExpr path.
                 log::debug!(
                     "RenderExpr::to_sql() OperatorApplicationExp: operator={:?}, operands.len()={}",
                     op.operator,


### PR DESCRIPTION
Follow-up to #818 (Operator enum unification). The two operator-render TODOs in `to_sql.rs` and `to_sql_query.rs` cited "two different Operator types (logical_expr vs render_expr)" as the consolidation blocker — which #818 removed. Refreshes both comments to describe the actual remaining Phase-2 step-3 work (bake `LogicalExpr`→`RenderExpr` via the existing `TryFrom`, retire Path D).

Comment-only in the `.rs` files (verified: no non-comment lines changed; check-build clean). Plus a PRIORITIES.md merge-log entry for #818 and its step-2-done marker.

Docs/comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)