### PR TITLE
fix: out-of-bounds list index returns null (was ClickHouse type default)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7529,17 +7529,19 @@ impl RenderExpr {
                         format!("{}[{}]", array_sql, index.to_sql())
                     }
                     _ => {
-                        // 1-based index (Cypher 0-based + 1). CH `arr[i]` is 1-based;
-                        // Spark `arr[i]` is 0-based, so Databricks must use the 1-based
-                        // `element_at(arr, i)` instead. CH form is left byte-identical.
+                        // 1-based index (Cypher 0-based + 1). The mapper's
+                        // `array_element_or_null` picks the right 1-based accessor
+                        // per dialect: CH `arrayElementOrNull(arr, i)`, Spark
+                        // `element_at(arr, i)`. Both return NULL for an
+                        // out-of-bounds index, matching openCypher `list[i]`
+                        // semantics (Neo4j returns null, not a type default).
                         //
-                        // Negative indices (Cypher `-1` = last) map UNCHANGED: both CH
-                        // arrayElement(arr,-1) and Spark element_at(arr,-1) already mean
-                        // "last", so a blind +1 wrongly shifts `-1`->`0` (CH then returns
-                        // the type default, silently wrong). Cypher `-1` reaches here as
-                        // the expression `0 - 1` (the parser lowers unary minus that way),
-                        // so a literal-only guard misses it — the runtime `if` below
-                        // handles both literal and computed negative indices.
+                        // Negative indices (Cypher `-1` = last) map UNCHANGED: both
+                        // CH and Spark already treat -1 as "last", so a blind +1
+                        // wrongly shifts `-1`->`0`. Cypher `-1` reaches here as the
+                        // expression `0 - 1` (the parser lowers unary minus that
+                        // way), so a literal-only guard misses it — the runtime
+                        // `if` below handles both literal and computed negatives.
                         let idx_1based = match index.as_ref() {
                             // Non-negative integer literal: clean compile-time +1.
                             RenderExpr::Literal(Literal::Integer(n)) if *n >= 0 => {
@@ -7552,12 +7554,8 @@ impl RenderExpr {
                                 format!("if(({i}) >= 0, ({i})+1, ({i}))")
                             }
                         };
-                        match crate::server::query_context::get_current_dialect() {
-                            crate::sql_generator::SqlDialect::Databricks => {
-                                format!("element_at({}, {})", array_sql, idx_1based)
-                            }
-                            _ => format!("{}[{}]", array_sql, idx_1based),
-                        }
+                        crate::sql_generator::function_mapper::current_function_mapper()
+                            .array_element_or_null(&array_sql, &idx_1based)
                     }
                 }
             }

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -14,6 +14,14 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         "arrayElement"
     }
 
+    fn array_element_or_null(&self, arr: &str, idx: &str) -> String {
+        // CH `arr[i]`/`arrayElement` return the element type's default (0, '')
+        // for an out-of-range index; `arrayElementOrNull` returns NULL instead,
+        // matching openCypher `list[i]` out-of-bounds semantics. In-bounds and
+        // negative (from-the-end) indices behave identically to `arrayElement`.
+        format!("arrayElementOrNull({}, {})", arr, idx)
+    }
+
     fn count_if(&self) -> &'static str {
         "countIf"
     }
@@ -184,6 +192,22 @@ mod tests {
         let m = ClickhouseFunctionMapper;
         assert_eq!(m.array_slice("a", "2", Some("3")), "arraySlice(a, 2, 3)");
         assert_eq!(m.array_slice("a", "2", None), "arraySlice(a, 2)");
+    }
+
+    #[test]
+    fn array_element_or_null_uses_clickhouse_null_returning_accessor() {
+        // CH `arr[i]`/`arrayElement` return the type default (0/'') on
+        // out-of-bounds; `arrayElementOrNull` returns NULL, matching the
+        // openCypher `list[i]` contract.
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(
+            m.array_element_or_null("[10, 20, 30]", "11"),
+            "arrayElementOrNull([10, 20, 30], 11)"
+        );
+        assert_eq!(
+            m.array_element_or_null("names", "if((0 - 1) >= 0, (0 - 1)+1, (0 - 1))"),
+            "arrayElementOrNull(names, if((0 - 1) >= 0, (0 - 1)+1, (0 - 1)))"
+        );
     }
 
     #[test]

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -49,6 +49,14 @@ impl FunctionMapper for DatabricksFunctionMapper {
         "element_at"
     }
 
