### PR TITLE
fix(#827 defect b, sym1): don't collapse label-discriminated sibling nodes

### DIFF
--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -1584,7 +1584,29 @@ impl TypeInference {
             // strict superset of type B's, keep only A. This handles cases like
             // Message (view over Post+Comment) where Message has all properties
             // of Post, making the Post candidate redundant.
+            //
+            // EXCEPTION (#827 defect b, symptom 1): two labels that share a
+            // physical table but are distinguished by a `label_column`
+            // discriminator with DIFFERENT `label_value`s (e.g. Folder/File both
+            // on `ds_fs_objects`, `fs_type='Folder'`/`'File'`) are *siblings*,
+            // not a parent/child view. The property-superset test misfires when
+            // one sibling happens to declare extra properties (File adds
+            // `sensitive_data`), collapsing a genuinely distinct label away and
+            // silently dropping its rows. Such pairs must each survive as their
+            // own UNION arm.
             if candidates.len() > 1 {
+                // True when i and j are label-discriminated siblings on one table.
+                let are_discriminated_siblings = |i: &str, j: &str| -> bool {
+                    let (Ok(si), Ok(sj)) =
+                        (graph_schema.node_schema(i), graph_schema.node_schema(j))
+                    else {
+                        return false;
+                    };
+                    si.table_name == sj.table_name
+                        && si.label_column.is_some()
+                        && sj.label_column.is_some()
+                        && si.label_value != sj.label_value
+                };
                 let mut to_remove = HashSet::new();
                 for i in 0..candidates.len() {
                     if to_remove.contains(&i) {
@@ -1597,6 +1619,9 @@ impl TypeInference {
                         .unwrap_or_default();
                     for j in 0..candidates.len() {
                         if i == j || to_remove.contains(&j) {
+                            continue;
+                        }
+                        if are_discriminated_siblings(&candidates[i], &candidates[j]) {
                             continue;
                         }
                         let props_j: HashSet<String> = graph_schema

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.clickhouse.sql
@@ -1,7 +1,27 @@
+SELECT `f.name` AS "f.name", count(`child.fs_id`) AS "children_count" FROM (
 SELECT 
-      f.name AS "f.name", 
-      count(t0.fs_id) AS "children_count"
+      toString(child.fs_id) AS "fs_id",
+      toString(child.name) AS "name",
+      toString(child.parent_id) AS "parent_id",
+      toString(child.path) AS "path",
+      toString(child.sensitive_data) AS "sensitive_data",
+      f.name AS "f.name",
+      toString(child.fs_id) AS "child.fs_id"
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-GROUP BY f.name
-ORDER BY children_count DESC
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+UNION ALL 
+SELECT 
+      toString(child.fs_id) AS "fs_id",
+      toString(child.name) AS "name",
+      toString(child.parent_id) AS "parent_id",
+      toString(child.path) AS "path",
+      NULL AS "sensitive_data",
+      f.name AS "f.name",
+      toString(child.fs_id) AS "child.fs_id"
+FROM data_security.ds_fs_objects AS f
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Folder'
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+) AS __union
+GROUP BY `f.name`
+ORDER BY `children_count` DESC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_count_with_alias.databricks.sql
@@ -1,7 +1,27 @@
+SELECT `f.name` AS `f.name`, count(`child.fs_id`) AS `children_count` FROM (
 SELECT 
-      f.name AS `f.name`, 
-      count(t0.fs_id) AS `children_count`
+      string(child.fs_id) AS `fs_id`,
+      string(child.name) AS `name`,
+      string(child.parent_id) AS `parent_id`,
+      string(child.path) AS `path`,
+      string(child.sensitive_data) AS `sensitive_data`,
+      f.name AS `f.name`,
+      string(child.fs_id) AS `child.fs_id`
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
-GROUP BY f.name
-ORDER BY children_count DESC
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+UNION ALL 
+SELECT 
+      string(child.fs_id) AS `fs_id`,
+      string(child.name) AS `name`,
+      string(child.parent_id) AS `parent_id`,
+      string(child.path) AS `path`,
+      NULL AS `sensitive_data`,
+      f.name AS `f.name`,
+      string(child.fs_id) AS `child.fs_id`
+FROM data_security.ds_fs_objects AS f
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Folder'
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+) AS __union
+GROUP BY `f.name`
+ORDER BY `children_count` DESC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.clickhouse.sql
@@ -1,9 +1,21 @@
-WITH with_folder_name_item_count_cte_0 AS (SELECT 
-      folder.name AS "folder_name", 
-      count(t0.fs_id) AS "item_count"
+WITH with_folder_name_item_count_cte_0 AS (SELECT `folder_name` AS "folder_name", count(`item.fs_id`) AS "item_count" FROM (
+SELECT 
+      folder.name AS "folder_name",
+      folder.name AS "folder.name",
+      item.fs_id AS "item.fs_id"
 FROM data_security.ds_fs_objects AS folder
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'File'
-GROUP BY folder.name
+INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
+UNION ALL 
+SELECT 
+      folder.name AS "folder_name",
+      folder.name AS "folder.name",
+      item.fs_id AS "item.fs_id"
+FROM data_security.ds_fs_objects AS folder
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'Folder'
+INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
+) AS __union
+GROUP BY `folder_name`
 HAVING (item_count >= 1 AND item_count <= 10)
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestHavingQueries_test_having_multiple_conditions.databricks.sql
@@ -1,9 +1,21 @@
-WITH with_folder_name_item_count_cte_0 AS (SELECT 
-      folder.name AS `folder_name`, 
-      count(t0.fs_id) AS `item_count`
+WITH with_folder_name_item_count_cte_0 AS (SELECT `folder_name` AS `folder_name`, count(`item.fs_id`) AS `item_count` FROM (
+SELECT 
+      folder.name AS `folder_name`,
+      folder.name AS `folder.name`,
+      item.fs_id AS `item.fs_id`
 FROM data_security.ds_fs_objects AS folder
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'File'
-GROUP BY folder.name
+INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
+UNION ALL 
+SELECT 
+      folder.name AS `folder_name`,
+      folder.name AS `folder.name`,
+      item.fs_id AS `item.fs_id`
+FROM data_security.ds_fs_objects AS folder
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = folder.fs_id AND t0.fs_type = 'Folder'
+INNER JOIN data_security.ds_fs_objects AS item ON item.fs_id = t0.fs_id
+) AS __union
+GROUP BY `folder_name`
 HAVING (item_count >= 1 AND item_count <= 10)
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
@@ -6,12 +6,13 @@ WITH RECURSIVE vlp_u_g AS (
         CAST([] AS Array(String)) as path_relationships,
         [start_node.user_id, end_node.group_id] as path_nodes,
         [tuple(rel.member_id, rel.group_id)] as path_edges,
+        start_node.exposure as start_exposure,
         start_node.name as start_name,
         end_node.name as end_name
     FROM data_security.ds_users AS start_node
     JOIN data_security.ds_memberships AS rel ON start_node.user_id = rel.member_id
     JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
-    WHERE rel.member_type = 'User' AND start_node.exposure = 'external'
+    WHERE rel.member_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -20,6 +21,7 @@ WITH RECURSIVE vlp_u_g AS (
         CAST([] AS Array(String)) as path_relationships,
         arrayConcat(vp.path_nodes, [end_node.group_id]) as path_nodes,
         arrayConcat(vp.path_edges, [tuple(rel.member_id, rel.group_id)]) as path_edges,
+        vp.start_exposure as start_exposure,
         vp.start_name as start_name,
         end_node.name as end_name
     FROM vlp_u_g vp
@@ -29,9 +31,21 @@ WITH RECURSIVE vlp_u_g AS (
       AND NOT has(vp.path_edges, tuple(rel.member_id, rel.group_id))
       AND rel.member_type = 'Group'
 )
+SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 
       t.start_name AS "u.name", 
-      t.end_name AS "via_group"
+      t.end_name AS "via_group", 
+      t.start_name AS "__order_col_0"
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND t0.subject_type = 'Group' AND t0.object_type = 'File'
-ORDER BY t.start_name ASC
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+WHERE t.start_exposure = 'external'
+UNION ALL 
+SELECT DISTINCT 
+      t.start_name AS "u.name", 
+      t.end_name AS "via_group", 
+      t.start_name AS "__order_col_0"
+FROM vlp_u_g AS t
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+WHERE t.start_exposure = 'external'
+) AS __union
+ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
@@ -6,12 +6,13 @@ WITH RECURSIVE vlp_u_g AS (
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         array(start_node.user_id, end_node.group_id) as path_nodes,
         array(struct(rel.member_id, rel.group_id)) as path_edges,
+        start_node.exposure as start_exposure,
         start_node.name as start_name,
         end_node.name as end_name
     FROM data_security.ds_users AS start_node
     JOIN data_security.ds_memberships AS rel ON start_node.user_id = rel.member_id
     JOIN data_security.ds_groups AS end_node ON rel.group_id = end_node.group_id
-    WHERE rel.member_type = 'User' AND start_node.exposure = 'external'
+    WHERE rel.member_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -20,6 +21,7 @@ WITH RECURSIVE vlp_u_g AS (
         CAST(array() AS ARRAY<STRING>) as path_relationships,
         concat(vp.path_nodes, array(end_node.group_id)) as path_nodes,
         concat(vp.path_edges, array(struct(rel.member_id, rel.group_id))) as path_edges,
+        vp.start_exposure as start_exposure,
         vp.start_name as start_name,
         end_node.name as end_name
     FROM vlp_u_g vp
@@ -29,9 +31,21 @@ WITH RECURSIVE vlp_u_g AS (
       AND NOT array_contains(vp.path_edges, struct(rel.member_id, rel.group_id))
       AND rel.member_type = 'Group'
 )
+SELECT `u.name` AS `u.name`, `via_group` AS `via_group` FROM (
 SELECT DISTINCT 
       t.start_name AS `u.name`, 
-      t.end_name AS `via_group`
+      t.end_name AS `via_group`, 
+      t.start_name AS `__order_col_0`
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND t0.subject_type = 'Group' AND t0.object_type = 'File'
-ORDER BY t.start_name ASC
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+WHERE t.start_exposure = 'external'
+UNION ALL 
+SELECT DISTINCT 
+      t.start_name AS `u.name`, 
+      t.end_name AS `via_group`, 
+      t.start_name AS `__order_col_0`
+FROM vlp_u_g AS t
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+WHERE t.start_exposure = 'external'
+) AS __union
+ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.clickhouse.sql
@@ -1,10 +1,21 @@
 SELECT 
-      child.fs_id AS "child.fs_id", 
-      child.name AS "child.name", 
-      child.parent_id AS "child.parent_id", 
-      child.path AS "child.path", 
-      child.sensitive_data AS "child.sensitive_data"
+      toString(child.fs_id) AS "child.fs_id", 
+      toString(child.name) AS "child.name", 
+      toString(child.parent_id) AS "child.parent_id", 
+      toString(child.path) AS "child.path", 
+      toString(child.sensitive_data) AS "child.sensitive_data"
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+WHERE f.name = 'docs'
+UNION ALL 
+SELECT 
+      toString(child.fs_id) AS "child.fs_id", 
+      toString(child.name) AS "child.name", 
+      toString(child.parent_id) AS "child.parent_id", 
+      toString(child.path) AS "child.path", 
+      NULL AS "child.sensitive_data"
+FROM data_security.ds_fs_objects AS f
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Folder'
 INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
 WHERE f.name = 'docs'

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSqlGeneration_test_sql_polymorphic_to.databricks.sql
@@ -1,10 +1,21 @@
 SELECT 
-      child.fs_id AS `child.fs_id`, 
-      child.name AS `child.name`, 
-      child.parent_id AS `child.parent_id`, 
-      child.path AS `child.path`, 
-      child.sensitive_data AS `child.sensitive_data`
+      string(child.fs_id) AS `child.fs_id`, 
+      string(child.name) AS `child.name`, 
+      string(child.parent_id) AS `child.parent_id`, 
+      string(child.path) AS `child.path`, 
+      string(child.sensitive_data) AS `child.sensitive_data`
 FROM data_security.ds_fs_objects AS f
 INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'File'
+INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
+WHERE f.name = 'docs'
+UNION ALL 
+SELECT 
+      string(child.fs_id) AS `child.fs_id`, 
+      string(child.name) AS `child.name`, 
+      string(child.parent_id) AS `child.parent_id`, 
+      string(child.path) AS `child.path`, 
+      NULL AS `child.sensitive_data`
+FROM data_security.ds_fs_objects AS f
+INNER JOIN data_security.ds_fs_objects AS t0 ON t0.parent_id = f.fs_id AND t0.fs_type = 'Folder'
 INNER JOIN data_security.ds_fs_objects AS child ON child.fs_id = t0.fs_id
 WHERE f.name = 'docs'

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12579,6 +12579,47 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
         );
     }
 
+    /// #827 defect (b) symptom 1: the property-superset collapse must NOT drop a
+    /// label-discriminated SIBLING. `Folder` and `File` share `ds_fs_objects`
+    /// (distinguished by `label_column: fs_type`, distinct `label_value`), and
+    /// `File`'s property set is a strict superset of `Folder`'s (`sensitive_data`),
+    /// so the "polymorphic parent" collapse wrongly treated `File` as a parent of
+    /// `Folder` and dropped the Folder arm — silently losing Folder-access rows.
+    /// The gate keeps both, so `(u:User)-[:HAS_ACCESS]->(target)` renders a
+    /// per-label arm each with its own `object_type` discriminator.
+    ///
+    /// NOTE: the VLP-continuation shape
+    /// (`...-[:MEMBER_OF*..]->(g)-[:HAS_ACCESS]->(target)`) still emits a
+    /// duplicate arm — a SEPARATE, pre-existing union-arm render-state
+    /// contamination bug (reproduces on main and on distinct-table polymorphic
+    /// schemas, independent of this collapse gate; #593/#619 family), tracked
+    /// as its own issue.
+    #[tokio::test]
+    async fn superset_collapse_keeps_discriminated_siblings_827() {
+        let schema = load_schema("examples/data_security/data_security.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (u:User)-[:HAS_ACCESS]->(target) RETURN u.name, target.name",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+        // Both legal target labels survive as their own arm with the correct
+        // per-arm edge discriminator (pre-fix: only the File arm, Folder dropped).
+        assert_eq!(
+            sql.matches("object_type = 'File'").count(),
+            1,
+            "#827(b) sym1: expected exactly one File arm:\n{sql}"
+        );
+        assert_eq!(
+            sql.matches("object_type = 'Folder'").count(),
+            1,
+            "#827(b) sym1: the Folder arm was dropped by the property-superset \
+             collapse (Folder/File are discriminated siblings, not parent/child):\n{sql}"
+        );
+    }
+
     /// #537: `id(a2)`/GROUP BY over a composite-id VLP endpoint (Account
     /// keyed by `(bank_id, account_number)`) used to resolve to only the
     /// FIRST composite-id column (`find_id_column_for_alias`'s GraphNode


### PR DESCRIPTION
## Summary
Symptom 1 of #827 defect (b). The type-inference "polymorphic parent" collapse drops a candidate node label when another candidate's property set is a strict superset — intended for a genuine view-over-parent type (Message over Post+Comment).

It **misfires for label-discriminated siblings**: Folder and File both map to `ds_fs_objects` (node `label_column: fs_type`, distinct `label_value`). File declares one extra property (`sensitive_data`), so File's props ⊃ Folder's → Folder was dropped, **silently losing Folder-access rows** for any untyped-endpoint polymorphic query.

## Fix
Gate the collapse to skip **discriminated siblings**: same `table_name`, both `label_column.is_some()`, different `label_value`. Uses the `NodeSchema` discriminator fields (CLAUDE.md §7), not a raw table-name compare alone.

## Why the genuine parent-collapse is preserved
The only genuine polymorphic-parent schema in the repo (LDBC `Message` over `Post`+`Comment`) models the parent and children as **distinct physical tables** (`Message`/`Post`/`Comment`), and the children carry no `label_column`. The guard requires `table_name` **equal**, so it provably cannot fire for Message/Post/Comment — confirmed structurally and by rendering (Message query still collapses to a single arm). `data_security` is the only schema with same-table `label_value` siblings, so the change is tightly scoped.

## Effect
- `(u:User)-[:HAS_ACCESS]->(target)` and denormalized CONTAINS queries now render a per-label arm each with its own discriminator (`object_type`/`fs_type` = `'Folder'`/`'File'`).
- 8 goldens: 6 clean Folder+File improvements; the 2 `external_users` goldens expose **#836**.

## Known-remaining (out of scope → #836)
The VLP-continuation shape (`...-[:MEMBER_OF*..]->(g)-[:HAS_ACCESS]->(target)`) still emits a duplicate arm — a **separate, pre-existing union-arm render-state contamination bug** (#593/#619 family) that clobbers the second arm's discriminator during outer-union assembly. Proven pre-existing: reproduces on `main` and on distinct-table `social_polymorphic` (`to_type='Post'` on both LIKES arms). It's the remaining blocker for un-xfailing `test_external_users_with_access` (kept xfail).

## Review
Adversarial subagent review: **APPROVE — 0 real issues**. Genuine parent-collapse preserved (verified structurally + rendered on LDBC Message); predicate symmetric/direction-correct; #836 proven pre-existing on main.

## Gate
fmt + clippy(0) + 1604 lib + 534 integration (full) + ratchet(no bump) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)