### PR TITLE
refactor(SQL-IR Phase 2): route Path C ReduceExpr through reduce_fold_sql

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -446,6 +446,30 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-01: **SQL-IR Phase 2 — route Path C `ReduceExpr` through `reduce_fold_sql`**
+  (PR #842, branch `refactor/sql-ir-path-c-reduce-fold-dialect`). Another of the
+  independent Path-C drift slices the §3.5 investigation flagged as shippable
+  without the full (design-cycle) C→A collapse — and the one genuine renderer leaf
+  an empirical re-scan of all 1,119 Databricks goldens turned up after the "clean
+  leaf pool exhausted" call (the multiIf/toFloat64/splitByChar/JSONExtract golden
+  hits are all schema-config raw SQL, already dispositioned; `arrayFold` is real
+  renderer output). Path C (`cte_extraction.rs::render_expr_to_sql_string`,
+  CTE-build stage) hardcoded CH `arrayFold((acc, x) -> expr, list, init)` for
+  `RenderExpr::ReduceExpr`, while Path A (`RenderExpr::to_sql`) already routes the
+  identical strings through `common::reduce_fold_sql` (→ Spark `aggregate(list,
+  init, (acc, x) -> expr)` on Databricks). Fix: added the one missing sibling
+  re-export (`reduce_fold_sql` to `emitters/clickhouse/mod.rs`) + routed Path C's
+  arm through it; `init_cast` Int64-wrapping preserved ahead of the call. CH
+  byte-identical (helper default arm = same spelling, arg order 1:1); **0 golden
+  churn** — no corpus query reaches ReduceExpr via the CTE-build path (the only
+  corpus `reduce()` goes through Path A), so latent correctness hardening, same
+  profile as #815. New `reduce_fold_sql_tests` module locks both dialect spellings.
+  Gate: fmt · clippy · 1606 lib (+2) · corpus_sweep + sql_golden byte-identical ·
+  ratchet net-zero. Adversarial review APPROVE-0 (byte-identity, arg order,
+  init_cast, re-export reachability, churn honesty all independently verified).
+  **Remaining Path-C hardcoded arm:** `POWER` (Exponentiation) at
+  `cte_extraction.rs:1750` — parser-unreachable dead code (§6/P-6), zero urgency.
+
 - 2026-07-30: **#689 bug 1 — heterogeneous from-side-polymorphic VLP recursive
   CTE joins the right end table** (#828, `c013c07a`). A directed VLP over a
   from-side-polymorphic edge (MEMBER_OF: `member_type ∈ {User, Group}`, target

--- a/docs/design/SQL_IR_DESIGN.md
+++ b/docs/design/SQL_IR_DESIGN.md
@@ -234,14 +234,17 @@ denormalized `rel_alias_mapping`) is logic with **no equivalent inside A at all*
     to it. `quote_json_key` stays backticked (load-bearing JSON key). Churn: 2 CH
     goldens, 0 Databricks. This was the one *empirically-reachable* C drift item.
   - **Hardcoded CH arms in C** (Path A routes all of these): `POWER` (A→dialect),
-    `arrayFold` for ReduceExpr (A→`reduce_fold_sql`→Spark `aggregate`), map-literal
-    `{…}` (A→`map(...)`), simple `CASE` (A→`simple_case_sql`), raw aggregate names,
-    `concat`. **Empirically UNREACHED** — grep of committed `.databricks.sql`
-    goldens for `arrayFold`/`POWER(`/`{'`/`caseWithExpression` = **0 hits each**,
-    while Path A's `aggregate(` appears once. So reduce/map/case/exponent
+    map-literal `{…}` (A→`map(...)`), simple `CASE` (A→`simple_case_sql`), raw
+    aggregate names, `concat`. **`arrayFold` for ReduceExpr — RESOLVED 2026-08-01**
+    (PR #842): C now routes through `common::reduce_fold_sql` (→ Spark `aggregate`),
+    the same helper Path A uses; CH byte-identical, 0 golden churn (ReduceExpr is
+    corpus-unreached via the CTE-build path — the only corpus `reduce()` renders via
+    A). The remaining arms are **empirically UNREACHED** — grep of committed
+    `.databricks.sql` goldens for `POWER(`/`{'`/`caseWithExpression` = **0 hits
+    each**, while Path A's `aggregate(` appears once. So map/case/exponent
     expressions reach the renderer via **A, not C**, in every corpus case. C's
-    hardcoded arms are latent-but-unreached — real drift, zero triggered bugs
-    (the same class as Exponentiation in §6).
+    remaining hardcoded arms are latent-but-unreached — real drift, zero triggered
+    bugs (the same class as Exponentiation in §6).
   - **`InSubquery` placeholder** in C (emits `/* subquery */`, arm 10) vs A's real
     subplan render — a semantic gap, but likely never hit at CTE-build (confirm
     before any collapse).

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1856,8 +1856,11 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             format!("EXISTS ({})", exists.sql)
         }
         RenderExpr::ReduceExpr(reduce) => {
-            // Convert to ClickHouse arrayFold((acc, x) -> expr, list, init)
-            // Cast numeric init to Int64 to prevent type mismatch issues
+            // Route reduce() through the dialect helper so the fold spelling
+            // follows the active dialect (CH `arrayFold(...)` / Spark `aggregate(...)`)
+            // instead of hardcoding ClickHouse here. Cast numeric init to Int64 to
+            // prevent type mismatch issues (mirrors Path A's `RenderExpr::to_sql`
+            // ReduceExpr arm exactly).
             let init_sql = render_expr_to_sql_string(&reduce.initial_value, alias_mapping);
             let list_sql = render_expr_to_sql_string(&reduce.list, alias_mapping);
             let expr_sql = render_expr_to_sql_string(&reduce.expression, alias_mapping);
@@ -1873,9 +1876,12 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 init_sql
             };
 
-            format!(
-                "arrayFold({}, {} -> {}, {}, {})",
-                reduce.variable, reduce.accumulator, expr_sql, list_sql, init_cast
+            crate::clickhouse_query_generator::reduce_fold_sql(
+                &reduce.variable,
+                &reduce.accumulator,
+                &expr_sql,
+                &list_sql,
+                &init_cast,
             )
         }
         RenderExpr::PatternCount(pc) => {

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -375,6 +375,37 @@ mod simple_case_sql_tests {
 }
 
 #[cfg(test)]
+mod reduce_fold_sql_tests {
+    use super::reduce_fold_sql;
+    use crate::server::query_context::{with_query_context, QueryContext};
+    use crate::sql_generator::SqlDialect;
+
+    #[test]
+    fn clickhouse_default_uses_array_fold() {
+        // Default (no scope) = ClickHouse: the historical `arrayFold` spelling,
+        // byte-identical to what both render paths emitted before this helper.
+        assert_eq!(
+            reduce_fold_sql("x", "acc", "acc + x", "[1, 2, 3]", "0"),
+            "arrayFold(x, acc -> acc + x, [1, 2, 3], 0)"
+        );
+    }
+
+    #[tokio::test]
+    async fn databricks_uses_aggregate() {
+        let ctx = QueryContext {
+            dialect: SqlDialect::Databricks,
+            ..QueryContext::default()
+        };
+        let sql = with_query_context(ctx, async {
+            reduce_fold_sql("x", "acc", "acc + x", "[1, 2, 3]", "0")
+        })
+        .await;
+        // Spark has no arrayFold; the fold is `aggregate(list, init, (acc, x) -> expr)`.
+        assert_eq!(sql, "aggregate([1, 2, 3], 0, (acc, x) -> acc + x)");
+    }
+}
+
+#[cfg(test)]
 mod string_predicate_tests {
     use super::{ends_with_predicate, starts_with_predicate};
     use crate::server::query_context::{with_query_context, QueryContext};

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -21,7 +21,7 @@ mod where_clause_tests;
 
 pub use common::{
     contains_predicate, dialect_function_name, ends_with_predicate, qualified_column,
-    quote_identifier, regex_match_predicate, starts_with_predicate,
+    quote_identifier, reduce_fold_sql, regex_match_predicate, starts_with_predicate,
 };
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{


### PR DESCRIPTION
## Summary

SQL-IR Phase-2 dialect-routing slice. Path C (`cte_extraction.rs::render_expr_to_sql_string`, the CTE-build-stage renderer) hardcoded ClickHouse `arrayFold((acc, x) -> expr, list, init)` for `RenderExpr::ReduceExpr`, while Path A (`RenderExpr::to_sql`) already routes the identical component strings through `common::reduce_fold_sql`, which emits Spark `aggregate(list, init, (acc, x) -> expr)` under the Databricks dialect.

So a Cypher `reduce()` reaching the renderer via the CTE-build path emitted CH-only SQL on Databricks — the same dialect-routing drift the SQL-IR track targets (mirrors the shipped simple-CASE #811, STARTS/ENDS WITH #813, and RegexMatch #815 slices).

## Change

- Add `reduce_fold_sql` to the `clickhouse` module re-export (`emitters/clickhouse/mod.rs`) — it was the one sibling helper missing there; `contains_predicate`/`regex_match_predicate`/etc. were already exported.
- Route Path C's `ReduceExpr` arm through `crate::clickhouse_query_generator::reduce_fold_sql`. The `init_cast` Int64-wrapping (identical to Path A) is preserved ahead of the call.
- New `reduce_fold_sql_tests` unit module locks both dialect spellings (sibling of the existing `simple_case_sql_tests`).

## Byte-identity / churn

CH byte-identical: the helper's default arm is the same `arrayFold(...)` spelling, argument order maps 1:1 to the old inline `format!` and to Path A's call. **0 `.clickhouse.sql`/`.databricks.sql` golden churn** — no committed corpus query reaches ReduceExpr via the CTE-build path (the only corpus `reduce()` goes through Path A). Latent correctness hardening, not a locked-bad leak — same profile as #815.

## Gate

fmt · clippy clean · 1606 lib (+2) · corpus_sweep + sql_golden byte-identical (0 churn) · ratchet net-zero.

Adversarial review: APPROVE, 0 real code defects (byte-identity, arg order, init_cast preservation, re-export reachability, and reachability/churn honesty all independently verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)