### PR TITLE
fix(#847): integer-constant division truncates toward zero (was float)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1776,7 +1776,25 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 }
                 Operator::Subtraction => format!("{} - {}", operands[0], operands[1]),
                 Operator::Multiplication => format!("{} * {}", operands[0], operands[1]),
-                Operator::Division => format!("{} / {}", operands[0], operands[1]),
+                Operator::Division => {
+                    // Cypher integer-constant division truncates toward zero
+                    // (`7/2 = 3`); CH/Spark `/` is float division. Mirror Path A
+                    // (`render_integer_division`): both operands integer constants
+                    // → `intDiv(a, b)` (CH) / `div(a, b)` (Spark). Column operands
+                    // aren't typeable here so stay `/` (tracked in #847).
+                    let both_int_consts = op.operands.len() == 2
+                        && op.operands.iter().all(
+                            crate::sql_generator::emitters::clickhouse::to_sql_query::is_integer_constant,
+                        );
+                    if both_int_consts {
+                        let int_div =
+                            crate::sql_generator::function_mapper::current_function_mapper()
+                                .integer_division();
+                        format!("{}({}, {})", int_div, operands[0], operands[1])
+                    } else {
+                        format!("{} / {}", operands[0], operands[1])
+                    }
+                }
                 Operator::ModuloDivision => format!("{} % {}", operands[0], operands[1]),
                 Operator::Exponentiation => format!("POWER({}, {})", operands[0], operands[1]),
                 Operator::In => {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -384,6 +384,48 @@ fn render_string_addition(op: &OperatorApplication) -> Option<String> {
     None
 }
 
+/// True when `e` is a compile-time INTEGER constant: an integer literal, or the
+/// unary-minus lowering `0 - <integer constant>` the parser emits for `-7`
+/// (`Subtraction(Integer(0), …)`). Used to classify integer division operands
+/// (see `render_integer_division`). Deliberately does NOT recurse into general
+/// arithmetic — only literals and negation — so it stays a conservative,
+/// type-certain check; a column or computed operand is never an integer constant
+/// here (its type isn't known at render time, #847).
+pub(crate) fn is_integer_constant(e: &RenderExpr) -> bool {
+    match e {
+        RenderExpr::Literal(Literal::Integer(_)) => true,
+        RenderExpr::OperatorApplicationExp(op)
+            if op.operator == Operator::Subtraction
+                && op.operands.len() == 2
+                && matches!(&op.operands[0], RenderExpr::Literal(Literal::Integer(0))) =>
+        {
+            is_integer_constant(&op.operands[1])
+        }
+        _ => false,
+    }
+}
+
+/// Integer division: Cypher `int / int` truncates toward zero (`7/2 = 3`,
+/// `-7/2 = -3`), only becoming float division when an operand is a float. CH/
+/// Spark `/` is always float division, so `7/2` wrongly yields `3.5`. When BOTH
+/// operands are integer CONSTANTS (literals or the `-n` negation form) we emit
+/// `intDiv(a, b)` (CH) / `div(a, b)` (Spark) — both truncate toward zero,
+/// matching Neo4j. Bounded to integer constants: a column's type isn't known at
+/// render time (the schema carries no column types), so `u.a / u.b` can't be
+/// classified here and stays `/` (tracked in #847). `rendered` holds the
+/// already-rendered operand SQL.
+fn render_integer_division(op: &OperatorApplication, rendered: &[String]) -> Option<String> {
+    if op.operator != Operator::Division || op.operands.len() != 2 || rendered.len() != 2 {
+        return None;
+    }
+    if !op.operands.iter().all(is_integer_constant) {
+        return None;
+    }
+    let int_div =
+        crate::sql_generator::function_mapper::current_function_mapper().integer_division();
+    Some(format!("{}({}, {})", int_div, rendered[0], rendered[1]))
+}
+
 /// Interval arithmetic on epoch-millis: wrap non-interval operands as a
 /// timestamp, do the `+`/`-`, and convert the result back to epoch-millis.
 /// Dialect-aware via the function mapper — ClickHouse:
@@ -7350,6 +7392,9 @@ impl RenderExpr {
                 if let Some(s) = render_interval_arithmetic(op, &rendered) {
                     return s;
                 }
+                if let Some(s) = render_integer_division(op, &rendered) {
+                    return s;
+                }
 
                 let sql_op = op_str(op.operator);
 
@@ -7827,6 +7872,9 @@ impl RenderExpr {
                 if let Some(s) = render_interval_arithmetic(op, &rendered) {
                     return s;
                 }
+                if let Some(s) = render_integer_division(op, &rendered) {
+                    return s;
+                }
 
                 let sql_op = op_str(op.operator);
 
@@ -8140,6 +8188,9 @@ impl ToSql for OperatorApplication {
             return s;
         }
         if let Some(s) = render_interval_arithmetic(self, &rendered) {
+            return s;
+        }
+        if let Some(s) = render_integer_division(self, &rendered) {
             return s;
         }
 

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -70,6 +70,11 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         "has"
     }
 
+    fn integer_division(&self) -> &'static str {
+        // Truncates toward zero: intDiv(-7, 2) = -3, matching Neo4j.
+        "intDiv"
+    }
+
     fn empty_string_array_cast(&self) -> &'static str {
         "CAST([] AS Array(String))"
     }

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -142,6 +142,12 @@ impl FunctionMapper for DatabricksFunctionMapper {
         "array_contains"
     }
 
+    fn integer_division(&self) -> &'static str {
+        // Spark `div(a, b)` is integer division truncating toward zero
+        // (div(-7, 2) = -3), matching Neo4j and CH `intDiv`.
+        "div"
+    }
+
     fn empty_string_array_cast(&self) -> &'static str {
         "CAST(array() AS ARRAY<STRING>)"
     }
