### PR TITLE
refactor(SQL-IR Phase 2): route quote_identifier through the dialect layer

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -354,7 +354,19 @@ fixed stats fixture.
   DESIGN CYCLE (stage/timing constraint), NOT a mechanical step — its drift items
   (backtick-vs-doublequote quoting, latent-unreached hardcoded `POWER`/`arrayFold`/
   map/CASE arms — verified 0 Databricks golden leak) can be reconciled as small
-  independent correctness slices without full collapse.
+  independent correctness slices without full collapse. **First such slice DONE
+  (2026-07-30): `quote_identifier` routed through the dialect layer** — Path C's
+  `common.rs::quote_identifier` hard-coded backticks for BOTH dialects, so on CH a
+  single query emitted both `` t2.`id.orig_h` `` (CTE body, Path C) and
+  `t1."id.orig_h"` (SELECT, Path A) for the same physical column. Now special-char
+  identifiers route through `FunctionMapper::quote_alias` (CH `"x"` / Spark
+  `` `x` ``); `json_builder.rs::quote_column_name` delegates too (`quote_json_key`
+  untouched — its backticks are a load-bearing JSON key). The one empirically-
+  reachable Path C drift item (23 backtick special-cols in committed CH goldens);
+  churn 2 CH goldens, 0 DBX. The hardcoded-arm + InSubquery-placeholder items stay
+  latent (verified 0 corpus leak / join-planner-consumed before C renders).
+  **Follow-up filed as a note:** `multi_type_vlp_joins.rs` emits
+  `toString(n2.id.orig_h)` — an UNquoted dotted column (CH parse error), pre-existing.
   Phase 3 (structural idioms) / 4 (Raw shrink) stay deferred behind Phase 2.
 - Phase 3 §6.2/§6.3: **COMPLETE** (slices 3/4/2 resolved 2026-07-28,
   #793/#795/#796; `pattern_schema.rs` dead_code audit done #799). No Phase-3
@@ -374,6 +386,33 @@ standing nightly-triage duty), 1× P-1 standing, 1–2× P-2/P-3 (then P-4
 after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
+
+- 2026-07-30: **SQL-IR Phase 2 step-4 slice — `quote_identifier` routed through
+  the dialect layer** (branch `refactor/sql-ir-path-c-quote-identifier-dialect`).
+  First of the independent Path-C drift slices the §3.5 investigation flagged as
+  shippable without the full (design-cycle) C→A collapse. Path C
+  (`cte_extraction.rs`, CTE-build stage) quoted special-char identifiers via
+  `common.rs::quote_identifier`, which hard-coded backticks for BOTH dialects;
+  Path A (final SELECT) uses `FunctionMapper::quote_alias` (CH `"x"`, Spark
+  `` `x` ``). On ClickHouse a single query therefore emitted BOTH `` t2.`id.orig_h` ``
+  (CTE body) and `t1."id.orig_h"` (SELECT) for the same column — valid CH, no
+  runtime bug, but exactly the dialect-routing drift the SQL-IR track targets (and
+  wrong SQL for a future Postgres/DuckDB dialect). Made `quote_identifier`
+  dialect-aware (route special-char names through `quote_alias`, plain names stay
+  bare); `json_builder.rs::quote_column_name` (parallel column-*ref* quoter)
+  delegates to it. `quote_json_key` untouched — its backticks are a load-bearing
+  JSON key (verified live on Databricks). The one empirically-reachable C drift
+  item (23 backtick special-cols in committed CH goldens); the hardcoded-arm
+  (`POWER`/`arrayFold`/CASE) + InSubquery-placeholder items stay latent (0 corpus
+  leak / join-planner-consumed before C renders). Churn: 2 CH goldens
+  (col-ref backtick→double-quote), 0 Databricks. Updated the
+  `pattern_union_quotes_dotted_physical_columns` regression guard +
+  `quote_identifier`/`qualified_column` doctests to the CH-default double-quote
+  spelling (invariant — dotted cols quoted, plain cols bare — unchanged). Gate:
+  fmt · clippy clean · 1601 lib · 531 integration (0 unexpected churn) · ratchet
+  net-zero · doctests. **Pre-existing follow-up surfaced:** `multi_type_vlp_joins.rs`
+  emits `toString(n2.id.orig_h)` — an UNquoted dotted column (CH parse error),
+  present on main, untouched here.
 
 - 2026-07-29: **SQL-IR Phase 2 step 1 — retire Path B; route write payloads
   through canonical Path A** (#822, `683fb10c`). Completes the shippable Phase-2

--- a/docs/design/SQL_IR_DESIGN.md
+++ b/docs/design/SQL_IR_DESIGN.md
@@ -223,11 +223,16 @@ denormalized `rel_alias_mapping`) is logic with **no equivalent inside A at all*
   registry into `query_context` at CTE-build time — a real design change, not a
   redirect.
 - **Historical drift (reconcilable, but each is a byte-level golden change):**
-  - **Identifier quoting divergence.** C uses `quote_identifier` → **backticks**
-    (`` t.`id.orig_h` ``); A uses `FunctionMapper::quote_alias` → CH
-    **double-quotes** (`t."id.orig_h"`). The premise "C is the only path that
-    quotes" was wrong — *both* quote, with different characters. Reconciling
-    changes special-char-column goldens.
+  - **Identifier quoting divergence — RESOLVED 2026-07-30.** C used
+    `quote_identifier` → **backticks** (`` t.`id.orig_h` ``); A uses
+    `FunctionMapper::quote_alias` → CH **double-quotes** (`t."id.orig_h"`). The
+    premise "C is the only path that quotes" was wrong — *both* quoted, with
+    different characters, so on CH a single query emitted both spellings for the
+    same column. Fixed by making `quote_identifier` dialect-aware (route
+    special-char names through `quote_alias`; plain names stay bare);
+    `json_builder.rs::quote_column_name` (a parallel column-ref quoter) delegates
+    to it. `quote_json_key` stays backticked (load-bearing JSON key). Churn: 2 CH
+    goldens, 0 Databricks. This was the one *empirically-reachable* C drift item.
   - **Hardcoded CH arms in C** (Path A routes all of these): `POWER` (A→dialect),
     `arrayFold` for ReduceExpr (A→`reduce_fold_sql`→Spark `aggregate`), map-literal
     `{…}` (A→`map(...)`), simple `CASE` (A→`simple_case_sql`), raw aggregate names,

--- a/src/render_plan/tests/pattern_union_dotted_column_tests.rs
+++ b/src/render_plan/tests/pattern_union_dotted_column_tests.rs
@@ -5,8 +5,9 @@
 //! interpolates raw physical column names into `{table}.{column}` references. When a
 //! physical column name contains a dot (e.g. Zeek's `id.orig_h`), the unquoted form
 //! `zeek.dns_log.id.orig_h` is parsed by ClickHouse as nested struct access and the
-//! identifier fails to resolve. Such columns must be backtick-quoted
-//! (`zeek.dns_log.`id.orig_h``), exactly as the labeled renderer already does.
+//! identifier fails to resolve. Such columns must be delimiter-quoted with the active
+//! dialect's identifier delimiter (CH `"id.orig_h"`, Spark `` `id.orig_h` ``) via the
+//! shared `quote_identifier` helper, exactly as the labeled renderer (Path A) does.
 
 use crate::{
     clickhouse_query_generator, graph_catalog::config::GraphSchemaConfig,
@@ -85,15 +86,16 @@ fn cypher_to_sql(cypher: &str) -> String {
 fn pattern_union_quotes_dotted_physical_columns() {
     let sql = cypher_to_sql("MATCH p=()-[]->() RETURN p LIMIT 25");
 
-    // Dotted physical columns must be backtick-quoted so ClickHouse does not
-    // interpret them as nested struct access.
+    // Dotted physical columns must be delimiter-quoted so ClickHouse does not
+    // interpret them as nested struct access. The default (no query context)
+    // dialect is ClickHouse, so the delimiter is a double-quote.
     assert!(
-        sql.contains("`id.orig_h`"),
-        "dotted column id.orig_h must be backtick-quoted; SQL:\n{sql}"
+        sql.contains("\"id.orig_h\""),
+        "dotted column id.orig_h must be double-quoted; SQL:\n{sql}"
     );
     assert!(
-        sql.contains("`id.resp_h`"),
-        "dotted column id.resp_h must be backtick-quoted; SQL:\n{sql}"
+        sql.contains("\"id.resp_h\""),
+        "dotted column id.resp_h must be double-quoted; SQL:\n{sql}"
     );
 
     // The unquoted form (parsed as nested access) must NOT appear.

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -13,20 +13,33 @@
 // Future Improvement: Create a unified Literal trait that both types implement,
 // enabling a single render_literal() function in this module.
 
-/// Quote a ClickHouse identifier (column name, table name) if it contains special characters.
+/// Quote an identifier (column name, table name) if it contains special
+/// characters, using the **active dialect's** identifier delimiter.
 ///
-/// ClickHouse requires backtick quoting for identifiers that contain:
+/// An identifier needs quoting when it contains any of:
 /// - Dots (.)
 /// - Spaces
 /// - Hyphens (-)
-/// - Other special characters
+/// - Parentheses
+///
+/// When quoting is needed the delimiter is dialect-specific — ClickHouse
+/// double-quotes (`"id.orig_h"`), Spark/Databricks backticks
+/// (`` `id.orig_h` ``) — routed through [`FunctionMapper::quote_alias`], which
+/// also escapes any embedded delimiter. This keeps a CTE-build-stage reference
+/// (Path C, `cte_extraction.rs`) byte-identical with the final-SELECT renderer
+/// (Path A, `to_sql_query.rs`), which qualifies special-char columns via the
+/// same dialect helper. Previously this hard-coded backticks for both dialects,
+/// which was valid CH but drifted from Path A's `"…"` — a query could emit both
+/// `` t2.`id.orig_h` `` (CTE body) and `t1."id.orig_h"` (SELECT). Plain
+/// identifiers (no special char) are returned bare, unchanged.
 ///
 /// # Examples
 /// ```
 /// use clickgraph::clickhouse_query_generator::quote_identifier;
+/// // Default dialect (outside a query context) is ClickHouse → double-quotes.
 /// assert_eq!(quote_identifier("user_id"), "user_id");
-/// assert_eq!(quote_identifier("id.orig_h"), "`id.orig_h`");
-/// assert_eq!(quote_identifier("user-name"), "`user-name`");
+/// assert_eq!(quote_identifier("id.orig_h"), "\"id.orig_h\"");
+/// assert_eq!(quote_identifier("user-name"), "\"user-name\"");
 /// ```
 pub fn quote_identifier(name: &str) -> String {
     if name.contains('.')
@@ -35,7 +48,7 @@ pub fn quote_identifier(name: &str) -> String {
         || name.contains('(')
         || name.contains(')')
     {
-        format!("`{}`", name)
+        crate::sql_generator::function_mapper::current_function_mapper().quote_alias(name)
     } else {
         name.to_string()
     }
@@ -43,13 +56,15 @@ pub fn quote_identifier(name: &str) -> String {
 
 /// Format a qualified column reference: table_alias.column_name
 ///
-/// This function properly quotes the column name if it contains special characters.
+/// Quotes the column name (via [`quote_identifier`]) with the active dialect's
+/// delimiter when it contains special characters.
 ///
 /// # Examples
 /// ```
 /// use clickgraph::clickhouse_query_generator::qualified_column;
+/// // Default dialect (outside a query context) is ClickHouse → double-quotes.
 /// assert_eq!(qualified_column("t1", "user_id"), "t1.user_id");
-/// assert_eq!(qualified_column("t1", "id.orig_h"), "t1.`id.orig_h`");
+/// assert_eq!(qualified_column("t1", "id.orig_h"), "t1.\"id.orig_h\"");
 /// ```
 pub fn qualified_column(table_alias: &str, column_name: &str) -> String {
     format!("{}.{}", table_alias, quote_identifier(column_name))

--- a/src/sql_generator/emitters/clickhouse/json_builder.rs
+++ b/src/sql_generator/emitters/clickhouse/json_builder.rs
@@ -28,14 +28,15 @@ use crate::graph_catalog::expression_parser::PropertyValue;
 use crate::graph_catalog::graph_schema::NodeSchema;
 use std::collections::HashMap;
 
-/// Quote a column name if it contains special characters (dots, spaces, etc.)
-/// ClickHouse requires backtick quoting for identifiers with special characters.
+/// Quote a column *reference* if it contains special characters, using the
+/// active dialect's delimiter (CH `"x"`, Spark `` `x` ``). Delegates to the
+/// shared [`quote_identifier`] so a JSON-args column ref stays byte-identical
+/// with the same column rendered elsewhere in the query (Path A / Path C),
+/// instead of the previous hard-coded backticks. NOTE this is distinct from
+/// [`quote_json_key`], whose backticks are load-bearing (a JSON *key*, verified
+/// live on Databricks) and must stay backticked in both dialects.
 fn quote_column_name(name: &str) -> String {
-    if name.contains('.') || name.contains(' ') || name.contains('-') {
-        format!("`{}`", name)
-    } else {
-        name.to_string()
-    }
+    super::common::quote_identifier(name)
 }
 
 /// Quote a JSON key name for use inside the JSON-object wrapper.

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -161,8 +161,8 @@ impl FunctionMapper for DatabricksFunctionMapper {
         // only valid identifier quote. Spark escapes `` ` `` inside a
         // backtick-quoted identifier by doubling it. Aliases inferred
         // from raw return text can contain backticks, so escape before
-        // wrapping. `quote_identifier` uses backticks for both dialects
-        // so this stays consistent with that.
+        // wrapping. `quote_identifier` routes special-char identifiers
+        // here too, so backticks stay consistent across both.
         format!("`{}`", name.replace('`', "``"))
     }
 

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -135,9 +135,10 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// Spark parses `"name"` as a string literal, so backticks are
     /// mandatory. Each impl is responsible for escaping its own
     /// delimiter inside `name` (CH doubles `"`, Spark doubles `` ` ``).
-    /// The bare `quote_identifier` helper in `common.rs` is a separate
-    /// concern — it already uses backticks for both dialects since
-    /// both accept them for plain column refs.
+    /// The bare `quote_identifier` helper in `common.rs` routes here for
+    /// special-char identifiers, so both stay dialect-consistent (CH `"x"`,
+    /// Spark `` `x` ``); it only skips this for plain identifiers, returning
+    /// them bare.
     fn quote_alias(&self, name: &str) -> String;
 
     /// Build a CAST expression. The two dialects diverge on both syntax and the

--- a/tests/rust/integration/golden/corpus/zeek_merged_test/test_schema_variations__TestCoupledEdgesSchema_test_return_type_function.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/zeek_merged_test/test_schema_variations__TestCoupledEdgesSchema_test_return_type_function.clickhouse.sql
@@ -1,13 +1,13 @@
 WITH vlp_multi_type_ip_target AS (
-SELECT 'IP' AS end_type, n2.`id.orig_h` AS end_id, ip_1.`id.orig_h` AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.id.resp_h) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.`id.orig_h` AS `id.orig_h`) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1.`id.orig_h`) AS start_properties, ip_1.`id.orig_h` AS start_id_orig_h, 1 AS hop_count, ['ACCESSED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.conn_state, n2.duration, n2.orig_bytes, n2.proto, n2.resp_bytes, n2.service, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1.`id.orig_h`), toString(n2.`id.orig_h`)] AS path_nodes
+SELECT 'IP' AS end_type, n2."id.orig_h" AS end_id, ip_1."id.orig_h" AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.id.resp_h) AS r_to_id, formatRowNoNewline('JSONEachRow', n2."id.orig_h" AS `id.orig_h`) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1."id.orig_h") AS start_properties, ip_1."id.orig_h" AS start_id_orig_h, 1 AS hop_count, ['ACCESSED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.conn_state, n2.duration, n2.orig_bytes, n2.proto, n2.resp_bytes, n2.service, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1."id.orig_h"), toString(n2."id.orig_h")] AS path_nodes
 FROM zeek.conn_log ip_1
-INNER JOIN zeek.conn_log n2 ON ip_1.`id.orig_h` = n2.`id.orig_h`
-WHERE (ip_1.`id.orig_h` = '192.168.1.10')
+INNER JOIN zeek.conn_log n2 ON ip_1."id.orig_h" = n2."id.orig_h"
+WHERE (ip_1."id.orig_h" = '192.168.1.10')
 UNION ALL
-SELECT 'Domain' AS end_type, n2.name AS end_id, ip_1.`id.orig_h` AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.query) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.name AS name) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1.`id.orig_h`) AS start_properties, ip_1.`id.orig_h` AS start_id_orig_h, 1 AS hop_count, ['REQUESTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.answers, n2.`id.resp_h`, n2.qtype_name, n2.rcode_name, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1.`id.orig_h`), toString(n2.name)] AS path_nodes
+SELECT 'Domain' AS end_type, n2.name AS end_id, ip_1."id.orig_h" AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.query) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.name AS name) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1."id.orig_h") AS start_properties, ip_1."id.orig_h" AS start_id_orig_h, 1 AS hop_count, ['REQUESTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.answers, n2."id.resp_h", n2.qtype_name, n2.rcode_name, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1."id.orig_h"), toString(n2.name)] AS path_nodes
 FROM zeek.conn_log ip_1
-INNER JOIN zeek.dns_log n2 ON ip_1.`id.orig_h` = n2.`id.orig_h`
-WHERE (ip_1.`id.orig_h` = '192.168.1.10')
+INNER JOIN zeek.dns_log n2 ON ip_1."id.orig_h" = n2."id.orig_h"
+WHERE (ip_1."id.orig_h" = '192.168.1.10')
 )
 SELECT 
       t.path_relationships[1] AS "type(r)", 

--- a/tests/rust/integration/golden/corpus/zeek_merged_test__TestCoupledEdgesSchema/test_schema_variations__TestCoupledEdgesSchema_test_multi_edge_type.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/zeek_merged_test__TestCoupledEdgesSchema/test_schema_variations__TestCoupledEdgesSchema_test_multi_edge_type.clickhouse.sql
@@ -1,13 +1,13 @@
 WITH vlp_multi_type_ip_target AS (
 SELECT 'IP' AS end_type, n2.ip AS end_id, ip_1.ip AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.id.resp_h) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.ip AS ip) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1.ip) AS start_properties, ip_1.ip AS start_ip, 1 AS hop_count, ['CONNECTED_TO'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.conn_state, n2.duration, n2.orig_bytes, n2.proto, n2.resp_bytes, n2.service, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1.ip), toString(n2.ip)] AS path_nodes
 FROM zeek.conn_log ip_1
