### PR TITLE
fix: negative-index list slicing returned wrong elements (silent)

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -2031,27 +2031,50 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             // complex alias references that need mapping.
             let array_sql = render_expr_to_sql_string(array, alias_mapping);
             let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+            use crate::sql_generator::emitters::clickhouse::to_sql_query::{
+                is_nonneg_int_literal, normalize_slice_bound,
+            };
             // Cypher list ranges are 0-based and HALF-OPEN: `list[from..to]` yields
             // indices [from, to), i.e. `to - from` elements. offset = from + 1.
+            // Negative bounds count from the end and are normalized first (the
+            // same rewrite Path A applies); non-negative integer literals stay
+            // verbatim so positive slices render identically.
             match (from, to) {
                 (Some(from_expr), Some(to_expr)) => {
-                    let from_sql = render_expr_to_sql_string(from_expr, alias_mapping);
-                    let to_sql = render_expr_to_sql_string(to_expr, alias_mapping);
-                    // Floor at 0 so from > to yields an empty slice (a negative length
-                    // is silently wrong on CH arraySlice and errors on Databricks slice).
+                    let nf = normalize_slice_bound(
+                        &render_expr_to_sql_string(from_expr, alias_mapping),
+                        &array_sql,
+                        is_nonneg_int_literal(from_expr),
+                    );
+                    let nt = normalize_slice_bound(
+                        &render_expr_to_sql_string(to_expr, alias_mapping),
+                        &array_sql,
+                        is_nonneg_int_literal(to_expr),
+                    );
+                    // Floor the length at 0 so from >= to yields an empty slice (a
+                    // negative length is silently wrong on CH arraySlice and errors
+                    // on Databricks slice).
                     mapper.array_slice(
                         &array_sql,
-                        &format!("{} + 1", from_sql),
-                        Some(&format!("greatest({} - {}, 0)", to_sql, from_sql)),
+                        &format!("{} + 1", nf),
+                        Some(&format!("greatest({} - {}, 0)", nt, nf)),
                     )
                 }
                 (Some(from_expr), None) => {
-                    let from_sql = render_expr_to_sql_string(from_expr, alias_mapping);
-                    mapper.array_slice(&array_sql, &format!("{} + 1", from_sql), None)
+                    let nf = normalize_slice_bound(
+                        &render_expr_to_sql_string(from_expr, alias_mapping),
+                        &array_sql,
+                        is_nonneg_int_literal(from_expr),
+                    );
+                    mapper.array_slice(&array_sql, &format!("{} + 1", nf), None)
                 }
                 (None, Some(to_expr)) => {
-                    let to_sql = render_expr_to_sql_string(to_expr, alias_mapping);
-                    mapper.array_slice(&array_sql, "1", Some(&to_sql))
+                    let nt = normalize_slice_bound(
+                        &render_expr_to_sql_string(to_expr, alias_mapping),
+                        &array_sql,
+                        is_nonneg_int_literal(to_expr),
+                    );
+                    mapper.array_slice(&array_sql, "1", Some(&nt))
                 }
                 (None, None) => array_sql,
             }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -439,6 +439,42 @@ fn render_exponentiation(op: &OperatorApplication, rendered: &[String]) -> Optio
     Some(mapper.power(&rendered[0], &rendered[1]))
 }
 
+/// Is `expr` a non-negative integer literal? Cypher list-range bounds that are
+/// plain non-negative constants need no from-the-end normalization, so the slice
+/// renderer keeps them on the simple `bound (+ 1)` path — which also keeps the
+/// existing positive-slice goldens byte-identical.
+pub(crate) fn is_nonneg_int_literal(expr: &RenderExpr) -> bool {
+    matches!(expr, RenderExpr::Literal(Literal::Integer(n)) if *n >= 0)
+}
+
+/// Normalize one Cypher list-slice bound into a non-negative index usable by
+/// `arraySlice`/`slice`. Cypher allows negative bounds that count from the end
+/// (`list[-2..]`) and clamps out-of-range bounds to the array edge, whereas the
+/// ClickHouse/Spark array-slice offset has no from-the-end meaning. A runtime or
+/// negative bound `i` is therefore rewritten to `i >= 0 ? i : greatest(len + i,
+/// 0)`, where `len` is the dialect's array-length call (Rule #7, via
+/// [`FunctionMapper::array_length`]). A statically non-negative integer literal
+/// is returned verbatim so positive slices render exactly as before.
+/// `bound_sql`/`array_sql` are pre-rendered SQL fragments; `array_sql` is
+/// re-evaluated inside the guard (fine for the column/literal arrays slicing
+/// targets in practice, matching the existing Spark 2-arg `array_slice` form).
+pub(crate) fn normalize_slice_bound(
+    bound_sql: &str,
+    array_sql: &str,
+    is_nonneg_literal: bool,
+) -> String {
+    if is_nonneg_literal {
+        return bound_sql.to_string();
+    }
+    let len =
+        crate::sql_generator::function_mapper::current_function_mapper().array_length(array_sql);
+    format!(
+        "if(({b}) >= 0, ({b}), greatest({len} + ({b}), 0))",
+        b = bound_sql,
+        len = len
+    )
+}
+
 /// Interval arithmetic on epoch-millis: wrap non-interval operands as a
 /// timestamp, do the `+`/`-`, and convert the result back to epoch-millis.
 /// Dialect-aware via the function mapper — ClickHouse:
