### PR TITLE
fix(#836): keep per-arm JOINs for polymorphic fixed hop after a VLP

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -116,12 +116,18 @@ Exit met: one fully green nightly run + xpass count 0.
   collapse dropped label-discriminated siblings (Folder/File, same table, distinct
   `label_value`) — File's props ⊃ Folder's silently dropped the Folder arm. Gated to
   skip same-table distinct-`label_value` pairs; genuine parent-collapse (LDBC Message,
-  distinct tables) provably preserved. Both reviews APPROVE-0. **Remaining before
-  un-xfailing `test_external_users_with_access` → split to #836:** the VLP-continuation
-  duplicate-arm bug (a fixed polymorphic hop AFTER a VLP clobbers the 2nd arm's
-  discriminator during outer-union render assembly). PROVEN pre-existing (reproduces on
-  main + on distinct-table `social_polymorphic`, independent of the b-fixes) — the
-  union-arm render-state contamination class (#593/#619, §1.6 systemic, not per-shape).
+  distinct tables) provably preserved. Both reviews APPROVE-0. **#836 DONE 2026-07-30
+  (#839):** the VLP-continuation duplicate-arm bug (a fixed polymorphic hop AFTER a VLP
+  emitted BOTH outer arms with the FIRST label's join+discriminator). The banked "#593/#619
+  systemic render-state contamination cycle" label was WRONG — re-tracing showed the SELECT
+  projections were already per-arm-correct; only the FROM/JOIN was shared. It's a BOUNDED
+  emitter bug: `rewrite_cte_body_vlp_refs` (`to_sql_query.rs`) cloned the base arm's JOINs
+  over every VLP-CTE-reading branch, discarding the branch's own correct joins (written for
+  a genuine undirected reverse arm that has none). Fix = keep the branch's own joins when
+  non-empty; clone base only when empty. Corpus-proven safe (instrument + full sweep: every
+  trigger had own joins empty or == base). One RenderPlan-level edit fixes both dialects.
+  `test_external_users_with_access` stays xfail — its status==200-only assertion can't detect
+  the row-drop; a real un-xfail needs a live server + Group→Group fixture + content asserts.
 
 ### P-1 — Keep a small silent-wrong bug lane open  (standing, ≤1 agent)
 **Lane state (2026-07-28): pool near-exhausted; #716 was the last clean pick.** Since

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4576,7 +4576,20 @@ fn rewrite_cte_body_vlp_refs(plan: &mut RenderPlan, vlp_info: &VlpAliasInfo) {
                 if !branch.joins.0.is_empty() {
                     rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
                 }
+            } else if !branch.joins.0.is_empty() {
+                // The branch already carries its OWN downstream JOINs (e.g. a
+                // polymorphic-target fixed hop AFTER the VLP: each per-label arm
+                // legitimately joins a DIFFERENT target table — `users_bench` vs
+                // `posts_bench`, or a different discriminator). Cloning the base
+                // arm's JOINs over them (as the empty-branch path below does)
+                // froze every arm to the FIRST label's table/discriminator and
+                // silently dropped all other labels' rows (#836). Keep the
+                // branch's own JOINs; only re-apply the VLP alias rewrite.
+                rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
             } else if !original_joins.is_empty() {
+                // Genuine undirected-VLP reverse arm: it has NO downstream JOINs
+                // of its own and depends on the base arm's chained JOINs (e.g.
+                // the anti-self CTE join in LDBC complex-3). Clone them.
                 branch.joins = JoinItems(original_joins.clone());
                 rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
             }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4572,24 +4572,63 @@ fn rewrite_cte_body_vlp_refs(plan: &mut RenderPlan, vlp_info: &VlpAliasInfo) {
             }
 
             // JOINs (same reverse-arm vs. mixed-anchor reasoning)
+            //
+            // Two DIFFERENT shapes both reach this `else` (non-mixed-anchor) path
+            // with a non-empty `branch.joins`, and they need OPPOSITE handling:
+            //
+            //  1. Polymorphic-target continuation (#836): a fixed polymorphic hop
+            //     AFTER the VLP fans into one arm per candidate label. Each arm
+            //     reads the same VLP CTE but joins a DIFFERENT target table
+            //     (`item:users_bench` vs `item:posts_bench`) under the SAME join
+            //     aliases as the base arm. The branch's own joins are a COMPLETE,
+            //     per-label-correct replacement — cloning the base arm's joins over
+            //     them froze every arm to the first label and dropped all other
+            //     labels' rows.
+            //  2. Undirected-VLP reverse arm (e.g. LDBC complex-1): the branch's
+            //     own joins are AUXILIARY (a direction-swapped edge self-join under
+            //     a NEW alias like `t1`) and it STILL depends on the base arm's
+            //     chained join (`friend_p:with_friend_p_cte_0`) under a DISJOINT
+            //     alias. Here the base arm's joins must replace the branch's, as
+            //     before, or `friend_p` is referenced but never defined.
+            //
+            // Discriminate by JOIN-ALIAS COVERAGE (not table names — data_security's
+            // Folder/File arms share one physical table `ds_fs_objects`): keep the
+            // branch's own joins only when they cover EVERY base-join alias slot
+            // (case 1); otherwise the base supplies joins under aliases the branch
+            // lacks, so clone as before (case 2).
+            let branch_covers_base_join_aliases = {
+                let branch_aliases: std::collections::HashSet<&str> = branch
+                    .joins
+                    .0
+                    .iter()
+                    .map(|j| j.table_alias.as_str())
+                    .collect();
+                !original_joins.is_empty()
+                    && original_joins
+                        .iter()
+                        .all(|j| branch_aliases.contains(j.table_alias.as_str()))
+            };
+
             if is_mixed_anchor_branch {
                 if !branch.joins.0.is_empty() {
                     rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
                 }
-            } else if !branch.joins.0.is_empty() {
-                // The branch already carries its OWN downstream JOINs (e.g. a
-                // polymorphic-target fixed hop AFTER the VLP: each per-label arm
-                // legitimately joins a DIFFERENT target table — `users_bench` vs
-                // `posts_bench`, or a different discriminator). Cloning the base
-                // arm's JOINs over them (as the empty-branch path below does)
-                // froze every arm to the FIRST label's table/discriminator and
-                // silently dropped all other labels' rows (#836). Keep the
-                // branch's own JOINs; only re-apply the VLP alias rewrite.
+            } else if branch_covers_base_join_aliases {
+                // Case 1 (#836): the branch's own joins cover every base-join
+                // alias slot — it is a complete per-label replacement (e.g. a
+                // polymorphic-target continuation whose `item` join targets a
+                // different table per label). Keep the branch's own joins; only
+                // re-apply the VLP alias rewrite. Cloning the base arm's joins
+                // here would freeze every arm to the first label's target and
+                // silently drop all other labels' rows.
                 rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
             } else if !original_joins.is_empty() {
-                // Genuine undirected-VLP reverse arm: it has NO downstream JOINs
-                // of its own and depends on the base arm's chained JOINs (e.g.
-                // the anti-self CTE join in LDBC complex-3). Clone them.
+                // Case 2: a genuine undirected-VLP reverse arm. Either it has no
+                // downstream joins of its own, or its own joins are auxiliary and
+                // do NOT cover the base arm's join aliases (e.g. LDBC complex-1's
+                // reverse arm carries a direction-swapped edge self-join but still
+                // needs the base's `friend_p` CROSS JOIN). Clone the base arm's
+                // joins, as before.
                 branch.joins = JoinItems(original_joins.clone());
                 rewrite_joins_for_vlp(&mut branch.joins.0, &reverse_aliases);
             }

--- a/tests/integration/test_security_graph.py
+++ b/tests/integration/test_security_graph.py
@@ -241,7 +241,7 @@ class TestVariableLengthPaths:
 class TestSecurityQueries:
     """Complex security analysis queries."""
     
-    @pytest.mark.xfail(reason="#827 defect (a) FIXED (#689 bug 1 also fixed): the polymorphic `target` no longer fans into triplicated identical UNION arms — `$any` now honors HAS_ACCESS.to_label_values [Folder, File], collapsing to a single arm. But defect (b) remains: that arm hardcodes object_type='File' (table→label reverse-lookup picks alphabetically-first label), so Folder-access rows are silently dropped. Leave xfail until #827 defect (b) lands.")
+    @pytest.mark.xfail(reason="#827 defect (a)+(b) and #836 all FIXED: the polymorphic `target` fixed hop after the MEMBER_OF VLP now emits BOTH per-label arms (object_type='File' AND object_type='Folder') with correct per-arm discriminators — no more first-label clobber (verified by the corpus golden). Remaining blocker is TEST INFRASTRUCTURE, not translation: this case needs a live server + a data_security fixture WITH a Group→Group membership row and CONTENT assertions (the current status==200-only check can't detect the historical row-drop). Un-xfail once that live oracle exists.")
     def test_external_users_with_access(self):
         """Find external users with any access permissions."""
         response = execute_cypher(

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.clickhouse.sql
@@ -45,7 +45,7 @@ SELECT DISTINCT
       t.end_name AS "via_group", 
       t.start_name AS "__order_col_0"
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'Folder')
 WHERE t.start_exposure = 'external'
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestSecurityQueries_test_external_users_with_access.databricks.sql
@@ -45,7 +45,7 @@ SELECT DISTINCT
       t.end_name AS `via_group`, 
       t.start_name AS `__order_col_0`
 FROM vlp_u_g AS t
-INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'File')
+INNER JOIN data_security.ds_permissions AS t0 ON t0.subject_id = t.end_id AND (t0.subject_type = 'Group' AND t0.object_type = 'Folder')
 WHERE t.start_exposure = 'external'
 ) AS __union
 ORDER BY __union.`__order_col_0` ASC

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -191,6 +191,25 @@ async fn ldbc_complex_1() {
     .await;
     assert!(!sql.is_empty());
     assert!(sql.contains("SELECT"));
+    // Regression guard (#836 fix must not break this): complex-1 is an
+    // UNDIRECTED `KNOWS*1..3` VLP whose outer query has TWO union arms, each
+    // referencing the `friend_p` WITH-CTE. Both arms must DEFINE `friend_p`
+    // via its CROSS JOIN — a reverse arm that references `friend_p` in its
+    // SELECT/ON but drops the `CROSS JOIN with_friend_p_cte_0 AS friend_p`
+    // yields `Unknown identifier friend_p` at execution. (The #836 join-clone
+    // fix originally regressed exactly this by keeping the reverse arm's own
+    // auxiliary edge self-join and discarding the base's `friend_p` join.)
+    let friend_p_refs = sql.matches("friend_p.").count();
+    if friend_p_refs > 0 {
+        let cross_join_defs = sql.matches("with_friend_p_cte_0 AS friend_p").count();
+        assert!(
+            cross_join_defs >= 2,
+            "#836 regression: complex-1's two union arms must EACH define \
+             `friend_p` (expected >=2 `with_friend_p_cte_0 AS friend_p` \
+             joins, found {cross_join_defs}); a reverse arm is referencing \
+             `friend_p` without defining it:\n{sql}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12620,6 +12620,59 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
         );
     }
 
+    /// #836: a fixed polymorphic hop FOLLOWING a VLP CTE. Each per-label outer
+    /// UNION arm reads the SAME upstream VLP CTE (`vlp_u_x`) but legitimately
+    /// joins a DIFFERENT downstream target table (User → `users_bench` vs
+    /// Post → `posts_bench`) with a DIFFERENT edge discriminator (`to_type`).
+    /// The ClickHouse emitter's undirected-VLP reverse-arm helper
+    /// (`rewrite_cte_body_vlp_refs`, `to_sql_query.rs`) used to CLONE the
+    /// base/first arm's JOINs onto every non-`vlp_multi_type_*` branch that
+    /// reads a VLP CTE, discarding the branch's OWN correct JOINs — freezing
+    /// every arm to the first label's table + discriminator and silently
+    /// dropping all other labels' rows (outer DISTINCT masked the duplication
+    /// but not the missing labels). Fix: keep the branch's own JOINs when it
+    /// has them; only clone the base arm's JOINs for a genuine reverse arm that
+    /// has NONE of its own. Uses the DISTINCT-table `social_polymorphic` schema
+    /// so the bug is visible as two different physical target tables, not just
+    /// a same-table discriminator flip.
+    #[tokio::test]
+    async fn vlp_continuation_polymorphic_hop_keeps_per_arm_joins_836() {
+        let schema = load_schema("schemas/test/social_polymorphic.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (u:User)-[:FOLLOWS*1..3]->(x:User)-[:LIKES]->(item) \
+                 RETURN u.name, item",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+        // Post arm: to_type='Post' joined to posts_bench on post_id.
+        assert!(
+            sql.contains("brahmand.posts_bench AS item ON item.post_id = t0.to_id"),
+            "#836: the Post arm must join posts_bench on post_id:\n{sql}"
+        );
+        // User arm: to_type='User' joined to users_bench on user_id — this is
+        // the arm that was clobbered to the Post arm's join pre-fix.
+        assert!(
+            sql.contains("brahmand.users_bench AS item ON item.user_id = t0.to_id"),
+            "#836: the User arm must keep its OWN join (users_bench on \
+             user_id), not be clobbered to the Post arm's posts_bench join:\n{sql}"
+        );
+        // Each discriminator appears exactly once across the two outer arms
+        // (pre-fix: to_type = 'Post' appeared twice, to_type = 'User' zero).
+        assert_eq!(
+            sql.matches("t0.to_type = 'Post'").count(),
+            1,
+            "#836: expected exactly one Post-discriminated outer arm:\n{sql}"
+        );
+        assert_eq!(
+            sql.matches("t0.to_type = 'User'").count(),
+            1,
+            "#836: the User-discriminated outer arm was dropped/clobbered:\n{sql}"
+        );
+    }
+
     /// #537: `id(a2)`/GROUP BY over a composite-id VLP endpoint (Account
     /// keyed by `(bank_id, account_number)`) used to resolve to only the
     /// FIRST composite-id column (`find_id_column_for_alias`'s GraphNode


### PR DESCRIPTION
## Problem (#836)

A fixed polymorphic hop **following a VLP CTE** silently dropped rows for every target label except the first-resolved one.

Repro (distinct-table `social_polymorphic`, reproduces on `main`):
```cypher
MATCH (u:User)-[:FOLLOWS*1..3]->(x:User)-[:LIKES]->(item) RETURN u.name, item
```
`item` ∈ {User, Post} → 2 outer UNION arms. **Both** arms emitted `to_type='Post'` + `posts_bench` — the User arm's own correct `users_bench` join was clobbered. Same on same-table `data_security` (both arms `object_type='File'`, all Folder-access rows dropped) — the blocker for `test_external_users_with_access`.

## Root cause

`rewrite_cte_body_vlp_refs` (`sql_generator/emitters/clickhouse/to_sql_query.rs`) — the emitter's undirected-VLP reverse-arm helper — cloned the **base/first arm's** JOINs onto every non-`vlp_multi_type_*` branch that reads a VLP CTE, discarding the branch's OWN correct JOINs. That froze every arm to the first label's table + discriminator. Outer `DISTINCT` masked the duplication but not the missing labels.

## Fix

The clone also serves a genuine **undirected-VLP reverse arm** (e.g. LDBC complex-1 `KNOWS*1..3` undirected + `WITH friend`), which carries an auxiliary direction-swapped edge self-join of its own but STILL depends on the base arm's chained `CROSS JOIN with_friend_p_cte_0 AS friend_p`. So "branch has own joins" is NOT the right discriminator — both shapes have own joins.

Discriminate by **JOIN-ALIAS COVERAGE**: keep the branch's own joins only when they cover *every* base-join alias slot (the polymorphic per-label arm reuses the same `{t2, item}` aliases, different target table); otherwise clone the base joins as before (the reverse arm's own joins use a disjoint alias `{t1}` and don't cover the base's `{friend_p}`). Table names are deliberately **not** used — data_security's Folder/File arms share one physical table `ds_fs_objects` yet are a legitimate keep-own case.

## Review caught a BLOCKING regression in the first cut

The initial version gated keep-own on `!branch.joins.0.is_empty()`, which broke complex-1 (dropped the `friend_p` CROSS JOIN from the reverse arm → `Unknown identifier friend_p`). Caught because the reviewer instrumented across the **full** `--test integration` suite, not just `corpus_sweep`. The corrected alias-coverage version renders complex-1 **byte-identical to main**.

## Verification

- Decision instrumented across the full integration suite: `KEEP_OWN` fires for `vlp_u_g` (data_security) + `vlp_u_x` (social_polymorphic); `CLONE_BASE` fires for `vlp_friend_p` (complex-1) — each correct.
- Golden churn vs main: exactly the 2 `external_users_with_access` files (File-only → File + Folder). Both dialects (one RenderPlan-level pass).
- New regression `vlp_continuation_polymorphic_hop_keeps_per_arm_joins_836` (distinct-table social_polymorphic); revert-checked.
- Strengthened `ldbc_complex_1` from `!is_empty()` to assert both arms DEFINE `friend_p`; revert-checked against the naive-fix regression.
- Full gate green: lib 1604 · integration 535 · ratchet no-bump · fmt · clippy clean.

## Scope

- Join-clone path only. The sibling filter-clone path is unchanged (verified: untyped-poly targets filter only on shared properties; a single-label WHERE prunes the non-matching arm entirely).
- `test_external_users_with_access` stays xfail: its `status==200`-only assertion can't detect the row-drop; a real un-xfail needs a live server + a Group→Group fixture row + content assertions. Reason string updated to record the *translation* bug is fixed.

Closes #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)