### PR TITLE
fix(#864): honor WITH rename of an UNWIND scalar in the CTE body

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -475,6 +475,33 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **P-1 — WITH-rename of an UNWIND scalar dropped the `AS` alias in
+  the CTE body → `count(y.y)` Code 47** (branch `fix/864-with-rename-unwind-scalar`,
+  closes #864). `UNWIND [1,2,3] AS x WITH x AS y RETURN count(y)` rendered an
+  invalid `count(y.y)` (spurious property access → ClickHouse Code 47). The issue's
+  two stated premises were BOTH wrong (verified by instrumented tracing): the
+  analyzer correctly classifies `y` as scalar (`register_cte_entity_types` →
+  `define_scalar`) AND the `count(<scalar>)` guard correctly fires
+  (`projection_tagging.rs:1341`, rewrites the arg to `ColumnAlias`). The real bug
+  is downstream in `build_with_projection_select_items`
+  (`with_to_cte/mod.rs:7238`): the UNWIND-alias branch hard-coded `alias.0` (the
+  SOURCE name `x`) for BOTH the expression AND the `col_alias`, ignoring
+  `item.col_alias` (the exported rename `y`). So the CTE body emitted `SELECT x AS
+  x` (then a downstream identity-mismatch check fell back to `SELECT *`), while the
+  outer query aliased the CTE `AS y` and referenced `y.y` — which does not exist.
+  The `count(y.y)` shape itself is the renderer's normal scalar-CTE-var
+  requalification (valid IF the column were named `y`). Fix: honor
+  `item.col_alias` for the output column name (`SELECT x AS "y"`), keeping the
+  expression as the physical ARRAY JOIN column `x`. One-line change. Passthrough
+  (`WITH x` — col_alias == alias.0) is unchanged; only UNWIND-scalar RENAMES
+  (all currently broken) are affected → can only fix, not regress. NOT in the
+  #592 reverse-mapping/forward-resolution policy-blocked class (doesn't touch
+  `define_scalar` property_mapping; the column is a bare ARRAY JOIN column) — a
+  plain projection-construction bug, §1.6-rule-6 always-in-scope. corpus_sweep +
+  sql_golden 0-churn; ratchet net-zero; new fail-when-reverted corpus golden
+  (`test_864__with_rename_of_unwind_scalar_count`, both dialects). Root-cause
+  scoping done by an investigation agent (corrected the filed premises);
+  SQL-shape-verified (no live CH).
 - 2026-08-02: **P-1 — projection pattern-comprehension inner WHERE now applies
   function / IN-list / CASE predicates** (branch `fix/882-inner-where-comprehensive-renderer`,
   closes #882). Follow-up to #878, unblocked by #863's infrastructure. #878 fixed

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -7236,12 +7236,27 @@ fn build_with_projection_select_items(
                             crate::query_planner::logical_expr::LogicalExpr::TableAlias(alias) => {
                                 // UNWIND aliases are ARRAY JOIN columns — emit a simple column reference
                                 if unwind_aliases.contains(alias.0.as_str()) {
-                                    log::debug!("🔧 build_chained_with_match_cte_plan: UNWIND alias '{}' — simple column reference", alias.0);
+                                    // Honor the WITH rename (`WITH x AS y`): the CTE
+                                    // body physically has the ARRAY JOIN column
+                                    // `alias.0` (x), but the exported column must be
+                                    // named after `item.col_alias` (y) so downstream
+                                    // references (`count(y)` → `y.y`) resolve. Before
+                                    // #864 this hard-coded `alias.0` for BOTH sides,
+                                    // so a rename produced `SELECT x AS x` while the
+                                    // outer query aliased the CTE `AS y` and looked
+                                    // for `y.y` — Code 47. Passthrough (no rename)
+                                    // has col_alias == alias.0, so it is unchanged.
+                                    let out_name = item
+                                        .col_alias
+                                        .as_ref()
+                                        .map(|a| a.0.clone())
+                                        .unwrap_or_else(|| alias.0.clone());
+                                    log::debug!("🔧 build_chained_with_match_cte_plan: UNWIND alias '{}' — simple column reference AS '{}'", alias.0, out_name);
                                     return vec![SelectItem {
                                         expression: super::render_expr::RenderExpr::ColumnAlias(
                                             super::render_expr::ColumnAlias(alias.0.clone()),
                                         ),
-                                        col_alias: Some(ColumnAlias(alias.0.clone())),
+                                        col_alias: Some(ColumnAlias(out_name)),
                                     }];
                                 }
 

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1227,3 +1227,4 @@
 {"cypher": "MATCH (a:Member)-[:MENTORS|HELPS*1..2]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_one_to_two", "schema": "mt_multitype_uniqueness"}
 {"cypher": "MATCH (a:Member)-[:MENTORS|HELPS*1..3]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_one_to_three", "schema": "mt_multitype_uniqueness"}
 {"cypher": "MATCH (a:Member)-[:MENTORS|HELPS]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_single_hop", "schema": "mt_multitype_uniqueness"}
+{"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            RETURN count(y) AS c", "name": "test_864__with_rename_of_unwind_scalar_count", "schema": "social_integration"}

--- a/tests/rust/integration/golden/corpus/social_integration/test_864__with_rename_of_unwind_scalar_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_864__with_rename_of_unwind_scalar_count.clickhouse.sql
@@ -1,0 +1,8 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS "y"
+FROM system.one
+ARRAY JOIN [1, 2, 3] AS x
+)
+SELECT 
+      count(y.y) AS "c"
+FROM with_y_cte_0 AS y

--- a/tests/rust/integration/golden/corpus/social_integration/test_864__with_rename_of_unwind_scalar_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_864__with_rename_of_unwind_scalar_count.databricks.sql
@@ -1,0 +1,8 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS `y`
+FROM (SELECT 1) AS _unwind
+LATERAL VIEW explode(array(1, 2, 3)) AS x
+)
+SELECT 
+      count(y.y) AS `c`
+FROM with_y_cte_0 AS y


### PR DESCRIPTION
## Summary

Fixes #864. `UNWIND [1,2,3] AS x WITH x AS y RETURN count(y) AS c` rendered an invalid `count(y.y)` (spurious property access → ClickHouse Code 47 UNKNOWN_IDENTIFIER).

## Root cause (filed premises were both wrong)

Instrumented tracing showed the issue's two stated premises are incorrect:
- The analyzer **does** classify `y` as scalar (`register_cte_entity_types` → `define_scalar`).
- The `count(<scalar>)` guard **does** fire (`projection_tagging.rs:1341`, rewrites the arg to `ColumnAlias`).

The real bug is downstream in `build_with_projection_select_items` (`src/render_plan/with_to_cte/mod.rs:7238`): the UNWIND-alias branch hard-coded `alias.0` (the **source** name `x`) for BOTH the expression AND the `col_alias`, ignoring `item.col_alias` (the exported rename `y`). So the CTE body emitted `SELECT x AS x` (then a downstream identity-mismatch check fell back to `SELECT *`), while the outer query aliased the CTE `AS y` and referenced `y.y` — which doesn't exist.

The `count(y.y)` shape itself is the renderer's **normal** scalar-CTE-var requalification (bare CTE var → `from_alias.alias`) — it's valid SQL *once the column is actually named `y`*.

## Fix

Honor `item.col_alias` for the output column name, keeping the expression as the physical ARRAY JOIN column:
```sql
-- before:  SELECT x  (col_alias hard-coded to x, then SELECT * fallback)
-- after:   SELECT x AS "y"   →  count(y.y) resolves
```

One-line change. Passthrough (`WITH x`, where `col_alias == alias.0`) is **unchanged**; only UNWIND-scalar **renames** (all currently broken) are affected → can only fix, not regress.

## Verification

- `count(y)` → `SELECT x AS "y"` + `count(y.y)` (valid). Also verified: `RETURN y AS z`, `sum(y)`, `collect(y)`, multi-export `WITH x AS y, x AS w`, both dialects (CH `ARRAY JOIN`, Spark `LATERAL VIEW explode`).
- Passthrough `WITH x RETURN count(x)` byte-identical.
- corpus_sweep + sql_golden **0-churn**; ratchet net-zero.
- New fail-when-reverted corpus golden `test_864__with_rename_of_unwind_scalar_count` (both dialects) — reverting the fix mismatches it.
- `cargo fmt` / `clippy --all-targets` clean; full suite (lib 1655, integration 542) green.

## Class

**Not** in the #592 reverse-mapping/forward-resolution policy-blocked class — it doesn't touch `define_scalar`'s `property_mapping` (the column is a bare ARRAY JOIN column, not a mapped property). A plain projection-construction bug (§1.6 rule 6, always-in-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)