### PR TITLE
fix(#861): support exponentiation operator ^ (parse + render as POWER)

### DIFF
--- a/src/open_cypher_parser/expression.rs
+++ b/src/open_cypher_parser/expression.rs
@@ -719,7 +719,7 @@ fn parse_unary_expression(input: &'_ str) -> IResult<&'_ str, Expression<'_>> {
 
 // Multiplicative operators: * / %
 fn parse_multiplicative_expression(input: &'_ str) -> IResult<&'_ str, Expression<'_>> {
-    let (input, lhs) = parse_unary_expression(input)?;
+    let (input, lhs) = parse_exponent_expression(input)?;
 
     let mut remaining_input = input;
     let mut final_expression = lhs;
@@ -732,6 +732,38 @@ fn parse_multiplicative_expression(input: &'_ str) -> IResult<&'_ str, Expressio
             map(tag_no_case("%"), |_| Operator::ModuloDivision),
         )))
         .parse(remaining_input);
+
+        match op_result {
+            Ok((new_input, op)) => {
+                let (new_input, rhs) = parse_exponent_expression(new_input)?;
+                final_expression = Expression::OperatorApplicationExp(OperatorApplication {
+                    operator: op,
+                    operands: vec![final_expression, rhs],
+                });
+                remaining_input = new_input;
+            }
+            Err(nom::Err::Error(_)) => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok((remaining_input, final_expression))
+}
+
+// Exponentiation: ^ — binds tighter than * / %, looser than unary sign, per the
+// openCypher grammar (`<arithmetic factor> ::= <arithmetic unary> |
+// <arithmetic factor> <circumflex> <arithmetic unary>`). The production is
+// left-recursive → left-associative, so `2 ^ 3 ^ 2` parses as `(2 ^ 3) ^ 2`.
+// Operands are unary expressions, so `-2 ^ 2` parses as `(-2) ^ 2` (the sign
+// binds tighter than `^`, matching the grammar's `<arithmetic unary>` operand).
+fn parse_exponent_expression(input: &'_ str) -> IResult<&'_ str, Expression<'_>> {
+    let (input, lhs) = parse_unary_expression(input)?;
+
+    let mut remaining_input = input;
+    let mut final_expression = lhs;
+
+    loop {
+        let op_result =
+            ws(map(tag_no_case("^"), |_| Operator::Exponentiation)).parse(remaining_input);
 
         match op_result {
             Ok((new_input, op)) => {
@@ -1944,6 +1976,77 @@ mod tests {
                 panic!("Parser should handle 100 * size([pattern])");
             }
         }
+    }
+
+    #[test]
+    fn test_parse_exponentiation_basic() {
+        // `2 ^ 3` parses as Exponentiation(2, 3).
+        let (rem, expr) = parse_expression("2 ^ 3").unwrap();
+        assert_eq!(rem, "");
+        if let Expression::OperatorApplicationExp(op) = expr {
+            assert_eq!(op.operator, Operator::Exponentiation);
+            assert_eq!(op.operands.len(), 2);
+        } else {
+            panic!("Expected Exponentiation, got {:?}", expr);
+        }
+    }
+
+    #[test]
+    fn test_parse_exponentiation_binds_tighter_than_multiply() {
+        // `2 ^ 3 * 4` → `(2 ^ 3) * 4`: outer op is Multiplication, left is `^`.
+        let (rem, expr) = parse_expression("2 ^ 3 * 4").unwrap();
+        assert_eq!(rem, "");
+        let Expression::OperatorApplicationExp(op) = expr else {
+            panic!("Expected operator, got {:?}", expr);
+        };
+        assert_eq!(op.operator, Operator::Multiplication);
+        assert!(
+            matches!(
+                &op.operands[0],
+                Expression::OperatorApplicationExp(inner) if inner.operator == Operator::Exponentiation
+            ),
+            "left of `*` should be the `^` subtree, got {:?}",
+            op.operands[0]
+        );
+    }
+
+    #[test]
+    fn test_parse_exponentiation_binds_tighter_than_add() {
+        // `1 + 2 ^ 3` → `1 + (2 ^ 3)`: outer op is Addition, right is `^`.
+        let (rem, expr) = parse_expression("1 + 2 ^ 3").unwrap();
+        assert_eq!(rem, "");
+        let Expression::OperatorApplicationExp(op) = expr else {
+            panic!("Expected operator, got {:?}", expr);
+        };
+        assert_eq!(op.operator, Operator::Addition);
+        assert!(
+            matches!(
+                &op.operands[1],
+                Expression::OperatorApplicationExp(inner) if inner.operator == Operator::Exponentiation
+            ),
+            "right of `+` should be the `^` subtree, got {:?}",
+            op.operands[1]
+        );
+    }
+
+    #[test]
+    fn test_parse_exponentiation_left_associative() {
+        // Grammar's `<arithmetic factor>` is left-recursive: `2 ^ 3 ^ 2`
+        // parses as `(2 ^ 3) ^ 2` — the OUTER `^` has a `^` subtree on its LEFT.
+        let (rem, expr) = parse_expression("2 ^ 3 ^ 2").unwrap();
+        assert_eq!(rem, "");
+        let Expression::OperatorApplicationExp(op) = expr else {
+            panic!("Expected operator, got {:?}", expr);
+        };
+        assert_eq!(op.operator, Operator::Exponentiation);
+        assert!(
+            matches!(
+                &op.operands[0],
+                Expression::OperatorApplicationExp(inner) if inner.operator == Operator::Exponentiation
+            ),
+            "left-associative: outer `^` left operand should be a `^` subtree, got {:?}",
+            op.operands[0]
+        );
     }
 
     #[test]

--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -1798,6 +1798,11 @@ fn render_logical_expr_to_sql(
                     join_clauses,
                     node_joins_added,
                 );
+                // Exponentiation has no infix form on ClickHouse/Spark; route
+                // through the dialect mapper's `POWER(base, exp)` (Rule #7).
+                if op.operator == Op::Exponentiation {
+                    return current_function_mapper().power(&left, &right);
+                }
                 format!("{}{}{}", left, op_str, right)
             } else {
                 let rendered: Vec<String> = op

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -426,6 +426,19 @@ fn render_integer_division(op: &OperatorApplication, rendered: &[String]) -> Opt
     Some(format!("{}({}, {})", int_div, rendered[0], rendered[1]))
 }
 
+/// Render the Cypher exponentiation operator `a ^ b`. Neither ClickHouse nor
+/// Databricks/Spark has an infix `^` (ClickHouse errors Code 62 on a bare `^`);
+/// both accept the ANSI `POWER(base, exp)` call form, routed through the
+/// function mapper (Rule #7). The call form is self-delimiting, so no
+/// precedence parens are needed around it or its operands.
+fn render_exponentiation(op: &OperatorApplication, rendered: &[String]) -> Option<String> {
+    if op.operator != Operator::Exponentiation || rendered.len() != 2 {
+        return None;
+    }
+    let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+    Some(mapper.power(&rendered[0], &rendered[1]))
+}
+
 /// Interval arithmetic on epoch-millis: wrap non-interval operands as a
 /// timestamp, do the `+`/`-`, and convert the result back to epoch-millis.
 /// Dialect-aware via the function mapper — ClickHouse:
@@ -7448,6 +7461,9 @@ impl RenderExpr {
                 if let Some(s) = render_integer_division(op, &rendered) {
                     return s;
                 }
+                if let Some(s) = render_exponentiation(op, &rendered) {
+                    return s;
+                }
 
                 let sql_op = op_str(op.operator);
 
@@ -7935,6 +7951,9 @@ impl RenderExpr {
                 if let Some(s) = render_integer_division(op, &rendered) {
                     return s;
                 }
+                if let Some(s) = render_exponentiation(op, &rendered) {
+                    return s;
+                }
 
                 let sql_op = op_str(op.operator);
 
@@ -8257,6 +8276,9 @@ impl ToSql for OperatorApplication {
             return s;
         }
         if let Some(s) = render_integer_division(self, &rendered) {
+            return s;
+        }
+        if let Some(s) = render_exponentiation(self, &rendered) {
             return s;
         }
 

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -238,6 +238,15 @@ mod tests {
     }
 
     #[test]
+    fn power_uses_ansi_power_call_form() {
+        // ClickHouse has no infix `^` (Code 62 SYNTAX_ERROR); the exponentiation
+        // operator must render as the ANSI `POWER(base, exp)` call.
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.power("2", "3"), "POWER(2, 3)");
+        assert_eq!(m.power("n.user_id", "2"), "POWER(n.user_id, 2)");
+    }
+
+    #[test]
     fn epoch_millis_timestamp_roundtrip_uses_clickhouse_functions() {
         let m = ClickhouseFunctionMapper;
         assert_eq!(

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -291,6 +291,9 @@ mod tests {
         assert_eq!(m.array_concat(), "concat");
         assert_eq!(m.array_contains(), "array_contains");
         assert_eq!(m.integer_division(), "div");
+        // Exponentiation uses the shared ANSI `POWER(base, exp)` default —
+        // Spark/Databricks has no infix `^` either.
+        assert_eq!(m.power("2", "3"), "POWER(2, 3)");
         assert_eq!(m.epoch_millis_to_timestamp("x"), "timestamp_millis(x)");
         assert_eq!(m.timestamp_to_epoch_millis("x"), "unix_millis(x)");
         assert_eq!(

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -135,6 +135,16 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// `/` is float division on both engines.
     fn integer_division(&self) -> &'static str;
 
+    /// Render the Cypher exponentiation operator `a ^ b`. Both ClickHouse and
+    /// Databricks/Spark accept the ANSI `POWER(base, exp)` call form; NEITHER
+    /// has an infix `^` operator (ClickHouse errors with Code 62 SYNTAX_ERROR
+    /// on a bare `^`). `base`/`exp` are pre-rendered SQL fragments. Keeping the
+    /// spelling in the dialect layer satisfies Rule #7; the shared default is
+    /// correct for both shipped dialects.
+    fn power(&self, base: &str, exp: &str) -> String {
+        format!("POWER({}, {})", base, exp)
+    }
+
     /// Empty `Array(String)` literal with explicit cast. CH:
     /// `CAST([] AS Array(String))`. Spark: `CAST(array() AS ARRAY<STRING>)`.
     /// Returned as a full snippet (not a function name) because the array

--- a/tests/rust/integration/golden/sql_ir/standard/arith_exponentiation__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/arith_exponentiation__clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      POWER(2, 3) AS "a", 
+      1 + POWER(2, 3) AS "b", 
+      POWER(2, 3) * 4 AS "c", 
+      POWER(POWER(2, 3), 2) AS "d", 
+      POWER(0 - 2, 2) AS "e"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/arith_exponentiation__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/arith_exponentiation__databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      POWER(2, 3) AS `a`, 
+      1 + POWER(2, 3) AS `b`, 
+      POWER(2, 3) * 4 AS `c`, 
+      POWER(POWER(2, 3), 2) AS `d`, 
+      POWER(0 - 2, 2) AS `e`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -404,6 +404,16 @@ const CORPUS: &[(&str, &str)] = &[
         "arith_left_parens",
         "MATCH (u:User) RETURN (1 + 2) * 3 AS a, (5 - 3) / 2 AS b, 1 - 2 - 3 AS c, 2 * 3 + 1 AS d, 10 - (2 + 3) AS e",
     ),
+    // Exponentiation `^` has NO infix form on ClickHouse (Code 62) or Spark;
+    // it renders as the ANSI `POWER(base, exp)` call. Precedence (grammar's
+    // `<arithmetic factor>`): `^` binds tighter than `*`/`/`/`%` and `+`/`-`
+    // (`1 + 2 ^ 3` = `1 + POWER(2,3)`), looser than unary sign (`-2 ^ 2` =
+    // `POWER(0 - 2, 2)`), and is left-associative (`2 ^ 3 ^ 2` =
+    // `POWER(POWER(2,3), 2)`).
+    (
+        "arith_exponentiation",
+        "MATCH (u:User) RETURN 2 ^ 3 AS a, 1 + 2 ^ 3 AS b, 2 ^ 3 * 4 AS c, 2 ^ 3 ^ 2 AS d, -2 ^ 2 AS e",
+    ),
     // range is INCLUSIVE in Cypher. CH range() is exclusive -> end bumped +1
     // (was silently wrong: range(1,5) gave [1,2,3,4]); Spark has no range() ->
     // sequence() (already inclusive).


### PR DESCRIPTION
## Summary

The Cypher exponentiation operator `^` **did not parse at all**. `parse_multiplicative_expression` only handled `*`/`/`/`%`, so any query containing `^` failed with `Unparsed input`. The operator enum, precedence table (`render_expr.rs`), and all render sites already existed but were **unreachable dead code** — and a `#[cfg(test)]`-only parse test (`parse_operator_symbols`) gave false confidence the operator worked end-to-end.

This corrects the original #861 filing (which assumed `^` reached Path A and rendered wrong infix). The real bug is upstream: it never parsed.

## Fix

**Parser** (`expression.rs`): insert a `parse_exponent_expression` tier between the multiplicative and unary tiers, faithful to the checked-in openCypher grammar:
```
<arithmetic factor> ::= <arithmetic unary> | <arithmetic factor> <circumflex> <arithmetic unary>
```
→ `^` binds **tighter than** `*`/`/`/`%`, **looser than** unary sign, **left-associative** (`2^3^2` = `(2^3)^2`).

**Render**: neither ClickHouse (Code 62 `SYNTAX_ERROR` on bare `^`) nor Spark has an infix `^`; both accept ANSI `POWER(base, exp)`. New `FunctionMapper::power()` (shared default — satisfies Rule #7) routes the three `to_sql_query.rs` infix sites + the `pattern_comprehension_sql.rs` site. Path C (`cte_extraction.rs`) already emitted `POWER`.

## Verification

Live end-to-end against ClickHouse (`db_standard`):
| query | `2^3` | `1+2^3` | `2^3*4` | `2^3^2` | `-2^2` |
|---|---|---|---|---|---|
| result | 8 | 9 | 32 | 64 | 4 |

All match grammar-faithful semantics (`^` tighter than `+`/`*`, unary tighter than `^`, left-assoc).

- **Zero golden churn** (`^` was previously unparseable, so no existing golden could use it)
- +1 new golden `arith_exponentiation` (both dialects — identical `POWER(...)` structure)
- +4 parser tests (basic, tighter-than-`*`, tighter-than-`+`, left-assoc)
- +2 mapper tests (CH + DBX)
- fmt / clippy / 1637 lib tests / 542 integration (incl. corpus_sweep) / **ratchet** all green

### Note on associativity
The project's checked-in openCypher grammar defines `^` as **left-associative** (left-recursive production), so `2^3^2 = 64`. Some engines use the right-assoc math convention (= 512); I followed the authoritative in-repo grammar and documented it inline. Moot for the common single-`^` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)