-INNER JOIN zeek.conn_log n2 ON ip_1.ip = n2.`id.orig_h`
-WHERE (t0.`id.orig_h` = '192.168.1.10')
+INNER JOIN zeek.conn_log n2 ON ip_1.ip = n2."id.orig_h"
+WHERE (t0."id.orig_h" = '192.168.1.10')
 UNION ALL
-SELECT 'Domain' AS end_type, n2.name AS end_id, ip_1.ip AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.query) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.name AS name) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1.ip) AS start_properties, ip_1.ip AS start_ip, 1 AS hop_count, ['DNS_REQUESTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.answers, n2.`id.resp_h`, n2.qtype_name, n2.rcode_name, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1.ip), toString(n2.name)] AS path_nodes
+SELECT 'Domain' AS end_type, n2.name AS end_id, ip_1.ip AS start_id, 'IP' AS start_type, toString(n2.id.orig_h) AS r_from_id, toString(n2.query) AS r_to_id, formatRowNoNewline('JSONEachRow', n2.name AS name) AS end_properties, formatRowNoNewline('JSONEachRow', ip_1.ip) AS start_properties, ip_1.ip AS start_ip, 1 AS hop_count, ['DNS_REQUESTED'] AS path_relationships, [formatRowNoNewline('JSONEachRow', n2.answers, n2."id.resp_h", n2.qtype_name, n2.rcode_name, n2.ts, n2.uid)] AS rel_properties, [toString(ip_1.ip), toString(n2.name)] AS path_nodes
 FROM zeek.conn_log ip_1
-INNER JOIN zeek.dns_log n2 ON ip_1.ip = n2.`id.orig_h`
-WHERE (t0.`id.orig_h` = '192.168.1.10')
+INNER JOIN zeek.dns_log n2 ON ip_1.ip = n2."id.orig_h"
+WHERE (t0."id.orig_h" = '192.168.1.10')
 )
 SELECT 
       t.end_properties AS "target.properties", 