@@ -284,6 +290,7 @@ mod tests {
         assert_eq!(m.cast_string(), "string");
         assert_eq!(m.array_concat(), "concat");
         assert_eq!(m.array_contains(), "array_contains");
+        assert_eq!(m.integer_division(), "div");
         assert_eq!(m.epoch_millis_to_timestamp("x"), "timestamp_millis(x)");
         assert_eq!(m.timestamp_to_epoch_millis("x"), "unix_millis(x)");
         assert_eq!(

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -129,6 +129,12 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// Used for cycle detection in VLP recursive CTEs.
     fn array_contains(&self) -> &'static str;
 
+    /// Integer (truncate-toward-zero) division. CH: `intDiv`. Spark: `div`.
+    /// Both match Neo4j's `int / int` (`intDiv(-7, 2) = -3`, toward zero, not
+    /// floor). Used to render Cypher integer-literal division, whose default
+    /// `/` is float division on both engines.
+    fn integer_division(&self) -> &'static str;
+
     /// Empty `Array(String)` literal with explicit cast. CH:
     /// `CAST([] AS Array(String))`. Spark: `CAST(array() AS ARRAY<STRING>)`.
     /// Returned as a full snippet (not a function name) because the array

--- a/tests/rust/integration/golden/sql_ir/standard/int_division_literals__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/int_division_literals__clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      intDiv(7, 2) AS "a", 
+      intDiv(0 - 7, 2) AS "b", 
+      7 / 2 AS "c"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/int_division_literals__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/int_division_literals__databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      div(7, 2) AS `a`, 
+      div(0 - 7, 2) AS `b`, 
+      7 / 2 AS `c`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -386,6 +386,15 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_reduce",
         "MATCH (u:User) RETURN reduce(s = 0, x IN [1, 2, 3] | s + x) AS r",
     ),
+    // Integer-constant division truncates toward zero in Cypher (`7/2 = 3`,
+    // `-7/2 = -3`); CH/Spark `/` is float division (`7/2 = 3.5`). Both integer
+    // constants (literals or the `-n` negation form) -> CH `intDiv(a, b)` /
+    // Spark `div(a, b)`. A float operand keeps `/` (float division); a column
+    // operand isn't typeable at render time so also keeps `/` (#847).
+    (
+        "int_division_literals",
+        "MATCH (u:User) RETURN 7 / 2 AS a, -7 / 2 AS b, 7 / 2.0 AS c",
+    ),
     // range is INCLUSIVE in Cypher. CH range() is exclusive -> end bumped +1
     // (was silently wrong: range(1,5) gave [1,2,3,4]); Spark has no range() ->
     // sequence() (already inclusive).


### PR DESCRIPTION
## Summary

Cypher `int / int` is **integer division truncating toward zero** (`7/2 = 3`, `-7/2 = -3`); it becomes float division only when an operand is a float. ClickHouse/Spark `/` is always float, so `7/2` wrongly returned `3.5`. Fixes #847 for the integer-constant case.

## Fix (bounded, Rule #7)

When **both** division operands are integer **constants** — an integer literal or the parser's `-n` negation form `Subtraction(0, n)` — emit `intDiv(a, b)` (CH) / `div(a, b)` (Spark) via the new `FunctionMapper::integer_division`. Both truncate toward zero, matching Neo4j (`intDiv(-7, 2) = -3`, not floor).

`render_integer_division` sits alongside the existing `render_{list,string}_addition` / `render_interval_arithmetic` special-cases at all three Path A operator sites (`to_sql_query.rs`); Path C (`cte_extraction.rs`) mirrors it via the shared `is_integer_constant`.

## Scope (honest boundary)

Integer **constants** only. A column operand's type isn't known at render time (the schema carries no column types), so `u.a / u.b` can't be classified and stays `/` (float) — the residual stays tracked on **#847**. A float operand keeps `/` (correct float division).

## Live-verified (ClickHouse)

`7/2=3, -7/2=-3, 7/-2=-3, -7/-2=3, 1/2=0, 10/3=3` (toward zero); `7.0/2=3.5, 7/2.0=3.5` unchanged; `% * -` unaffected; column division stays float. Works in RETURN and CTE-body WHERE (Path C).

## Churn

**0 corpus/golden churn** (no corpus query does integer-literal division) — latent correctness hardening. New `int_division_literals` golden (both dialects: CH `intDiv`, DBX `div`) + mapper spelling assertion.

## Coordination

Touches `to_sql_query.rs` at the operator-render sites (~7123/7671/8023) — disjoint from #581's regions (3469-3692/8283), so rebases clean.

## Gate
fmt · clippy · 1626 lib · 249 golden · corpus + ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)