### PR TITLE
fix: count(<scalar>) crashed with "Missing label for node" (UNWIND/WITH-scalar/param)

### DIFF
--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1318,6 +1318,50 @@ impl ProjectionTagging {
 
                     if let Some(t_alias) = table_alias_opt {
                         if aggregate_fn_call.name.to_lowercase() == "count" {
+                            // A scalar variable (UNWIND element, WITH-scalar alias,
+                            // or parameter) is NOT a graph entity: it has no label or
+                            // id column, so the per-label node/rel id-column rewrite
+                            // below would fail resolution ("Missing label for node
+                            // `x`") when it calls `get_label_str()`. Neo4j's
+                            // `count(<scalar>)` counts non-NULL values of the
+                            // expression — exactly what a bare `count(x)` /
+                            // `count(DISTINCT x)` means in SQL.
+                            //
+                            // The arg is a `TableAlias(x)`, but the render-phase
+                            // `AggregateFnCall::try_from` rejects a bare
+                            // `count(TableAlias(_))` (a fail-fast for UNRESOLVED
+                            // NODE vars, which would silently miscount under
+                            // OPTIONAL MATCH). A scalar is legitimately `count(x)`,
+                            // so rewrite the arg to `ColumnAlias(x)` — it renders
+                            // to the identical bare `x` but is not the node-var
+                            // shape the render guard trips on. `count(DISTINCT x)`
+                            // already dodges the guard (its arg is an
+                            // `OperatorApplication(Distinct, ..)`, not a bare
+                            // TableAlias), but rewrite it too for consistency.
+                            if plan_ctx
+                                .lookup_variable(t_alias)
+                                .is_some_and(|v| v.is_scalar())
+                            {
+                                let col = LogicalExpr::ColumnAlias(
+                                    crate::query_planner::logical_expr::ColumnAlias(
+                                        t_alias.to_string(),
+                                    ),
+                                );
+                                let new_arg = if is_distinct {
+                                    LogicalExpr::OperatorApplicationExp(OperatorApplication {
+                                        operator: Operator::Distinct,
+                                        operands: vec![col],
+                                    })
+                                } else {
+                                    col
+                                };
+                                item.expression = LogicalExpr::AggregateFnCall(AggregateFnCall {
+                                    name: aggregate_fn_call.name.clone(),
+                                    args: vec![new_arg],
+                                });
+                                return Ok(());
+                            }
+
                             // First check if this is a projection alias (from WITH clause)
                             // If so, resolve it to the underlying table alias
                             let resolved_alias: String = if plan_ctx.is_projection_alias(t_alias) {

--- a/tests/rust/integration/golden/sql_ir/standard/count_scalar_and_node__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/count_scalar_and_node__clickhouse.sql
@@ -1,0 +1,9 @@
+WITH with_one_u_cte_0 AS (SELECT 
+      u.user_id AS "p1_u_user_id", 
+      1 AS "one"
+FROM social.users_bench AS u
+)
+SELECT 
+      count(one_u.one) AS "c", 
+      count(one_u.p1_u_user_id) AS "uc"
+FROM with_one_u_cte_0 AS one_u

--- a/tests/rust/integration/golden/sql_ir/standard/count_scalar_and_node__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/count_scalar_and_node__databricks.sql
@@ -1,0 +1,9 @@
+WITH with_one_u_cte_0 AS (SELECT 
+      u.user_id AS `p1_u_user_id`, 
+      1 AS `one`
+FROM social.users_bench AS u
+)
+SELECT 
+      count(one_u.one) AS `c`, 
+      count(one_u.p1_u_user_id) AS `uc`
+FROM with_one_u_cte_0 AS one_u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -421,6 +421,17 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_range",
         "MATCH (u:User) RETURN range(1, 5) AS r",
     ),
+    // count(<scalar>) — a scalar variable (WITH-scalar / UNWIND element /
+    // parameter) is not a graph entity, so it must render as a plain
+    // `count(one)`, NOT be rewritten to a per-label node-id column. On main this
+    // crashed in ProjectionTagging ("Missing label for node") because the
+    // count-arg node/rel id rewrite assumed a graph alias. The scalar `one`
+    // stays `count(one)`; the sibling `count(u)` still routes to the node-id
+    // form (`count(u.user_id)`) — proving the guard fires only for scalars.
+    (
+        "count_scalar_and_node",
+        "MATCH (u:User) WITH u, 1 AS one RETURN count(one) AS c, count(u) AS uc",
+    ),
     (
         "optional_match",
         "MATCH (u:User) OPTIONAL MATCH (u)-[:AUTHORED]->(p:Post) RETURN u.name, p.title",


### PR DESCRIPTION
## Summary

`count(x)` where `x` is a **scalar variable** — an `UNWIND` element, a `WITH`-scalar passthrough, or a parameter — crashed loudly in `ProjectionTagging` with `Missing label for node \`x\``.

```cypher
UNWIND [1,2,3] AS x RETURN count(x)     -- ❌ Missing label for node `x`
```

The count-arg tagging path unconditionally treats a bare aggregate arg as a graph entity and rewrites `count(n)` → `count(n.<id_column>)` (correct NULL semantics under OPTIONAL MATCH). A scalar has no label or id column, so `get_label_str()` raised. `sum(x)`/`collect(x)`/`min(x)`/`count(*)` were all fine — only the count-node-id rewrite has this assumption.

## Fix

Neo4j's `count(<scalar>)` counts non-NULL values of the expression — exactly a bare SQL `count(x)` / `count(DISTINCT x)`. In the count-tagging branch, detect a scalar arg via `plan_ctx.lookup_variable(x).is_scalar()` and rewrite the arg from `TableAlias(x)` to `ColumnAlias(x)`:
- renders to the identical bare `x`, **and**
- is not the bare-`TableAlias` node-var shape that `AggregateFnCall::try_from` fail-fasts on in render (that guard catches *unresolved node vars*, which would miscount under OPTIONAL MATCH — it must stay).

DISTINCT is preserved.

## Verification (live: db_standard + system.one)

| query | result |
|---|---|
| `UNWIND [1,2,3] AS x RETURN count(x)` | 3 |
| `UNWIND [1,2,null,3] AS x RETURN count(x)` | 3 (nulls skipped) |
| `UNWIND ['a','b','a'] AS s RETURN count(s), count(DISTINCT s)` | 3, 2 |
| `UNWIND [1,2,3] AS x WITH x RETURN count(x)` | 3 |
| **MIXED** `MATCH (u:User) WITH u, 1 AS one RETURN count(one), count(u)` | 5, 5 |
| `MATCH (u:User) RETURN count(u)` / `count(r)` (regression) | 5 / 9 |

The **mixed** case is the key proof: the scalar `one` stays `count(one)` while the node `u` still resolves to `count(u.user_id)` — the guard fires only for scalars. Node/rel/OPTIONAL counts are unregressed.

- +1 golden `count_scalar_and_node` (both dialects — scalar renders `count(one)`, node renders `count(...user_id)`)
- **0 existing-golden churn** (scalar count previously crashed, so nothing covered it)
- fmt / clippy / 1637 lib / 542 integration (incl. corpus_sweep) / ratchet all green

## Out of scope (filed #864)

`WITH x AS y RETURN count(y)` — a scalar **renamed** across a WITH barrier — is a distinct pre-existing bug: it advances past the analyzer (thanks to this fix) but renders a spurious `count(y.y)` property access. That's the post-WITH scalar-alias resolution problem (#602/#616 family); untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)