### PR TITLE
fix(#827 defect b, sym2): per-arm label for from-side polymorphic UNION arms

### DIFF
--- a/src/query_planner/analyzer/graph_context.rs
+++ b/src/query_planner/analyzer/graph_context.rs
@@ -30,6 +30,26 @@ fn strip_database_prefix(table_name: &str) -> String {
         .unwrap_or_else(|| table_name.to_string())
 }
 
+/// Extract the concrete node label stamped directly on a pattern endpoint,
+/// unwrapping the `GraphNode`/`Projection`/`Filter` wrappers a branch may carry.
+///
+/// This is the per-arm label TypeInference sets on each UNION branch's
+/// `GraphNode` (e.g. `User` on one arm, `Group` on another). It is more
+/// specific than `TableCtx::get_label_str()`, which reads the shared `PlanCtx`
+/// where a polymorphic endpoint still carries ALL candidate labels and
+/// `first()` would pick the same one for every arm (#827 defect b).
+pub(crate) fn endpoint_label_from_plan(plan: &LogicalPlan) -> Option<String> {
+    let label = match plan {
+        LogicalPlan::GraphNode(gn) => gn.label.clone(),
+        LogicalPlan::Projection(p) => endpoint_label_from_plan(&p.input),
+        LogicalPlan::Filter(f) => endpoint_label_from_plan(&f.input),
+        _ => None,
+    };
+    // Never surface the polymorphic `$any` sentinel as a concrete label — let
+    // the caller fall through to ctx / relationship-schema resolution.
+    label.filter(|l| l != "$any")
+}
+
 #[derive(Debug, Clone)]
 pub struct GraphContext<'a> {
     pub left: GraphNodeContext<'a>,
@@ -188,16 +208,23 @@ pub fn get_graph_context<'a>(
     // FK-edges, where the anonymous endpoint stayed unlabeled and got resolved
     // to the wrong node table (Code 47: reading `from_id`/`to_id` off the node
     // table instead of the FK-edge table).
-    let left_label = match left_ctx.get_label_str() {
-        Ok(label) => label,
-        Err(_) => rel_schema_for_inference.from_node.clone(),
-    };
+    // Prefer the per-arm label stamped on the endpoint's own `GraphNode`
+    // (`graph_rel.left`/`right`) over the shared `PlanCtx`. For a polymorphic
+    // endpoint that fans into per-label UNION arms, TypeInference stamps each
+    // arm's `GraphNode` with its OWN label but leaves the shared `PlanCtx`
+    // carrying ALL candidate labels — so `get_label_str().first()` returns the
+    // same (first) candidate for every arm, giving every arm the first label's
+    // discriminator and join column (#827 defect b: the `ds_users` MEMBER_OF
+    // arm inherited `member_type='Group'` + `m.group_id`). The per-arm
+    // `GraphNode.label` is the authoritative choice when present; fall back to
+    // the shared ctx, then to relationship-schema inference for anonymous nodes.
+    let left_label = endpoint_label_from_plan(&graph_rel.left)
+        .or_else(|| left_ctx.get_label_str().ok())
+        .unwrap_or_else(|| rel_schema_for_inference.from_node.clone());
 
-    // Try to get right label, or infer from relationship if anonymous
-    let right_label = match right_ctx.get_label_str() {
-        Ok(label) => label,
-        Err(_) => rel_schema_for_inference.to_node.clone(),
-    };
+    let right_label = endpoint_label_from_plan(&graph_rel.right)
+        .or_else(|| right_ctx.get_label_str().ok())
+        .unwrap_or_else(|| rel_schema_for_inference.to_node.clone());
 
     // NOTE: For polymorphic $any nodes, this function should not be called.
     // The graph_traversal_planning pass should skip $any nodes and let the normal JOIN path handle them.

--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -2452,9 +2452,17 @@ impl GraphJoinInference {
             .get_table_ctx_from_alias_opt(&Some(right_alias.clone()))
             .ok()?;
 
-        // Try to get labels from plan_ctx, but allow empty for anonymous nodes
-        let left_label_opt = left_ctx.get_label_str().ok();
-        let right_label_opt = right_ctx.get_label_str().ok();
+        // Prefer the per-arm label stamped on the endpoint's own `GraphNode`
+        // over the shared `PlanCtx` — a polymorphic endpoint keeps ALL candidate
+        // labels in `PlanCtx`, so `get_label_str().first()` returns the same
+        // label for every UNION arm, giving each arm the first candidate's node
+        // schema (hence join column) and discriminator (#827 defect b). The
+        // per-arm `GraphNode.label` is authoritative when present.
+        let left_label_opt = super::super::graph_context::endpoint_label_from_plan(&graph_rel.left)
+            .or_else(|| left_ctx.get_label_str().ok());
+        let right_label_opt =
+            super::super::graph_context::endpoint_label_from_plan(&graph_rel.right)
+                .or_else(|| right_ctx.get_label_str().ok());
 
         // 2. Get relationship type(s) from labels
         let rel_types: Vec<String> = graph_rel.labels.clone().unwrap_or_default();

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.clickhouse.sql
@@ -10,7 +10,7 @@ SELECT DISTINCT
       g.name AS "g.name", 
       g.name AS "__order_col_0"
 FROM data_security.ds_users AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.user_id AND t0.member_type = 'User'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregations_test_distinct_group_types.databricks.sql
@@ -10,7 +10,7 @@ SELECT DISTINCT
       g.name AS `g.name`, 
       g.name AS `__order_col_0`
 FROM data_security.ds_users AS m
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.group_id AND t0.member_type = 'Group'
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = m.user_id AND t0.member_type = 'User'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.clickhouse.sql
@@ -20,6 +20,6 @@ SELECT
       toString(member.name) AS "member.name", 
       toString(member.user_id) AS "member.user_id"
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'Group'
-INNER JOIN data_security.ds_users AS member ON t0.member_id = member.group_id
+INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'User'
+INNER JOIN data_security.ds_users AS member ON t0.member_id = member.user_id
 WHERE g.name = 'Engineering'

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_from.databricks.sql
@@ -20,6 +20,6 @@ SELECT
       string(member.name) AS `member.name`, 
       string(member.user_id) AS `member.user_id`
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'Group'
-INNER JOIN data_security.ds_users AS member ON t0.member_id = member.group_id
+INNER JOIN data_security.ds_memberships AS t0 ON g.group_id = t0.group_id AND t0.member_type = 'User'
+INNER JOIN data_security.ds_users AS member ON t0.member_id = member.user_id
 WHERE g.name = 'Engineering'

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12524,6 +12524,61 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
         );
     }
 
