### PR TITLE
fix(#858): preserve parens on a lower-precedence left operand ((1+2)*3 was 7)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1750,6 +1750,35 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                     .collect()
             };
 
+            // Parenthesize arithmetic operands to preserve grouping — Path C
+            // previously emitted bare `{a} OP {b}`, dropping parens on BOTH sides
+            // (`(1+2)*3` → `1 + 2 * 3`, `10-(2+3)` → `10 - 2 + 3`). Uses the same
+            // precedence rules as Path A (`needs_left_parens`/`needs_right_parens`).
+            let arith_lhs = || {
+                if op.operands.len() == 2
+                    && crate::render_plan::render_expr::needs_left_parens(
+                        op.operator,
+                        &op.operands[0],
+                    )
+                {
+                    format!("({})", operands[0])
+                } else {
+                    operands[0].clone()
+                }
+            };
+            let arith_rhs = || {
+                if op.operands.len() == 2
+                    && crate::render_plan::render_expr::needs_right_parens(
+                        op.operator,
+                        &op.operands[1],
+                    )
+                {
+                    format!("({})", operands[1])
+                } else {
+                    operands[1].clone()
+                }
+            };
+
             match op.operator {
                 Operator::Equal => format!("{} = {}", operands[0], operands[1]),
                 Operator::NotEqual => format!("{} != {}", operands[0], operands[1]),
@@ -1771,11 +1800,11 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                             .collect();
                         format!("concat({})", flattened.join(", "))
                     } else {
-                        format!("{} + {}", operands[0], operands[1])
+                        format!("{} + {}", arith_lhs(), arith_rhs())
                     }
                 }
-                Operator::Subtraction => format!("{} - {}", operands[0], operands[1]),
-                Operator::Multiplication => format!("{} * {}", operands[0], operands[1]),
+                Operator::Subtraction => format!("{} - {}", arith_lhs(), arith_rhs()),
+                Operator::Multiplication => format!("{} * {}", arith_lhs(), arith_rhs()),
                 Operator::Division => {
                     // Cypher integer-constant division truncates toward zero
                     // (`7/2 = 3`); CH/Spark `/` is float division. Mirror Path A
@@ -1792,10 +1821,10 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                                 .integer_division();
                         format!("{}({}, {})", int_div, operands[0], operands[1])
                     } else {
-                        format!("{} / {}", operands[0], operands[1])
+                        format!("{} / {}", arith_lhs(), arith_rhs())
                     }
                 }
-                Operator::ModuloDivision => format!("{} % {}", operands[0], operands[1]),
+                Operator::ModuloDivision => format!("{} % {}", arith_lhs(), arith_rhs()),
                 Operator::Exponentiation => format!("POWER({}, {})", operands[0], operands[1]),
                 Operator::In => {
                     // Cypher: x IN array_property → CH: has(arr, x), Spark: array_contains(arr, x)

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -1758,6 +1758,35 @@ pub fn needs_right_parens(outer_op: Operator, right_operand: &RenderExpr) -> boo
     }
 }
 
