### PR TITLE
docs(#887): mark Phase 0 done (#890) + correct stale VLC-arm note

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -466,21 +466,21 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 DONE #890)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
   inconsistent edge-vs-node copies / 6 edge-identity spellings. Retires the
-  self-spawning residual chain #606/#628/#710/#806/#808. Key finding: the 5
-  `analyze_pattern` CM strategies are corpus-unreachable dead code (sole caller
-  is `#[cfg(test)]` at `cte_manager/mod.rs:3826`), so **Phase 0 (dead-code
-  deletion) is unblocked and shippable today**, ratchets the 148-occurrence VLP
-  axis-predicate baseline down immediately. Phases 1–2 (policy + transition-
-  assert + switch, byte-identical) then Phases 3–4 fix #806/#628 with
-  regenerated goldens + live oracle. A **design-cycle commitment** (~4 refactor
-  PRs before the first behavior fix) — pick up when there's appetite for a
-  multi-PR arc, or when a new corpus makes a latent node-unique arm reachable.
-  Explicitly NOT this cluster: #643/#840/#627/#683 (different subsystems).
+  self-spawning residual chain #606/#628/#710/#806/#808. **Phase 0 SHIPPED
+  (#890, `1c3bce85`)**: deleted the test-only `CteStrategy` dispatch cluster (the
+  5 `analyze_pattern` strategies were corpus-unreachable — sole caller inside
+  `#[cfg(test)]`), −2290 lines, byte-identical corpus sweep, APPROVE-0. Remaining:
+  Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical)
+  then Phases 3–4 fix #806/#628 with regenerated goldens + live oracle. A
+  **design-cycle commitment** (~3 more refactor PRs before the first behavior
+  fix) — pick up when there's appetite for a multi-PR arc, or when a new corpus
+  makes a latent node-unique arm reachable. Explicitly NOT this cluster:
+  #643/#840/#627/#683 (different subsystems).
 
 ## 3. Capacity split (guideline)
 
@@ -490,6 +490,23 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **#887 Phase 0 — delete test-only `CteStrategy` dispatch cluster**
+  (branch `refactor/vlp-phase0-dead-strategies`, #890 / `1c3bce85`). First slice
+  of the VLP edge-identity/uniqueness unification
+  (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Pure dead-code deletion:
+  `CteManager::analyze_pattern` (sole builder of the `Traditional / FkEdge /
+  MixedAccess / EdgeToEdge / Coupled` `CteStrategy` variants + `::Denormalized`)
+  had exactly one caller, inside `#[cfg(test)]` — the live VLP path builds
+  `VariableLengthCteStrategy` / `DenormalizedCteStrategy` directly, never through
+  the enum. Deleted the enum + dispatch, `analyze_pattern`, the 5 dead strategy
+  structs+impls+tests, `get_fk_edge_node_id_column`, `build_where_clause_from_filters`,
+  the test-only `CteGenerationContext::with_schema`, and the dead re-export.
+  Deadness compiler-verified (construction confined to the test-only factory).
+  **−2290 lines**; `corpus_sweep` byte-identical (0 golden churn); ratchet
+  `is_denormalized` in cte_manager 13→12 (baseline locked); adversarial review
+  APPROVE-0. KEPT: `generate_mixed_*` VLC arms (corpus-empty but reachable, per
+  #808/#860). Phases 1–4 (the actual `EdgeUniquenessPolicy` unification + #806/#628
+  fixes) remain a design-cycle commitment.
 - 2026-08-02: **P-1 — WITH-rename of an UNWIND scalar dropped the `AS` alias in
   the CTE body → `count(y.y)` Code 47** (branch `fix/864-with-rename-unwind-scalar`,
   closes #864). `UNWIND [1,2,3] AS x WITH x AS y RETURN count(y)` rendered an

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -213,14 +213,30 @@ Every slice: byte-identical goldens + 319-of-1229 VLP corpus-sweep entries
 worktree-isolated adversarial subagent review, `PRIORITIES.md` + this
 checklist updated in the same PR.
 
-### Phase 0 — delete the dead code (pure hygiene, 0 behavior change) → closes part of #606, #808
-Delete the 5 corpus-unreachable CM strategy classes (`Traditional / FkEdge /
-MixedAccess / EdgeToEdge / Coupled` + `analyze_pattern` + its `#[cfg(test)]`
-caller), and the 3 confirmed-dead VLC recursive arms (#808 option (a)). Prove
-dead first: the `analyze_pattern`-only-test-caller fact + the #808 eprintln
-sweep are the evidence; re-run the sweep with an `unreachable!()` tripwire in
-each before deleting. **Ratchet baseline falls immediately** (much of the
-`is_denormalized`×13 / `from_label_column`×6 in CM is in these classes).
+### Phase 0 — delete the dead code (pure hygiene, 0 behavior change) → **DONE (#890, `1c3bce85`)**
+**Shipped.** Deleted the test-only `CteStrategy` dispatch cluster: the enum + its
+`generate_sql`/`validate` dispatch, `analyze_pattern` (sole builder of the 5
+`Traditional / FkEdge / MixedAccess / EdgeToEdge / Coupled` variants and of
+`CteStrategy::Denormalized`, with its only caller inside `#[cfg(test)]`), the
+arg-taking `generate_cte`/`validate_strategy` (0 live callers), the 5 dead
+strategy structs+impls + their `#[cfg(test)]` tests, `get_fk_edge_node_id_column`,
+the orphaned `build_where_clause_from_filters`, the test-only
+`CteGenerationContext::with_schema`, and the `render_plan::CteStrategy`
+re-export. Deadness was **compiler-verified** (construction statically confined
+to the test-only `analyze_pattern`, so the crate compiling after deletion proves
+nothing live referenced it) — stronger than the tripwire originally planned.
+Kept `DenormalizedCteStrategy` + `VariableLengthCteStrategy` (live via direct
+construction) and every `VariableLengthCteGenerator` arm. **−2290 lines.**
+Adversarial review APPROVE-0 (multiset line-diff: kept lines byte-identical);
+`corpus_sweep` byte-identical with zero golden churn; ratchet `is_denormalized`
+in CM 13→12 (baseline locked).
+
+NOTE (corrects an earlier draft): the "3 dead VLC recursive arms" this section
+first named were **already deleted in #860** (denorm + heterogeneous-polymorphic
+recursive generators); the still-present `generate_mixed_*` arms are
+corpus-empty **but reachable** (`cte_manager` `new_mixed`), so they were
+deliberately KEPT — deleting them would silently change SQL. Phase 0 was
+therefore the CM dispatch cluster only.
 
 ### Phase 1 — introduce `EdgeUniquenessPolicy`, transition-assert only (no switch) → §2.5
 Land the type + `from_pattern`. At each of the ~14 sites, compute the policy's


### PR DESCRIPTION
Follow-up to the merged Phase 0 (#890, `1c3bce85`).

- Records the Phase 0 merge in `PRIORITIES.md` §4 merge log and marks the P-6 item `◐ (Phase 0 DONE #890)`.
- Corrects `VLP_EDGE_IDENTITY_UNIFICATION.md` §4 Phase 0: the "3 dead VLC recursive arms" it first named were **already deleted in #860** (denorm + heterogeneous-polymorphic); the surviving `generate_mixed_*` arms are corpus-empty **but reachable** (`cte_manager` `new_mixed`) and were deliberately kept. Phase 0 was therefore the CM dispatch-cluster deletion only, and deadness was compiler-verified (not tripwire-proven).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)