### PR TITLE
fix(#827 defect a): polymorphic $any endpoint honors from/to_label_values

### DIFF
--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -1767,6 +1767,32 @@ impl GraphSchema {
         }
     }
 
+    /// Like [`expand_node_type`](Self::expand_node_type), but constrains a `$any`
+    /// endpoint by an explicit allow-list when the relationship declares one.
+    ///
+    /// A polymorphic edge may omit `from_node`/`to_node` (defaulting to `$any`)
+    /// yet still carry `from_label_values`/`to_label_values` naming the concrete
+    /// endpoint labels it actually targets (e.g. `to_label_values: [Folder, File]`).
+    /// In that case `$any` means "any of *these* labels", not "any node label",
+    /// so expanding it to every node in the schema over-fans the candidate set
+    /// (see #827). When the allow-list is present and non-empty it wins; otherwise
+    /// this falls back to the unconstrained expansion (concrete type unchanged;
+    /// bare `$any` with no allow-list still expands to all labels).
+    pub fn expand_node_type_constrained(
+        &self,
+        node_type: &str,
+        label_values: Option<&Vec<String>>,
+    ) -> Vec<String> {
+        if node_type == "$any" {
+            if let Some(values) = label_values {
+                if !values.is_empty() {
+                    return values.clone();
+                }
+            }
+        }
+        self.expand_node_type(node_type)
+    }
+
     pub fn node_schema_opt(&self, node_label: &str) -> Option<&NodeSchema> {
         self.nodes.get(node_label)
     }
@@ -3452,5 +3478,56 @@ mod tests {
         let mut result = schema.expand_generic_relationship_type("IS_LOCATED_IN", None, None);
         result.sort();
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_expand_node_type_constrained_honors_label_values_827() {
+        // Schema with four node labels; a polymorphic edge whose `$any` endpoint
+        // legally targets only two of them (via `to_label_values`).
+        let mut nodes = HashMap::new();
+        for label in ["User", "Group", "Folder", "File"] {
+            nodes.insert(
+                label.to_string(),
+                NodeSchema::new_traditional(
+                    "db".to_string(),
+                    label.to_string(),
+                    vec![],
+                    "id".to_string(),
+                    NodeIdSchema {
+                        id: Identifier::from("id"),
+                        dtype: SchemaType::Integer,
+                    },
+                    HashMap::new(),
+                    None,
+                    None,
+                    None,
+                ),
+            );
+        }
+        let schema = GraphSchema::build(1, "db".to_string(), nodes, HashMap::new());
+
+        // Bare `$any` with no allow-list → every node label (unchanged legacy).
+        let mut all = schema.expand_node_type_constrained("$any", None);
+        all.sort();
+        assert_eq!(all, vec!["File", "Folder", "Group", "User"]);
+
+        // `$any` constrained by `to_label_values` → only the declared labels (#827).
+        let allow = vec!["Folder".to_string(), "File".to_string()];
+        let mut constrained = schema.expand_node_type_constrained("$any", Some(&allow));
+        constrained.sort();
+        assert_eq!(constrained, vec!["File", "Folder"]);
+
+        // An empty allow-list is ignored → falls back to full expansion (never
+        // collapses the candidate set to nothing).
+        let empty: Vec<String> = vec![];
+        let mut none_listed = schema.expand_node_type_constrained("$any", Some(&empty));
+        none_listed.sort();
+        assert_eq!(none_listed, vec!["File", "Folder", "Group", "User"]);
+
+        // A concrete (non-`$any`) type is returned as-is, allow-list irrelevant.
+        assert_eq!(
+            schema.expand_node_type_constrained("User", Some(&allow)),
+            vec!["User"]
+        );
     }
 }

