### PR TITLE
fix(#872): escape literal '?' for the clickhouse-rs query path

### DIFF
--- a/src/executor/remote.rs
+++ b/src/executor/remote.rs
@@ -121,6 +121,28 @@ impl RemoteClickHouseExecutor {
     }
 }
 
+/// Escape literal `?` as `??` for the `clickhouse` crate's `Client::query`.
+///
+/// The crate treats `?` in the SQL template as a bind-parameter placeholder
+/// (and `?fields` as a special field-list placeholder), erroring with
+/// "unbound query argument" at execution if no matching `.bind()` supplies a
+/// value (see clickhouse-rs `src/sql/mod.rs`). ClickGraph never parameterizes —
+/// it hands the crate fully-rendered SQL with all literals inlined — so every
+/// `?` is meant to reach ClickHouse verbatim (e.g. a string literal like
+/// `'why?'`, a regex `=~ 'a?c'`, or a `(?i)` inline flag). The crate's own
+/// escape for a literal `?` is `??`, which its template scanner collapses back
+/// to a single `?`; doubling is therefore an exact, reversible transform.
+///
+/// This MUST be applied only on the crate `Client::query` path — the direct-HTTP
+/// path (`execute_json_via_http`) sends the raw body and needs the literal `?`.
+fn escape_question_marks(sql: &str) -> std::borrow::Cow<'_, str> {
+    if sql.contains('?') {
+        std::borrow::Cow::Owned(sql.replace('?', "??"))
+    } else {
+        std::borrow::Cow::Borrowed(sql)
+    }
+}
+
 /// Parse the `X-ClickHouse-Summary` JSON (fields are quoted decimal strings) and
 /// record read_rows / read_bytes / elapsed_ns into the per-query metrics slot.
 fn record_summary_header(header: &str) {
@@ -170,10 +192,13 @@ impl QueryExecutor for RemoteClickHouseExecutor {
             return self.execute_json_via_http(sql, role).await;
         }
         let client = self.pool.get_client(role).await;
-        let cursor = client.query(sql).fetch_bytes("JSONEachRow").map_err(|e| {
-            log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
-            ExecutorError::QueryFailed(e.to_string())
-        })?;
+        let cursor = client
+            .query(&escape_question_marks(sql))
+            .fetch_bytes("JSONEachRow")
+            .map_err(|e| {
+                log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
+                ExecutorError::QueryFailed(e.to_string())
+            })?;
         let buf = drain_cursor(cursor, sql).await?;
 
         let mut rows = Vec::new();
@@ -197,10 +222,13 @@ impl QueryExecutor for RemoteClickHouseExecutor {
         role: Option<&str>,
     ) -> Result<String, ExecutorError> {
         let client = self.pool.get_client(role).await;
-        let cursor = client.query(sql).fetch_bytes(format).map_err(|e| {
-            log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
-            ExecutorError::QueryFailed(e.to_string())
-        })?;
+        let cursor = client
+            .query(&escape_question_marks(sql))
+            .fetch_bytes(format)
+            .map_err(|e| {
+                log::error!("ClickHouse query failed. SQL was:\n{}\nError: {}", sql, e);
+                ExecutorError::QueryFailed(e.to_string())
+            })?;
         let buf = drain_cursor(cursor, sql).await?;
 
         let mut text = String::from_utf8(buf).map_err(|e| ExecutorError::Parse(e.to_string()))?;
@@ -217,6 +245,44 @@ impl QueryExecutor for RemoteClickHouseExecutor {
 mod tests {
     use super::*;
     use crate::server::metrics::{current_ch_stats, with_ch_stats_scope};
+
+    #[test]
+    fn escape_question_marks_doubles_every_literal_question_mark() {
+        assert_eq!(escape_question_marks("no marks here"), "no marks here");
+        assert_eq!(escape_question_marks("SELECT 'why?'"), "SELECT 'why??'");
+        assert_eq!(
+            escape_question_marks("replace('a?b', '?', '!')"),
+            "replace('a??b', '??', '!')"
+        );
+        // Regex operands: a `?` quantifier and a `(?i)` inline flag.
+        assert_eq!(escape_question_marks("match(x, 'a?c')"), "match(x, 'a??c')");
+        assert_eq!(
+            escape_question_marks("match(x, '(?i)hello')"),
+            "match(x, '(??i)hello')"
+        );
+    }
+
+    #[test]
+    fn escaped_sql_round_trips_through_the_clickhouse_query_builder() {
+        // The crate collapses `??` back to a single `?` and treats a bare `?` as
+        // an unbound placeholder. `Query::sql_display()` renders the final SQL the
+        // crate would send; feeding our escaped form must reproduce the original
+        // literal `?` exactly, with no leftover placeholder.
+        let client = clickhouse::Client::default();
+        for original in [
+            "SELECT 'why?' AS s",
+            "SELECT replace('a?b', '?', '!') AS s",
+            "SELECT match('Hello', '(?i)hello') AS s",
+            "SELECT 'no marks' AS s",
+        ] {
+            let escaped = escape_question_marks(original);
+            let rendered = client.query(&escaped).sql_display().to_string();
+            assert_eq!(
+                rendered, original,
+                "escaped SQL did not round-trip back to the literal for {original:?}"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn summary_header_parsed_and_recorded() {

--- a/src/executor/remote.rs
+++ b/src/executor/remote.rs
@@ -284,6 +284,47 @@ mod tests {
         }
     }
 
+    #[test]
+    fn unescaped_question_mark_is_rejected_by_the_builder_but_escaped_is_accepted() {
+        // Necessity check: `fetch_bytes` calls the crate's `SqlBuilder::finish()`
+        // (which errors on any unbound `?` placeholder) BEFORE any network I/O —
+        // `do_execute` only *builds* the request future, it does not await it — so
+        // this proves the failure mode, and that the escape fixes it, without a
+        // live server. A `?` run of any parity must round-trip.
+        //
+        // The client needs a syntactically valid URL so the only pre-network
+        // failure is the unbound `?` itself (a default client has an empty URL
+        // that would fail `Url::parse` regardless).
+        let client = clickhouse::Client::default().with_url("http://localhost:8123");
+        let is_unbound = |sql: &str| {
+            client
+                .clone()
+                .query(sql)
+                .fetch_bytes("TSV")
+                .err()
+                .map(|e| e.to_string().contains("unbound query argument"))
+                .unwrap_or(false)
+        };
+        for sql in [
+            "SELECT 'why?' AS s",
+            "SELECT 'a???b' AS s",
+            "SELECT '?fields' AS s",
+        ] {
+            // Raw literal `?` -> the crate reads a placeholder and refuses to build.
+            assert!(
+                is_unbound(sql),
+                "expected an unbound-argument error for raw {sql:?}"
+            );
+            // Escaped -> no unbound placeholder remains, so the builder succeeds.
+            assert!(
+                !is_unbound(&escape_question_marks(sql)),
+                "escaped {sql:?} should build without an unbound argument"
+            );
+        }
+        // A `?`-free query never trips the placeholder path.
+        assert!(!is_unbound("SELECT 1 AS s"));
+    }
+
     #[tokio::test]
     async fn summary_header_parsed_and_recorded() {
         let stats = with_ch_stats_scope(async {

--- a/tests/integration/test_return_only_regression.py
+++ b/tests/integration/test_return_only_regression.py
@@ -102,3 +102,56 @@ class TestReturnOnlyRegression:
         assert_query_success(result)
         assert len(result["results"]) == 1
         assert result["results"][0]["num"] == 1
+
+
+class TestQuestionMarkInStringLiterals:
+    """Regression tests for #872.
+
+    A literal `?` in the generated SQL (e.g. inside a string literal) was
+    consumed by the clickhouse-rs `Client::query` template scanner as a
+    bind-parameter placeholder, so the query failed with "unbound query
+    argument" even though the SQL was valid. The remote executor now escapes
+    `?` -> `??` on the crate path (the crate collapses it back to a literal
+    `?`). These execute end-to-end through the server's remote executor.
+    """
+
+    def test_return_string_with_trailing_question_mark(self, simple_graph):
+        """RETURN 'why?' - the minimal repro that used to fail."""
+        result = execute_cypher("RETURN 'why?' AS s", schema_name="social_integration")
+        assert_query_success(result)
+        assert len(result["results"]) == 1
+        assert result["results"][0]["s"] == "why?"
+
+    def test_return_string_with_embedded_question_mark(self, simple_graph):
+        """A `?` in the middle of a string literal."""
+        result = execute_cypher("RETURN 'a?b' AS s", schema_name="social_integration")
+        assert_query_success(result)
+        assert result["results"][0]["s"] == "a?b"
+
+    def test_return_multiple_question_marks(self, simple_graph):
+        """Several `?` in one literal all survive."""
+        result = execute_cypher(
+            "RETURN 'is it? yes! or? no?' AS s", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["s"] == "is it? yes! or? no?"
+
+    def test_replace_question_mark(self, simple_graph):
+        """`?` as both a function argument and inside the target string."""
+        result = execute_cypher(
+            "RETURN replace('a?b', '?', '!') AS s", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["s"] == "a!b"
+
+    def test_regex_match_with_question_quantifier(self, simple_graph):
+        """A regex `=~` operand containing a `?` quantifier."""
+        result = execute_cypher("RETURN 'abc' =~ 'a?bc' AS s", schema_name="social_integration")
+        assert_query_success(result)
+        assert result["results"][0]["s"] in (True, 1)
+
+    def test_no_question_mark_unaffected(self, simple_graph):
+        """A query with no `?` is passed through unchanged (control)."""
+        result = execute_cypher("RETURN 'no marks here' AS s", schema_name="social_integration")
+        assert_query_success(result)
+        assert result["results"][0]["s"] == "no marks here"


### PR DESCRIPTION
## Problem

Any Cypher query whose rendered SQL contains a literal `?` — most commonly a string literal like `'why?'`, but also a regex `=~ 'a?c'` or a `(?i)` inline flag — failed at **execution**:

```
invalid params: invalid SQL: unbound query argument
```

The Cypher→SQL translation was correct; the failure was in the remote executor. This blocks correct queries on extremely common data (any text containing `?`).

```cypher
RETURN 'why?' AS s   -- Neo4j: 'why?' ; ClickGraph: unbound query argument
```

## Root cause

The `clickhouse` crate's `Client::query(sql)` (clickhouse-rs 0.13.x) treats `?` in the SQL template as a **bind-parameter placeholder** (and `?fields` specially), erroring if no matching `.bind()` supplies a value — see the crate's `src/sql/mod.rs`. ClickGraph never parameterizes; it hands the crate fully-rendered SQL with all literals inlined, so every `?` is meant to reach ClickHouse verbatim, yet the crate consumed it. The crate path is the **default** (`ch_summary == false`), so server, Bolt, `cg query`, and embedded-remote all hit it.

## Fix

Escape `?` → `??` — the crate's own literal-`?` escape, which its template scanner collapses back to a single `?` — immediately before `Client::query`, on **both** crate-path sites (`execute_json`, `execute_text`). The doubling is an exact, reversible transform (verified by round-tripping through the crate's real `SqlBuilder`).

The direct-HTTP path (`execute_json_via_http`, used when `CLICKGRAPH_METRICS_CH_SUMMARY=1`) sends the raw body and is deliberately **left untouched** — it needs the literal `?`.

## Scope (verified)

| Path | Uses `?` binding? | Action |
|---|---|---|
| clickhouse-rs `Client::query` (remote.rs 173/200) | **yes** | escaped |
| direct HTTP (`execute_json_via_http`) | no (raw body) | untouched |
| chdb (`session.execute`, C FFI) | no | unaffected |
| Databricks (SQL in JSON REST body) | no | unaffected |

All remote consumers share `RemoteClickHouseExecutor` → fixed at once.

## Verification

- **Server e2e** (live ClickGraph server against real CH): `'why?'`→`why?`, `replace('a?b','?','!')`→`a!b`, `'is it? yes! or? no?'` round-trips, regex `=~ 'a?bc'`→true, and `MATCH (u:User) RETURN u.name` unregressed. Pre-fix binary still fails on `RETURN 'why?'`.
- **`cg query`** (crate path): all `?` cases pass; no-`?` queries unaffected.
- **Rust unit tests**: escape doubles every `?`; escaped SQL round-trips back to the literal through the crate's real `SqlBuilder` (`Query::sql_display`).
- **Python integration**: new `TestQuestionMarkInStringLiterals` class exercises the server path.
- Full suite green (1641 unit + 542 integration), ratchet + clippy + fmt clean.

Closes #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)