### PR TITLE
fix(#689): heterogeneous from-side-polymorphic VLP recursive CTE joins the right end table

### DIFF
--- a/examples/data_security/setup_schema.sql
+++ b/examples/data_security/setup_schema.sql
@@ -89,11 +89,22 @@ FROM numbers(1, 200);
 
 -- Additional memberships (some users in multiple groups)
 INSERT INTO data_security.ds_memberships
-SELECT 
+SELECT
     number AS member_id,
     ((number - 1) % 25) + 26 AS group_id,  -- Second group for half the users
     'User' AS member_type
 FROM numbers(1, 100);
+
+-- Nested-group memberships (Group -> Group), member_type = 'Group'.
+-- MEMBER_OF is from-side polymorphic: a Group can be a member of another Group,
+-- so MEMBER_OF*1..N must transitively traverse these Group->Group hops.
+-- Deterministic chain for the transitive-membership oracle (#689):
+--   group 5  -MEMBER_OF-> group 10
+--   group 10 -MEMBER_OF-> group 15
+-- => any User in group 5 transitively reaches groups 10 and 15.
+INSERT INTO data_security.ds_memberships (member_id, group_id, member_type) VALUES
+    (5, 10, 'Group'),
+    (10, 15, 'Group');
 
 -- Insert Root Folders (10 root folders, parent_id = 0, is_root = 1)
 -- Insert Root Folders (10 root folders, parent_id = 0)

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -602,6 +602,39 @@ impl<'a> VariableLengthCteGenerator<'a> {
     /// For multiple relationship types (e.g., [:FOLLOWS|LIKES]):
     /// - `rel.interaction_type IN ('FOLLOWS', 'LIKES')`
     fn generate_polymorphic_edge_filter(&self) -> Option<String> {
+        // Base arm: the from-side label discriminator uses the START label
+        // (`from_node_label`), because the first hop leaves the query's start node.
+        self.generate_polymorphic_edge_filter_with_from_label(None)
+    }
+
+    /// #689: polymorphic edge filter for the RECURSIVE arm of a
+    /// from-side-polymorphic cross-type VLP (see
+    /// `is_from_side_polymorphic_cross_type`). Identical to the base filter
+    /// EXCEPT the from-side label discriminator uses the END label
+    /// (`to_node_label`, e.g. `'Group'`) instead of the base arm's START label
+    /// (`from_node_label`, `'User'`): the recursive hops are Group→Group, so the
+    /// edge's *source* is now a Group. The base arm keeps the start label.
+    ///
+    /// Falls back to the base filter (identical output) when `to_node_label` is
+    /// absent/empty, so it is never worse than the pre-#689 behavior.
+    fn generate_polymorphic_edge_filter_from_recursive(&self) -> Option<String> {
+        match self.to_node_label {
+            Some(ref l) if !l.is_empty() && self.is_from_side_polymorphic_cross_type() => {
+                self.generate_polymorphic_edge_filter_with_from_label(Some(l.as_str()))
+            }
+            _ => self.generate_polymorphic_edge_filter(),
+        }
+    }
+
+    /// Shared implementation of the VLP polymorphic edge filter. `from_label_override`
+    /// replaces the from-side discriminator value (`from_node_label`) — `None` keeps
+    /// the start label (base arm), `Some("Group")` is the recursing/end label used by
+    /// the from-side-polymorphic recursive arm (#689). All schema-axis reads live in
+    /// this single helper so both arms branch identically.
+    fn generate_polymorphic_edge_filter_with_from_label(
+        &self,
+        from_label_override: Option<&str>,
+    ) -> Option<String> {
         let mut filter_parts = Vec::new();
 
         // Add type filter if type_column is defined
@@ -628,9 +661,12 @@ impl<'a> VariableLengthCteGenerator<'a> {
             }
         }
 
-        // Add from_label filter if from_label_column is defined
+        // Add from-side label filter if that discriminator column is defined.
+        // The value is the override (recursing/end label) when provided, else
+        // the base start label.
         if let Some(ref from_label_col) = self.from_label_column {
-            if let Some(ref from_label) = self.from_node_label {
+            let from_label = from_label_override.or(self.from_node_label.as_deref());
+            if let Some(from_label) = from_label {
                 filter_parts.push(format!(
                     "{}.{} = '{}'",
                     self.relationship_alias, from_label_col, from_label
@@ -860,6 +896,30 @@ impl<'a> VariableLengthCteGenerator<'a> {
         self.to_label_column.is_some()
             && self.start_node_table != self.end_node_table
             && self.intermediate_node_table.is_some()
+    }
+
+    /// #689: is this a directed cross-type VLP over a *from-side-polymorphic*
+    /// edge — i.e. the edge discriminates its SOURCE node via a from-side label
+    /// column (e.g. `ds_memberships.member_type ∈ {User, Group}`) and has no
+    /// target-side label column (the target node label is fixed, e.g.
+    /// `MEMBER_OF → Group`)?
+    ///
+    /// For such an edge a `(:User)-[:MEMBER_OF*1..N]->(:Group)` traversal
+    /// legitimately recurses **Group→Group** (a group can be a member of a
+    /// group). The recursive arm must therefore (a) re-join the END-node table
+    /// (`ds_groups`), exactly like the base arm, NOT the START table — see the
+    /// `recursive_end_table` heuristic below; and (b) discriminate the edge's
+    /// *from* side with the END label (`member_type = 'Group'`), not the base
+    /// arm's start label (`'User'`). Both recursive-arm fixes gate on this
+    /// predicate so they agree by construction.
+    ///
+    /// Deliberately narrow (from-side label present, target-side absent,
+    /// cross-table) so it cannot touch a plain cross-type recursive VLP or the
+    /// multi-type / heterogeneous generators.
+    fn is_from_side_polymorphic_cross_type(&self) -> bool {
+        self.start_node_table != self.end_node_table
+            && self.from_label_column.is_some()
+            && self.to_label_column.is_none()
     }
 
     /// Generate polymorphic edge filter for INTERMEDIATE hops (Group→Group)
@@ -2852,8 +2912,12 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         let mut where_conditions = vec![format!("vp.hop_count < {}", max_hops), cycle_pred];
 
-        // Add polymorphic edge filter if this is a polymorphic edge table
-        if let Some(poly_filter) = self.generate_polymorphic_edge_filter() {
+        // Add polymorphic edge filter if this is a polymorphic edge table.
+        // #689: the recursive arm uses the *from-recursive* variant, which flips
+        // the from-label discriminator to the END label for from-side-polymorphic
+        // cross-type edges (Group→Group hops); it is byte-identical to the base
+        // filter for every other shape.
+        if let Some(poly_filter) = self.generate_polymorphic_edge_filter_from_recursive() {
             where_conditions.push(poly_filter);
         }
 
@@ -2947,7 +3011,17 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // Cross-type VLP (e.g., Message→Post via REPLY_OF): the recursive step must
         // traverse through the START type (Message) to allow intermediate hops through
         // Comments. The Post constraint is enforced by the outer query's JOIN.
-        let recursive_end_table = if self.start_node_table != self.end_node_table {
+        //
+        // #689 EXCEPTION: a from-side-polymorphic cross-type edge (e.g. MEMBER_OF,
+        // `member_type ∈ {User, Group}`, target fixed = Group) recurses through the
+        // END type (Group→Group), NOT the start type. The `start_node_table` swap
+        // would join `ds_users` (which lacks the `group_id` column that `join_on_end`
+        // equates) → ClickHouse 500. For that shape use the END table, matching the
+        // base arm. Gate is narrow (see `is_from_side_polymorphic_cross_type`) so the
+        // #142 REPLY_OF branch is untouched.
+        let recursive_end_table = if self.start_node_table != self.end_node_table
+            && !self.is_from_side_polymorphic_cross_type()
+        {
             log::info!(
                 "VLP cross-type recursion: using {} instead of {} for intermediate hops",
                 self.start_node_table,
@@ -4444,6 +4518,85 @@ mod tests {
         assert!(
             sql.contains("interaction_type IN ('FOLLOWS', 'LIKES')"),
             "Expected polymorphic IN filter in base case. SQL: {}",
+            sql
+        );
+    }
+
+    /// #689: a directed cross-type VLP over a from-side-polymorphic edge
+    /// (`member_type ∈ {User, Group}`, target fixed = Group) must recurse
+    /// Group→Group: the recursive arm joins the END table (`ds_groups`) with the
+    /// END discriminator (`member_type = 'Group'`), NOT the START table
+    /// (`ds_users`) with the base discriminator (`member_type = 'User'`). The old
+    /// `recursive_end_table` heuristic joined `ds_users AS end_node` on
+    /// `rel.group_id = end_node.group_id` (a column ds_users lacks → CH 500), and
+    /// reused the base `member_type = 'User'` filter (silent undercount).
+    #[test]
+    fn test_from_side_polymorphic_vlp_recursive_arm_689() {
+        let schema = create_test_schema();
+        let spec = VariableLengthSpec::range(1, 5);
+        let generator = VariableLengthCteGenerator::new_with_polymorphic(
+            &schema,
+            spec,
+            "ds_users",                          // start table
+            "user_id",                           // start id column
+            "ds_memberships",                    // relationship table (from-side polymorphic)
+            "member_id",                         // from column
+            "group_id",                          // to column
+            "ds_groups",                         // end table (DIFFERENT from start)
+            "group_id",                          // end id column
+            "u",                                 // start alias
+            "g",                                 // end alias
+            "r",                                 // relationship_cypher_alias
+            vec![],                              // no properties
+            None,                                // no shortest path mode
+            None,                                // no start node filters
+            None,                                // no end node filters
+            None,                                // no relationship filters
+            None,                                // no path variable
+            Some(vec!["MEMBER_OF".to_string()]), // relationship type
+            None,                                // no edge_id
+            None,                                // no rel-type discriminator col
+            Some("member_type".to_string()),     // from-side label col (polymorphic source)
+            None,                                // NO to-side label col (target fixed = Group)
+            Some("User".to_string()),            // from_node_label (query start)
+            Some("Group".to_string()),           // to_node_label (recursing/target type)
+        );
+
+        let sql = generator.generate_recursive_sql();
+        println!("From-side-polymorphic VLP SQL:\n{}", sql);
+
+        // Split base arm from recursive arm at the UNION ALL barrier so we can
+        // assert per-arm.
+        let (base_arm, recursive_arm) = sql
+            .split_once("UNION ALL")
+            .expect("recursive VLP must have a UNION ALL");
+
+        // Defect 1: recursive arm joins the END table (ds_groups), never ds_users.
+        assert!(
+            recursive_arm.contains("ds_groups AS end_node"),
+            "recursive arm must join ds_groups (end table). SQL:\n{}",
+            sql
+        );
+        assert!(
+            !recursive_arm.contains("ds_users AS end_node"),
+            "recursive arm must NOT join ds_users as end_node (the #689 500). SQL:\n{}",
+            sql
+        );
+
+        // Defect 2: recursive arm discriminates on the END label; base on START.
+        assert!(
+            base_arm.contains("member_type = 'User'"),
+            "base arm must keep member_type = 'User' (first hop User→Group). SQL:\n{}",
+            sql
+        );
+        assert!(
+            recursive_arm.contains("member_type = 'Group'"),
+            "recursive arm must use member_type = 'Group' (Group→Group hops). SQL:\n{}",
+            sql
+        );
+        assert!(
+            !recursive_arm.contains("member_type = 'User'"),
+            "recursive arm must NOT keep the base member_type = 'User' filter. SQL:\n{}",
             sql
         );
     }

--- a/tests/integration/test_security_graph.py
+++ b/tests/integration/test_security_graph.py
@@ -175,25 +175,34 @@ class TestSimpleRelationships:
 class TestVariableLengthPaths:
     """Variable-length path queries."""
     
-    @pytest.mark.xfail(
-        reason="VLP with polymorphic edges: recursive CTE uses base case filter (member_type='User') "
-               "for all hops, but Group->Group traversal needs member_type='Group'"
-    )
     def test_user_transitive_group_membership(self):
-        """Find all groups a user belongs to (direct + transitive)."""
+        """Find all groups a user belongs to (direct + transitive).
+
+        #689: MEMBER_OF is from-side polymorphic (member_type ∈ {User, Group}),
+        so a Group can be a member of another Group and MEMBER_OF*1..N must
+        traverse Group→Group hops. Fixture (setup_schema.sql) wires:
+          User_5 ∈ group 5,  group 5 → group 10,  group 10 → group 15.
+        So User_5 transitively reaches groups 5, 10, 15 (plus its second direct
+        group 30 from the modulo-25 rule). The pre-#689 recursive CTE joined
+        ds_users on rel.group_id (500) and filtered member_type='User' on every
+        hop (would miss the Group→Group hops even without the 500).
+        """
         response = execute_cypher(
             """
             MATCH (u:User)-[:MEMBER_OF*1..5]->(g:Group)
-            WHERE u.name = 'Alice'
+            WHERE u.name = 'User_5'
             RETURN DISTINCT g.name AS group_name
             ORDER BY g.name
             """
         )
         assert response.status_code == 200
         data = response.json()
-        # Alice -> Backend-Team (direct)
-        # VLP may not traverse polymorphic Group->Group hops correctly
-        assert len(data["results"]) >= 1
+        group_names = {row["group_name"] for row in data["results"]}
+        # Direct: group 5 (and group 30 via the second-membership rule).
+        # Transitive Group→Group: group 5 → 10 → 15.
+        assert "Group_5" in group_names, group_names
+        assert "Group_10" in group_names, group_names  # 1 hop of Group→Group
+        assert "Group_15" in group_names, group_names  # 2 hops of Group→Group
     
     def test_folder_recursive_contents(self):
         """Find all files/folders under a folder recursively."""
@@ -232,7 +241,7 @@ class TestVariableLengthPaths:
 class TestSecurityQueries:
     """Complex security analysis queries."""
     
-    @pytest.mark.xfail(reason="#689: #659 fixed the end_group_id dangle, but this VLP-then-fixed-hop-to-polymorphic-target shape still generates a malformed recursive CTE (2nd arm joins ds_users on rel.group_id) + triplicated UNION arms — 500 live")
+    @pytest.mark.xfail(reason="#689 bug 1 (recursive CTE 2nd arm joined ds_users on rel.group_id → 500) is FIXED; this query also exercises bug 2 (fixed hop to polymorphic `target` fans out into triplicated identical UNION arms), tracked separately — leave xfail until bug 2 lands")
     def test_external_users_with_access(self):
         """Find external users with any access permissions."""
         response = execute_cypher(

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_after_vlp.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_after_vlp.clickhouse.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         vp.start_name as start_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.start_name AS "u.name", 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_after_vlp.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_after_vlp.databricks.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         vp.start_name as start_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.start_name AS `u.name`, 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_on_path_length.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_on_path_length.clickhouse.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         vp.start_name as start_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.start_name AS "u.name", 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_on_path_length.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestComplexAggregatePatterns_test_aggregate_on_path_length.databricks.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         vp.start_name as start_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.start_name AS `u.name`, 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_very_deep_recursion.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_very_deep_recursion.clickhouse.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 100
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT DISTINCT 
       t.end_name AS "g.name"

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_very_deep_recursion.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_very_deep_recursion.databricks.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 100
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT DISTINCT 
       t.end_name AS `g.name`

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_zero_hop_path.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_zero_hop_path.clickhouse.sql
@@ -20,10 +20,10 @@ WITH RECURSIVE vlp_u_target AS (
         end_node.name as end_name
     FROM vlp_u_target vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 1
       AND NOT has(vp.path_nodes, end_node.group_id)
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.end_description AS "target.description", 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_zero_hop_path.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_zero_hop_path.databricks.sql
@@ -20,10 +20,10 @@ WITH RECURSIVE vlp_u_target AS (
         end_node.name as end_name
     FROM vlp_u_target vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 1
       AND NOT array_contains(vp.path_nodes, end_node.group_id)
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.end_description AS `target.description`, 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
@@ -26,10 +26,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 5
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
@@ -26,10 +26,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 5
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_variable_length.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_variable_length.clickhouse.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.end_name AS "g.name"

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_variable_length.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_variable_length.databricks.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 3
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT 
       t.end_name AS `g.name`

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestVariableLengthPaths_test_user_transitive_group_membership.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestVariableLengthPaths_test_user_transitive_group_membership.clickhouse.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 5
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT DISTINCT 
       t.end_name AS "group_name"

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestVariableLengthPaths_test_user_transitive_group_membership.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestVariableLengthPaths_test_user_transitive_group_membership.databricks.sql
@@ -22,10 +22,10 @@ WITH RECURSIVE vlp_u_g AS (
         end_node.name as end_name
     FROM vlp_u_g vp
     JOIN data_security.ds_memberships AS rel ON vp.end_id = rel.member_id
-    JOIN data_security.ds_users AS end_node ON rel.group_id = end_node.group_id
+    JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
     WHERE vp.hop_count < 5
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
-      AND rel.member_type = 'User'
+      AND rel.member_type = 'Group'
 )
 SELECT DISTINCT 
       t.end_name AS `group_name`

--- a/tests/rust/ratchet/baseline.txt
+++ b/tests/rust/ratchet/baseline.txt
@@ -137,7 +137,7 @@ schema	to_label_column	src/render_plan/plan_builder_helpers.rs	9
 schema	to_label_column	src/render_plan/with_to_cte/mod.rs	1
 schema	to_label_column	src/server/bolt_protocol/result_transformer.rs	3
 schema	to_label_column	src/sql_generator/emitters/clickhouse/multi_type_vlp_joins.rs	2
-schema	to_label_column	src/sql_generator/emitters/clickhouse/variable_length_cte.rs	17
+schema	to_label_column	src/sql_generator/emitters/clickhouse/variable_length_cte.rs	18
 schema	to_node_properties	src/procedures/apoc_meta_schema.rs	1
 schema	to_node_properties	src/query_planner/analyzer/bidirectional_union.rs	2
 schema	to_node_properties	src/query_planner/analyzer/filter_tagging.rs	7


### PR DESCRIPTION
## Summary

Fixes the 500 in #689 (bug 1). A directed VLP over a **from-side-polymorphic** edge (`MEMBER_OF`: `member_type ∈ {User, Group}`, target fixed = `Group`) generated a malformed `WITH RECURSIVE` CTE. Repro (`examples/data_security/data_security.yaml`):
```cypher
MATCH (u:User)-[:MEMBER_OF*1..5]->(g:Group) WHERE u.exposure='external' RETURN DISTINCT u.name, g.name
```

Two defects in the recursive (2nd) arm:
1. **Wrong end table (the 500).** `generate_recursive_case_with_cte_name`'s `recursive_end_table` heuristic (added #142 for complex-12) unconditionally swaps in `start_node_table` for ALL cross-type VLP. MEMBER_OF recurses **Group→Group**, so the arm must re-join the END table (`ds_groups`) — the swap joined `ds_users`, which lacks the `group_id` column that `join_on_end` equates → ClickHouse 500.
2. **Wrong discriminator (silent undercount).** The recursive arm reused the base `member_type='User'` filter; Group→Group hops need `member_type='Group'`.

## Fix

A new narrow gate `is_from_side_polymorphic_cross_type` (cross-table + from-side label column present + **to-side label column absent**) — provably cannot touch the #142 REPLY_OF branch, multi-type, or heterogeneous generators. Both recursive-arm fixes gate on it:
- Gate the `recursive_end_table` swap off for this shape → use `end_node_table` (`ds_groups`), matching the base arm.
- Route the recursive arm through `generate_polymorphic_edge_filter_from_recursive`, which flips the from-side discriminator to the END label (`member_type='Group'`). Consolidated base + recursive onto one `generate_polymorphic_edge_filter_with_from_label(override)` so both arms branch identically (net **−1** `from_label_column` raw read).

Base arm unchanged (`ds_groups` + `member_type='User'` — first hop is User→Group).

## Reachability safety (corpus-proven)

Swept every `WITH RECURSIVE` golden for base-arm-end-table ≠ recursive-arm-end-table → **all divergent goldens are data_security/MEMBER_OF** (captured-buggy). complex-12 routes through `multi_type_vlp_joins.rs` (different generator, no WITH RECURSIVE golden); REPLY_OF is Comment→Comment (same-table → else branch). **Golden churn: 14 data_security files, each EXACTLY two lines** (`ds_users AS end_node`→`ds_groups AS end_node`; recursive `member_type='User'`→`'Group'`). **0 files outside `corpus/data_security/`.** The `external_users` OUTER triplicated-UNION block (bug 2, #827) is UNCHANGED.

## Tests

- **Unit** `test_from_side_polymorphic_vlp_recursive_arm_689`: asserts recursive arm joins `ds_groups` + `member_type='Group'`, base keeps `'User'`, no `ds_users AS end_node`. **Verified it FAILS when EITHER edit is reverted.**
- **Live oracle**: added Group→Group membership fixture rows (chain 5→10→15) to `setup_schema.sql`; un-xfailed `test_user_transitive_group_membership` with concrete transitive-reachability assertions (User_5 → Group_5/10/15). `test_external_users_with_access` stays xfail (exercises bug 2, #827).

## Ratchet

+1 `to_label_column` baseline (`src/sql_generator/.../variable_length_cte.rs` 17→18) — the new gate's `to_label_column.is_none()` check. Justified: the VLP generator works from these raw schema fields by design (17 pre-existing reads in this file); there is no schema-catalog API expressing "from-side-polymorphic cross-type", and the guard is deliberately narrow. `from_label_column`/`type_column` are back at baseline (the filter consolidation removed a net occurrence).

## Gate

fmt · clippy clean · 1603 lib · 531 integration (14 goldens, 0 outside data_security) · ratchet.

## Out of scope

Bug 2 — polymorphic-target candidate over-fan-out + label-collapse (the triplicated identical UNION arms) — filed as **#827** with full root-cause pointers.

Refs #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)