### PR TITLE
fix: head([])/last([]) on empty list return null (was ClickHouse type default)

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -376,10 +376,13 @@ lazy_static::lazy_static! {
 
         // ===== LIST FUNCTIONS =====
 
-        // head(list) -> arrayElement(list, 1) [first element]
+        // head(list) -> arrayElementOrNull(list, 1) [first element, NULL if empty]
+        // openCypher: head([]) is null, not the element type's default. CH
+        // `arrayElement` returns 0/'' on an empty list; `arrayElementOrNull`
+        // returns NULL. Spark `element_at` already returns NULL on out-of-bounds.
         m.insert("head", FunctionMapping {
             neo4j_name: "head",
-            clickhouse_name: "arrayElement",
+            clickhouse_name: "arrayElementOrNull",
             databricks_name: Some("element_at"), // Spark 1-based element access
             arg_transform: Some(|args| {
                 if !args.is_empty() {
@@ -416,10 +419,11 @@ lazy_static::lazy_static! {
             }),
         });
 
-        // last(list) -> arrayElement(list, -1) [last element]
+        // last(list) -> arrayElementOrNull(list, -1) [last element, NULL if empty]
+        // openCypher: last([]) is null, not the element type's default (see head).
         m.insert("last", FunctionMapping {
             neo4j_name: "last",
-            clickhouse_name: "arrayElement",
+            clickhouse_name: "arrayElementOrNull",
             databricks_name: Some("element_at"), // Spark element_at supports -1 (last)
             arg_transform: Some(|args| {
                 if !args.is_empty() {

--- a/tests/rust/integration/golden/sql_ir/standard/fn_head_last_empty__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/fn_head_last_empty__clickhouse.sql
@@ -1,6 +1,7 @@
 WITH with_ns_cte_0 AS (SELECT 
       groupArray(u.full_name) AS "ns"
 FROM social.users_bench AS u
+WHERE u.full_name = 'NOBODY'
 )
 SELECT 
       arrayElementOrNull(ns.ns, 1) AS "h", 

--- a/tests/rust/integration/golden/sql_ir/standard/fn_head_last_empty__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/fn_head_last_empty__databricks.sql
@@ -1,0 +1,9 @@
+WITH with_ns_cte_0 AS (SELECT 
+      collect_list(u.full_name) AS `ns`
+FROM social.users_bench AS u
+WHERE u.full_name = 'NOBODY'
+)
+SELECT 
+      element_at(ns.ns, 1) AS `h`, 
+      element_at(ns.ns, -1) AS `l`
+FROM with_ns_cte_0 AS ns

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -292,9 +292,10 @@ const CORPUS: &[(&str, &str)] = &[
         "MATCH (u:User) RETURN [10, 20, 30][10] AS oob_hi, [10, 20, 30][-10] AS oob_lo, [10, 20, 30][0] AS first",
     ),
     // Dialect function-name mappings (regression for the Databricks overrides):
-    // replace -> CH replaceAll / Spark replace; head/last -> CH arrayElement /
-    // Spark element_at; stdev -> CH stddevSamp / Spark stddev_samp. Previously all
-    // emitted the CH name on Databricks (unmapped function -> execution error).
+    // replace -> CH replaceAll / Spark replace; head/last -> CH
+    // arrayElementOrNull / Spark element_at; stdev -> CH stddevSamp / Spark
+    // stddev_samp. Previously all emitted the CH name on Databricks (unmapped
+    // function -> execution error).
     (
         "fn_replace",
         "MATCH (u:User) RETURN replace(u.name, 'a', 'X') AS r",
@@ -302,6 +303,15 @@ const CORPUS: &[(&str, &str)] = &[
     (
         "fn_head_last",
         "MATCH (u:User) WITH collect(u.name) AS ns RETURN head(ns) AS h, last(ns) AS l",
+    ),
+    // head([])/last([]) on an empty list must be NULL (openCypher), not the
+    // element type's default. CH `arrayElement` returns 0/'' on an empty list,
+    // so head/last route through `arrayElementOrNull`; Spark `element_at`
+    // already returns NULL out of bounds. (The empty list is produced by a
+    // collect() over a WHERE that matches no rows.)
+    (
+        "fn_head_last_empty",
+        "MATCH (u:User) WHERE u.name = 'NOBODY' WITH collect(u.name) AS ns RETURN head(ns) AS h, last(ns) AS l",
     ),
     (
         "fn_stdev",


### PR DESCRIPTION
## Summary

Sibling of #850, same **openCypher fidelity** class. `head(list)`/`last(list)` on an **empty** list must return `null` (Neo4j), but they lowered to CH `arrayElement(list, 1)` / `arrayElement(list, -1)`, which return the element type's **default** (`0`/`''`) on an empty array instead of NULL:

```
MATCH (u:User) WHERE u.name = 'NOBODY'
WITH collect(u.name) AS ns
RETURN head(ns), last(ns)      -- returned '', '' ; should be null, null
```

## Fix

The `head`/`last` mappings in the ClickHouse function registry now use `arrayElementOrNull` (the null-on-out-of-bounds accessor added in #850) instead of `arrayElement`. In-bounds behavior is identical (index 1 = first, -1 = last on a non-empty list). **Databricks unchanged** — `element_at` already returns NULL out of bounds, so the Spark override stays `element_at` and DBX goldens are byte-identical.

## Live-verified (ClickHouse)

head/last over an empty `collect()` → NULL (both); non-empty → first/last; literal `head([10,20,30])`=10 / `last`=30; NULL propagates through arithmetic and recovers via `coalesce`.

## Golden churn

1 CH golden (`fn_head_last`: `arrayElement`→`arrayElementOrNull`); **0 Databricks churn**. New `fn_head_last_empty` golden locks the empty-list NULL behavior on both dialects.

## Gate
fmt · clippy · 1624 lib · 248 golden · corpus + ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)