### PR TITLE
fix(#855): three-valued IN/NOT IN when the list holds an explicit null

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1683,6 +1683,26 @@ fn render_in_list_rhs(
         .iter()
         .map(|item| render_expr_to_sql_string(item, alias_mapping))
         .collect();
+    // An explicit null element in the list requires three-valued IN/NOT IN
+    // semantics (#855): `x IN [1,2,null]` with no non-null match is null, not
+    // false. The `IN (…)` value-list collapses that to a non-match, so expand
+    // to element-wise OR/AND where a `x = null` / `x <> null` term propagates
+    // the unknown. A null-free list keeps the byte-stable value-list form.
+    let has_null = items
+        .iter()
+        .any(|i| matches!(i, RenderExpr::Literal(super::render_expr::Literal::Null)));
+    if has_null && !item_sqls.is_empty() {
+        let (cmp, joiner) = if negate {
+            ("<>", " AND ")
+        } else {
+            ("=", " OR ")
+        };
+        let clauses: Vec<String> = item_sqls
+            .iter()
+            .map(|rhs| format!("{} {} {}", lhs_sql, cmp, rhs))
+            .collect();
+        return Some(format!("({})", clauses.join(joiner)));
+    }
     Some(
         crate::sql_generator::function_mapper::current_function_mapper()
             .in_list_predicate(lhs_sql, &item_sqls, negate),
@@ -8436,6 +8456,36 @@ mod tests {
     use super::*;
     use crate::query_planner::logical_expr::{Literal, LogicalExpr};
     use std::sync::Arc;
+
+    #[test]
+    fn render_in_list_rhs_with_null_expands_for_three_valued_logic_855() {
+        use crate::render_plan::render_expr::Literal as RLit;
+        // `x IN [1, 2, null]` on the CTE-body path must expand element-wise so
+        // three-valued IN holds (#855): a plain `x IN (…)` value-list would
+        // collapse the null to a non-match. `x` here is a pre-rendered LHS.
+        let list = RenderExpr::List(vec![
+            RenderExpr::Literal(RLit::Integer(1)),
+            RenderExpr::Literal(RLit::Integer(2)),
+            RenderExpr::Literal(RLit::Null),
+        ]);
+        assert_eq!(
+            render_in_list_rhs(&list, "x", false, &[]).unwrap(),
+            "(x = 1 OR x = 2 OR x = NULL)"
+        );
+        assert_eq!(
+            render_in_list_rhs(&list, "x", true, &[]).unwrap(),
+            "(x <> 1 AND x <> 2 AND x <> NULL)"
+        );
+        // A null-free list keeps the byte-stable value-list form (0 churn).
+        let nn = RenderExpr::List(vec![
+            RenderExpr::Literal(RLit::Integer(1)),
+            RenderExpr::Literal(RLit::Integer(2)),
+        ]);
+        assert_eq!(
+            render_in_list_rhs(&nn, "x", false, &[]).unwrap(),
+            "x IN (1, 2)"
+        );
+    }
 
     #[test]
     fn rewrite_cte_name_structural_targets_refs_not_string_literals_618() {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -551,6 +551,23 @@ fn render_interval_arithmetic(op: &OperatorApplication, rendered: &[String]) -> 
 /// for non-constant lists (those are expanded to OR/AND by the caller first).
 /// `rendered[0]` is the path-rendered LHS; list items are constants so they
 /// render identically regardless of aliasing.
+///
+/// Does the RHS of an `IN`/`NOT IN` contain an explicit `null` list element?
+/// openCypher's `IN` is three-valued: when the probe matches no non-null
+/// element AND the list holds an unknown (null), the result is `null`, not
+/// `false` (`3 IN [1,2,null]` → null; `3 NOT IN [1,null]` → null). ClickHouse's
+/// `x IN (…)` / `x IN [array]` treat a null element as a plain non-match (→ 0),
+/// losing that. When this returns true the caller routes the predicate through
+/// the OR/AND element-wise expansion instead, where a `x = null` / `x <> null`
+/// term propagates the null exactly per three-valued logic (verified on CH).
+/// A null-free list is unaffected (keeps the byte-stable `IN` form).
+fn in_list_has_null_literal(op: &OperatorApplication) -> bool {
+    matches!(op.operator, Operator::In | Operator::NotIn)
+        && matches!(&op.operands.get(1),
+            Some(RenderExpr::List(items))
+                if items.iter().any(|i| matches!(i, RenderExpr::Literal(Literal::Null))))
+}
+
 fn render_constant_in_list(op: &OperatorApplication, rendered: &[String]) -> Option<String> {
     use crate::server::query_context::get_current_dialect;
     use crate::sql_generator::SqlDialect;
@@ -7619,7 +7636,11 @@ impl RenderExpr {
                         let has_non_constant = list_items.iter().any(|item| {
                             !matches!(item, RenderExpr::Literal(_) | RenderExpr::Parameter(_))
                         });
-                        if has_non_constant {
+                        // A null element forces the element-wise OR/AND expansion
+                        // so three-valued IN/NOT IN semantics hold (#855): a
+                        // `x = null` / `x <> null` term propagates the unknown,
+                        // whereas CH `IN (…)` collapses it to a non-match.
+                        if has_non_constant || in_list_has_null_literal(op) {
                             let lhs = &rendered[0];
                             let item_sqls: Vec<String> =
                                 list_items.iter().map(|item| item.to_sql()).collect();
@@ -8112,7 +8133,11 @@ impl RenderExpr {
                         let has_non_constant = list_items.iter().any(|item| {
                             !matches!(item, RenderExpr::Literal(_) | RenderExpr::Parameter(_))
                         });
-                        if has_non_constant {
+                        // A null element forces the element-wise OR/AND expansion
+                        // so three-valued IN/NOT IN semantics hold (#855): a
+                        // `x = null` / `x <> null` term propagates the unknown,
+                        // whereas CH `IN (…)` collapses it to a non-match.
+                        if has_non_constant || in_list_has_null_literal(op) {
                             let lhs = &rendered[0];
                             let item_sqls: Vec<String> =
                                 list_items.iter().map(|item| item.to_sql()).collect();
@@ -8460,7 +8485,9 @@ impl ToSql for OperatorApplication {
                 let has_non_constant = list_items
                     .iter()
                     .any(|item| !matches!(item, RenderExpr::Literal(_) | RenderExpr::Parameter(_)));
-                if has_non_constant {
+                // A null element forces the element-wise OR/AND expansion so
+                // three-valued IN/NOT IN semantics hold (#855).
+                if has_non_constant || in_list_has_null_literal(self) {
                     let lhs = &rendered[0];
                     let item_sqls: Vec<String> =
                         list_items.iter().map(|item| item.to_sql()).collect();
@@ -9094,6 +9121,63 @@ mod tests {
             },
         )
         .await;
+    }
+
+    // ---- #855: three-valued IN / NOT IN when the list holds an explicit null ----
+
+    /// `x IN [1, 2, null]` must NOT render the plain `IN` form (CH collapses a
+    /// null element to a non-match → `false`, but openCypher wants `null` when
+    /// no non-null element matches). It expands element-wise so the `x = NULL`
+    /// term propagates the unknown.
+    #[test]
+    fn test_in_list_with_null_literal_expands_to_or_for_three_valued_logic() {
+        let expr = RenderExpr::OperatorApplicationExp(OperatorApplication {
+            operator: Operator::In,
+            operands: vec![
+                RenderExpr::Literal(Literal::Integer(3)),
+                RenderExpr::List(vec![
+                    RenderExpr::Literal(Literal::Integer(1)),
+                    RenderExpr::Literal(Literal::Integer(2)),
+                    RenderExpr::Literal(Literal::Null),
+                ]),
+            ],
+        });
+        assert_eq!(expr.to_sql(), "(3 = 1 OR 3 = 2 OR 3 = NULL)");
+    }
+
+    /// `x NOT IN [1, null]` expands to an AND chain including `x <> NULL`, which
+    /// yields null (not `true`) when the probe matches no non-null element.
+    #[test]
+    fn test_not_in_list_with_null_literal_expands_to_and_for_three_valued_logic() {
+        let expr = RenderExpr::OperatorApplicationExp(OperatorApplication {
+            operator: Operator::NotIn,
+            operands: vec![
+                RenderExpr::Literal(Literal::Integer(3)),
+                RenderExpr::List(vec![
+                    RenderExpr::Literal(Literal::Integer(1)),
+                    RenderExpr::Literal(Literal::Null),
+                ]),
+            ],
+        });
+        assert_eq!(expr.to_sql(), "(3 <> 1 AND 3 <> NULL)");
+    }
+
+    /// A null-free constant list keeps the byte-stable `IN [array]` form — the
+    /// fix must not churn the common case (this is what keeps existing goldens
+    /// unchanged).
+    #[test]
+    fn test_in_list_without_null_keeps_plain_in_form() {
+        let expr = RenderExpr::OperatorApplicationExp(OperatorApplication {
+            operator: Operator::In,
+            operands: vec![
+                RenderExpr::Literal(Literal::Integer(3)),
+                RenderExpr::List(vec![
+                    RenderExpr::Literal(Literal::Integer(1)),
+                    RenderExpr::Literal(Literal::Integer(2)),
+                ]),
+            ],
+        });
+        assert_eq!(expr.to_sql(), "3 IN [1, 2]");
     }
 
     // ---- WHERE alias inlining for Spark/Databricks (LDBC Q10) ----

--- a/tests/integration/test_return_only_regression.py
+++ b/tests/integration/test_return_only_regression.py
@@ -155,3 +155,64 @@ class TestQuestionMarkInStringLiterals:
         result = execute_cypher("RETURN 'no marks here' AS s", schema_name="social_integration")
         assert_query_success(result)
         assert result["results"][0]["s"] == "no marks here"
+
+
+class TestInListThreeValuedLogic:
+    """Regression tests for #855 — openCypher three-valued IN / NOT IN.
+
+    When an `IN` / `NOT IN` list contains an explicit `null` and the probe
+    matches none of the non-null elements, the result is `null` (unknown), not
+    `false` / `true`. ClickHouse's `x IN (…)` treats a null element as a plain
+    non-match, so the null-bearing list is expanded element-wise
+    (`x = a OR x = b OR x = NULL`) where the `x = NULL` term propagates the
+    unknown. Null-free lists are unaffected.
+    """
+
+    def test_in_list_null_no_match_is_null(self, simple_graph):
+        """3 IN [1, 2, null] -> null (no non-null match, list has a null)."""
+        result = execute_cypher(
+            "RETURN 3 IN [1, 2, null] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] is None
+
+    def test_not_in_list_null_no_match_is_null(self, simple_graph):
+        """3 NOT IN [1, null] -> null."""
+        result = execute_cypher(
+            "RETURN 3 NOT IN [1, null] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] is None
+
+    def test_in_list_null_with_match_is_true(self, simple_graph):
+        """1 IN [1, null] -> true (matches a non-null element)."""
+        result = execute_cypher(
+            "RETURN 1 IN [1, null] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] in (True, 1)
+
+    def test_not_in_list_null_with_match_is_false(self, simple_graph):
+        """1 NOT IN [1, null] -> false (a non-null element matches)."""
+        result = execute_cypher(
+            "RETURN 1 NOT IN [1, null] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] in (False, 0)
+
+    def test_in_list_no_null_no_match_is_false(self, simple_graph):
+        """3 IN [1, 2] -> false (null-free list, unchanged behavior)."""
+        result = execute_cypher(
+            "RETURN 3 IN [1, 2] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] in (False, 0)
+
+    def test_in_list_no_null_with_match_is_true(self, simple_graph):
+        """1 IN [1, 2] -> true (null-free control)."""
+        result = execute_cypher(
+            "RETURN 1 IN [1, 2] AS x", schema_name="social_integration"
+        )
+        assert_query_success(result)
+        assert result["results"][0]["x"] in (True, 1)
+


### PR DESCRIPTION
## Summary

Fixes #855 — a silent-wrong fidelity bug. openCypher's `IN` is three-valued: when the probe matches no non-null element **and** the list contains an explicit `null`, the result is `null`, not `false`/`true`. ClickHouse's `x IN (…)` / `x IN [array]` treats a null list element as a plain non-match (→ 0), so ClickGraph returned the wrong boolean:

```
RETURN 3 IN [1, 2, null]    -- was false (0);  Neo4j: null
RETURN 3 NOT IN [1, null]   -- was true (1);   Neo4j: null
```

Correct truth table (all now match Neo4j, live-verified):

| expression | Neo4j | before | after |
|---|---|---|---|
| `1 IN [1, null]` | true | true ✓ | true ✓ |
| `3 IN [1, 2, null]` | **null** | false ✗ | **null ✓** |
| `3 IN [1, 2]` (no null) | false | false ✓ | false ✓ |
| `null IN [1, 2]` | null | null ✓ | null ✓ |
| `3 NOT IN [1, null]` | **null** | true ✗ | **null ✓** |
| `1 NOT IN [1, null]` | false | false ✓ | false ✓ |

## Root cause & fix

The element-wise OR/AND expansion the render paths already use for **non-constant** lists (`x = a OR x = b …`) is three-valued-correct on both dialects — a `x = null` / `x <> null` term propagates the unknown (verified on ClickHouse). The bug was only that a **constant** list containing a `null` was routed to the plain infix `IN` instead of that expansion.

Fix: detect a `Literal::Null` element and route the predicate through the existing expansion.

- **Path A** (3 near-identical `RenderExpr`/`OperatorApplication` sites in `to_sql_query.rs`): extend the expansion gate with a shared `in_list_has_null_literal` helper.
- **Path C** (`render_in_list_rhs` in `cte_extraction.rs`, the CTE-body path): expand element-wise when a null literal is present, before the `FunctionMapper::in_list_predicate` value-list form.

## Scope / safety

- **Zero golden churn** — null-free lists keep the byte-stable `IN` form; no golden in the corpus had an `IN (...NULL...)` list predicate.
- Full suite **2226 passing** (was 2222 + 4 new Rust tests), **ratchet green**.
- Rule #7 clean: structural match on `RenderExpr`, no raw-flag/dialect branching. The OR/AND expansion uses dialect-neutral `=`/`<>`, correct on ClickHouse and Databricks.
- Edge cases verified: `3 IN [null]` → null; nullable-property lists already OR-expanded and correct; empty/no-null controls unchanged.
- The `#581` coordination note in the issue is obsolete (#581 is closed).

## Verification

- Live server end-to-end: `RETURN 3 IN [1,2,null]` → `{"x":null}`.
- Rust unit tests for both paths + both dialects.
- Python `TestInListThreeValuedLogic` server-path regression class (6 tests, all pass live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)