+    fn array_element_or_null(&self, arr: &str, idx: &str) -> String {
+        // Spark `element_at(arr, i)` returns NULL for an out-of-bounds index
+        // (non-ANSI default), already matching openCypher `list[i]` semantics —
+        // so this is byte-identical to the plain `element_at` accessor the
+        // ArraySubscript arm emitted before, no CH-style OrNull variant needed.
+        format!("element_at({}, {})", arr, idx)
+    }
+
     fn count_if(&self) -> &'static str {
         // Databricks Runtime 13.1+ ships count_if. Older runtimes need
         // SUM(CASE WHEN ... THEN 1 ELSE 0 END) — flagged here so a future
@@ -256,6 +264,12 @@ mod tests {
         let m = for_dialect(SqlDialect::Databricks);
         assert_eq!(m.collect_list(), "collect_list");
         assert_eq!(m.array_element(), "element_at");
+        // element_at already returns NULL on out-of-bounds (non-ANSI default),
+        // so array_element_or_null is byte-identical to the plain accessor.
+        assert_eq!(
+            m.array_element_or_null("array(10, 20, 30)", "11"),
+            "element_at(array(10, 20, 30), 11)"
+        );
         assert_eq!(m.count_if(), "count_if");
         assert_eq!(
             m.min_if("int(hop)", "node_id = 14"),

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -36,6 +36,17 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// 1-based array indexing. CH: `arrayElement`. Spark: `element_at`.
     fn array_element(&self) -> &'static str;
 
+    /// 1-based array indexing that yields NULL when the index is out of
+    /// bounds (either end) — the openCypher contract for `list[i]`
+    /// (Neo4j returns `null`, not a type default). CH `arrayElement`/`arr[i]`
+    /// silently returns the element type's default (`0`, `''`) for an
+    /// out-of-range index, so CH must use `arrayElementOrNull(arr, i)`.
+    /// Spark's `element_at(arr, i)` already returns NULL on out-of-bounds
+    /// (non-ANSI default), so Databricks keeps `element_at` — byte-identical
+    /// to the plain `array_element` accessor. `arr` and `idx` are
+    /// pre-rendered SQL fragments (the caller applies the 1-based offset).
+    fn array_element_or_null(&self, arr: &str, idx: &str) -> String;
+
     /// Conditional count. CH: `countIf`. Spark: `count_if` (DBR 13.1+).
     fn count_if(&self) -> &'static str;
 

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_empty_relationship_type.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_empty_relationship_type.clickhouse.sql
@@ -13,7 +13,7 @@ WHERE r1.member_type = 'User'
 )
 SELECT 
       JSONExtractString(t.start_properties, 'name') AS "u.name", 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       JSONExtractString(t.end_properties, 'name') AS "g.name"
 FROM vlp_multi_type_u_g AS t
 LIMIT 5

--- a/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_return_type_function.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/polymorphic/test_schema_variations__TestPolymorphicSchema_test_return_type_function.clickhouse.sql
@@ -60,7 +60,7 @@ INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 WHERE r1.interaction_type = 'SHARED' AND r1.from_type = 'User' AND r1.to_type = 'User' AND (u_1.user_id = 1)
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       t.end_properties AS "target.properties", 
       t.end_id AS "target.id", 
       t.end_type AS "target.__label__"

--- a/tests/rust/integration/golden/corpus/social_integration/test_browser_patterns__TestBrowserNodeExpansion_test_expand_labeled_node_all_relationships.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_browser_patterns__TestBrowserNodeExpansion_test_expand_labeled_node_all_relationships.clickhouse.sql
@@ -23,7 +23,7 @@ INNER JOIN test_integration.posts_test p2 ON r1.post_id = p2.post_id
 WHERE (n_1.user_id = 1)
 )
 SELECT 
