### PR TITLE
test(#523): lock partial-ref undirected 2-hop render determinism

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -138,11 +138,17 @@ Exit met: one fully green nightly run + xpass count 0.
   pre-existing on main, byte-identical, untouched by #839).
 
 ### P-1 — Keep a small silent-wrong bug lane open  (standing, ≤1 agent)
-**Lane state (2026-08-01): #581 shipped — agg-arg NULL-padding validity now
+**Lane state (2026-08-01): #523 closed as already-fixed (determinism-lock test
+added); #581 shipped — agg-arg NULL-padding validity now
 alias-qualified (was matching by bare physical column name, a latent
 name-coincidence false-positive).** Since
 the 07-19 reconcile this lane shipped ~23 fixes (all live- or SQL-gen-verified,
-newest first): **#581 (agg-arg NULL-padding validity check matched columns by
+newest first): **#523 (partial-ref undirected 2-hop golden flake, reported
+2026-07-10 — root-caused as already-eliminated by the #480/#481 HashMap-order
+fixes + `normalize()` counter anonymization; verified byte-stable across 40
+fresh-process renders and 45 isolated test runs; locked by
+`partial_ref_undirected_2hop_render_is_deterministic_523`)**,
+**#581 (agg-arg NULL-padding validity check matched columns by
 unqualified name — a node column sharing a name with an unrelated branch table's
 column was deemed valid on every branch; `table_valid_columns` now also keys
 columns by render alias and `agg_arg_col_valid_for_branch` checks the

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -5270,6 +5270,61 @@ async fn coupled_multihop_middle_node_binds_shared_endpoint_481() {
     );
 }
 
+/// #523 regression: the standard-schema partial-ref undirected 2-hop
+/// `MATCH (a:User)-[:FOLLOWS]-(b)-[:FOLLOWS]-(c:User) RETURN a.name, c.name`
+/// was reported (2026-07-10) as a process/seed-dependent flake — its
+/// `partial_ref_undirected_2hop` corpus golden passed in the full suite but
+/// was suspected to flap when run in isolation, same family as the #458/#480/
+/// #481 HashMap-iteration nondeterminism.
+///
+/// The underlying flap was eliminated by the #480/#481 fixes (sorted-by-
+/// cypher-property emission + owning-edge-first role resolution) landing AFTER
+/// the report, plus `normalize()`'s counter anonymization. This test LOCKS
+/// that resolution: the query is an undirected 2-hop with the middle node `b`
+/// unreferenced, so it splits into a 4-branch `UNION ALL` (each direction of
+/// each hop) whose branch order and per-branch JOIN order must be byte-stable
+/// across many fresh in-process renders — different HashMap seeds per map flip
+/// a nondeterministic site within a single process, so a repeated-render loop
+/// catches a regression the full-suite ordering would mask.
+///
+/// Verified additionally across 40 fresh-process `cg` renders (normalized):
+/// all byte-identical, structure fully deterministic.
+#[tokio::test]
+async fn partial_ref_undirected_2hop_render_is_deterministic_523() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let repro = "MATCH (a:User)-[:FOLLOWS]-(b)-[:FOLLOWS]-(c:User) RETURN a.name, c.name";
+
+    let first = normalize(&render(&schema, repro, SqlDialect::ClickHouse).await);
+    // Structural sanity: the undirected 2-hop with unreferenced middle splits
+    // into a 4-branch UNION ALL (3 UNION ALL joiners).
+    assert_eq!(
+        first.matches("UNION ALL").count(),
+        3,
+        "#523: partial-ref undirected 2-hop must render 4 branches:\n{first}"
+    );
+
+    for _ in 0..30 {
+        let again = normalize(&render(&schema, repro, SqlDialect::ClickHouse).await);
+        assert_eq!(
+            first, again,
+            "#523: partial-ref undirected 2-hop render is nondeterministic \
+             (branch/JOIN order flapping on HashMap seed):\nFIRST:\n{first}\n\
+             AGAIN:\n{again}"
+        );
+    }
+
+    // Both dialects must be deterministic.
+    let first_dbx = normalize(&render(&schema, repro, SqlDialect::Databricks).await);
+    for _ in 0..10 {
+        let again = normalize(&render(&schema, repro, SqlDialect::Databricks).await);
+        assert_eq!(
+            first_dbx, again,
+            "#523: Databricks render is nondeterministic:\nFIRST:\n{first_dbx}\n\
+             AGAIN:\n{again}"
+        );
+    }
+}
+
 /// #491 regression: `MATCH (a:Airport)-[:FLIGHT]->(b) OPTIONAL MATCH
 /// (b)-[:FLIGHT]->(c)` on the denormalized flights schema bound the REQUIRED
 /// node `b` to the OPTIONAL hop's LEFT-JOINed table alias (the


### PR DESCRIPTION
## Summary

Closes #523. The standard-schema `partial_ref_undirected_2hop` corpus golden — `MATCH (a:User)-[:FOLLOWS]-(b)-[:FOLLOWS]-(c:User) RETURN a.name, c.name` — was reported (2026-07-10) as a process/seed-dependent flake, same family as the #458/#480/#481 HashMap-iteration nondeterminism.

## Investigation → already fixed

Root-caused: the underlying flap was **eliminated by the #480/#481 fixes** (sorted-by-cypher-property emission + owning-edge-first role resolution) that landed *after* the report, plus `normalize()`'s counter anonymization. No source change is warranted.

**Evidence of determinism:**
- **40 fresh-process `cg` renders** (normalized by first-appearance): all byte-identical — branch order and per-branch JOIN order fully stable.
- **45 isolated `sql_golden_snapshots` runs** (25 parallel + 20 single-threaded): 0 failures.
- The stored golden matches the normalized fresh render exactly (only a trailing-newline artifact from the CLI echo).

## What this PR adds

A permanent **determinism-lock** regression test `partial_ref_undirected_2hop_render_is_deterministic_523`, mirroring the existing #470/#480/#481 repeated-render pattern (different HashMap seeds per map flip a nondeterministic site *within* a single process, so a repeated-render loop catches a regression the full-suite ordering would mask). It locks:
- the 4-branch `UNION ALL` structure (undirected 2-hop, unreferenced middle), and
- byte-stability across 30 ClickHouse + 10 Databricks in-process renders.

**Test-only change** — no source modification.

## Verification
- New test passes; **fail-mode** is a real nondeterministic render (the loop asserts byte-equality).
- Byte-lock gate: `corpus_sweep` **0 churn**, `sql_golden` 249, full suite **2206 passed, 0 failed**.
- `cargo fmt --all` clean, `cargo clippy --all-targets` clean.

## Docs
- `docs/design/PRIORITIES.md`: logged #523 as closed-already-fixed in the P-1 lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)