+    /// #827 defect (b) symptom 2: from-side per-arm discriminator + join key.
+    /// When an untyped endpoint fans into per-label UNION arms over a
+    /// from-side-polymorphic edge (`MATCH (m)-[:MEMBER_OF]->(g:Group)`, m ∈
+    /// {User, Group}), each arm's node join column and edge discriminator must
+    /// be derived from the arm's OWN label, not the first shared-`PlanCtx`
+    /// candidate. Pre-fix both arms inherited `member_type='Group'` +
+    /// `m.group_id` (the `ds_users` arm a latent Code-47: ds_users has no
+    /// group_id). The fix routes label resolution in `get_graph_context` and
+    /// `compute_pattern_context` through the per-arm `GraphNode.label`.
+    #[tokio::test]
+    async fn from_side_polymorphic_per_arm_discriminator_and_join_key_827() {
+        let schema = load_schema("examples/data_security/data_security.yaml");
+        let raw = render(
+            &schema,
+            "MATCH (m)-[:MEMBER_OF]->(g:Group) RETURN m.name, g.name",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        // Normalize the process-global `t{n}` rel-alias counter to a stable
+        // token so the assertions are order-independent in the full suite
+        // (see `normalize`; #798 — a raw `t1.` substring flakes with the
+        // counter). After normalize the rel alias is `t0`.
+        let sql = normalize(&raw);
+
+        // The ds_users arm must use the User node id + the 'User' discriminator.
+        assert!(
+            sql.contains("FROM data_security.ds_users AS m")
+                && sql.contains("t0.member_id = m.user_id AND t0.member_type = 'User'"),
+            "#827(b): the ds_users arm must join on m.user_id with \
+             member_type='User' (per-arm label), not the shared first \
+             candidate:\n{sql}"
+        );
+        // The ds_groups arm keeps the Group node id + 'Group' discriminator.
+        assert!(
+            sql.contains("FROM data_security.ds_groups AS m")
+                && sql.contains("t0.member_id = m.group_id AND t0.member_type = 'Group'"),
+            "#827(b): the ds_groups arm must join on m.group_id with \
+             member_type='Group':\n{sql}"
+        );
+        // The pre-fix bug emitted `member_type = 'Group'` on BOTH arms; with
+        // the per-arm fix exactly one arm carries each discriminator value.
+        assert_eq!(
+            sql.matches("member_type = 'Group'").count(),
+            1,
+            "#827(b): exactly one arm may carry the 'Group' discriminator \
+             (pre-fix both arms did):\n{sql}"
+        );
+        assert_eq!(
+            sql.matches("member_type = 'User'").count(),
+            1,
+            "#827(b): the ds_users arm's 'User' discriminator is missing \
+             (per-arm label lost):\n{sql}"
+        );
+    }
+
     /// #537: `id(a2)`/GROUP BY over a composite-id VLP endpoint (Account
     /// keyed by `(bank_id, account_number)`) used to resolve to only the
     /// FIRST composite-id column (`find_id_column_for_alias`'s GraphNode


### PR DESCRIPTION
## Summary
Symptom 2 of #827 defect (b). For a from-side-polymorphic edge whose untyped endpoint fans into per-label UNION arms — `MATCH (m)-[:MEMBER_OF]->(g:Group)`, m ∈ {User, Group} — each arm derived its node join column **and** edge discriminator from the *shared* PlanCtx instead of the arm's own label.

`get_graph_context` and `compute_pattern_context` both resolved the label via `TableCtx::get_label_str()` = `labels.first()`. TypeInference leaves the shared PlanCtx carrying ALL candidate labels, so every arm got the FIRST candidate → the same node schema (join key) and discriminator. The `ds_users` arm inherited `m.group_id` + `member_type='Group'` — a **latent ClickHouse Code 47** (ds_users has no `group_id`).

## Fix
The correct per-arm label is already on `graph_rel.left.label`/`right.label` — it just wasn't read. New shared `endpoint_label_from_plan` helper (unwraps GraphNode/Projection/Filter, guards the `$any` sentinel); preferred over the shared ctx at both sites, falling back to ctx → relationship-schema inference.

## Effect
- `ds_users` MEMBER_OF arm → `m.user_id` + `member_type='User'` ✓
- `ds_groups` arm → `m.group_id` + `member_type='Group'` ✓
- 4 data_security goldens corrected (both latent Code-47 join keys).
- **Differential-verified byte-identical** across 25 patterns × 10 schemas (standard, FK-edge, denormalized, composite-id, polymorphic, undirected/BidirectionalUnion, VLP, WITH-barrier) beyond the 2 intended shapes.

## Out of scope
Symptom 1 (to-side superset-collapse dropping the Folder arm) — separate follow-up.

## Tests
Lock test `from_side_polymorphic_per_arm_discriminator_and_join_key_827` (join key + discriminator, exactly-one-arm-per-value); routed through `normalize()` because the `t{n}` rel-alias counter is process-global (a raw `t1.` substring flakes in the full suite — #798). Verified: passes in **full suite**, fails on source revert.

## Review
Adversarial subagent review: **REQUEST-CHANGES → resolved**. The analyzer fix was APPROVED (differential clean, no regression). The one blocking issue was the lock test flaking on the alias counter — fixed here (normalize), re-verified in the full suite.

## Gate
fmt + clippy(0) + 1604 lib + 533 integration (full) + ratchet(no bump) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)