-      t.path_relationships[1] AS "rel_type", 
+      arrayElementOrNull(t.path_relationships, 1) AS "rel_type", 
       t.end_type AS "target_label"
 FROM vlp_multi_type_n_m AS t
 WHERE t.start_id = 1

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_multi_type_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_multi_type_0.clickhouse.sql
@@ -2,7 +2,7 @@ WITH vlp_multi_type_a_b AS (
 SELECT '' AS end_type, CAST(NULL, 'Nullable(Int64)') AS end_id, CAST(NULL, 'Nullable(Int64)') AS start_id, '' AS start_type, '{}' AS end_properties, '{}' AS start_properties, 0 AS hop_count, CAST([] AS Array(String)) AS path_relationships, CAST([] AS Array(String)) AS rel_properties, CAST([] AS Array(String)) AS path_nodes WHERE 0 = 1
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_multi_type_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_multi_type_1.clickhouse.sql
@@ -5,7 +5,7 @@ INNER JOIN test_integration.user_follows_test r1 ON a_1.user_id = r1.follower_id
 INNER JOIN test_integration.users_test u2 ON r1.followed_id = u2.user_id
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_aggregation_groups_across_union.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_schema_variations_comprehensive__TestSchemaInteractions_test_aggregation_groups_across_union.clickhouse.sql
@@ -15,7 +15,7 @@ INNER JOIN test_integration.posts_test p2 ON r1.post_id = p2.post_id
 )
 SELECT 
       t.start_id AS "u.user_id", 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "action_count"
 FROM vlp_multi_type_u_target AS t
-GROUP BY t.start_id, t.path_relationships[1]
+GROUP BY t.start_id, arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_0.clickhouse.sql
@@ -12,7 +12,7 @@ INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User'
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_1.clickhouse.sql
@@ -12,7 +12,7 @@ INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User'
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_multi_type_2.clickhouse.sql
@@ -12,7 +12,7 @@ INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 WHERE r1.interaction_type = 'FOLLOWS' AND r1.from_type = 'User' AND r1.to_type = 'User'
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_return_type_function.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_schema_variations__TestStandardSchema_test_return_type_function.clickhouse.sql
@@ -17,7 +17,7 @@ INNER JOIN test_integration.posts_test p2 ON r1.post_id = p2.post_id
 WHERE (u_1.user_id = 1)
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       t.end_properties AS "target.properties", 
       t.end_id AS "target.id", 
       t.end_type AS "target.__label__"

