### PR TITLE
fix(#637): implicit GROUP BY keeps grouping keys buried in aggregate items (RETURN + WITH)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -457,6 +457,45 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-01: **#637 — implicit GROUP BY drops grouping keys buried inside
+  aggregate-containing items (RETURN + WITH barriers)** (`fix/637-buried-grouping-keys`).
+  A grouping key buried inside a RETURN/WITH item that ALSO contains an aggregate
+  (`RETURN a.user_id + count(b)`, `RETURN a.city + ':' + toString(count(b))`,
+  `WITH a.user_id + count(b) AS x`) was dropped → no GROUP BY emitted → ClickHouse
+  Code 215 NOT_AN_AGGREGATE (silent wrong buckets on lenient backends). Root cause
+  was **independent aggregate/non-aggregate split sites across phases**, each
+  keying GROUP BY on whole aggregate-FREE items only: analyzer
+  `group_by_building.rs` (RETURN barrier) and render `with_to_cte/mod.rs:~7852`
+  (WITH barrier). Fix: one shared exhaustive `collect_grouping_keys` in
+  `logical_expr/visitors.rs` (built on `HasAggregateCheck`/`walk_expression`)
+  returning the **maximal aggregate-free sub-expression(s)** that reference a
+  column/alias; routed through both barriers; the RETURN-barrier's incomplete
+  local `contains_aggregate` (missed the legacy `Operator` variant + array/map
+  containers) retired in favor of `HasAggregateCheck`. Maximal-subtree (not
+  leaf-fragment) semantics keeps the existing `CASE…END`/`u1.name` corpus grouping
+  keys byte-identical AND renders valid CH (`GROUP BY concat(a.city, ':')` matches
+  the SELECT's non-aggregate operand). Behavior-preserving split: aggregate-free
+  whole items pushed as before (incl. constant keys, `RETURN 'all_users', count(n)`
+  → `GROUP BY 'all_users'`), buried keys added; deduped structurally. **0 corpus
+  churn** (1,229 queries × 2 dialects — verified independently + by Explore agent;
+  no corpus query mixed a column ref with an aggregate in one item). Gate: fmt ·
+  clippy clean · full lib+integration+doctests · corpus_sweep + sql_golden (+3 new
+  #637 goldens, fail-when-reverted) 0 churn · ratchet net-zero. No live CH in env —
+  correctness bar is SQL shape + byte goldens + full gate (the required
+  `GROUP BY a.id` with `a.id + count(...)` in SELECT is standard SQL).
+  **THIRD SITE DEFERRED:** the UNION-return builder `return_clause.rs`
+  `build_union_with_aggregation` (~741) has the same buried-key gap, but a correct
+  fix there needs additional inner-UNION projection plumbing (the collected
+  grouping expr must reference a column the inner `__union` actually projects) — an
+  isolated `collect_grouping_keys` swap is **inert** (byte-identical to main;
+  verified via branch-vs-main diff on the `#503` denorm shape). Filed as
+  **follow-up #844**; NOT fixed here to keep the change honest and byte-locked.
+  Adversarial review (general-purpose subagent): SUBSTANTIVE COUNT 1 (the missing
+  site-3 lock), which on follow-through revealed the site-3 change was inert — hence
+  the deferral. **Closes #637 (RETURN+WITH); also closes #600** (sub-defects 2
+  `name`→`full_name` inline-map WHERE + 3 stDev-post-WITH were already fixed on main
+  via #638/#551; sub-defect 1 == #637, now fixed for RETURN+WITH).
+
 - 2026-08-01: **P-1 — `round()` matches Neo4j semantics (was ClickHouse banker's
   rounding)** (PR #848, branch `fix/round-neo4j-half-up-fidelity`). Silent-wrong
   openCypher fidelity bug from the same live hunt: `round`→CH `round` = HALF_EVEN
@@ -477,6 +516,7 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   (negatives/ties/prec-0/decimal/overflow/NULL/columns/WHERE-CTE) all match Neo4j;
   5 unit + 1 golden test assert correct values. Gate: fmt · clippy · 1611 lib · 244
   golden · corpus byte-identical (0 churn) · ratchet net-zero.
+
 
 - 2026-08-01: **P-1 — OPTIONAL MATCH over FK-edge-to-node table drops unmatched
   anchor rows** (PR #845, branch `fix/optional-fk-edge-anchor-inversion`). Silent
@@ -505,6 +545,7 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   inference in `Operator::Division`, column operands untypeable without schema
   column types).
 
+
 - 2026-08-01: **SQL-IR Phase 2 — route Path C `ReduceExpr` through `reduce_fold_sql`**
   (PR #842, branch `refactor/sql-ir-path-c-reduce-fold-dialect`). Another of the
   independent Path-C drift slices the §3.5 investigation flagged as shippable
@@ -528,6 +569,7 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   init_cast, re-export reachability, churn honesty all independently verified).
   **Remaining Path-C hardcoded arm:** `POWER` (Exponentiation) at
   `cte_extraction.rs:1750` — parser-unreachable dead code (§6/P-6), zero urgency.
+
 
 - 2026-07-30: **#689 bug 1 — heterogeneous from-side-polymorphic VLP recursive
   CTE joins the right end table** (#828, `c013c07a`). A directed VLP over a

--- a/src/query_planner/analyzer/group_by_building.rs
+++ b/src/query_planner/analyzer/group_by_building.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use crate::query_planner::{
     analyzer::analyzer_pass::{AnalyzerPass, AnalyzerResult},
+    logical_expr::visitors::{self, HasAggregateCheck},
     logical_expr::LogicalExpr,
-    logical_plan::{GroupBy, LogicalPlan, Projection, ProjectionItem},
+    logical_plan::{GroupBy, LogicalPlan, Projection},
     plan_ctx::PlanCtx,
     transformed::Transformed,
 };
@@ -43,42 +44,6 @@ impl GroupByBuilding {
                     .any(|item| Self::references_projection_alias(item, plan_ctx))
             }
             // Other expression types don't contain aliases
-            _ => false,
-        }
-    }
-
-    /// Check if an expression contains any aggregate function calls (recursively).
-    /// This is needed to detect computed aggregates like COUNT(b) * 10.
-    fn contains_aggregate(expr: &LogicalExpr) -> bool {
-        match expr {
-            LogicalExpr::AggregateFnCall(_) => true,
-            LogicalExpr::OperatorApplicationExp(op) => {
-                op.operands.iter().any(Self::contains_aggregate)
-            }
-            LogicalExpr::ScalarFnCall(func) => func.args.iter().any(Self::contains_aggregate),
-            LogicalExpr::List(list) => list.iter().any(Self::contains_aggregate),
-            LogicalExpr::Case(case_expr) => {
-                // Check if CASE expression contains aggregates in:
-                // 1. The optional simple CASE expression
-                // 2. Any WHEN condition or THEN value
-                // 3. The optional ELSE expression
-                if let Some(expr) = &case_expr.expr {
-                    if Self::contains_aggregate(expr) {
-                        return true;
-                    }
-                }
-                for (when_cond, then_val) in &case_expr.when_then {
-                    if Self::contains_aggregate(when_cond) || Self::contains_aggregate(then_val) {
-                        return true;
-                    }
-                }
-                if let Some(else_expr) = &case_expr.else_expr {
-                    if Self::contains_aggregate(else_expr) {
-                        return true;
-                    }
-                }
-                false
-            }
             _ => false,
         }
     }
@@ -124,24 +89,47 @@ impl GroupByBuilding {
     ) -> Transformed<Arc<LogicalPlan>> {
         match node.as_ref() {
             LogicalPlan::Projection(projection) => {
-                // Use contains_aggregate to properly detect aggregates including computed expressions
-                let non_agg_projections: Vec<ProjectionItem> = projection
+                // Split items into aggregate-containing and aggregate-free, and
+                // build the implicit GROUP BY keys.
+                //
+                // #637: a grouping key can be BURIED inside an item that also
+                // contains an aggregate (e.g. `a.city` in
+                // `a.city + toString(count(b))`). The old code keyed GROUP BY on
+                // whole aggregate-free items only, so such buried keys were
+                // dropped and no GROUP BY was emitted → ClickHouse Code 215.
+                //
+                // Behavior-preserving split:
+                //  - aggregate-FREE item  → push the WHOLE item as a key,
+                //    byte-identically to the old path (incl. constant keys like
+                //    `RETURN 'all_users', count(n)` → `GROUP BY 'all_users'`).
+                //  - aggregate-CONTAINING item → extract its buried
+                //    non-aggregate keys via the shared `collect_grouping_keys`
+                //    (the #637 fix; empty for an aggregates-only item).
+                let has_aggregate = projection
                     .items
                     .iter()
-                    .filter(|item| !Self::contains_aggregate(&item.expression))
-                    .cloned()
-                    .collect();
+                    .any(|item| HasAggregateCheck::check(&item.expression));
 
-                let agg_count = projection.items.len() - non_agg_projections.len();
+                let mut grouping_keys: Vec<LogicalExpr> = Vec::new();
+                for item in &projection.items {
+                    if HasAggregateCheck::check(&item.expression) {
+                        for key in visitors::collect_grouping_keys(&item.expression) {
+                            if !grouping_keys.contains(&key) {
+                                grouping_keys.push(key);
+                            }
+                        }
+                    } else if !grouping_keys.contains(&item.expression) {
+                        grouping_keys.push(item.expression.clone());
+                    }
+                }
+
                 log::trace!(
-                    "GroupByBuilding: Found {} aggregations, {} non-aggregations",
-                    agg_count,
-                    non_agg_projections.len()
+                    "GroupByBuilding: has_aggregate={}, {} grouping keys",
+                    has_aggregate,
+                    grouping_keys.len()
                 );
 
-                if non_agg_projections.len() < projection.items.len()
-                    && !non_agg_projections.is_empty()
-                {
+                if has_aggregate && !grouping_keys.is_empty() {
                     // Projection mixes aggregates and plain expressions — wrap
                     // it in a GroupBy keyed on the non-aggregate items. (The
                     // old walker had separate "two-level" and "single-level"
@@ -167,7 +155,7 @@ impl GroupByBuilding {
                     } else {
                         log::trace!(
                             "GroupByBuilding: Creating GroupBy node with {} grouping expressions",
-                            non_agg_projections.len()
+                            grouping_keys.len()
                         );
                     }
                     let wrapped: Arc<LogicalPlan> =
@@ -183,10 +171,7 @@ impl GroupByBuilding {
                         };
                     Transformed::Yes(Arc::new(LogicalPlan::GroupBy(GroupBy {
                         input: wrapped,
-                        expressions: non_agg_projections
-                            .into_iter()
-                            .map(|item| item.expression)
-                            .collect(),
+                        expressions: grouping_keys,
                         having_clause: None,
                         is_materialization_boundary: false,
                         exposed_alias: None,
@@ -302,7 +287,7 @@ mod tests {
     use super::*;
     #[allow(unused_imports)]
     use crate::query_planner::logical_expr::{AggregateFnCall, Column, PropertyAccess, TableAlias};
-    use crate::query_planner::logical_plan::{LogicalPlan, Projection};
+    use crate::query_planner::logical_plan::{LogicalPlan, Projection, ProjectionItem};
 
     fn create_property_access(table: &str, column: &str) -> LogicalExpr {
         LogicalExpr::PropertyAccessExp(PropertyAccess {
@@ -523,6 +508,113 @@ mod tests {
                 assert_eq!(plan, projection);
             }
             _ => panic!("Expected no transformation for empty projection"),
+        }
+    }
+
+    fn operator(
+        op: crate::query_planner::logical_expr::Operator,
+        operands: Vec<LogicalExpr>,
+    ) -> LogicalExpr {
+        LogicalExpr::OperatorApplicationExp(
+            crate::query_planner::logical_expr::OperatorApplication {
+                operator: op,
+                operands,
+            },
+        )
+    }
+
+    /// #637: a SINGLE projection item that BURIES a grouping key inside an
+    /// aggregate-containing expression (`user.name + count(order.id)`) must
+    /// still build a GroupBy keyed on the buried `user.name` — the old split
+    /// produced no GroupBy at all (ClickHouse Code 215).
+    #[test]
+    fn test_projection_buried_key_in_aggregate_item() {
+        let analyzer = GroupByBuilding::new();
+        let mut plan_ctx = PlanCtx::new_empty();
+
+        // RETURN user.name + count(order.id) AS mixed
+        let item = operator(
+            crate::query_planner::logical_expr::Operator::Addition,
+            vec![
+                create_property_access("user", "name"),
+                create_aggregate_function("count", "order", "id"),
+            ],
+        );
+        let projection = Arc::new(LogicalPlan::Projection(Projection {
+            input: create_scan(Some("user".to_string()), Some("users".to_string())),
+            items: vec![ProjectionItem {
+                expression: item,
+                col_alias: None,
+            }],
+            distinct: false,
+            pattern_comprehensions: vec![],
+        }));
+
+        let result = analyzer.analyze(projection.clone(), &mut plan_ctx).unwrap();
+
+        match result {
+            Transformed::Yes(new_plan) => match new_plan.as_ref() {
+                LogicalPlan::GroupBy(group_by) => {
+                    assert_eq!(
+                        group_by.expressions.len(),
+                        1,
+                        "buried user.name must be the sole key"
+                    );
+                    match &group_by.expressions[0] {
+                        LogicalExpr::PropertyAccessExp(prop_acc) => {
+                            assert_eq!(prop_acc.table_alias.0, "user");
+                            assert_eq!(prop_acc.column.raw(), "name");
+                        }
+                        other => panic!("Expected user.name grouping key, got {other:?}"),
+                    }
+                }
+                other => panic!("Expected GroupBy plan, got {other:?}"),
+            },
+            _ => panic!("Expected transformation (GroupBy) for buried-key item"),
+        }
+    }
+
+    /// #637: a buried key alongside a SEPARATE bare key must not duplicate the
+    /// bare key, and both must appear.
+    #[test]
+    fn test_projection_buried_key_dedups_with_bare_key() {
+        let analyzer = GroupByBuilding::new();
+        let mut plan_ctx = PlanCtx::new_empty();
+
+        // RETURN user.name, user.name + count(order.id) AS mixed
+        let projection = Arc::new(LogicalPlan::Projection(Projection {
+            input: create_scan(Some("user".to_string()), Some("users".to_string())),
+            items: vec![
+                ProjectionItem {
+                    expression: create_property_access("user", "name"),
+                    col_alias: None,
+                },
+                ProjectionItem {
+                    expression: operator(
+                        crate::query_planner::logical_expr::Operator::Addition,
+                        vec![
+                            create_property_access("user", "name"),
+                            create_aggregate_function("count", "order", "id"),
+                        ],
+                    ),
+                    col_alias: None,
+                },
+            ],
+            distinct: false,
+            pattern_comprehensions: vec![],
+        }));
+
+        let result = analyzer.analyze(projection.clone(), &mut plan_ctx).unwrap();
+
+        match result {
+            Transformed::Yes(new_plan) => match new_plan.as_ref() {
+                LogicalPlan::GroupBy(group_by) => {
+                    // user.name appears once (deduped), not twice.
+                    assert_eq!(group_by.expressions.len(), 1);
+                }
+                other => panic!("Expected GroupBy plan, got {other:?}"),
+            },
+            _ => panic!("Expected transformation"),
         }
     }
 }

--- a/src/query_planner/logical_expr/visitors.rs
+++ b/src/query_planner/logical_expr/visitors.rs
@@ -475,6 +475,155 @@ impl ExpressionVisitor for HasAggregateCheck {
     }
 }
 
+/// Does this expression (transitively) reference a column, property, or table
+/// alias — i.e. is it a *grouping candidate* rather than a pure constant?
+///
+/// A projection item like `':'` (a literal) or `$p` (a parameter) contributes
+/// nothing to an implicit GROUP BY, whereas `a.city`, a bare alias `a`, or a
+/// `CASE`/arithmetic expression built over them does. Recurses via the
+/// exhaustive [`walk_expression`] child set, so a new container variant can
+/// never silently hide a column reference.
+fn references_column_or_alias(expr: &LogicalExpr) -> bool {
+    struct RefCheck {
+        found: bool,
+    }
+    impl ExpressionVisitor for RefCheck {
+        type Output = ();
+        fn visit_property_access(&mut self, _prop: &PropertyAccess) {
+            self.found = true;
+        }
+        fn visit_table_alias(&mut self, _alias: &str) {
+            self.found = true;
+        }
+        fn visit_leaf(&mut self, expr: &LogicalExpr) {
+            // `walk_expression` routes Column / ColumnAlias / CteEntityRef
+            // through `visit_leaf`; all three name a value that varies per row
+            // and therefore belongs in GROUP BY.
+            if matches!(
+                expr,
+                LogicalExpr::Column(_) | LogicalExpr::ColumnAlias(_) | LogicalExpr::CteEntityRef(_)
+            ) {
+                self.found = true;
+            }
+        }
+    }
+    let mut c = RefCheck { found: false };
+    walk_expression(expr, &mut c);
+    c.found
+}
+
+/// Collect the **grouping keys** for a projection/RETURN/WITH item that may mix
+/// non-aggregate sub-expressions with aggregate function calls.
+///
+/// A grouping key is a *maximal aggregate-free sub-expression that references a
+/// column/alias*. The walk is top-down: as soon as a node contains no aggregate
+/// (per the exhaustive [`HasAggregateCheck`]) and references a column/alias, the
+/// whole node is emitted as one key and its children are NOT descended — so
+/// `a.city + ':'` stays a single key rather than fragmenting into `a.city`. When
+/// a node DOES contain an aggregate, we recurse into its children to find the
+/// non-aggregate keys buried inside it (e.g. `a.city` inside
+/// `a.city + ':' + toString(count(b))`, or the scrutinee/branches of a CASE that
+/// also holds an aggregate). Pure constants (literals, parameters) yield nothing.
+///
+/// This is the single source of truth for implicit-GROUP-BY key extraction,
+/// shared by the analyzer RETURN barrier (`group_by_building.rs`), the render
+/// WITH barrier (`with_to_cte`), and the UNION-return builder (`return_clause.rs`)
+/// — previously each hand-rolled its own aggregate/non-aggregate split, and each
+/// dropped keys buried inside an aggregate-containing item (issue #637).
+///
+/// Callers dedup and adapt (rewrite to CTE columns / ColumnAlias / ID-only) as
+/// needed; this function only decides *which sub-expressions are keys*.
+pub fn collect_grouping_keys(expr: &LogicalExpr) -> Vec<LogicalExpr> {
+    let mut keys = Vec::new();
+    collect_grouping_keys_into(expr, &mut keys);
+    keys
+}
+
+fn collect_grouping_keys_into(expr: &LogicalExpr, keys: &mut Vec<LogicalExpr>) {
+    // A bare aggregate call itself is never a key, and neither are its
+    // arguments (they are aggregated, not grouped) — stop here.
+    if matches!(expr, LogicalExpr::AggregateFnCall(_)) {
+        return;
+    }
+
+    if !HasAggregateCheck::check(expr) {
+        // Maximal aggregate-free subtree. Only a column/alias-referencing one is
+        // a grouping key; a pure constant contributes nothing.
+        if references_column_or_alias(expr) {
+            keys.push(expr.clone());
+        }
+        return;
+    }
+
+    // Contains an aggregate somewhere below — descend to find the non-aggregate
+    // keys buried inside, mirroring `walk_expression`'s exhaustive child set.
+    match expr {
+        LogicalExpr::ScalarFnCall(f) => {
+            for a in &f.args {
+                collect_grouping_keys_into(a, keys);
+            }
+        }
+        LogicalExpr::Operator(op) | LogicalExpr::OperatorApplicationExp(op) => {
+            for o in &op.operands {
+                collect_grouping_keys_into(o, keys);
+            }
+        }
+        LogicalExpr::Case(case) => {
+            if let Some(scrutinee) = &case.expr {
+                collect_grouping_keys_into(scrutinee, keys);
+            }
+            for (when, then) in &case.when_then {
+                collect_grouping_keys_into(when, keys);
+                collect_grouping_keys_into(then, keys);
+            }
+            if let Some(else_expr) = &case.else_expr {
+                collect_grouping_keys_into(else_expr, keys);
+            }
+        }
+        LogicalExpr::List(items) => {
+            for i in items {
+                collect_grouping_keys_into(i, keys);
+            }
+        }
+        LogicalExpr::MapLiteral(entries) => {
+            for (_, v) in entries {
+                collect_grouping_keys_into(v, keys);
+            }
+        }
+        LogicalExpr::ArraySubscript { array, index } => {
+            collect_grouping_keys_into(array, keys);
+            collect_grouping_keys_into(index, keys);
+        }
+        LogicalExpr::ArraySlicing { array, from, to } => {
+            collect_grouping_keys_into(array, keys);
+            if let Some(f) = from {
+                collect_grouping_keys_into(f, keys);
+            }
+            if let Some(t) = to {
+                collect_grouping_keys_into(t, keys);
+            }
+        }
+        LogicalExpr::ReduceExpr(reduce) => {
+            collect_grouping_keys_into(&reduce.initial_value, keys);
+            collect_grouping_keys_into(&reduce.list, keys);
+            collect_grouping_keys_into(&reduce.expression, keys);
+        }
+        LogicalExpr::Lambda(lambda) => {
+            collect_grouping_keys_into(&lambda.body, keys);
+        }
+        LogicalExpr::InSubquery(subq) => {
+            collect_grouping_keys_into(&subq.expr, keys);
+        }
+        // No other variant can reach here: it would have to contain an
+        // aggregate (so `HasAggregateCheck` returned true above) yet not be one
+        // of the container variants `walk_expression` descends. `AggregateFnCall`
+        // is handled at the top; every remaining variant is a leaf that cannot
+        // hold an aggregate, so this arm is unreachable in practice — clone
+        // nothing rather than risk a spurious key.
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -679,5 +828,169 @@ mod tests {
         });
         let out = map_expression(&expr, &mut |_| ExprRewrite::Recurse);
         assert_eq!(out, expr);
+    }
+
+    // -------------------------------------------------------------------------
+    // collect_grouping_keys (#637)
+    // -------------------------------------------------------------------------
+
+    use crate::query_planner::logical_expr::{LambdaExpr, LogicalCase, ScalarFnCall};
+
+    fn agg(name: &str, arg: LogicalExpr) -> LogicalExpr {
+        LogicalExpr::AggregateFnCall(AggregateFnCall {
+            name: name.to_string(),
+            args: vec![arg],
+        })
+    }
+    fn count_b() -> LogicalExpr {
+        LogicalExpr::AggregateFnCall(AggregateFnCall {
+            name: "count".to_string(),
+            args: vec![LogicalExpr::TableAlias(TableAlias("b".to_string()))],
+        })
+    }
+    fn scalar(name: &str, args: Vec<LogicalExpr>) -> LogicalExpr {
+        LogicalExpr::ScalarFnCall(ScalarFnCall {
+            name: name.to_string(),
+            args,
+        })
+    }
+    fn op(operator: Operator, operands: Vec<LogicalExpr>) -> LogicalExpr {
+        LogicalExpr::OperatorApplicationExp(OperatorApplication { operator, operands })
+    }
+    fn plus(l: LogicalExpr, r: LogicalExpr) -> LogicalExpr {
+        op(Operator::Addition, vec![l, r])
+    }
+
+    /// `a.user_id + count(b)` → the single buried key `a.user_id`.
+    #[test]
+    fn grouping_keys_buried_in_operator() {
+        let expr = op(Operator::Addition, vec![prop("user_id"), count_b()]);
+        assert_eq!(collect_grouping_keys(&expr), vec![prop("user_id")]);
+    }
+
+    /// `a.city + ':' + toString(count(b))` → the maximal aggregate-free operand
+    /// `a.city + ':'` is the key (Cypher groups by the whole non-aggregate
+    /// operand, NOT the fragmented leaf); the aggregate-bearing
+    /// `toString(count(b))` contributes nothing.
+    #[test]
+    fn grouping_keys_buried_with_literal_and_scalar_wrapped_aggregate() {
+        // Parses as ((a.city + ':') + toString(count(b)))
+        let city_colon = plus(
+            prop("city"),
+            LogicalExpr::Literal(Literal::String(":".to_string())),
+        );
+        let expr = plus(city_colon.clone(), scalar("toString", vec![count_b()]));
+        assert_eq!(collect_grouping_keys(&expr), vec![city_colon]);
+    }
+
+    /// A fully aggregate-free compound item is emitted WHOLE (maximal subtree),
+    /// not fragmented — this is what preserves byte-identical output for the
+    /// existing `CASE ... END`/`u1.name` corpus grouping keys.
+    #[test]
+    fn grouping_keys_aggregate_free_compound_stays_whole() {
+        let expr = op(
+            Operator::Addition,
+            vec![
+                prop("city"),
+                LogicalExpr::Literal(Literal::String("!".to_string())),
+            ],
+        );
+        // One key, equal to the whole expression (not just `a.city`).
+        assert_eq!(collect_grouping_keys(&expr), vec![expr.clone()]);
+    }
+
+    /// An aggregates-only item (`count(b) + sum(b)`) yields NO grouping key.
+    #[test]
+    fn grouping_keys_aggregates_only_none() {
+        let expr = op(
+            Operator::Addition,
+            vec![
+                count_b(),
+                agg("sum", LogicalExpr::TableAlias(TableAlias("b".to_string()))),
+            ],
+        );
+        assert!(collect_grouping_keys(&expr).is_empty());
+    }
+
+    /// A bare aggregate and a pure literal both yield nothing.
+    #[test]
+    fn grouping_keys_bare_aggregate_and_constant_none() {
+        assert!(collect_grouping_keys(&count_b()).is_empty());
+        assert!(collect_grouping_keys(&LogicalExpr::Literal(Literal::Integer(0))).is_empty());
+        assert!(collect_grouping_keys(&LogicalExpr::Parameter("p".to_string())).is_empty());
+    }
+
+    /// `count(b) + 0` (the existing corpus near-match) yields nothing — the
+    /// literal operand is not a key, guaranteeing 0 golden churn there.
+    #[test]
+    fn grouping_keys_aggregate_plus_literal_none() {
+        let expr = op(
+            Operator::Addition,
+            vec![count_b(), LogicalExpr::Literal(Literal::Integer(0))],
+        );
+        assert!(collect_grouping_keys(&expr).is_empty());
+    }
+
+    /// Legacy `Operator` variant is descended too (the gap the old local
+    /// `contains_aggregate` copies missed).
+    #[test]
+    fn grouping_keys_legacy_operator_variant() {
+        let expr = LogicalExpr::Operator(OperatorApplication {
+            operator: Operator::Addition,
+            operands: vec![prop("user_id"), count_b()],
+        });
+        assert_eq!(collect_grouping_keys(&expr), vec![prop("user_id")]);
+    }
+
+    /// CASE holding an aggregate in one branch: the aggregate-free scrutinee /
+    /// other branches surface their keys.
+    #[test]
+    fn grouping_keys_buried_in_case() {
+        // CASE a.city WHEN 'x' THEN count(b) ELSE a.country END
+        let expr = LogicalExpr::Case(LogicalCase {
+            expr: Some(Box::new(prop("city"))),
+            when_then: vec![(
+                LogicalExpr::Literal(Literal::String("x".to_string())),
+                count_b(),
+            )],
+            else_expr: Some(Box::new(prop("country"))),
+        });
+        let keys = collect_grouping_keys(&expr);
+        assert!(keys.contains(&prop("city")));
+        assert!(keys.contains(&prop("country")));
+        assert_eq!(keys.len(), 2);
+    }
+
+    /// Buried key inside an ArraySubscript that also holds an aggregate.
+    #[test]
+    fn grouping_keys_buried_in_array_subscript() {
+        // labels(a)[count(b)]  → key: labels(a) (aggregate-free, references a)
+        let expr = LogicalExpr::ArraySubscript {
+            array: Box::new(scalar(
+                "labels",
+                vec![LogicalExpr::TableAlias(TableAlias("a".to_string()))],
+            )),
+            index: Box::new(count_b()),
+        };
+        let keys = collect_grouping_keys(&expr);
+        assert_eq!(
+            keys,
+            vec![scalar(
+                "labels",
+                vec![LogicalExpr::TableAlias(TableAlias("a".to_string()))]
+            )]
+        );
+    }
+
+    /// Buried key inside a Lambda body that also holds an aggregate is reached
+    /// (variant the old local copies never descended).
+    #[test]
+    fn grouping_keys_buried_in_lambda() {
+        // x -> a.city + count(b)   → key: a.city
+        let expr = LogicalExpr::Lambda(LambdaExpr {
+            params: vec!["x".to_string()],
+            body: Box::new(op(Operator::Addition, vec![prop("city"), count_b()])),
+        });
+        assert_eq!(collect_grouping_keys(&expr), vec![prop("city")]);
     }
 }

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -7850,20 +7850,47 @@ fn apply_with_items_projection(
                 // 2. ANY() picks the single value in each group (safe for PK)
                 // 3. GROUP BY 1 column is much faster than GROUP BY 7 columns
                 if has_aggregation {
-                    let group_by_exprs: Vec<RenderExpr> = items.iter()
-                                .filter(|item| {
-                                    // Exclude: direct aggregates, literals, and expressions containing aggregates
-                                    // (#591: use expr_contains_aggregate, which recurses into
-                                    // Case/List/legacy-Operator — a narrower helper here silently
-                                    // pushed CASE/List-wrapped aggregates into GROUP BY → Code 184).
-                                    !matches!(&item.expression, crate::query_planner::logical_expr::LogicalExpr::AggregateFnCall(_))
-                                    && !is_literal_expr(&item.expression)
-                                    && !expr_contains_aggregate(&item.expression)
-                                })
-                                .flat_map(|item| {
+                    // #637: a grouping key can be BURIED inside a WITH item that
+                    // also contains an aggregate (e.g. `a.city` in
+                    // `WITH a.city + count(b) AS x`). Build the key set as:
+                    //  - each aggregate-FREE, non-literal item, WHOLE (preserves
+                    //    the prior per-item GROUP BY behavior byte-for-byte,
+                    //    including the ID-only / ArraySubscript / property-mapping
+                    //    handling below);
+                    //  - the buried non-aggregate sub-expressions of each
+                    //    aggregate-CONTAINING item, via the shared
+                    //    `collect_grouping_keys` (empty for aggregates-only items).
+                    // Without the buried extraction the CTE emitted an aggregate
+                    // with NO GROUP BY → ClickHouse Code 215.
+                    use crate::query_planner::logical_expr::LogicalExpr;
+                    let mut key_exprs: Vec<LogicalExpr> = Vec::new();
+                    let push_key = |k: LogicalExpr, keys: &mut Vec<LogicalExpr>| {
+                        if !keys.contains(&k) {
+                            keys.push(k);
+                        }
+                    };
+                    for item in items.iter() {
+                        if matches!(&item.expression, LogicalExpr::AggregateFnCall(_)) {
+                            continue;
+                        }
+                        if expr_contains_aggregate(&item.expression) {
+                            for key in
+                                crate::query_planner::logical_expr::visitors::collect_grouping_keys(
+                                    &item.expression,
+                                )
+                            {
+                                push_key(key, &mut key_exprs);
+                            }
+                        } else if !is_literal_expr(&item.expression) {
+                            push_key(item.expression.clone(), &mut key_exprs);
+                        }
+                    }
+
+                    let group_by_exprs: Vec<RenderExpr> = key_exprs.iter()
+                                .flat_map(|key_expr| {
                                     // For TableAlias, only GROUP BY the ID column
                                     // (other columns are wrapped with ANY() in SELECT)
-                                    match &item.expression {
+                                    match key_expr {
                                         crate::query_planner::logical_expr::LogicalExpr::TableAlias(alias) => {
                                             // Use ID-only helper for efficient GROUP BY
                                             // Pass VLP CTE metadata for deterministic lookups
@@ -7893,7 +7920,7 @@ fn apply_with_items_projection(
                                             } else {
                                                 ExpressionRewriteContext::new(plan_to_render)
                                             };
-                                            let rewritten = rewrite_expression_with_property_mapping(&item.expression, &rewrite_ctx);
+                                            let rewritten = rewrite_expression_with_property_mapping(key_expr, &rewrite_ctx);
                                             let expr_vec: Vec<RenderExpr> = rewritten.try_into().ok().map(|mut expr: RenderExpr| {
                                                 resolve_denormalized_property_in_expr_impl(&mut expr, plan_to_render, cte_from_alias.as_deref());
                                                 expr

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -2258,6 +2258,76 @@ async fn with_case_wrapped_aggregate_not_pushed_into_group_by_591() {
     }
 }
 
+/// Regression for #637: a grouping key BURIED inside a RETURN item that also
+/// contains an aggregate (`a.user_id + count(b)`) must still be extracted into
+/// GROUP BY. Previously no GROUP BY was emitted at all → ClickHouse Code 215
+/// NOT_AN_AGGREGATE.
+#[tokio::test]
+async fn buried_grouping_key_in_return_aggregate_item_637() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b) RETURN a.user_id + count(b) AS mixed";
+
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(&schema, cypher, dialect).await;
+        let group_by_lines: Vec<&str> = sql
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("GROUP BY"))
+            .collect();
+        assert_eq!(
+            group_by_lines,
+            vec!["GROUP BY a.user_id"],
+            "#637: the buried key a.user_id must be the sole GROUP BY key for {dialect:?}, got:\n{sql}"
+        );
+    }
+}
+
+/// Regression for #637 (maximal-subtree semantics): the grouping key is the
+/// whole aggregate-free operand `a.city + ':'` (rendered `concat(a.city, ':')`),
+/// NOT the fragmented leaf `a.city` — this is what makes the SELECT expression
+/// `concat(a.city, ':', toString(count(..)))` valid ClickHouse.
+#[tokio::test]
+async fn buried_grouping_key_maximal_subtree_637() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b) RETURN a.city + ':' + toString(count(b)) AS m";
+
+    // ClickHouse spelling; Databricks concat spelling can differ, so only pin CH.
+    let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+    let group_by_lines: Vec<&str> = sql
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("GROUP BY"))
+        .collect();
+    assert_eq!(
+        group_by_lines,
+        vec!["GROUP BY concat(a.city, ':')"],
+        "#637: GROUP BY must be the maximal aggregate-free subtree, got:\n{sql}"
+    );
+}
+
+/// Regression for #637 (WITH barrier, render path): the same buried-key bug
+/// existed independently in `with_to_cte`. `WITH a.user_id + count(b) AS x`
+/// previously emitted a CTE with NO GROUP BY → Code 215.
+#[tokio::test]
+async fn buried_grouping_key_in_with_aggregate_item_637() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(b) WITH a.user_id + count(b) AS x RETURN x";
+
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(&schema, cypher, dialect).await;
+        let group_by_lines: Vec<&str> = sql
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("GROUP BY"))
+            .collect();
+        assert_eq!(
+            group_by_lines,
+            vec!["GROUP BY a.user_id"],
+            "#637: the WITH-CTE must GROUP BY the buried key a.user_id for {dialect:?}, got:\n{sql}"
+        );
+    }
+}
+
 /// Regression for #452: on the FK-edge schema the PLACED_BY edge IS the
 /// `orders_fk` node table, so `MATCH (c:Customer) OPTIONAL MATCH
 /// (c)<-[:PLACED_BY]-(o:Order)` must reach the optional Order with a SINGLE


### PR DESCRIPTION
## Summary

Fixes **#637**: a grouping key buried inside a RETURN/WITH item that also contains an aggregate was dropped, so no `GROUP BY` was emitted → ClickHouse **Code 215 NOT_AN_AGGREGATE** (silent wrong buckets on lenient backends).

Repros (now fixed):
```cypher
MATCH (a:User)-[:FOLLOWS]->(b) RETURN a.user_id + count(b) AS mixed
MATCH (a:User)-[:FOLLOWS]->(b) RETURN a.city + ':' + toString(count(b)) AS m
MATCH (a:User)-[:FOLLOWS]->(b) WITH a.user_id + count(b) AS x RETURN x
```

## Root cause & fix

Independent aggregate/non-aggregate split sites, each keying `GROUP BY` on whole aggregate-FREE items only:
- analyzer `group_by_building.rs` (**RETURN** barrier) — fixed
- render `with_to_cte/mod.rs` (~7852, **WITH** barrier) — fixed

New shared exhaustive `collect_grouping_keys` in `logical_expr/visitors.rs` (built on `HasAggregateCheck`/`walk_expression`) returns the **maximal aggregate-free sub-expression(s)** that reference a column/alias; routed through both barriers. The RETURN-barrier's incomplete local `contains_aggregate` (missed legacy `Operator` + array/map containers) retired in favor of `HasAggregateCheck`.

**Maximal-subtree** (not leaf-fragment) semantics: `a.city + ':' + toString(count(b))` → `GROUP BY concat(a.city, ':')` — matches the SELECT's non-aggregate operand and keeps the existing `CASE…END`/`u1.name` corpus keys byte-identical.

Behavior-preserving: aggregate-free whole items pushed exactly as before (incl. constant keys `RETURN 'all_users', count(n)` → `GROUP BY 'all_users'`); buried keys added; deduped structurally.

## Third site deferred → #844

The UNION-return builder `return_clause.rs::build_union_with_aggregation` has the same gap, but a correct fix needs additional inner-`__union` projection plumbing — an isolated `collect_grouping_keys` swap there is **inert** (byte-identical to main, verified on the `#503` denorm shape). Filed as **#844**; not touched here to keep this change honest and byte-locked.

## Verification

- **0 corpus churn** (1,229 queries × 2 dialects — no corpus query mixed a column ref with an aggregate in one item)
- Gate: `cargo fmt` · `clippy` clean · full `cargo test` · `corpus_sweep` + `sql_golden` (+3 new #637 goldens, fail-when-reverted) **0 churn** · `ratchet` net-zero
- Adversarially reviewed (subagent). No live ClickHouse in the dev env — correctness bar is SQL shape + byte goldens + full gate (the required `GROUP BY a.id` with `a.id + count(...)` in SELECT is standard SQL)

Closes #637 (RETURN + WITH). Also closes #600 (sub-defects 2 & 3 were already fixed on main via #638/#551; sub-defect 1 == #637).

🤖 Generated with [Claude Code](https://claude.com/claude-code)