--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -1466,7 +1466,15 @@ impl TypeInference {
                                 // node type so an unlabeled endpoint keeps all candidates
                                 // instead of being narrowed to the literal "$any" (which
                                 // matches nothing and would collapse the plan to Empty).
-                                .flat_map(|rs| graph_schema.expand_node_type(&rs.from_node))
+                                // When the edge declares `from_label_values`, `$any` means
+                                // "any of *those* labels" — constrain to them so the
+                                // endpoint does not fan out to every node in the schema (#827).
+                                .flat_map(|rs| {
+                                    graph_schema.expand_node_type_constrained(
+                                        &rs.from_node,
+                                        rs.from_label_values.as_ref(),
+                                    )
+                                })
                         })
                         .collect();
                     if !valid_types.is_empty() {
@@ -1488,8 +1496,16 @@ impl TypeInference {
                                 .get_all_rel_schemas_for_type(rel_type)
                                 .into_iter()
                                 // Expand polymorphic `$any` to_node to all concrete node
-                                // types (see the from_node branch above).
-                                .flat_map(|rs| graph_schema.expand_node_type(&rs.to_node))
+                                // types (see the from_node branch above). When the edge
+                                // declares `to_label_values`, `$any` means "any of *those*
+                                // labels" — constrain to them so the endpoint does not fan
+                                // out to every node in the schema (#827).
+                                .flat_map(|rs| {
+                                    graph_schema.expand_node_type_constrained(
+                                        &rs.to_node,
+                                        rs.to_label_values.as_ref(),
+                                    )
+                                })
                         })
                         .collect();
                     if !valid_types.is_empty() {

--- a/tests/integration/test_security_graph.py
+++ b/tests/integration/test_security_graph.py
@@ -241,7 +241,7 @@ class TestVariableLengthPaths:
 class TestSecurityQueries:
     """Complex security analysis queries."""
     
-    @pytest.mark.xfail(reason="#689 bug 1 (recursive CTE 2nd arm joined ds_users on rel.group_id → 500) is FIXED; this query also exercises bug 2 (fixed hop to polymorphic `target` fans out into triplicated identical UNION arms), tracked separately — leave xfail until bug 2 lands")
+    @pytest.mark.xfail(reason="#827 defect (a) FIXED (#689 bug 1 also fixed): the polymorphic `target` no longer fans into triplicated identical UNION arms — `$any` now honors HAS_ACCESS.to_label_values [Folder, File], collapsing to a single arm. But defect (b) remains: that arm hardcodes object_type='File' (table→label reverse-lookup picks alphabetically-first label), so Folder-access rows are silently dropped. Leave xfail until #827 defect (b) lands.")
     def test_external_users_with_access(self):
         """Find external users with any access permissions."""
         response = execute_cypher(

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.clickhouse.sql
@@ -1,63 +1,7 @@
-SELECT `f.name` AS "f.name", count(coalesce(`child.fs_id`, `child.group_id`, `child.user_id`)) AS "children_count" FROM (
 SELECT 
-      NULL AS "department",
-      NULL AS "description",
-      NULL AS "email",
-      NULL AS "exposure",
-      toString(child.fs_id) AS "fs_id",
-      NULL AS "group_id",
-      toString(child.name) AS "name",
-      toString(child.parent_id) AS "parent_id",
-      toString(child.path) AS "path",
-      toString(child.sensitive_data) AS "sensitive_data",
-      NULL AS "user_id",
-      f.name AS "f.name",
-      toString(child.fs_id) AS "child.fs_id",
-      NULL AS "child.group_id",
-      NULL AS "child.user_id"
+      f.name AS "f.name", 
+      count(t0.fs_id) AS "children_count"
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
-UNION ALL 
-SELECT 
-      NULL AS "department",
-      toString(child.description) AS "description",
-      NULL AS "email",
-      NULL AS "exposure",
-      toString(f.fs_id) AS "fs_id",
-      toString(child.group_id) AS "group_id",
-      toString(child.name) AS "name",
-      toString(f.parent_id) AS "parent_id",
-      toString(f.path) AS "path",
-      NULL AS "sensitive_data",
-      NULL AS "user_id",
-      f.name AS "f.name",
-      toString(f.fs_id) AS "child.fs_id",
-      toString(child.group_id) AS "child.group_id",
-      NULL AS "child.user_id"
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Group'
-INNER JOIN data_security.ds_groups AS child ON child.group_id = t0.fs_id
-UNION ALL 
-SELECT 
-      toString(child.department) AS "department",
-      NULL AS "description",
-      toString(child.email) AS "email",
-      toString(child.exposure) AS "exposure",
-      toString(f.fs_id) AS "fs_id",
-      NULL AS "group_id",
-      toString(child.name) AS "name",
-      toString(f.parent_id) AS "parent_id",
-      toString(f.path) AS "path",
-      NULL AS "sensitive_data",
-      toString(child.user_id) AS "user_id",
-      f.name AS "f.name",
-      toString(f.fs_id) AS "child.fs_id",
-      NULL AS "child.group_id",
-      toString(child.user_id) AS "child.user_id"
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'User'
-INNER JOIN data_security.ds_users AS child ON child.user_id = t0.fs_id
-) AS __union
-GROUP BY `f.name`
-ORDER BY `children_count` DESC
+GROUP BY f.name
+ORDER BY children_count DESC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.databricks.sql
@@ -1,63 +1,7 @@
-SELECT `f.name` AS `f.name`, count(coalesce(`child.fs_id`, `child.group_id`, `child.user_id`)) AS `children_count` FROM (
 SELECT 
-      NULL AS `department`,
-      NULL AS `description`,
-      NULL AS `email`,
-      NULL AS `exposure`,
-      string(child.fs_id) AS `fs_id`,
-      NULL AS `group_id`,
-      string(child.name) AS `name`,
-      string(child.parent_id) AS `parent_id`,
-      string(child.path) AS `path`,
-      string(child.sensitive_data) AS `sensitive_data`,
-      NULL AS `user_id`,
-      f.name AS `f.name`,
-      string(child.fs_id) AS `child.fs_id`,
-      NULL AS `child.group_id`,
-      NULL AS `child.user_id`
+      f.name AS `f.name`, 
+      count(t0.fs_id) AS `children_count`
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
-UNION ALL 
-SELECT 
-      NULL AS `department`,
-      string(child.description) AS `description`,
-      NULL AS `email`,
-      NULL AS `exposure`,
-      string(f.fs_id) AS `fs_id`,
-      string(child.group_id) AS `group_id`,
-      string(child.name) AS `name`,
-      string(f.parent_id) AS `parent_id`,
-      string(f.path) AS `path`,
-      NULL AS `sensitive_data`,
-      NULL AS `user_id`,
-      f.name AS `f.name`,
-      string(f.fs_id) AS `child.fs_id`,
-      string(child.group_id) AS `child.group_id`,
-      NULL AS `child.user_id`
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Group'
-INNER JOIN data_security.ds_groups AS child ON child.group_id = t0.fs_id
-UNION ALL 
-SELECT 
-      string(child.department) AS `department`,
-      NULL AS `description`,
-      string(child.email) AS `email`,
-      string(child.exposure) AS `exposure`,
-      string(f.fs_id) AS `fs_id`,
-      NULL AS `group_id`,
-      string(child.name) AS `name`,
-      string(f.parent_id) AS `parent_id`,
-      string(f.path) AS `path`,
-      NULL AS `sensitive_data`,
-      string(child.user_id) AS `user_id`,
-      f.name AS `f.name`,
-      string(f.fs_id) AS `child.fs_id`,
-      NULL AS `child.group_id`,
-      string(child.user_id) AS `child.user_id`
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'User'
-INNER JOIN data_security.ds_users AS child ON child.user_id = t0.fs_id
-) AS __union
-GROUP BY `f.name`
-ORDER BY `children_count` DESC
+GROUP BY f.name
+ORDER BY children_count DESC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.clickhouse.sql
@@ -2,22 +2,15 @@ SELECT `g.name` AS `g.name` FROM (
 SELECT DISTINCT 
       g.name AS "g.name", 
       g.name AS "__order_col_0"
-FROM data_security.ds_fs_objects AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
-UNION ALL 
-SELECT DISTINCT 
-      g.name AS "g.name", 
-      g.name AS "__order_col_0"
 FROM data_security.ds_groups AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 UNION ALL 
 SELECT DISTINCT 
       g.name AS "g.name", 
       g.name AS "__order_col_0"
 FROM data_security.ds_users AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.databricks.sql
@@ -2,22 +2,15 @@ SELECT `g.name` AS `g.name` FROM (
 SELECT DISTINCT 
       g.name AS `g.name`, 
       g.name AS `__order_col_0`
-FROM data_security.ds_fs_objects AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
-UNION ALL 
-SELECT DISTINCT 
-      g.name AS `g.name`, 
-      g.name AS `__order_col_0`
 FROM data_security.ds_groups AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 UNION ALL 
 SELECT DISTINCT 
       g.name AS `g.name`, 
       g.name AS `__order_col_0`
 FROM data_security.ds_users AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.fs_id AND t0.member_type = 'File'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.clickhouse.sql
@@ -1,35 +1,9 @@
-WITH with_folder_name_item_count_cte_0 AS (SELECT `folder_name` AS "folder_name", count(coalesce(`item.fs_id`, `item.group_id`, `item.user_id`)) AS "item_count" FROM (
-SELECT 
-      folder.name AS "folder_name",
-      folder.name AS "folder.name",
-      item.fs_id AS "item.fs_id",
-      NULL AS "item.group_id",
-      NULL AS "item.user_id"
+WITH with_folder_name_item_count_cte_0 AS (SELECT 
+      folder.name AS "folder_name", 
+      count(t0.fs_id) AS "item_count"
 FROM data_security.ds_fs_objects AS folder
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
-UNION ALL 
-SELECT 
-      folder.name AS "folder_name",
-      folder.name AS "folder.name",
-      item.fs_id AS "item.fs_id",
-      item.group_id AS "item.group_id",
-      NULL AS "item.user_id"
-FROM data_security.ds_fs_objects AS folder
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'Group'
-INNER JOIN data_security.ds_groups AS item ON item.group_id = t0.fs_id
-UNION ALL 
-SELECT 
-      folder.name AS "folder_name",
-      folder.name AS "folder.name",
-      item.fs_id AS "item.fs_id",
-      NULL AS "item.group_id",
-      item.user_id AS "item.user_id"
-FROM data_security.ds_fs_objects AS folder
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'User'
-INNER JOIN data_security.ds_users AS item ON item.user_id = t0.fs_id
-) AS __union
-GROUP BY `folder_name`
+GROUP BY folder.name
 HAVING (item_count >= 1 AND item_count <= 10)
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.databricks.sql
@@ -1,35 +1,9 @@
-WITH with_folder_name_item_count_cte_0 AS (SELECT `folder_name` AS `folder_name`, count(coalesce(`item.fs_id`, `item.group_id`, `item.user_id`)) AS `item_count` FROM (
-SELECT 
-      folder.name AS `folder_name`,
-      folder.name AS `folder.name`,
-      item.fs_id AS `item.fs_id`,
-      NULL AS `item.group_id`,
-      NULL AS `item.user_id`
+WITH with_folder_name_item_count_cte_0 AS (SELECT 
+      folder.name AS `folder_name`, 
+      count(t0.fs_id) AS `item_count`
 FROM data_security.ds_fs_objects AS folder
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
-UNION ALL 
-SELECT 
-      folder.name AS `folder_name`,
-      folder.name AS `folder.name`,
-      item.fs_id AS `item.fs_id`,
-      item.group_id AS `item.group_id`,
-      NULL AS `item.user_id`
-FROM data_security.ds_fs_objects AS folder
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'Group'
-INNER JOIN data_security.ds_groups AS item ON item.group_id = t0.fs_id
-UNION ALL 
-SELECT 
-      folder.name AS `folder_name`,
-      folder.name AS `folder.name`,
-      item.fs_id AS `item.fs_id`,
-      NULL AS `item.group_id`,
-      item.user_id AS `item.user_id`
-FROM data_security.ds_fs_objects AS folder
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'User'
-INNER JOIN data_security.ds_users AS item ON item.user_id = t0.fs_id
-) AS __union
-GROUP BY `folder_name`
+GROUP BY folder.name
 HAVING (item_count >= 1 AND item_count <= 10)
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
@@ -6,13 +6,12 @@ WITH RECURSIVE vlp_u_g AS (
         CAST([] AS Array(String)) as path_relationships,
         [start_node.user_id, end_node.group_id] as path_nodes,
         [tuple(rel.member_id, rel.group_id)] as path_edges,
-        start_node.exposure as start_exposure,
         start_node.name as start_name,
         end_node.name as end_name
     FROM data_security.ds_users AS start_node
     JOIN data_security.ds_memberships AS rel ON start_node.user_id = rel.member_id
     JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
-    WHERE rel.member_type = 'User'
+    WHERE rel.member_type = 'User' AND start_node.exposure = 'external'
     UNION ALL
     SELECT
         vp.start_id,
@@ -21,7 +20,6 @@ WITH RECURSIVE vlp_u_g AS (
         CAST([] AS Array(String)) as path_relationships,
         arrayConcat(vp.path_nodes, [end_node.group_id]) as path_nodes,
         arrayConcat(vp.path_edges, [tuple(rel.member_id, rel.group_id)]) as path_edges,
-        vp.start_exposure as start_exposure,
         vp.start_name as start_name,
         end_node.name as end_name
     FROM vlp_u_g vp
@@ -31,29 +29,9 @@ WITH RECURSIVE vlp_u_g AS (
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
       AND rel.member_type = 'Group'
 )
-SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 
       t.start_name AS "u.name", 
-      t.end_name AS "via_group", 
-      t.start_name AS "__order_col_0"
+      t.end_name AS "via_group"
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-UNION ALL 
-SELECT DISTINCT 
-      t.start_name AS "u.name", 
-      t.end_name AS "via_group", 
-      t.start_name AS "__order_col_0"
-FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-UNION ALL 
-SELECT DISTINCT 
-      t.start_name AS "u.name", 
-      t.end_name AS "via_group", 
-      t.start_name AS "__order_col_0"
-FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-) AS __union
-ORDER BY __union.`__order_col_0` ASC
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND t0.subject_type = 'Group' AND t0.object_type = 'File'
+ORDER BY t.start_name ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
@@ -6,13 +6,12 @@ WITH RECURSIVE vlp_u_g AS (
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         array(start_node.user_id, end_node.group_id) as path_nodes,
         array(struct(rel.member_id, rel.group_id)) as path_edges,
-        start_node.exposure as start_exposure,
         start_node.name as start_name,
         end_node.name as end_name
     FROM data_security.ds_users AS start_node
     JOIN data_security.ds_memberships AS rel ON start_node.user_id = rel.member_id
     JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
-    WHERE rel.member_type = 'User'
+    WHERE rel.member_type = 'User' AND start_node.exposure = 'external'
     UNION ALL
     SELECT
         vp.start_id,
@@ -21,7 +20,6 @@ WITH RECURSIVE vlp_u_g AS (
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         concat(vp.path_nodes, array(end_node.group_id)) as path_nodes,
         concat(vp.path_edges, array(struct(rel.member_id, rel.group_id))) as path_edges,
-        vp.start_exposure as start_exposure,
         vp.start_name as start_name,
         end_node.name as end_name
     FROM vlp_u_g vp
@@ -31,29 +29,9 @@ WITH RECURSIVE vlp_u_g AS (
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
       AND rel.member_type = 'Group'
 )
-SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 
       t.start_name AS `u.name`, 
-      t.end_name AS `via_group`, 
-      t.start_name AS `__order_col_0`
+      t.end_name AS `via_group`
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-UNION ALL 
-SELECT DISTINCT 
-      t.start_name AS `u.name`, 
-      t.end_name AS `via_group`, 
-      t.start_name AS `__order_col_0`
-FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-UNION ALL 
-SELECT DISTINCT 
-      t.start_name AS `u.name`, 
-      t.end_name AS `via_group`, 
-      t.start_name AS `__order_col_0`
-FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
-WHERE t.start_exposure = 'external'
-) AS __union
-ORDER BY __union.`__order_col_0` ASC
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND t0.subject_type = 'Group' AND t0.object_type = 'File'
+ORDER BY t.start_name ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.clickhouse.sql
@@ -1,35 +1,14 @@
 SELECT 
       NULL AS "member.department", 
-      NULL AS "member.description", 
-      NULL AS "member.email", 
-      NULL AS "member.exposure", 
-      toString(member.fs_id) AS "member.fs_id", 
-      NULL AS "member.group_id", 
-      toString(member.name) AS "member.name", 
-      toString(member.parent_id) AS "member.parent_id", 
-      toString(member.path) AS "member.path", 
-      toString(member.sensitive_data) AS "member.sensitive_data", 
-      NULL AS "member.user_id"
-FROM data_security.ds_fs_objects AS member
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = member.fs_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
-WHERE g.name = 'Engineering'
-UNION ALL 
-SELECT 
-      NULL AS "member.department", 
       toString(member.description) AS "member.description", 
       NULL AS "member.email", 
       NULL AS "member.exposure", 
-      NULL AS "member.fs_id", 
       toString(member.group_id) AS "member.group_id", 
       toString(member.name) AS "member.name", 
-      NULL AS "member.parent_id", 
-      NULL AS "member.path", 
-      NULL AS "member.sensitive_data", 
       NULL AS "member.user_id"
-FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS member ON t0.member_id = member.fs_id
+FROM data_security.ds_groups AS member
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = member.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 WHERE g.name = 'Engineering'
 UNION ALL 
 SELECT 
@@ -37,14 +16,10 @@ SELECT
       NULL AS "member.description", 
       toString(member.email) AS "member.email", 
       toString(member.exposure) AS "member.exposure", 
-      NULL AS "member.fs_id", 
       NULL AS "member.group_id", 
       toString(member.name) AS "member.name", 
-      NULL AS "member.parent_id", 
-      NULL AS "member.path", 
-      NULL AS "member.sensitive_data", 
       toString(member.user_id) AS "member.user_id"
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_users AS member ON t0.member_id = member.fs_id
+INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_users AS member ON t0.member_id = member.group_id
 WHERE g.name = 'Engineering'

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.databricks.sql
@@ -1,35 +1,14 @@
 SELECT 
       NULL AS `member.department`, 
-      NULL AS `member.description`, 
-      NULL AS `member.email`, 
-      NULL AS `member.exposure`, 
-      string(member.fs_id) AS `member.fs_id`, 
-      NULL AS `member.group_id`, 
-      string(member.name) AS `member.name`, 
-      string(member.parent_id) AS `member.parent_id`, 
-      string(member.path) AS `member.path`, 
-      string(member.sensitive_data) AS `member.sensitive_data`, 
-      NULL AS `member.user_id`
-FROM data_security.ds_fs_objects AS member
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = member.fs_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
-WHERE g.name = 'Engineering'
-UNION ALL 
-SELECT 
-      NULL AS `member.department`, 
       string(member.description) AS `member.description`, 
       NULL AS `member.email`, 
       NULL AS `member.exposure`, 
-      NULL AS `member.fs_id`, 
       string(member.group_id) AS `member.group_id`, 
       string(member.name) AS `member.name`, 
-      NULL AS `member.parent_id`, 
-      NULL AS `member.path`, 
-      NULL AS `member.sensitive_data`, 
       NULL AS `member.user_id`
-FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_groups AS member ON t0.member_id = member.fs_id
+FROM data_security.ds_groups AS member
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = member.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 WHERE g.name = 'Engineering'
 UNION ALL 
 SELECT 
@@ -37,14 +16,10 @@ SELECT
       NULL AS `member.description`, 
       string(member.email) AS `member.email`, 
       string(member.exposure) AS `member.exposure`, 
-      NULL AS `member.fs_id`, 
       NULL AS `member.group_id`, 
       string(member.name) AS `member.name`, 
-      NULL AS `member.parent_id`, 
-      NULL AS `member.path`, 
-      NULL AS `member.sensitive_data`, 
       string(member.user_id) AS `member.user_id`
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'File'
-INNER JOIN data_security.ds_users AS member ON t0.member_id = member.fs_id
+INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_users AS member ON t0.member_id = member.group_id
 WHERE g.name = 'Engineering'

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.clickhouse.sql
@@ -1,50 +1,10 @@
 SELECT 
-      NULL AS "child.department", 
-      NULL AS "child.description", 
-      NULL AS "child.email", 
-      NULL AS "child.exposure", 
-      toString(child.fs_id) AS "child.fs_id", 
-      NULL AS "child.group_id", 
-      toString(child.name) AS "child.name", 
-      toString(child.parent_id) AS "child.parent_id", 
-      toString(child.path) AS "child.path", 
-      toString(child.sensitive_data) AS "child.sensitive_data", 
-      NULL AS "child.user_id"
+      child.fs_id AS "child.fs_id", 
+      child.name AS "child.name", 
+      child.parent_id AS "child.parent_id", 
+      child.path AS "child.path", 
+      child.sensitive_data AS "child.sensitive_data"
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
 INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
-WHERE f.name = 'docs'
-UNION ALL 
-SELECT 
-      NULL AS "child.department", 
-      toString(child.description) AS "child.description", 
-      NULL AS "child.email", 
-      NULL AS "child.exposure", 
-      NULL AS "child.fs_id", 
-      toString(child.group_id) AS "child.group_id", 
-      toString(child.name) AS "child.name", 
-      NULL AS "child.parent_id", 
-      NULL AS "child.path", 
-      NULL AS "child.sensitive_data", 
-      NULL AS "child.user_id"
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_groups AS child ON child.fs_id = t0.fs_id
-WHERE f.name = 'docs'
-UNION ALL 
-SELECT 
-      toString(child.department) AS "child.department", 
-      NULL AS "child.description", 
-      toString(child.email) AS "child.email", 
-      toString(child.exposure) AS "child.exposure", 
-      NULL AS "child.fs_id", 
-      NULL AS "child.group_id", 
-      toString(child.name) AS "child.name", 
-      NULL AS "child.parent_id", 
-      NULL AS "child.path", 
-      NULL AS "child.sensitive_data", 
-      toString(child.user_id) AS "child.user_id"
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_users AS child ON child.fs_id = t0.fs_id
 WHERE f.name = 'docs'

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.databricks.sql
@@ -1,50 +1,10 @@
 SELECT 
-      NULL AS `child.department`, 
-      NULL AS `child.description`, 
-      NULL AS `child.email`, 
-      NULL AS `child.exposure`, 
-      string(child.fs_id) AS `child.fs_id`, 
-      NULL AS `child.group_id`, 
-      string(child.name) AS `child.name`, 
-      string(child.parent_id) AS `child.parent_id`, 
-      string(child.path) AS `child.path`, 
-      string(child.sensitive_data) AS `child.sensitive_data`, 
-      NULL AS `child.user_id`
+      child.fs_id AS `child.fs_id`, 
+      child.name AS `child.name`, 
+      child.parent_id AS `child.parent_id`, 
+      child.path AS `child.path`, 
+      child.sensitive_data AS `child.sensitive_data`
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
 INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
-WHERE f.name = 'docs'
-UNION ALL 
-SELECT 
-      NULL AS `child.department`, 
-      string(child.description) AS `child.description`, 
-      NULL AS `child.email`, 
-      NULL AS `child.exposure`, 
-      NULL AS `child.fs_id`, 
-      string(child.group_id) AS `child.group_id`, 
-      string(child.name) AS `child.name`, 
-      NULL AS `child.parent_id`, 
-      NULL AS `child.path`, 
-      NULL AS `child.sensitive_data`, 
-      NULL AS `child.user_id`
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_groups AS child ON child.fs_id = t0.fs_id
-WHERE f.name = 'docs'
-UNION ALL 
-SELECT 
-      string(child.department) AS `child.department`, 
-      NULL AS `child.description`, 
-      string(child.email) AS `child.email`, 
-      string(child.exposure) AS `child.exposure`, 
-      NULL AS `child.fs_id`, 
-      NULL AS `child.group_id`, 
-      string(child.name) AS `child.name`, 
-      NULL AS `child.parent_id`, 
-      NULL AS `child.path`, 
-      NULL AS `child.sensitive_data`, 
-      string(child.user_id) AS `child.user_id`
-FROM data_security.ds_fs_objects AS f
-INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-INNER JOIN data_security.ds_users AS child ON child.fs_id = t0.fs_id
 WHERE f.name = 'docs'

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8861,9 +8861,17 @@ mod walker_drift_family_484_490_495_476_483 {
     /// which preserve `id()` for the render-side guard to see).
     #[tokio::test]
     async fn group_by_order_by_directed_multilabel_raw_union_not_hard_fail_484() {
-        let schema = load_schema("examples/data_security/data_security.yaml");
+        // Vehicle: a genuinely multi-TABLE polymorphic endpoint. `LIKES` on the
+        // social_polymorphic schema fans an untyped `item` across DISTINCT tables
+        // (posts_bench / users_bench) with no `to_label_values` to collapse it, so
+        // `generate_union_for_untyped_nodes` clones the whole GraphRel per label
+        // into a raw `UNION ALL` — the exact shape this guard protects. (Formerly
+        // exercised via data_security `(folder:Folder)-[:CONTAINS]->(item)`; that
+        // edge now honors `to_label_values: [Folder, File]` (#827) and collapses to
+        // a single ds_fs_objects scan, so it no longer reaches the raw-union path.)
+        let schema = load_schema(SchemaId::Polymorphic.yaml_path());
 
-        let group_by_cypher = "MATCH (folder:Folder)-[:CONTAINS]->(item) RETURN id(item), count(*)";
+        let group_by_cypher = "MATCH (u:User)-[:LIKES]->(item) RETURN id(item), count(*)";
         let group_by_sql = render(&schema, group_by_cypher, SqlDialect::ClickHouse).await;
         assert!(
             !group_by_sql.contains("GROUP BY item."),
@@ -8879,7 +8887,7 @@ mod walker_drift_family_484_490_495_476_483 {
         );
 
         let order_by_cypher =
-            "MATCH (folder:Folder)-[:CONTAINS]->(item) RETURN id(item), count(*) ORDER BY id(item)";
+            "MATCH (u:User)-[:LIKES]->(item) RETURN id(item), count(*) ORDER BY id(item)";
         let order_by_sql = render(&schema, order_by_cypher, SqlDialect::ClickHouse).await;
         assert!(
             !order_by_sql.contains("GROUP BY item.") && !order_by_sql.contains("ORDER BY item."),
@@ -12399,12 +12407,32 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
     /// 200 (matches an independently-computed `count(DISTINCT id)` over the
     /// 3 unioned child tables — same ground truth as the #539 junction-table
     /// case above, since both count the same underlying CONTAINS children).
+    ///
+    /// #827 update (2026-07-30): the original vehicle above — data_security
+    /// `(folder:Folder)-[:CONTAINS]-(item)` — no longer reaches the raw
+    /// multi-table UNION. `CONTAINS`/`HAS_ACCESS` now honor `to_label_values`
+    /// (`$any` endpoint constrained to the declared labels), so those edges
+    /// collapse to a single `ds_fs_objects` union and can't exercise this Code-47
+    /// hazard. The test was repointed to `social_polymorphic`'s `LIKES` edge
+    /// (`item` genuinely fans across the distinct posts_bench / users_bench
+    /// tables, no `to_label_values` to collapse it) — same hazard, live vehicle.
+    /// The old "3 child tables / 200" figures reflect the pre-#827 data_security
+    /// shape and are kept only as the historical origin of this guard.
     #[tokio::test]
     async fn graph_rel_connection_role_replaced_by_vlp_endpoint_role_in_count_distinct_alias_541() {
-        let schema = load_schema("examples/data_security/data_security.yaml");
+        // Vehicle: a genuine multi-TABLE polymorphic endpoint (see #484 above).
+        // `(u:User)-[:LIKES]-(item)` on social_polymorphic renders an undirected
+        // raw per-label UNION over DISTINCT tables (posts_bench / users_bench),
+        // `variable_length=None` on every clone — so `item` is only addressable
+        // inside each branch and `count(DISTINCT item)` must fall through to the
+        // per-branch id-column tuple, not a multi_type_vlp_joins CTE's end_id/type.
+        // (Formerly exercised via data_security `(folder:Folder)-[:CONTAINS]-(item)`;
+        // that edge now honors `to_label_values` (#827) and collapses to a single
+        // ds_fs_objects union, no longer reaching the multi-table raw-union path.)
+        let schema = load_schema(SchemaId::Polymorphic.yaml_path());
         let sql = render(
             &schema,
-            "MATCH (folder:Folder)-[:CONTAINS]-(item) RETURN count(DISTINCT item)",
+            "MATCH (u:User)-[:LIKES]-(item) RETURN count(DISTINCT item)",
             SqlDialect::ClickHouse,
         )
         .await;
@@ -12415,11 +12443,11 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
             "#541: count(DISTINCT item) over a junction-table undirected \
              endpoint must not reference the multi_type_vlp_joins CTE's \
              end_id/type columns — this junction-table schema has no such \
-             CTE, only a raw per-label UNION with real fs_id/group_id/user_id \
-             columns per branch (Code 47 UNKNOWN_IDENTIFIER otherwise):\n{sql}"
+             CTE, only a raw per-label UNION with real per-branch id columns \
+             (Code 47 UNKNOWN_IDENTIFIER otherwise):\n{sql}"
         );
         assert!(
-            sql.contains("tuple(`item.fs_id`, `item.group_id`, `item.user_id`)"),
+            sql.contains("tuple(`item.post_id`, `item.user_id`)"),
             "#541: must fall through to the per-label id-column tuple \
              (#467-style), using the REAL per-branch columns:\n{sql}"
         );


### PR DESCRIPTION
## Summary
Partial fix for #827 — **defect (a)** only (candidate over-fan-out). A polymorphic edge may declare `to_node: $any` (a sentinel) while carrying `to_label_values: [Folder, File]` — the concrete labels it legally targets. Previously, an untyped query endpoint reaching such an edge expanded `$any` to **every** node label, producing one raw UNION arm per label, including illegal ones.

Repro (no VLP needed): `MATCH (u:User)-[:HAS_ACCESS]->(target) RETURN u.name, target.name` on `examples/data_security/data_security.yaml` fanned `target` to `ds_fs_objects` + `ds_groups` + `ds_users` (3 arms, with nonsensical `ds_users AS target ON target.fs_id = ...` joins). Post-fix: a single legal `ds_fs_objects` arm.

## Fix
New `GraphSchema::expand_node_type_constrained(node_type, label_values)`: when `$any` and the edge declares a non-empty allow-list, expand to those labels; otherwise unchanged (concrete type as-is; bare `$any` with no allow-list still all labels). Routed the two `generate_union_for_untyped_nodes` call sites (from-side + to-side) through it. **Does not touch** the shared `expand_node_type` (8 callers) — surgical, low blast radius.

The behavior change is scoped to exactly one schema in the repo: `data_security` is the **only** schema declaring endpoint `label_values` (grep-confirmed). Open-polymorphic edges (e.g. `social_polymorphic` LIKES, no `to_label_values`) still fan to all labels.

## Effect
`target`/`child` fan only to legal labels. 12 data_security goldens lose their illegal arms (net −413 lines). Several **encoded the bug** — `test_sql_polymorphic_to`/`_from` had Folder→User/Group child arms; `test_distinct_group_types` had a spurious `fs_objects` arm with `member_type='File'` on a MEMBER_OF edge.

## Out of scope (still open under #827)
- **Defect (b)**: the single remaining arm hardcodes `object_type='File'` (table→label reverse-lookup picks the alphabetically-first label), so Folder-access rows are silently dropped and the from-side `MEMBER_OF` User arm keeps a `member_type='Group'`/`group_id` discriminator. Pre-existing; unchanged here.
- **Both-endpoints-untyped over-fan**: `MATCH (a)-[:HAS_ACCESS]->(b)` (both unlabeled) still emits 16 arms via a *different*, unpatched site (`type_inference.rs:~2179`, `infer_pattern_types`). Byte-identical main-vs-branch; the natural next site.

## Tests
- New unit test locking the helper (bare `$any`, constrained, empty-allow-list fallback, concrete type).
- Repointed the #484/#541 raw-union Code-47 hazard guards from data_security CONTAINS (no longer a multi-table union) to `social_polymorphic` LIKES (Post/Comment across distinct tables, no `to_label_values` — genuine multi-table union preserved). Same hazard, assertions unchanged in spirit. data_security undirected coverage retained in the sibling junction-table test.
- Updated `test_external_users_with_access` xfail reason (defect a fixed; xfail retained for defect b).

## Gate
`cargo fmt` + `clippy` (0 warnings) + 1604 lib + 531 integration + ratchet (no baseline bump) all green.

## Review
Adversarial subagent review: **APPROVE — 0 blocking, 0 major, 3 minor** (all pre-existing/deferred: un-validated label_values footgun; both-untyped over-fan at the separate 2179 site; from-side defect-b discriminator, xfailed). Built + rendered + diffed vs main + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)