--- a/tests/rust/integration/golden/corpus/zeek_dns/test_pattern_schema_matrix__TestCoupledSchema_test_multi_type_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/zeek_dns/test_pattern_schema_matrix__TestCoupledSchema_test_multi_type_0.clickhouse.sql
@@ -2,7 +2,7 @@ WITH vlp_multi_type_a_b AS (
 SELECT '' AS end_type, CAST(NULL, 'Nullable(Int64)') AS end_id, CAST(NULL, 'Nullable(Int64)') AS start_id, '' AS start_type, '{}' AS end_properties, '{}' AS start_properties, 0 AS hop_count, CAST([] AS Array(String)) AS path_relationships, CAST([] AS Array(String)) AS rel_properties, CAST([] AS Array(String)) AS path_nodes WHERE 0 = 1
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/zeek_dns/test_pattern_schema_matrix__TestCoupledSchema_test_multi_type_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/zeek_dns/test_pattern_schema_matrix__TestCoupledSchema_test_multi_type_1.clickhouse.sql
@@ -2,7 +2,7 @@ WITH vlp_multi_type_a_b AS (
 SELECT '' AS end_type, CAST(NULL, 'Nullable(Int64)') AS end_id, CAST(NULL, 'Nullable(Int64)') AS start_id, '' AS start_type, '{}' AS end_properties, '{}' AS start_properties, 0 AS hop_count, CAST([] AS Array(String)) AS path_relationships, CAST([] AS Array(String)) AS rel_properties, CAST([] AS Array(String)) AS path_nodes WHERE 0 = 1
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       count(*) AS "cnt"
 FROM vlp_multi_type_a_b AS t
-GROUP BY t.path_relationships[1]
+GROUP BY arrayElementOrNull(t.path_relationships, 1)

--- a/tests/rust/integration/golden/corpus/zeek_merged_test/test_schema_variations__TestCoupledEdgesSchema_test_return_type_function.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/zeek_merged_test/test_schema_variations__TestCoupledEdgesSchema_test_return_type_function.clickhouse.sql
@@ -10,7 +10,7 @@ INNER JOIN zeek.dns_log n2 ON ip_1."id.orig_h" = n2."id.orig_h"
 WHERE (ip_1."id.orig_h" = '192.168.1.10')
 )
 SELECT 
-      t.path_relationships[1] AS "type(r)", 
+      arrayElementOrNull(t.path_relationships, 1) AS "type(r)", 
       t.end_properties AS "target.properties", 
       t.end_id AS "target.id", 
       t.end_type AS "target.__label__"

--- a/tests/rust/integration/golden/sql_ir/polymorphic/rel_type_fn__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/polymorphic/rel_type_fn__clickhouse.sql
@@ -24,5 +24,5 @@ INNER JOIN brahmand.users_bench u2 ON r1.to_id = u2.user_id
 WHERE r1.interaction_type = 'LIKES' AND r1.from_type = 'User' AND r1.to_type = 'User'
 )
 SELECT 
-      t.path_relationships[1] AS "t"
+      arrayElementOrNull(t.path_relationships, 1) AS "t"
 FROM vlp_multi_type_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/standard/browser_type_probe__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/browser_type_probe__clickhouse.sql
@@ -6,6 +6,6 @@ UNION ALL
 SELECT 'User' AS start_type, toString(social.users_bench.user_id) as start_id, toString(social.posts_bench.post_id) as end_id, 'Post' AS end_type, ['LIKED'] as path_relationships, [formatRowNoNewline('JSONEachRow', social.post_likes_bench.like_date AS like_date)] as rel_properties, formatRowNoNewline('JSONEachRow', social.users_bench.city, social.users_bench.country, social.users_bench.email_address, social.users_bench.is_active, social.users_bench.full_name, social.users_bench.registration_date, social.users_bench.user_id) as start_properties, formatRowNoNewline('JSONEachRow', social.posts_bench.author_id, social.posts_bench.post_content, social.posts_bench.post_date, social.posts_bench.post_id, social.posts_bench.post_title) as end_properties, NULL AS authored_date, NULL AS follow_date, social.post_likes_bench.like_date AS like_date FROM social.post_likes_bench INNER JOIN social.users_bench ON social.users_bench.user_id = social.post_likes_bench.user_id INNER JOIN social.posts_bench ON social.posts_bench.post_id = social.post_likes_bench.post_id
 )
 SELECT DISTINCT 
-      r.path_relationships[1] AS "type(r)"
+      arrayElementOrNull(r.path_relationships, 1) AS "type(r)"
 FROM pattern_union_r AS r
 LIMIT 25

--- a/tests/rust/integration/golden/sql_ir/standard/cypher_union_unlabeled_type__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/cypher_union_unlabeled_type__clickhouse.sql
@@ -13,9 +13,9 @@ UNION ALL
 SELECT 'User' AS start_type, toString(social.users_bench.user_id) as start_id, toString(social.posts_bench.post_id) as end_id, 'Post' AS end_type, ['LIKED'] as path_relationships, [formatRowNoNewline('JSONEachRow', social.post_likes_bench.like_date AS like_date)] as rel_properties, formatRowNoNewline('JSONEachRow', social.users_bench.city, social.users_bench.country, social.users_bench.email_address, social.users_bench.is_active, social.users_bench.full_name, social.users_bench.registration_date, social.users_bench.user_id) as start_properties, formatRowNoNewline('JSONEachRow', social.posts_bench.author_id, social.posts_bench.post_content, social.posts_bench.post_date, social.posts_bench.post_id, social.posts_bench.post_title) as end_properties, NULL AS authored_date, NULL AS follow_date, social.post_likes_bench.like_date AS like_date FROM social.post_likes_bench INNER JOIN social.users_bench ON social.users_bench.user_id = social.post_likes_bench.user_id INNER JOIN social.posts_bench ON social.posts_bench.post_id = social.post_likes_bench.post_id
 )
 SELECT 