### PR DESCRIPTION
## Summary

First of the independent **Path C** drift slices the SQL-IR Phase-2 §3.5 investigation flagged as shippable *without* the full (design-cycle) C→A collapse. Path C (`cte_extraction.rs`, CTE-build stage) quoted special-char identifiers via `common.rs::quote_identifier`, which **hard-coded backticks for both dialects**. Path A (final-SELECT renderer) qualifies the same columns via `FunctionMapper::quote_alias` — CH double-quotes, Spark backticks. Result: on ClickHouse a single query emitted **both** spellings for the same physical column — `` t2.`id.orig_h` `` in the CTE body (Path C) and `t1."id.orig_h"` in the SELECT (Path A). Both are valid CH, so no runtime bug, but it's exactly the dialect-routing drift the SQL-IR track exists to remove, and `quote_identifier`'s backticks would be wrong SQL for a future Postgres/DuckDB dialect.

## Change

- `quote_identifier` is now **dialect-aware**: special-char names route through `FunctionMapper::quote_alias` (CH `"x"`, Spark `` `x` ``, both escaping the embedded delimiter); plain names stay bare.
- `json_builder.rs::quote_column_name` (a parallel column-*reference* quoter) delegates to the shared helper, so JSON-args column refs stay consistent within a query.
- `quote_json_key` is **untouched** — its backticks are load-bearing (a JSON *key*, verified live on Databricks).

This is the one *empirically-reachable* Path C drift item (23 backtick special-cols in committed CH goldens). The hardcoded-arm (`POWER`/`arrayFold`/`CASE`) and `InSubquery`-placeholder items were verified 0-corpus-leak / join-planner-consumed-before-C-renders and are left as latent.

## Footprint

- **2 CH goldens** changed (column-ref backtick → double-quote), **0 Databricks** (already backtick).
- Updated the `pattern_union_quotes_dotted_physical_columns` regression guard + `quote_identifier`/`qualified_column` doctests to the CH-default double-quote spelling; the invariant (dotted cols quoted, plain cols bare) is unchanged.

## Gate

fmt · clippy clean · 1601 lib · 531 integration (corpus + sql_golden, 0 unexpected churn) · ratchet net-zero · doctests. Adversarial review: **APPROVE-0** (verified escaping is strictly safer on pathological names, no JSON-key regression, Databricks byte-identical, golden coverage complete).

## Out of scope (pre-existing, noted for follow-up)

`multi_type_vlp_joins.rs` emits `toString(n2.id.orig_h)` — an **unquoted** dotted column (CH parse error). Present on `main`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)