### PR TITLE
fix: OPTIONAL MATCH over FK-edge-to-node table drops unmatched anchor rows

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -457,6 +457,34 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-01: **P-1 — OPTIONAL MATCH over FK-edge-to-node table drops unmatched
+  anchor rows** (PR #845, branch `fix/optional-fk-edge-anchor-inversion`). Silent
+  DATA LOSS found via a live silent-wrong bug hunt: `MATCH (u:User) OPTIONAL MATCH
+  (u)-[:AUTHORED]->(p:Post)` returned 5 rows not 6 — post-less users vanished. The
+  FROM anchor inverted to `FROM posts LEFT JOIN users` (mandatory `u` on the
+  nullable side). Trigger: `AUTHORED` is an FK-edge whose edge table IS the to-node
+  table (`table: posts`, `to_node: Post`) → `FkEdgeJoin{join_side:Left}`, whose
+  natural FROM node is the RIGHT (optional) node, so `select_anchor` rooted FROM at
+  the optional side; latent under non-optional (INNER symmetric), data loss under
+  OPTIONAL/LEFT JOIN. Fix (3 files, schema-catalog dispatch per Rule #7, ratchet
+  net-zero): new `JoinStrategy::natural_from_node_position()` (pattern_schema.rs);
+  "signal 2" in inference.rs re-roots FROM at the required node when
+  `natural_from == Some(Right)` && right-optional && left-required (only
+  `FkEdgeJoin{join_side:Left}`); generalized the join_builder.rs FK-edge
+  phantom-join dedup (skip an input rel join duplicating an edge already under a
+  NODE-connection alias, guarded to keep two-hop self-chains + `pre_filter` named
+  rels). Live-verified (6 rows w/ Eve NULL; LIKED/non-optional/reverse/self-ref/
+  polymorphic all correct); `test_nested_optional_matches` golden had DROPPED the
+  mandatory users table (real data loss) — now preserved. 8 goldens, +1 regression
+  test. Adversarial review APPROVE-0 (both guards stress-tested live incl. an
+  over-fire probe). **Two secondary silent-wrong findings from the same hunt
+  DEFERRED** (different class — Cypher function-semantics fidelity, needs a small
+  Neo4j-compat policy call, not one-off patching): (1) `round()` uses CH banker's
+  rounding (`round(2.5)`→2) vs Neo4j half-away-from-zero (→3), root
+  `function_registry.rs` round→round 1:1; (2) integer division `7/2`→3.5 (Cypher
+  int/int should be 3 via intDiv), root `Operator::Division` renders `/`
+  unconditionally without operand-type awareness.
+
 - 2026-08-01: **SQL-IR Phase 2 — route Path C `ReduceExpr` through `reduce_fold_sql`**
   (PR #842, branch `refactor/sql-ir-path-c-reduce-fold-dialect`). Another of the
   independent Path-C drift slices the §3.5 investigation flagged as shippable

--- a/src/graph_catalog/pattern_schema.rs
+++ b/src/graph_catalog/pattern_schema.rs
@@ -503,6 +503,41 @@ impl JoinStrategy {
         )
     }
 
+    /// Which node position this strategy roots the FROM clause at when neither
+    /// endpoint is already bound (the "first pattern" / `(false, false)` case in
+    /// `generate_pattern_joins`).
+    ///
+    /// This is the node that becomes the `from_marker` — the preserved/anchor
+    /// side of the pattern. It is NOT always the left node: an `FkEdgeJoin`
+    /// where the edge table IS the *right* node table (e.g. `AUTHORED` mapped to
+    /// `posts` with `to_node = Post`) roots FROM at the *right* node and JOINs
+    /// the left node onto it.
+    ///
+    /// Returns `None` for edge-rooted strategies (denormalized / mixed / coupled
+    /// / edge-to-edge), where the FROM marker is the relationship table itself
+    /// rather than a node — those use a separate OPTIONAL-MATCH anchor mechanism
+    /// (standalone denorm-scan CTEs), so callers should fall back to their
+    /// default (left-node) assumption.
+    pub fn natural_from_node_position(&self) -> Option<NodePosition> {
+        match self {
+            // (false, false) emits `from_marker(left)`, then JOIN edge + right.
+            JoinStrategy::Traditional { .. } => Some(NodePosition::Left),
+            // Fk-edge: `join_side` names the node that needs a JOIN, so the
+            // OTHER node is the edge table and roots FROM.
+            //   join_side = Left  → right node IS the edge table → FROM = right
+            //   join_side = Right → left node IS the edge table  → FROM = left
+            JoinStrategy::FkEdgeJoin { join_side, .. } => Some(match join_side {
+                NodePosition::Left => NodePosition::Right,
+                NodePosition::Right => NodePosition::Left,
+            }),
+            // Edge-rooted strategies: FROM is the relationship table, not a node.
+            JoinStrategy::SingleTableScan { .. }
+            | JoinStrategy::MixedAccess { .. }
+            | JoinStrategy::EdgeToEdge { .. }
+            | JoinStrategy::CoupledSameRow { .. } => None,
+        }
+    }
+
     /// Returns a human-readable description
     pub fn description(&self) -> &'static str {
         match self {

--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -2778,21 +2778,75 @@ impl GraphJoinInference {
 
         // Step 1: Generate anchor-aware joins based on strategy
         // Pass join_ctx aliases so the generator knows which nodes are already available.
-        // For OPTIONAL MATCH with incoming direction, the anchor_connection (from the
-        // required MATCH) must be treated as "already available" so that the join
-        // generator places it as FROM (not as a new JOIN target). Without this,
-        // incoming OPTIONAL MATCH puts the optional node as FROM instead of the anchor.
-        // Only activate when anchor != left_alias — for outgoing patterns where
-        // anchor IS the left alias, the default (false,false) path already works.
+        // For OPTIONAL MATCH, the required node (from the outer MATCH) must become the
+        // FROM/preserved side so anchor rows with zero optional matches survive the
+        // LEFT JOIN. The join generator places a node as FROM by treating it as
+        // "already available"; we inject the required node here when the strategy would
+        // otherwise root FROM at the OPTIONAL node.
+        //
+        // Two distinct signals feed this:
+        //  1. `anchor_connection` (set by the analyzer for the INCOMING override shape
+        //     `MATCH (a) OPTIONAL MATCH (b)-[:R]->(a)`, where the anchor `a` is the
+        //     right connection). This is the historical case.
+        //  2. An OPTIONAL pattern whose strategy roots FROM at a node that is itself
+        //     the optional side. `determine_optional_anchor` deliberately leaves
+        //     `anchor_connection = None` for the common outgoing left-anchor shape
+        //     `MATCH (u) OPTIONAL MATCH (u)-[:R]->(p)` (setting it would wrongly filter
+        //     out WHERE predicates on the optional alias). For a Traditional strategy
+        //     that's fine — FROM roots at the required left node `u` anyway. But an
+        //     FK-edge whose edge table IS the RIGHT node table (e.g. `AUTHORED`
+        //     collapsed onto `posts`, `to_node = Post`) roots FROM at the right node
+        //     `p` — the OPTIONAL side — so `p` becomes the preserved side and every
+        //     post-less user is silently dropped. Detect this via the schema-catalog
+        //     `JoinStrategy::natural_from_node_position` (which equals the left node for
+        //     every strategy EXCEPT `FkEdgeJoin { join_side: Left }`) and re-root FROM
+        //     at the required (non-optional) node. Byte-identical for all previously
+        //     correct shapes; only the collapsed FK-edge-to-right-node OPTIONAL case
+        //     changes.
         let mut already_available = join_ctx.to_hashset();
-        let anchor_needs_from = if let Some(ref anchor) = _graph_rel.anchor_connection {
-            // Only inject anchor as "already available" when it's NOT the left alias.
-            // For outgoing OPTIONAL MATCH (u)-[:R]->(f) with anchor=u (left), the
-            // standard (false,false) branch in generate_pattern_joins handles it correctly.
-            // For incoming OPTIONAL MATCH (b)-[:R]->(a) with anchor=a (right), we need
-            // to force the generator to treat anchor as available so it doesn't create
-            // a FROM marker for the optional node instead.
-            if anchor.as_str() != left_alias && !already_available.contains(anchor) {
+        let natural_from_position = ctx.join_strategy.natural_from_node_position();
+        let natural_from_alias: &str = match natural_from_position {
+            Some(crate::graph_catalog::pattern_schema::NodePosition::Right) => right_alias,
+            // Left node, or edge-rooted strategies (None) whose FROM is the
+            // relationship table — for those the left-node default is retained,
+            // exactly as before this dispatch existed.
+            _ => left_alias,
+        };
+        // Derive the alias that must anchor FROM. Prefer the analyzer's explicit
+        // anchor_connection (signal 1); otherwise, for an OPTIONAL FK-edge whose
+        // edge table IS the RIGHT node (`natural_from_position == Right`) and that
+        // right node is the optional side, re-root at the required node (signal 2).
+        //
+        // Signal 2 is scoped to `natural_from_position == Some(Right)` — the ONLY
+        // strategy that roots FROM at a non-left node (`FkEdgeJoin { join_side:
+        // Left }`). Every other strategy roots FROM at the left node (or, for
+        // edge-rooted strategies, the relationship table), and their OPTIONAL
+        // anchoring is already handled by `anchor_connection` (incoming override)
+        // and the BidirectionalUnion combined-anchor mechanism — leaving those
+        // paths untouched keeps this change byte-identical for them.
+        let is_optional_pattern = _graph_rel.is_optional.unwrap_or(false);
+        let effective_anchor: Option<String> = _graph_rel.anchor_connection.clone().or_else(|| {
+            if is_optional_pattern
+                && matches!(
+                    natural_from_position,
+                    Some(crate::graph_catalog::pattern_schema::NodePosition::Right)
+                )
+                && right_is_optional
+                && !left_is_optional
+            {
+                // FK-edge collapsed onto the OPTIONAL right node → anchor the
+                // required left node so its zero-match rows survive.
+                Some(left_alias.to_string())
+            } else {
+                None
+            }
+        });
+        let anchor_needs_from = if let Some(ref anchor) = effective_anchor {
+            // Inject the anchor as "already available" only when it is NOT the
+            // strategy's natural FROM node. When the anchor already IS the FROM
+            // node (standard outgoing patterns), the default (false, false) branch
+            // in generate_pattern_joins already places it as FROM.
+            if anchor.as_str() != natural_from_alias && !already_available.contains(anchor) {
                 already_available.insert(anchor.clone());
                 true
             } else {
@@ -2812,10 +2866,10 @@ impl GraphJoinInference {
 
         // Step 1b: If the anchor was injected as "already available" but doesn't have
         // a FROM marker in collected_graph_joins, prepend one. This happens for
-        // OPTIONAL MATCH with incoming edges where the anchor node comes from the
-        // required MATCH but hasn't been added as a JOIN yet.
+        // OPTIONAL MATCH where the anchor node comes from the required MATCH but the
+        // strategy would not otherwise emit a FROM marker for it.
         if anchor_needs_from {
-            if let Some(ref anchor) = _graph_rel.anchor_connection {
+            if let Some(ref anchor) = effective_anchor {
                 let anchor_already_joined = collected_graph_joins
                     .iter()
                     .any(|j| j.table_alias.as_str() == anchor.as_str());

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -1591,6 +1591,75 @@ impl JoinBuilder for LogicalPlan {
                     Vec<OperatorApplication>,
                 > = std::collections::HashMap::new();
 
+                // #—: An FK-edge relationship collapses onto its owning node
+                // table: the analyzer emits it ONCE in `graph_joins.joins`, under
+                // the collapsed NODE's connection alias (e.g. `p` for `(p:Post)`),
+                // carrying the relationship's own from/to id columns. The generic
+                // extract_joins recursion over the same GraphRel independently
+                // emits the relationship AGAIN under its auto-generated REL alias
+                // (e.g. `t1`), producing a phantom duplicate scan of the same table
+                // with the same join columns.
+                //
+                // The pre-existing `anchor_table_name` check below drops that
+                // phantom only when the collapsed node is the FROM anchor. When the
+                // anchor is the OTHER endpoint — e.g. OPTIONAL `MATCH (u) OPTIONAL
+                // MATCH (u)-[:AUTHORED]->(p)` with FROM rooted at the required `u`,
+                // leaving the collapsed `p` as a non-anchor JOIN — the phantom `t1`
+                // no longer matches the anchor table and would leak through as a
+                // spurious extra `LEFT JOIN posts AS t1`.
+                //
+                // Drop it precisely: skip an input relationship join whose
+                // (table, from_id, to_id) already appears in `graph_joins.joins`
+                // under a DIFFERENT alias that is a NODE connection alias (the
+                // collapse target). Gating on the existing alias being a node —
+                // NOT a relationship alias — is what distinguishes the FK-edge
+                // collapse from a legitimate two-hop self-chain on a normal edge
+                // table (e.g. `(p)-[:FOLLOWS]->()-[:FOLLOWS]->(c)`, where `t0` and
+                // `t1` share (table, from_id, to_id) but are BOTH needed and BOTH
+                // live under rel aliases, so neither is a node connection).
+                let node_connection_aliases: std::collections::HashSet<String> = {
+                    fn collect(plan: &LogicalPlan, acc: &mut std::collections::HashSet<String>) {
+                        match plan {
+                            LogicalPlan::GraphRel(gr) => {
+                                acc.insert(gr.left_connection.clone());
+                                acc.insert(gr.right_connection.clone());
+                                collect(&gr.left, acc);
+                                collect(&gr.right, acc);
+                            }
+                            LogicalPlan::Projection(p) => collect(&p.input, acc),
+                            LogicalPlan::Filter(f) => collect(&f.input, acc),
+                            LogicalPlan::GroupBy(g) => collect(&g.input, acc),
+                            LogicalPlan::GraphNode(gn) => collect(&gn.input, acc),
+                            LogicalPlan::GraphJoins(gj) => collect(&gj.input, acc),
+                            _ => {}
+                        }
+                    }
+                    let mut acc = std::collections::HashSet::new();
+                    collect(&graph_joins.input, &mut acc);
+                    acc
+                };
+                let input_join_is_dup_fk_edge = |input_join: &Join| -> bool {
+                    if input_join.from_id_column.is_none() || input_join.to_id_column.is_none() {
+                        return false;
+                    }
+                    // A phantom duplicate carries no additional constraint of its
+                    // own: it is the bare re-emission of the same collapsed edge.
+                    // A join with a `pre_filter` (e.g. a NAMED relationship with a
+                    // WHERE clause, `[r:PLACED_BY]->(c) WHERE r.order_date > …`)
+                    // is a legitimately-separate reference that must survive —
+                    // dropping it would silently lose the filter. Keep those.
+                    if input_join.pre_filter.is_some() {
+                        return false;
+                    }
+                    graph_joins.joins.iter().any(|j| {
+                        j.table_alias != input_join.table_alias
+                            && node_connection_aliases.contains(&j.table_alias)
+                            && j.table_name == input_join.table_name
+                            && j.from_id_column == input_join.from_id_column
+                            && j.to_id_column == input_join.to_id_column
+                    })
+                };
+
                 for input_join in input_joins {
                     // Skip if alias already exists
                     if existing_aliases.contains(&input_join.table_alias) {
@@ -1616,27 +1685,33 @@ impl JoinBuilder for LogicalPlan {
                     //   - relationship alias "r" also points to posts_bench
                     //   - We should NOT add: JOIN posts_bench AS r
                     //   - Instead, "r" properties should be accessed via "po" alias
-                    if let Some(ref anchor_name) = anchor_table_name {
-                        if &input_join.table_name == anchor_name {
-                            log::info!(
-                                "🔑 Skipping duplicate JOIN for FK-edge: {} AS {} (same table as anchor '{}')",
-                                input_join.table_name,
-                                input_join.table_alias,
-                                graph_joins.anchor_table.as_ref().unwrap()
-                            );
-                            // Also capture conditions from this skipped join
-                            for cond in &input_join.joining_on {
-                                for cte_alias in graph_joins.cte_references.keys() {
-                                    if condition_references_alias(cond, cte_alias) {
-                                        skipped_cte_conditions
-                                            .entry(cte_alias.clone())
-                                            .or_default()
-                                            .push(cond.clone());
-                                    }
+                    //
+                    // The collapsed node need not be the anchor: also skip an
+                    // input relationship join that duplicates an FK-edge already
+                    // materialized under a different alias (see the
+                    // `input_join_is_dup_fk_edge` note above).
+                    let matches_anchor = anchor_table_name
+                        .as_ref()
+                        .is_some_and(|anchor_name| &input_join.table_name == anchor_name);
+                    if matches_anchor || input_join_is_dup_fk_edge(&input_join) {
+                        log::info!(
+                            "🔑 Skipping duplicate JOIN for FK-edge: {} AS {} (collapses onto already-covered node table; anchor='{:?}')",
+                            input_join.table_name,
+                            input_join.table_alias,
+                            graph_joins.anchor_table
+                        );
+                        // Also capture conditions from this skipped join
+                        for cond in &input_join.joining_on {
+                            for cte_alias in graph_joins.cte_references.keys() {
+                                if condition_references_alias(cond, cte_alias) {
+                                    skipped_cte_conditions
+                                        .entry(cte_alias.clone())
+                                        .or_default()
+                                        .push(cond.clone());
                                 }
                             }
-                            continue;
                         }
+                        continue;
                     }
 
                     log::info!(

--- a/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_nested_optional_matches.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_nested_optional_matches.clickhouse.sql
@@ -1,4 +1,5 @@
 SELECT 
       count(*) AS "total"
-FROM test_integration.posts_test AS p
+FROM test_integration.users_test AS a
+LEFT JOIN test_integration.posts_test AS p ON p.author_id = a.user_id
 LEFT JOIN test_integration.post_likes_test AS t0 ON t0.post_id = p.post_id

--- a/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_nested_optional_matches.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_nested_optional_matches.databricks.sql
@@ -1,4 +1,5 @@
 SELECT 
       count(*) AS `total`
-FROM test_integration.posts_test AS p
+FROM test_integration.users_test AS a
+LEFT JOIN test_integration.posts_test AS p ON p.author_id = a.user_id
 LEFT JOIN test_integration.post_likes_test AS t0 ON t0.post_id = p.post_id

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestCrossSchemaPatterns_test_optional_match_pattern__standard_MATCH_u_User_OPTIONAL_MATCH_u_AUTHORED_p_Post_RETURN_u_name_count_p_AS_cnt.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestCrossSchemaPatterns_test_optional_match_pattern__standard_MATCH_u_User_OPTIONAL_MATCH_u_AUTHORED_p_Post_RETURN_u_name_count_p_AS_cnt.clickhouse.sql
@@ -1,6 +1,6 @@
 SELECT 
       u.full_name AS "u.name", 
       count(p.post_id) AS "cnt"
-FROM db_standard.posts AS p
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestCrossSchemaPatterns_test_optional_match_pattern__standard_MATCH_u_User_OPTIONAL_MATCH_u_AUTHORED_p_Post_RETURN_u_name_count_p_AS_cnt.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestCrossSchemaPatterns_test_optional_match_pattern__standard_MATCH_u_User_OPTIONAL_MATCH_u_AUTHORED_p_Post_RETURN_u_name_count_p_AS_cnt.databricks.sql
@@ -1,6 +1,6 @@
 SELECT 
       u.full_name AS `u.name`, 
       count(p.post_id) AS `cnt`
-FROM db_standard.posts AS p
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_basic.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_basic.clickhouse.sql
@@ -1,6 +1,6 @@
 SELECT 
       u.full_name AS "u.name", 
       count(p.post_id) AS "posts"
-FROM db_standard.posts AS p
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_basic.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_basic.databricks.sql
@@ -1,6 +1,6 @@
 SELECT 
       u.full_name AS `u.name`, 
       count(p.post_id) AS `posts`
-FROM db_standard.posts AS p
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_chain.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_chain.clickhouse.sql
@@ -2,7 +2,7 @@ SELECT
       u.full_name AS "u.name", 
       count(DISTINCT p.post_id) AS "posts", 
       count(DISTINCT t0.user_id) AS "likers"
-FROM db_standard.posts AS p
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 LEFT JOIN db_standard.post_likes AS t0 ON t0.post_id = p.post_id
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_chain.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_standard/test_schema_sql_generation__TestStandardSchema_test_optional_match_chain.databricks.sql
@@ -2,7 +2,7 @@ SELECT
       u.full_name AS `u.name`, 
       count(DISTINCT p.post_id) AS `posts`, 
       count(DISTINCT t0.user_id) AS `likers`
-FROM db_standard.posts AS p
+FROM db_standard.users AS u
+LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
 LEFT JOIN db_standard.post_likes AS t0 ON t0.post_id = p.post_id
-LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
 GROUP BY u.full_name

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -4147,12 +4147,57 @@ async fn denorm_count_node_resolves_embedded_id_column_493() {
     }
 }
 
+/// FK-edge-to-to-node OPTIONAL MATCH FROM-anchoring regression: an OPTIONAL
+/// MATCH over an FK-edge relationship whose edge table IS the *to-node*'s
+/// table (`AUTHORED` mapped onto `posts`, `from_node = User`, `to_node =
+/// Post`, edge lives on `posts`) must root the FROM clause at the REQUIRED
+/// outer-MATCH node (`users`), NOT the optional/collapsed `posts` node.
+///
+/// The `FkEdgeJoin { join_side: Left }` strategy naturally roots FROM at the
+/// RIGHT node (`posts`) — correct for a plain MATCH (INNER JOIN is symmetric),
+/// but catastrophic under OPTIONAL: `posts` became the preserved FROM side and
+/// `users` the LEFT-JOINed nullable side, so every user who authored no post
+/// was silently dropped (5 rows instead of 6, missing the NULL-extended row).
+/// The fix (`JoinStrategy::natural_from_node_position` +
+/// `handle_graph_pattern_v2` signal-2) re-roots FROM at the required `users`
+/// and folds the collapsed `posts` as a single LEFT JOIN, with no phantom
+/// duplicate `posts` edge join. Locks both invariants.
+#[tokio::test]
+async fn fk_edge_to_node_optional_from_anchors_required_node() {
+    let schema = load_schema("schemas/dev/social_standard.yaml");
+    let cypher = "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.post_id";
+    let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+
+    // FROM must be the required node `users` (preserved side), not the
+    // optional/collapsed `posts`.
+    let from_line = sql
+        .lines()
+        .find(|l| l.trim_start().starts_with("FROM "))
+        .unwrap_or("");
+    assert!(
+        from_line.contains("users") && !from_line.contains("posts"),
+        "OPTIONAL FK-edge (edge IS to-node): FROM must root at the required \
+         `users`, not the optional `posts`. Got FROM line: `{from_line}`\n\nFull SQL:\n{sql}"
+    );
+
+    // `posts` must appear exactly once as a LEFT JOIN (the collapsed FK-edge
+    // node) — never a phantom duplicate edge scan (`LEFT JOIN posts AS t1`).
+    let posts_join_count = sql
+        .lines()
+        .filter(|l| l.contains("JOIN") && l.contains("posts"))
+        .count();
+    assert_eq!(
+        posts_join_count, 1,
+        "OPTIONAL FK-edge: `posts` must be a single LEFT JOIN, no phantom \
+         duplicate edge scan. Got {posts_join_count} posts JOINs.\n\nFull SQL:\n{sql}"
+    );
+    assert!(
+        sql.contains("LEFT JOIN"),
+        "OPTIONAL MATCH must render a LEFT JOIN (preserves anchor rows):\n{sql}"
+    );
+}
+
 /// #502 regression: `count(r)` on an OPTIONAL MATCH relationship must render
-/// as a NULL-sensitive count over one of the edge's own (edge_id) columns,
-/// not `count(*)`. `count(*)` counts the anchor row itself, which a LEFT
-/// JOIN always preserves (NULL-extended) even when the relationship never
-/// matched — so a zero-edge anchor silently reported `count(r) == 1`. This
-/// is the relationship-count sibling of #493's node-count fix (`count(b)` ->
 /// `count(t0.dest_code)`).
 #[tokio::test]
 async fn denorm_count_relationship_resolves_edge_id_column_502() {


### PR DESCRIPTION
## Summary

Fixes a **silent-wrong data-loss bug**: `MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.post_id` returned **5 rows instead of 6** — users who authored no posts (Eve Davis) were silently dropped instead of appearing with a NULL post.

The generated SQL inverted the join anchor:
```sql
-- BEFORE (wrong): mandatory `u` on the nullable LEFT-JOIN side → post-less users eliminated
FROM db_standard.posts AS p
LEFT JOIN db_standard.users AS u ON u.user_id = p.user_id
-- AFTER (correct):
FROM db_standard.users AS u
LEFT JOIN db_standard.posts AS p ON p.user_id = u.user_id
```

## Trigger

`AUTHORED` is an FK-edge whose edge table **IS** the to-node's table (`table: posts`, `to_node: Post`, `edge_id: post_id`). Edge + `Post` node collapse onto `posts` → strategy `FkEdgeJoin { join_side: Left }`, whose natural FROM node is the **right** (optional) node. `select_anchor` rooted FROM at the optional side. Latent under non-optional MATCH (INNER JOIN is symmetric), it becomes data loss under OPTIONAL/LEFT JOIN.

Found via a live silent-wrong bug hunt (confirmed independently 3×); not in PRIORITIES/git log. Anchor-aware-join class (CLAUDE Rule #4), **not** the reverse-mapping/systemic class.

## Fix (3 source files, routed through schema-catalog dispatch per Rule #7)

- **`pattern_schema.rs`** — new `JoinStrategy::natural_from_node_position()` naming which node position roots FROM (`Left` for Traditional; the non-edge node for FkEdgeJoin; `None` for edge-rooted strategies).
- **`inference.rs`** — "signal 2": for an OPTIONAL pattern where `natural_from_node_position() == Some(Right)` (only `FkEdgeJoin{join_side:Left}`) with the right node optional and the left required, inject the required left node as the effective anchor. Scoped so Traditional / BidirectionalUnion / edge-rooted / incoming-override paths are byte-identical.
- **`join_builder.rs`** — generalized the FK-edge phantom-join dedup (once FROM re-roots at `users`, the recursion re-emitted a spurious `LEFT JOIN posts AS t1`). Skip an input rel join whose `(table, from_id, to_id)` already appears under a NODE-connection alias, guarded to (a) exclude two-hop self-chains and (b) preserve filtered named relationships (`pre_filter.is_some()`).

## Verification (live ClickHouse)

| Query | Before | After |
|---|---|---|
| OPTIONAL AUTHORED | 5 (Eve dropped) | **6, Eve/NULL** ✓ |
| OPTIONAL LIKED (separate table) | correct | unchanged ✓ |
| non-optional AUTHORED | 5 posts | unchanged ✓ |
| reverse FK-edge / chained OPTIONALs / WHERE-on-optional / self-ref / polymorphic | — | all correct ✓ |

**Golden churn:** 8 files (4 tests × 2 dialects), each a FROM-inversion correction. `test_nested_optional_matches` had **dropped the mandatory users table entirely** (real data loss) — now preserved. New regression test `fk_edge_to_node_optional_from_anchors_required_node`.

**Gate:** fmt · clippy clean · 1606 lib · 243 golden (+1) · corpus_sweep byte-identical · ratchet net-zero.

**Adversarial review: APPROVE — 0 real code defects** (both guards stress-tested live: reverse FK-edges, two-hop self-chains, filtered named rels, and a two-nodes-sharing-columns over-fire probe all correct; non-optional paths byte-identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)