@@ -7703,32 +7739,56 @@ impl RenderExpr {
                 // both 1-based offset + element count. Cypher list ranges are 0-based
                 // and HALF-OPEN: `list[from..to]` yields indices [from, to), i.e.
                 // `to - from` elements. So offset = from + 1 and length = to - from.
+                // Cypher also permits NEGATIVE bounds that count from the end
+                // (`list[-2..]`) and clamps out-of-range bounds; each bound is
+                // normalized to a non-negative index first (see
+                // `normalize_slice_bound`). Statically non-negative integer
+                // literals bypass normalization, so positive slices render
+                // exactly as before.
                 let array_sql = array.to_sql();
                 let mapper = crate::sql_generator::function_mapper::current_function_mapper();
 
                 match (from, to) {
                     (Some(from_expr), Some(to_expr)) => {
                         // [from..to) -> 1-based offset + half-open length (to - from).
-                        // Floor at 0: when from > to the slice is empty, but a negative
+                        // Floor the length at 0: when from >= to (after
+                        // normalization) the slice is empty, but a negative
                         // length means "drop from the end" on ClickHouse arraySlice
                         // (silent wrong data) and errors on Databricks slice().
+                        let nf = normalize_slice_bound(
+                            &from_expr.to_sql(),
+                            &array_sql,
+                            is_nonneg_int_literal(from_expr),
+                        );
+                        let nt = normalize_slice_bound(
+                            &to_expr.to_sql(),
+                            &array_sql,
+                            is_nonneg_int_literal(to_expr),
+                        );
                         mapper.array_slice(
                             &array_sql,
-                            &format!("{} + 1", from_expr.to_sql()),
-                            Some(&format!(
-                                "greatest({} - {}, 0)",
-                                to_expr.to_sql(),
-                                from_expr.to_sql()
-                            )),
+                            &format!("{} + 1", nf),
+                            Some(&format!("greatest({} - {}, 0)", nt, nf)),
                         )
                     }
                     (Some(from_expr), None) => {
                         // [from..] - slice to end. CH 2-arg form; Spark computes the length.
-                        mapper.array_slice(&array_sql, &format!("{} + 1", from_expr.to_sql()), None)
+                        let nf = normalize_slice_bound(
+                            &from_expr.to_sql(),
+                            &array_sql,
+                            is_nonneg_int_literal(from_expr),
+                        );
+                        mapper.array_slice(&array_sql, &format!("{} + 1", nf), None)
                     }
                     (None, Some(to_expr)) => {
                         // [..to) - from index 1, take `to` elements (indices [0, to)).
-                        mapper.array_slice(&array_sql, "1", Some(&to_expr.to_sql()))
+                        // With offset 1 the length equals the normalized end index.
+                        let nt = normalize_slice_bound(
+                            &to_expr.to_sql(),
+                            &array_sql,
+                            is_nonneg_int_literal(to_expr),
+                        );
+                        mapper.array_slice(&array_sql, "1", Some(&nt))
                     }
                     (None, None) => {
                         // [..] - no bounds, return entire array (identity operation)

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -115,6 +115,11 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         }
     }
 
+    fn array_length(&self, arr: &str) -> String {
+        // CH `length` is overloaded for arrays and strings alike.
+        format!("length({})", arr)
+    }
+
     fn epoch_millis_to_timestamp(&self, expr: &str) -> String {
         format!("fromUnixTimestamp64Milli({})", expr)
     }
@@ -197,6 +202,14 @@ mod tests {
         let m = ClickhouseFunctionMapper;
         assert_eq!(m.array_slice("a", "2", Some("3")), "arraySlice(a, 2, 3)");
         assert_eq!(m.array_slice("a", "2", None), "arraySlice(a, 2)");
+    }
+
+    #[test]
+    fn array_length_uses_clickhouse_overloaded_length() {
+        // CH `length` works on arrays and strings alike; used to normalize
+        // negative list-slice bounds.
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(m.array_length("arr"), "length(arr)");
     }
 
     #[test]

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -201,6 +201,11 @@ impl FunctionMapper for DatabricksFunctionMapper {
         }
     }
 