-      r.path_relationships[1] AS "t"
+      arrayElementOrNull(r.path_relationships, 1) AS "t"
 FROM pattern_union_r AS r
 UNION DISTINCT 
 SELECT 
-      r2.path_relationships[1] AS "t"
+      arrayElementOrNull(r2.path_relationships, 1) AS "t"
 FROM pattern_union_r2 AS r2

--- a/tests/rust/integration/golden/sql_ir/standard/list_index_negative__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/list_index_negative__clickhouse.sql
@@ -1,4 +1,4 @@
 SELECT 
-      [10, 20, 30][if((0 - 1) >= 0, (0 - 1)+1, (0 - 1))] AS "last", 
-      [10, 20, 30][1] AS "first"
+      arrayElementOrNull([10, 20, 30], if((0 - 1) >= 0, (0 - 1)+1, (0 - 1))) AS "last", 
+      arrayElementOrNull([10, 20, 30], 1) AS "first"
 FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/list_index_out_of_bounds__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/list_index_out_of_bounds__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      arrayElementOrNull([10, 20, 30], 11) AS "oob_hi", 
+      arrayElementOrNull([10, 20, 30], if((0 - 10) >= 0, (0 - 10)+1, (0 - 10))) AS "oob_lo", 
+      arrayElementOrNull([10, 20, 30], 1) AS "first"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/list_index_out_of_bounds__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/list_index_out_of_bounds__databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      element_at(array(10, 20, 30), 11) AS `oob_hi`, 
+      element_at(array(10, 20, 30), if((0 - 10) >= 0, (0 - 10)+1, (0 - 10))) AS `oob_lo`, 
+      element_at(array(10, 20, 30), 1) AS `first`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/multi_type_rel_type_fn__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/multi_type_rel_type_fn__clickhouse.sql
@@ -11,9 +11,9 @@ INNER JOIN social.user_follows_bench r1 ON a_1.user_id = r1.follower_id
 INNER JOIN social.users_bench u2 ON r1.followed_id = u2.user_id
 )
 SELECT 
-      t.path_relationships[1] AS "t"
+      arrayElementOrNull(t.path_relationships, 1) AS "t"
 FROM vlp_multi_type_a_b AS t
 UNION ALL 
 SELECT 
-      t.path_relationships[1] AS "t"
+      arrayElementOrNull(t.path_relationships, 1) AS "t"
 FROM vlp_multi_type_a_b_2 AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -235,9 +235,11 @@ const CORPUS: &[(&str, &str)] = &[
     ),
     // type(r) on a multi-type edge reads the CTE's `path_relationships` array.
     // Regression guard for the array-index fix: the FIRST relationship is index 0