+/// Check whether a LEFT operand needs parenthesization to preserve semantics.
+///
+/// Parens are needed when the left operand is an operator expression whose
+/// precedence is strictly LESS than the outer operator's — otherwise flattening
+/// changes the grouping. Because arithmetic operators are left-associative,
+/// EQUAL precedence on the left needs no parens (`(a - b) - c` == `a - b - c`,
+/// `(a / b) * c` == `a / b * c`), unlike the right side.
+///
+/// Examples:
+/// - `(a + b) * c` must NOT flatten to `a + b * c` (inner `+` prec 1 < `*` prec 2)
+/// - `(a - b) / c` must NOT flatten to `a - b / c`
+/// - `(a - b) - c` MAY flatten to `a - b - c` (equal prec, left-associative)
+/// - `(a * b) + c` MAY flatten to `a * b + c` (inner prec higher)
+pub fn needs_left_parens(outer_op: Operator, left_operand: &RenderExpr) -> bool {
+    let outer_prec = match outer_op.arithmetic_precedence() {
+        Some(p) => p,
+        None => return false,
+    };
+
+    if let RenderExpr::OperatorApplicationExp(inner) = left_operand {
+        match inner.operator.arithmetic_precedence() {
+            Some(inner_prec) => inner_prec < outer_prec,
+            None => false,
+        }
+    } else {
+        false
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct OperatorApplication {
     pub operator: Operator,
@@ -2279,6 +2308,43 @@ mod tests {
     fn test_no_parens_literal() {
         // a - 5 does NOT need parens (right is literal, not operator)
         assert!(!needs_right_parens(Operator::Subtraction, &lit_int(5)));
+    }
+
+    #[test]
+    fn test_needs_left_parens_add_mul() {
+        // (a + b) * c needs parens: inner + (prec 1) < outer * (prec 2)
+        let left = make_binop(Operator::Addition, lit_int(1), lit_int(2));
+        assert!(needs_left_parens(Operator::Multiplication, &left));
+    }
+
+    #[test]
+    fn test_needs_left_parens_sub_div() {
+        // (a - b) / c needs parens: inner - (prec 1) < outer / (prec 2)
+        let left = make_binop(Operator::Subtraction, lit_int(5), lit_int(3));
+        assert!(needs_left_parens(Operator::Division, &left));
+    }
+
+    #[test]
+    fn test_no_left_parens_equal_precedence() {
+        // (a - b) - c does NOT need parens: left-associative, equal precedence.
+        let left = make_binop(Operator::Subtraction, lit_int(1), lit_int(2));
+        assert!(!needs_left_parens(Operator::Subtraction, &left));
+        // (a / b) * c likewise (equal precedence, left-assoc).
+        let left = make_binop(Operator::Division, lit_int(6), lit_int(2));
+        assert!(!needs_left_parens(Operator::Multiplication, &left));
+    }
+
+    #[test]
+    fn test_no_left_parens_higher_precedence() {
+        // (a * b) + c does NOT need parens: inner * (prec 2) > outer + (prec 1).
+        let left = make_binop(Operator::Multiplication, lit_int(2), lit_int(3));
+        assert!(!needs_left_parens(Operator::Addition, &left));
+    }
+
+    #[test]
+    fn test_no_left_parens_literal() {
+        // 5 - a: left literal, not an operator expression.
+        assert!(!needs_left_parens(Operator::Subtraction, &lit_int(5)));
     }
 
     // -------------------------------------------------------------------------

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7472,10 +7472,17 @@ impl RenderExpr {
                                 format!("({} {} {})", &rendered[0], sql_op, &rendered[1])
                             }
                             _ => {
+                                let lhs =
+                                    if render_expr::needs_left_parens(op.operator, &op.operands[0])
+                                    {
+                                        format!("({})", &rendered[0])
+                                    } else {
+                                        rendered[0].clone()
+                                    };
                                 if render_expr::needs_right_parens(op.operator, &op.operands[1]) {
-                                    format!("{} {} ({})", &rendered[0], sql_op, &rendered[1])
+                                    format!("{} {} ({})", lhs, sql_op, &rendered[1])
                                 } else {
-                                    format!("{} {} {}", &rendered[0], sql_op, &rendered[1])
+                                    format!("{} {} {}", lhs, sql_op, &rendered[1])
                                 }
                             }
                         }
@@ -7946,10 +7953,16 @@ impl RenderExpr {
                             format!("({} {} {})", &rendered[0], sql_op, &rendered[1])
                         }
                         _ => {
+                            let lhs =
+                                if render_expr::needs_left_parens(op.operator, &op.operands[0]) {
+                                    format!("({})", &rendered[0])
+                                } else {
+                                    rendered[0].clone()
+                                };
                             if render_expr::needs_right_parens(op.operator, &op.operands[1]) {
-                                format!("{} {} ({})", &rendered[0], sql_op, &rendered[1])
+                                format!("{} {} ({})", lhs, sql_op, &rendered[1])
                             } else {
-                                format!("{} {} {}", &rendered[0], sql_op, &rendered[1])
+                                format!("{} {} {}", lhs, sql_op, &rendered[1])
                             }
                         }
                     },
@@ -8265,10 +8278,15 @@ impl ToSql for OperatorApplication {
                 }
             }
             2 => {
-                if render_expr::needs_right_parens(self.operator, &self.operands[1]) {
-                    format!("{} {} ({})", &rendered[0], sql_op, &rendered[1])
+                let lhs = if render_expr::needs_left_parens(self.operator, &self.operands[0]) {
+                    format!("({})", &rendered[0])
                 } else {
-                    format!("{} {} {}", &rendered[0], sql_op, &rendered[1])
+                    rendered[0].clone()
+                };
+                if render_expr::needs_right_parens(self.operator, &self.operands[1]) {
+                    format!("{} {} ({})", lhs, sql_op, &rendered[1])
+                } else {
+                    format!("{} {} {}", lhs, sql_op, &rendered[1])
                 }
             }
             _ => {

--- a/tests/rust/integration/golden/sql_ir/standard/arith_left_parens__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/arith_left_parens__clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      (1 + 2) * 3 AS "a", 
+      (5 - 3) / 2 AS "b", 
+      1 - 2 - 3 AS "c", 
+      2 * 3 + 1 AS "d", 
+      10 - (2 + 3) AS "e"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/arith_left_parens__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/arith_left_parens__databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      (1 + 2) * 3 AS `a`, 
+      (5 - 3) / 2 AS `b`, 
+      1 - 2 - 3 AS `c`, 
+      2 * 3 + 1 AS `d`, 
+      10 - (2 + 3) AS `e`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -395,6 +395,15 @@ const CORPUS: &[(&str, &str)] = &[
         "int_division_literals",
         "MATCH (u:User) RETURN 7 / 2 AS a, -7 / 2 AS b, 7 / 2.0 AS c",
     ),
+    // Parenthesization of a lower-precedence LEFT operand must be preserved:
+    // `(1+2)*3` is 9, not `1+2*3` = 7. `needs_left_parens` wraps the left operand
+    // when its precedence is strictly below the outer op; equal precedence
+    // (`(a-b)-c`) stays bare by left-associativity, and a higher-precedence left
+    // (`a*b + c`) needs none. Right-operand parens (`10-(2+3)`) already worked.
+    (
+        "arith_left_parens",
+        "MATCH (u:User) RETURN (1 + 2) * 3 AS a, (5 - 3) / 2 AS b, 1 - 2 - 3 AS c, 2 * 3 + 1 AS d, 10 - (2 + 3) AS e",
+    ),
     // range is INCLUSIVE in Cypher. CH range() is exclusive -> end bumped +1
     // (was silently wrong: range(1,5) gave [1,2,3,4]); Spark has no range() ->
     // sequence() (already inclusive).


### PR DESCRIPTION
## Summary

Parentheses around a **lower-precedence LEFT operand** were dropped during SQL rendering, silently corrupting arithmetic:

```
(1 + 2) * 3        → rendered  1 + 2 * 3      = 7   (Neo4j: 9)
(5 - 3) / 2        → rendered  5 - 3 / 2      = 3.5 (Neo4j: 1)
(2 + 3) * (4 + 1)  → rendered  2 + 3 * (4 + 1) = 17 (Neo4j: 25)
```

Right-operand parens were already handled (`needs_right_parens`); the left side had no equivalent. Present on `main`, not a regression. Fixes #858.

## Fix

New `render_expr::needs_left_parens(outer_op, left_operand)` — parens when the left operand's arithmetic precedence is **strictly less** than the outer op's. Equal precedence stays bare by left-associativity (`(a-b)-c` == `a-b-c`); a higher-precedence left (`a*b + c`) needs none.

Applied at all three Path A binary-operator render sites (`to_sql_query.rs`, symmetric with the existing right handling) **and** Path C (`cte_extraction.rs`) — whose arithmetic arms previously emitted bare `{a} OP {b}`, dropping parens on **both** sides; now routed through `needs_left_parens`/`needs_right_parens`.

## Live-verified (ClickHouse)

- Bug cases fixed: `(1+2)*3`=9, `(5-3)/2`=1, `(2+3)*(4+1)`=25, `(10-4)-2`=4.
- Already-correct unchanged: `1+2*3`=7, `2*(3+4)`=14, `10-(2+3)`=5.
- No over-parenthesization: `1-2-3` (equal-prec left-assoc) stays bare.
- Deep nesting (`((1+2)*3)-4`=5, `(1+2)*(3-1)`=6), modulo (`(5+1)%4`=2), column arithmetic (`(u.user_id+1)*2`), and Path C CTE-body WHERE all correct.

## Churn

**0 corpus/golden churn** (no existing query has a parenthesized lower-precedence left operand) — latent correctness hardening. New `arith_left_parens` golden (both dialects) + 5 `needs_left_parens` unit tests.

## Gate
fmt · clippy · 1632 lib · 250 golden · corpus + ratchet net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)