+    fn array_length(&self, arr: &str) -> String {
+        // Spark reserves `length` for strings/binary; arrays need `size`.
+        format!("size({})", arr)
+    }
+
     fn epoch_millis_to_timestamp(&self, expr: &str) -> String {
         // Spark TIMESTAMP from epoch milliseconds. Verified on Databricks SQL:
         // unix_millis(timestamp_millis(x)) round-trips exactly under UTC.
@@ -322,6 +327,9 @@ mod tests {
             m.array_slice("arr", "2", None),
             "slice(arr, 2, greatest(size(arr) - (2) + 1, 0))"
         );
+        // Spark arrays need `size` (its `length` is string/binary-only), unlike
+        // ClickHouse's overloaded `length`; used to normalize negative slice bounds.
+        assert_eq!(m.array_length("arr"), "size(arr)");
         // #639: Spark percentileCont = `percentile(expr, p)` (interpolated).
         // percentileDisc has no matching comma-arg builtin (Spark's
         // `percentile_disc` uses WITHIN GROUP + a different index), so it's the

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -202,6 +202,15 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// `offset`/`length` are pre-rendered SQL fragments.
     fn array_slice(&self, arr: &str, offset: &str, length: Option<&str>) -> String;
 
+    /// Element count of an array expression, used to normalize Cypher's
+    /// negative list-range bounds (`list[-2..]`) into the non-negative
+    /// offset/length that `array_slice` needs. The two dialects diverge:
+    /// ClickHouse `length(arr)` is overloaded for arrays AND strings, whereas
+    /// Spark reserves `length` for strings/binary and requires `size(arr)` for
+    /// arrays — so the spelling must live in the dialect layer (Rule #7).
+    /// `arr` is a pre-rendered SQL fragment.
+    fn array_length(&self, arr: &str) -> String;
+
     /// Convert an epoch-millis `BIGINT` expression to a timestamp value, so
     /// interval arithmetic can run on it. CH: `fromUnixTimestamp64Milli(expr)`
     /// (-> DateTime64). Spark: `timestamp_millis(expr)` (-> TIMESTAMP). The

--- a/tests/rust/integration/golden/sql_ir/standard/list_slice_negative__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/list_slice_negative__clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      arraySlice([10, 20, 30, 40, 50], if((0 - 2) >= 0, (0 - 2), greatest(length([10, 20, 30, 40, 50]) + (0 - 2), 0)) + 1) AS "a", 
+      arraySlice([10, 20, 30, 40, 50], 1 + 1, greatest(if((0 - 1) >= 0, (0 - 1), greatest(length([10, 20, 30, 40, 50]) + (0 - 1), 0)) - 1, 0)) AS "b", 
+      arraySlice([10, 20, 30, 40, 50], if((0 - 10) >= 0, (0 - 10), greatest(length([10, 20, 30, 40, 50]) + (0 - 10), 0)) + 1, greatest(2 - if((0 - 10) >= 0, (0 - 10), greatest(length([10, 20, 30, 40, 50]) + (0 - 10), 0)), 0)) AS "c", 
+      arraySlice([10, 20, 30, 40, 50], if((0 - 3) >= 0, (0 - 3), greatest(length([10, 20, 30, 40, 50]) + (0 - 3), 0)) + 1, greatest(if((0 - 1) >= 0, (0 - 1), greatest(length([10, 20, 30, 40, 50]) + (0 - 1), 0)) - if((0 - 3) >= 0, (0 - 3), greatest(length([10, 20, 30, 40, 50]) + (0 - 3), 0)), 0)) AS "d", 
+      arraySlice([10, 20, 30, 40, 50], 1, if((0 - 1) >= 0, (0 - 1), greatest(length([10, 20, 30, 40, 50]) + (0 - 1), 0))) AS "e"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/list_slice_negative__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/list_slice_negative__databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      slice(array(10, 20, 30, 40, 50), if((0 - 2) >= 0, (0 - 2), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 2), 0)) + 1, greatest(size(array(10, 20, 30, 40, 50)) - (if((0 - 2) >= 0, (0 - 2), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 2), 0)) + 1) + 1, 0)) AS `a`, 
+      slice(array(10, 20, 30, 40, 50), 1 + 1, greatest(if((0 - 1) >= 0, (0 - 1), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 1), 0)) - 1, 0)) AS `b`, 
+      slice(array(10, 20, 30, 40, 50), if((0 - 10) >= 0, (0 - 10), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 10), 0)) + 1, greatest(2 - if((0 - 10) >= 0, (0 - 10), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 10), 0)), 0)) AS `c`, 
+      slice(array(10, 20, 30, 40, 50), if((0 - 3) >= 0, (0 - 3), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 3), 0)) + 1, greatest(if((0 - 1) >= 0, (0 - 1), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 1), 0)) - if((0 - 3) >= 0, (0 - 3), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 3), 0)), 0)) AS `d`, 
+      slice(array(10, 20, 30, 40, 50), 1, if((0 - 1) >= 0, (0 - 1), greatest(size(array(10, 20, 30, 40, 50)) + (0 - 1), 0))) AS `e`
+FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -194,6 +194,18 @@ const CORPUS: &[(&str, &str)] = &[
     ),
     // tail() -> CH arraySlice(list, 2) / Spark slice(list, 2, greatest(size-1, 0))
     ("list_tail", "MATCH (u:User) RETURN tail([10, 20, 30]) AS t"),
