### PR TITLE
fix(#827): both-untyped polymorphic endpoints honor label_values

### DIFF
--- a/src/query_planner/logical_plan/match_clause/traversal.rs
+++ b/src/query_planner/logical_plan/match_clause/traversal.rs
@@ -517,10 +517,19 @@ fn traverse_connected_pattern_with_mode<'a>(
                                     rel_schemas
                                         .into_iter()
                                         .flat_map(|schema| {
-                                            let froms =
-                                                graph_schema.expand_node_type(&schema.from_node);
-                                            let tos =
-                                                graph_schema.expand_node_type(&schema.to_node);
+                                            // Constrain `$any` endpoints by the edge's
+                                            // declared label allow-lists so a polymorphic
+                                            // edge that targets only some labels does not
+                                            // generate a full cartesian of (from, to) label
+                                            // pairs when BOTH endpoints are untyped (#827).
+                                            let froms = graph_schema.expand_node_type_constrained(
+                                                &schema.from_node,
+                                                schema.from_label_values.as_ref(),
+                                            );
+                                            let tos = graph_schema.expand_node_type_constrained(
+                                                &schema.to_node,
+                                                schema.to_label_values.as_ref(),
+                                            );
                                             let bt = base_type.clone();
                                             froms.into_iter().flat_map(move |f| {
                                                 let bt2 = bt.clone();

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12453,6 +12453,77 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
         );
     }
 
+    /// #827 both-endpoints-untyped over-fan: when BOTH endpoints of a
+    /// polymorphic edge are unlabeled (`MATCH (a)-[:HAS_ACCESS]->(b)`), the
+    /// deferred-UNION traversal path expands each `$any` endpoint to every node
+    /// label and takes the full cartesian product — 16 (from×to) arms on
+    /// data_security, only 4 of them legal. HAS_ACCESS declares
+    /// `from_label_values: [User, Group]` and `to_label_values: [Folder, File]`,
+    /// so the legal set is exactly those 4 combinations; the other 12 (e.g.
+    /// `File→User`, `Group→Group`) are illegal. The fix routes the
+    /// both-untyped arm generator (`match_clause/traversal.rs`'s
+    /// `expand_node_type` cartesian) through `expand_node_type_constrained`,
+    /// the same helper that fixed the single-untyped shape (#831). The
+    /// `type_inference.rs` combination generator (`~2179`) also expands `$any`
+    /// unconstrained, but was verified inert for this shape (patching it
+    /// changed no output — traversal.rs is the sole arm source here) and left
+    /// as-is. This is the companion site the #831 review surfaced;
+    /// open-polymorphic edges (no `label_values`, e.g. LIKES) are unaffected
+    /// and still fan to every label.
+    #[tokio::test]
+    async fn both_untyped_polymorphic_endpoints_honor_label_values_827() {
+        let schema = load_schema("examples/data_security/data_security.yaml");
+        let sql = render(
+            &schema,
+            "MATCH (a)-[:HAS_ACCESS]->(b) RETURN a.name, b.name",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+
+        // Exactly the 4 legal (from,to) combinations, each with the correct
+        // discriminator pair — no illegal arm.
+        for (from, to) in [
+            ("User", "Folder"),
+            ("User", "File"),
+            ("Group", "Folder"),
+            ("Group", "File"),
+        ] {
+            let disc = format!(
+                "subject_type = '{from}' AND data_security.ds_permissions.object_type = '{to}'"
+            );
+            assert!(
+                sql.contains(&disc),
+                "#827: expected the legal {from}->{to} arm (discriminator \
+                 `{disc}`):\n{sql}"
+            );
+        }
+
+        // None of the illegal combinations may appear. Spot-check the ones that
+        // are structurally nonsensical for HAS_ACCESS (subject can't be a
+        // Folder/File; object can't be a User/Group).
+        for illegal in [
+            "subject_type = 'Folder'",
+            "subject_type = 'File'",
+            "object_type = 'User'",
+            "object_type = 'Group'",
+        ] {
+            assert!(
+                !sql.contains(illegal),
+                "#827: illegal arm leaked (`{illegal}`) — `$any` endpoint \
+                 ignored its label_values allow-list:\n{sql}"
+            );
+        }
+
+        // 4 arms = exactly 3 UNION ALL separators (the full 4x4 cartesian would
+        // be 16 arms / 15 separators).
+        assert_eq!(
+            sql.matches("UNION ALL").count(),
+            3,
+            "#827: expected 4 legal arms (3 UNION ALL), not the 16-arm \
+             cartesian:\n{sql}"
+        );
+    }
+
     /// #537: `id(a2)`/GROUP BY over a composite-id VLP endpoint (Account
     /// keyed by `(bank_id, account_number)`) used to resolve to only the
     /// FIRST composite-id column (`find_id_column_for_alias`'s GraphNode


### PR DESCRIPTION
## Summary
Companion to #831. When **both** endpoints of a polymorphic edge are unlabeled — `MATCH (a)-[:HAS_ACCESS]->(b)` — the deferred-UNION traversal path expanded each `$any` endpoint to every node label and took the full cartesian: **16** (from×to) arms on data_security, only **4** legal.

HAS_ACCESS declares `from_label_values: [User, Group]` and `to_label_values: [Folder, File]`, so 12 combinations (`File→User`, `Group→Group`, …) are illegal.

## Root cause
The `#831` review surfaced this as the separate, unpatched site. The generator is the `expand_node_type` cartesian in `traversal.rs::traverse_connected_pattern_with_mode` (the both-endpoints-untyped branch, gated on `start_label.is_none() && end_label.is_none()`) — **not** the `infer_pattern_types` combination generator (`type_inference.rs:~2179`) the #831 note guessed. Patching that was inert; found the real site by patch-and-rebuild.

## Fix
Route both `$any` expansions through `expand_node_type_constrained` (the #831 helper), passing the edge's `from_label_values`/`to_label_values`. One call site, side-symmetric.

Effect: `(a)-[:HAS_ACCESS]->(b)` → 4 legal arms (User/Group → Folder/File).

Controls verified:
- Single-untyped shape unchanged (1 arm)
- Open-polymorphic LIKES (no `label_values`) still fans all 4 pairs
- MEMBER_OF (to=Group fixed) correct

## Tests
No corpus golden churn (no corpus query uses the both-untyped polymorphic shape). Locked instead by a hand-written assertion test asserting the 4 legal discriminator pairs, 4 illegal patterns absent, and exactly 3 `UNION ALL`. Verified it fails on full revert **and** on either single-side revert (from-side → `subject_type='Folder'` leaks; to-side → `object_type='User'` leaks).

## Out of scope
#827 defect (b) (single-arm `object_type='File'` reverse-lookup collapse) remains open.

## Gate
fmt + clippy(0) + 1604 lib + 532 integration + ratchet(no bump) green.

## Review
Focused subagent review: **APPROVE — 0 blocking/major, 1 minor** (a test doc-comment inaccuracy, fixed in the final commit). Independently reproduced the 4-arm render, open-polymorphic fallback, and partial-regression detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)