### PR TITLE
fix(#788): multi-type VLP aggregate ORDER BY on endpoint drops __order_col_0

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -138,9 +138,15 @@ Exit met: one fully green nightly run + xpass count 0.
   pre-existing on main, byte-identical, untouched by #839).
 
 ### P-1 — Keep a small silent-wrong bug lane open  (standing, ≤1 agent)
-**Lane state (2026-07-28): pool near-exhausted; #716 was the last clean pick.** Since
-the 07-19 reconcile this lane shipped ~21 fixes (all live- or SQL-gen-verified,
-newest first): **#716 (multi-type VLP non-id endpoint property → native CTE column,
+**Lane state (2026-08-01): #788 shipped — was mis-triaged as design-cycle but is
+the same small #503-family `__order_col_N` asymmetry.** Since
+the 07-19 reconcile this lane shipped ~22 fixes (all live- or SQL-gen-verified,
+newest first): **#788 (multi-type VLP aggregate ORDER-BY-on-endpoint →
+`__order_col_0` Code 47: `build_outer_aggregate_select`'s expr→alias rewrite map
+now excludes `__order_col_*` items exactly as `build_aliased_group_by` already
+does — the injected ORDER BY helper column could otherwise hijack an aggregate
+argument's rewrite to a column the inner UNION drops)**,
+**#716 (multi-type VLP non-id endpoint property → native CTE column,
 #787)**, #580 (multi-type VLP endpoint id, #715), #606 denorm + fk-edge
 VLP relationship-uniqueness variants (#709/#712), #705 (shared EXISTS predicate
 rewriter, #707), #640 shapes 1 & 3 (#694/#704), #642 (VLP multi-sub-CTE union
@@ -148,8 +154,7 @@ collision, #698), #672 part 2 (#696), #678 (#692), #636 (#674), #683 r1 (#685),
 #659 (#682), #641 (#680), #620 (#677, closed via #700), #635 (#675, not-a-bug),
 #646 (#671), #648 (#670), #649 (#669), #595 (closed via #702), #647 (#652).
 Every remaining open issue is either **design-cycle-sized** (#604/#627/#643/
-#673/#628, #640 shapes 2/4/5, #683 residual-2, #788 multi-type-VLP aggregate
-ORDER-BY-on-endpoint) or in the **reverse-mapping / systemic class** owned by P-4
+#673/#628, #640 shapes 2/4/5, #683 residual-2) or in the **reverse-mapping / systemic class** owned by P-4
 (#592/#583/#613/#615). **#504 (coupled OPTIONAL collapse) triaged as design-cycle,
 NOT a P-1 pick**: root cause is an array-valued `node_id` never ARRAY-JOIN-flattened
 (not CoupledSameRow — scalar coupled OPTIONAL renders a correct LEFT JOIN), which

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3842,10 +3842,28 @@ fn build_outer_aggregate_select(
     // This maps raw expression SQL (e.g., "n.answers") to the output alias
     // (e.g., "n.resolved_ip") so aggregate expressions can reference the correct
     // UNION output column when the raw DB column name differs from the alias.
+    //
+    // #788: exclude `__order_col_N` synthetic items — exactly as
+    // `build_aliased_group_by` does below. These ORDER BY helper items carry
+    // the SAME expression as a grouped property (e.g. `ORDER BY u.city` →
+    // `__order_col_0` whose expression is `t.start_city`), and
+    // `build_union_inner_select` deliberately drops ALL `__order_col_*` items
+    // from the inner UNION branches. If left in this map, the agg-argument
+    // rewrite below would turn `anyLast(t.start_city)` into
+    // `anyLast(\`__order_col_0\`)` — a reference to a column that never exists
+    // in the `__union` derived table (ClickHouse UNKNOWN_IDENTIFIER Code 47,
+    // #503 family). Excluding them lets the aggregate keep referencing the
+    // real projected column via the `agg_arg_cols` rewrite instead.
     let expr_to_alias: std::collections::BTreeMap<String, String> = select
         .items
         .iter()
         .filter(|item| !render_expr_contains_aggregate(&item.expression))
+        .filter(|item| {
+            !item
+                .col_alias
+                .as_ref()
+                .is_some_and(|a| a.0.starts_with("__order_col"))
+        })
         .filter_map(|item| {
             item.col_alias
                 .as_ref()

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -9270,6 +9270,58 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #788: a MULTI-TYPE VLP aggregate that ORDER-BYs a grouped endpoint
+    /// property mis-aliased the outer projection to `anyLast(`__order_col_0`)`.
+    /// The ORDER-BY-column-injection pass adds a synthetic non-aggregate SELECT
+    /// item (`t.start_city AS __order_col_0`) to feed the outer ORDER BY, but
+    /// `build_union_inner_select` deliberately DROPS all `__order_col_*` items
+    /// from the inner UNION branches. `build_outer_aggregate_select`'s
+    /// expression→alias rewrite map still contained that dropped item, so its
+    /// agg-argument rewrite turned `anyLast(t.start_city)` into
+    /// `anyLast(`__order_col_0`)` — a reference to a column that never exists in
+    /// the `__union` derived table (ClickHouse UNKNOWN_IDENTIFIER Code 47, the
+    /// #503 family). The fix mirrors the exclusion `build_aliased_group_by`
+    /// already applies: `__order_col_*` items must not seed the rewrite map, so
+    /// the aggregate keeps referencing the REAL projected column.
+    ///
+    /// The single-type VLP path (a plain recursive CTE, no internal UNION)
+    /// never routes through these helpers and was already correct.
+    #[tokio::test]
+    async fn multi_type_vlp_aggregate_order_by_endpoint_no_dangling_order_col_788() {
+        let schema = load_schema(SchemaId::Standard.yaml_path());
+
+        let sql = render(
+            &schema,
+            "MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id=1 \
+             RETURN u.city, count(*) ORDER BY u.city",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+
+        // The outer aggregate must reference the REAL inner-union column, not
+        // the dropped ORDER BY helper alias.
+        assert!(
+            sql.contains("anyLast(`t.start_city`)"),
+            "#788: outer aggregate must wrap the real projected column \
+             t.start_city, which the inner UNION actually exports:\n{sql}"
+        );
+        assert!(
+            !sql.contains("__order_col"),
+            "#788: no `__order_col_*` may survive into the outer projection — \
+             those items are dropped from the inner UNION, so any reference to \
+             one dangles (Code 47):\n{sql}"
+        );
+        // GROUP BY and ORDER BY both resolve to the real column too.
+        assert!(
+            sql.contains("GROUP BY `t.start_city`"),
+            "#788: GROUP BY must reference the real grouped column:\n{sql}"
+        );
+        assert!(
+            sql.contains("ORDER BY t.start_city ASC"),
+            "#788: ORDER BY must reference the real grouped column:\n{sql}"
+        );
+    }
+
     /// alias `t` in the outer SELECT even when the relationship actually
     /// routes through a `pattern_union_r AS r` CTE (both endpoints
     /// unlabeled) — unbound `t.path_relationships`, ClickHouse Code 47. The


### PR DESCRIPTION
## Summary

Fixes #788. A **multi-type VLP** (e.g. `FOLLOWS|AUTHORED*1..2`) aggregate that ORDER-BYs a grouped endpoint property crashed with **ClickHouse Code 47 `UNKNOWN_IDENTIFIER: __order_col_0`**.

### Repro (social benchmark)
```cypher
MATCH (u:User)-[:FOLLOWS|AUTHORED*1..2]->(x) WHERE u.user_id=1
RETURN u.city, count(*) ORDER BY u.city
```

**Before** — outer projection referenced a column dropped from the inner union:
```sql
SELECT anyLast(`__order_col_0`) AS "u.city", count(*) ...  -- __order_col_0 undefined in __union
FROM ( SELECT t.start_city AS "t.start_city" FROM vlp_multi_type_u_x AS t UNION ALL ... ) AS __union
GROUP BY `t.start_city` ORDER BY t.start_city ASC
```

**After** — references the real projected column:
```sql
SELECT anyLast(`t.start_city`) AS "u.city", count(*) ...
FROM ( SELECT t.start_city AS "t.start_city" FROM vlp_multi_type_u_x AS t UNION ALL ... ) AS __union
GROUP BY `t.start_city` ORDER BY t.start_city ASC
```

## Root cause

The ORDER-BY-column-injection pass adds a synthetic non-aggregate SELECT item (`t.start_city AS __order_col_0`) to feed the outer ORDER BY. `build_union_inner_select` **deliberately drops all `__order_col_*` items** from the inner UNION branches ("ORDER BY is handled by the outer query"). But `build_outer_aggregate_select`'s expression→alias rewrite map still contained that dropped item, so its agg-argument rewrite turned `anyLast(t.start_city)` → `anyLast(\`__order_col_0\`)` — a dangling reference (#503 family).

This is a pure **asymmetry**: the sibling `build_aliased_group_by` was already hardened to exclude `__order_col_*` from its own expr→alias map; `build_outer_aggregate_select` was the one site missing that exact filter.

## Fix

Add the same `__order_col_*` exclusion to `build_outer_aggregate_select`'s `expr_to_alias` construction. One-site, surgical. Single-type VLP (a plain recursive CTE, no internal UNION) never routes through these helpers and was already correct — this is specific to the multi-type UNION path.

## Verification

- **Repro fixed** + related shapes checked: ORDER BY DESC, ORDER BY aggregate-alias (unaffected), no-ORDER-BY (no `__order_col`), multi-key ORDER BY — all resolve to real columns, zero `__order_col` leakage.
- **Byte-lock gate**: `corpus_sweep` **0 churn**, `sql_golden` 247, `ratchet` net-zero. Full suite **2201 passed, 0 failed**.
- **New regression golden** `multi_type_vlp_aggregate_order_by_endpoint_no_dangling_order_col_788` — **fail-when-reverted verified**.
- `cargo fmt --all` clean, `cargo clippy --all-targets` clean.
- No live ClickHouse in this env — correctness bar is SQL shape + byte goldens + full gate. The required SQL (`anyLast(t.start_city)` + `GROUP BY t.start_city` + `ORDER BY t.start_city`, all over a column the inner union projects) is standard, well-formed ClickHouse.

## Docs
- `docs/design/PRIORITIES.md`: moved #788 from the design-cycle list to the shipped P-1 lane (it was mis-triaged as design-cycle-sized; it's the same small #503-family asymmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)