+    // Negative list-range bounds count from the end (`list[-2..]` = last two) and
+    // out-of-range bounds clamp — Cypher semantics the raw `from + 1` offset got
+    // wrong (silently) on both dialects. Each non-literal / negative bound is
+    // normalized to `i >= 0 ? i : greatest(len + i, 0)` via the dialect's
+    // array-length call (CH `length`, Spark `size`). `d` mixes a negative from
+    // with a negative to; `e` exercises the `[..to)` (from-index-1) path.
+    (
+        "list_slice_negative",
+        "MATCH (u:User) RETURN [10, 20, 30, 40, 50][-2..] AS a, \
+         [10, 20, 30, 40, 50][1..-1] AS b, [10, 20, 30, 40, 50][-10..2] AS c, \
+         [10, 20, 30, 40, 50][-3..-1] AS d, [10, 20, 30, 40, 50][..-1] AS e",
+    ),
     // Interval arithmetic on an epoch-millis column -> CH
     // `toUnixTimestamp64Milli(fromUnixTimestamp64Milli(x) + toIntervalDay(n))`
     // vs Spark `unix_millis(timestamp_millis(x) + make_dt_interval(n,0,0,0))`.


### PR DESCRIPTION
## Problem

Cypher list ranges allow **negative bounds** that count from the end (`list[-2..]` = last two elements) and clamp out-of-range bounds to the array edge. Both SQL-emission paths applied `from + 1` — the 0-based→1-based offset shift — blindly to *every* bound, so a negative offset landed at the wrong place on ClickHouse `arraySlice` / Spark `slice`. **Silent wrong data, not an error:**

| Query | ClickGraph (before) | Neo4j |
|---|---|---|
| `[1,2,3,4,5][-2..]` | `[5]` | `[4,5]` |
| `[1,2,3,4,5][-1..]` | `[]` | `[5]` |
| `[1,2,3,4,5][-3..-1]` | `[]` | `[3,4]` |
| `[1,2,3,4,5][0..-1]` | `[]` | `[1,2,3,4]` |
| `[1,2,3,4,5][1..-1]` | `[]` | `[2,3,4]` |
| `[1,2,3,4,5][..-1]` | length `-1` | `[1,2,3,4]` |

The array-**index** path (`list[-1]`) already normalized negatives; the **slice** path never did.

## Fix

Each non-literal / negative bound is normalized to a non-negative index first:

```
i >= 0 ? i : greatest(len + i, 0)
```

where `len` is the dialect's array-length call. That length spelling is the **only** dialect-specific piece — ClickHouse `length` is overloaded for arrays and strings, whereas Spark reserves `length` for strings and needs `size` for arrays — so it routes through a new **`FunctionMapper::array_length`** (Rule #7 axis-dispatch), not inline branching. Statically non-negative integer literals bypass normalization, so **every existing positive-slice golden stays byte-identical (0 churn)**.

Shared helpers `normalize_slice_bound` / `is_nonneg_int_literal` live in `to_sql_query.rs` and are reused by Path C (`cte_extraction.rs`), so both emission paths stay in lockstep.

## Verification

- **Live ClickHouse**: 11/11 positive and negative cases (double- and single-bound, both direct and through a WITH-barrier CTE) now match Neo4j exactly.
- New `list_slice_negative` golden covers both dialects; mapper unit tests assert the `length`/`size` spellings.
- Full suite green (1638 unit + 542 integration), `cargo fmt`/`clippy -D warnings` clean, **ratchet passes** (routed through the mapper, no new raw-flag branching), **0 existing-golden churn**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)