-    // (Cypher 0-based) -> renders 1-based as CH `path_relationships[1]` and
-    // Databricks `element_at(path_relationships, 1)`. The previous `[2]` was out of
-    // bounds on a 1-element array (CH silently returned ""; Databricks errored).
+    // (Cypher 0-based) -> renders 1-based as CH
+    // `arrayElementOrNull(path_relationships, 1)` and Databricks
+    // `element_at(path_relationships, 1)`. The previous `[2]` was out of bounds on
+    // a 1-element array (CH silently returned ""; Databricks errored — now both
+    // return NULL out of bounds via the null-safe accessor).
     (
         "multi_type_rel_type_fn",
         "MATCH (a:User)-[r:FOLLOWS|AUTHORED]->(b) RETURN type(r) AS t",
@@ -273,10 +275,21 @@ const CORPUS: &[(&str, &str)] = &[
     // offset by +1). The old +1 shifted -1 -> 0, and CH `arr[0]` silently returned
     // the type default (0) instead of the last element. Guards CH `[-1]` /
     // Databricks `element_at(..., -1)`; a non-negative index (index0 -> [1]) is the
-    // control.
+    // control. Both indices go through `arrayElementOrNull` (CH) / `element_at`
+    // (Spark) so an out-of-range sibling index would surface as NULL.
     (
         "list_index_negative",
         "MATCH (u:User) RETURN [10, 20, 30][-1] AS last, [10, 20, 30][0] AS first",
+    ),
+    // Out-of-bounds list index: openCypher `list[i]` returns NULL when i is past
+    // either end (Neo4j semantics), NOT the element type's default. CH `arr[i]`/
+    // `arrayElement` silently returns 0/'' for an out-of-range index, so CH must
+    // route through `arrayElementOrNull`; Spark `element_at` already returns NULL
+    // on out-of-bounds. `[10]` (past the end) and `[-10]` (before the start) both
+    // must yield NULL; `[0]` (first) is the in-bounds control.
+    (
+        "list_index_out_of_bounds",
+        "MATCH (u:User) RETURN [10, 20, 30][10] AS oob_hi, [10, 20, 30][-10] AS oob_lo, [10, 20, 30][0] AS first",
     ),
     // Dialect function-name mappings (regression for the Databricks overrides):
     // replace -> CH replaceAll / Spark replace; head/last -> CH arrayElement /
@@ -12352,7 +12365,7 @@ mod label_id_resolution_family_536_537_539_540_541_526_527 {
         .await;
         assert!(
             distinct_sql.contains(
-                "tuple(r.start_type, r.start_id, r.end_type, r.end_id, r.path_relationships[1])"
+                "tuple(r.start_type, r.start_id, r.end_type, r.end_id, arrayElementOrNull(r.path_relationships, 1))"
             ),
             "#526: count(DISTINCT r) must build a full row-identity tuple \
              over the CTE's label-agnostic columns (type-paired with id, \


### PR DESCRIPTION
## Summary

Silent-wrong **openCypher fidelity** bug found via a live bug hunt. Cypher `list[i]` with an out-of-range index must return `null` (Neo4j semantics), but ClickHouse `arr[i]`/`arrayElement` return the element type's **default** (`0` for numbers, `''` for strings) — indistinguishable from a real `0`/`''` element:

```
RETURN [1,2,3][10]     ->  0     (should be null)
RETURN [0,1,2][10]     ->  0     (collides with a real element!)
RETURN ['x','y'][5]    ->  ''    (should be null)
```

## Fix (Rule #7 dispatch)

New `FunctionMapper::array_element_or_null(arr, idx)`:
- **CH**: `arrayElementOrNull(arr, idx)` — NULL on out-of-bounds
- **Databricks**: `element_at(arr, idx)` — already NULL on out-of-bounds (non-ANSI default), so **byte-identical** to the prior accessor

The `ArraySubscript` numeric-index arm (`to_sql_query.rs`) routes through it; the hardcoded dialect branch collapses into the mapper. Untouched:
- in-bounds access and negative (from-the-end) indices
- string-literal map-key access (`arr['key']`)
- internal `arrayElement(groupArray(...), 1)` head-extraction (its array is always non-empty)

## Live-verified (ClickHouse)

OOB (both ends, zero-element list, string list) → NULL; `[0]`/`[2]`/`[-1]` correct; null propagates through arithmetic and is recoverable via `coalesce`; map-key access still works; `type(r)` over real VLP data still returns the type.

## Golden churn — behavior-identical

`type(r)` over a VLP path lowers to `path_relationships[1]`, which also renders as `ArraySubscript`, so 13 corpus + 4 sql_ir goldens shift `arr[1]` → `arrayElementOrNull(arr, 1)`. A matched relationship's array is always non-empty, so the element is identical (and NULL is *more* correct than `''` for a hypothetical zero-length path). **Zero Databricks churn.** New `list_index_out_of_bounds` golden + mapper unit tests lock the fix.

## Gate
fmt · clippy · 1612 lib · 244 golden · corpus + ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)