### PR TITLE
fix(#880): dispatch toInteger/toFloat to OrNull cast on string-typed args

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -490,6 +490,29 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **P-1 — `toInteger`/`toFloat` on an unparseable string threw CH
+  Code 6 instead of returning null** (branch `fix/880-tointeger-tofloat-ornull`,
+  closes #880). PR2 of the operand-typing design cycle (built on PR1's #889
+  classifier). Neo4j `toInteger('abc')`/`toFloat('xyz')` return NULL; ClickGraph
+  mapped them to CH `toInt64`/`toFloat64`, which THROW (Code 6) on a bad string.
+  The OrNull variants (`toInt64OrNull`/`toFloat64OrNull`) fix it but accept ONLY a
+  String argument, so a correct fix must dispatch on the arg's static type. Fix:
+  in the `ScalarFnCall` render arm, special-case `tointeger`/`tofloat` BEFORE the
+  generic registry mapping — when `infer_render_type(arg0) == String` (string
+  literal, `toString(...)`, or a declared string column), emit the dialect's
+  parse-or-null cast via two new `FunctionMapper` methods (Rule #7):
+  `cast_int64_or_null`/`cast_float64_or_null` — CH `toInt64OrNull`/
+  `toFloat64OrNull`; Databricks keeps `bigint`/`double` (Spark's cast is already
+  null-on-failure, so byte-identical to today). Numeric/unknown arg → falls
+  through to the plain cast (unchanged): `toInteger(3.9)`=3 truncation preserved,
+  a numeric or unknown-typed column never mis-parsed (conservative-None). Only CH
+  string-arg calls change. corpus_sweep 0-churn; 2 pre-existing #871
+  negative-control goldens updated (`toFloat('1')+toFloat('2')` now
+  `toFloat64OrNull('1') + toFloat64OrNull('2')` — the string-literal args are
+  genuinely string-typed; the #871 assertion that the OPERATOR stays `+` (not
+  concat) still holds); 5 new fail-when-reverted #880 goldens (string-literal →
+  OrNull ×2, toString-arg → OrNull, numeric-literal → plain, unknown-column →
+  plain). ratchet net-zero; full gate green. SQL-shape-verified (no live CH).
 - 2026-08-02: **P-1 — string `+` concat missed when both operands are
   string-returning function calls → CH Code 43** (branch
   `fix/operand-typing-classifier-871`, closes #871). PR1 of a 3-PR operand-typing

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -505,14 +505,21 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   `toFloat64OrNull`; Databricks keeps `bigint`/`double` (Spark's cast is already
   null-on-failure, so byte-identical to today). Numeric/unknown arg → falls
   through to the plain cast (unchanged): `toInteger(3.9)`=3 truncation preserved,
-  a numeric or unknown-typed column never mis-parsed (conservative-None). Only CH
-  string-arg calls change. corpus_sweep 0-churn; 2 pre-existing #871
+  a numeric or unknown-typed column never mis-parsed (conservative-None). Applied
+  on BOTH renderers: the projection/main path (`to_sql_query.rs`) AND the
+  VLP-filter/pattern-comprehension path (`cte_extraction.rs` "Path C", a
+  review-caught second-renderer gap). Only CH string-arg calls change. corpus_sweep 0-churn; 2 pre-existing #871
   negative-control goldens updated (`toFloat('1')+toFloat('2')` now
   `toFloat64OrNull('1') + toFloat64OrNull('2')` — the string-literal args are
   genuinely string-typed; the #871 assertion that the OPERATOR stays `+` (not
   concat) still holds); 5 new fail-when-reverted #880 goldens (string-literal →
   OrNull ×2, toString-arg → OrNull, numeric-literal → plain, unknown-column →
-  plain). ratchet net-zero; full gate green. SQL-shape-verified (no live CH).
+  plain, + 1 VLP-filter OrNull). ratchet net-zero; full gate green. Adversarial
+  review verdict fix-then-ship (Path-C gap); applied. Known residual (documented
+  in #880, NOT a regression — throw→NULL is strictly better): a DECIMAL string
+  `toInteger('3.9')` yields NULL on CH vs Neo4j's `3` (Neo4j parses as float then
+  truncates); CH `toInt64OrNull` doesn't parse a float string. SQL-shape-verified
+  (no live CH).
 - 2026-08-02: **P-1 — string `+` concat missed when both operands are
   string-returning function calls → CH Code 43** (branch
   `fix/operand-typing-classifier-871`, closes #871). PR1 of a 3-PR operand-typing

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1915,6 +1915,30 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                     return sql;
                 }
             }
+            // #880: toInteger/toFloat on a string-typed arg must dispatch to the
+            // dialect's parse-or-null cast (CH toInt64OrNull/toFloat64OrNull;
+            // Spark bigint/double already null-on-failure) so an unparseable
+            // string yields NULL instead of throwing Code 6. Mirrors the Path-A
+            // renderer (to_sql_query.rs); gated on the classifier so numeric/
+            // unknown args keep the plain cast (conservative-None). This Path-C
+            // renderer backs VLP bound-node / pattern-comprehension WHERE filters.
+            let fn_lower = func.name.to_lowercase();
+            if (fn_lower == "tointeger" || fn_lower == "tofloat")
+                && func.args.len() == 1
+                && args.len() == 1
+                && crate::sql_generator::emitters::clickhouse::type_inference::infer_render_type(
+                    &func.args[0],
+                ) == Some(
+                    crate::sql_generator::emitters::clickhouse::type_inference::RenderType::String,
+                )
+            {
+                let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+                return if fn_lower == "tointeger" {
+                    mapper.cast_int64_or_null(&args[0])
+                } else {
+                    mapper.cast_float64_or_null(&args[0])
+                };
+            }
             // Map dialect-divergent names (e.g. tuple -> Spark struct) via the registry.
             let name = crate::clickhouse_query_generator::dialect_function_name(&func.name);
             format!("{}({})", name, args.join(", "))

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7104,6 +7104,30 @@ impl RenderExpr {
                     }
                 }
 
+                // #880: Cypher `toInteger`/`toFloat` return NULL (not an error)
+                // for an unparseable STRING. CH `toInt64`/`toFloat64` THROW
+                // (Code 6) on a bad string, so when the argument is known to be
+                // string-typed we route to the dialect's parse-or-null cast
+                // (CH `toInt64OrNull`/`toFloat64OrNull`; Spark keeps the plain
+                // null-on-failure cast). The OrNull variants accept ONLY a String
+                // arg, so this fires strictly when the classifier proves the arg
+                // is a String — a numeric/unknown arg falls through to the plain
+                // cast below (byte-identical to today), preserving `toInteger(3.9)`
+                // = 3 and never mis-parsing a numeric column.
+                if (fn_name_lower == "tointeger" || fn_name_lower == "tofloat")
+                    && fn_call.args.len() == 1
+                    && super::type_inference::infer_render_type(&fn_call.args[0])
+                        == Some(super::type_inference::RenderType::String)
+                {
+                    let arg_sql = fn_call.args[0].to_sql();
+                    let mapper = crate::sql_generator::function_mapper::current_function_mapper();
+                    return if fn_name_lower == "tointeger" {
+                        mapper.cast_int64_or_null(&arg_sql)
+                    } else {
+                        mapper.cast_float64_or_null(&arg_sql)
+                    };
+                }
+
                 // Check if we have a Neo4j -> ClickHouse mapping
                 match get_function_mapping(&fn_name_lower) {
                     Some(mapping) => {

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -58,6 +58,15 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         "toFloat64"
     }
 
+    fn cast_int64_or_null(&self, expr: &str) -> String {
+        // CH `toInt64OrNull` returns NULL on parse failure (String arg only).
+        format!("toInt64OrNull({})", expr)
+    }
+
+    fn cast_float64_or_null(&self, expr: &str) -> String {
+        format!("toFloat64OrNull({})", expr)
+    }
+
     fn cast_string(&self) -> &'static str {
         "toString"
     }

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -128,6 +128,17 @@ impl FunctionMapper for DatabricksFunctionMapper {
         "double"
     }
 
+    fn cast_int64_or_null(&self, expr: &str) -> String {
+        // Spark `bigint(...)` already returns NULL on parse failure (non-ANSI
+        // cast), so the OrNull form is just the plain cast — byte-identical to
+        // `cast_int64`. #880.
+        format!("bigint({})", expr)
+    }
+
+    fn cast_float64_or_null(&self, expr: &str) -> String {
+        format!("double({})", expr)
+    }
+
     fn cast_string(&self) -> &'static str {
         "string"
     }

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -118,6 +118,25 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// (function-call cast alias).
     fn cast_float64(&self) -> &'static str;
 
+    /// Parse-or-null cast to a 64-bit integer, for Cypher `toInteger(<string>)`,
+    /// which returns NULL (not an error) when the string is not a valid number
+    /// (#880). `expr` is a pre-rendered SQL fragment.
+    ///
+    /// ClickHouse `toInt64` THROWS (Code 6) on an unparseable string, so the CH
+    /// impl must use `toInt64OrNull({expr})` — but that variant only accepts a
+    /// String argument, so the caller must route here ONLY when `expr` is known
+    /// to be string-typed (a string literal, `toString(...)`, or a declared
+    /// string column; see the render-site type classifier). Spark's `bigint(...)`
+    /// already returns NULL on parse failure, so the Databricks impl returns the
+    /// plain cast — byte-identical to `cast_int64`.
+    fn cast_int64_or_null(&self, expr: &str) -> String;
+
+    /// Parse-or-null cast to a 64-bit float, for Cypher `toFloat(<string>)`
+    /// (#880). CH: `toFloat64OrNull({expr})` (String arg only — caller gates on
+    /// string type); Spark: plain `double({expr})` (already null-on-failure). See
+    /// [`cast_int64_or_null`](Self::cast_int64_or_null).
+    fn cast_float64_or_null(&self, expr: &str) -> String;
+
     /// Cast to string. CH: `toString`. Spark: `string` (function-call alias).
     fn cast_string(&self) -> &'static str;
 

--- a/tests/rust/integration/golden/sql_ir/standard/numeric_add_tofloat_stays_plus_871__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/numeric_add_tofloat_stays_plus_871__clickhouse.sql
@@ -1,2 +1,2 @@
 SELECT 
-      toFloat64('1') + toFloat64('2') AS "s"
+      toFloat64OrNull('1') + toFloat64OrNull('2') AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/numeric_add_tointeger_stays_plus_871__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/numeric_add_tointeger_stays_plus_871__clickhouse.sql
@@ -1,2 +1,2 @@
 SELECT 
-      toInt64('5') + toInt64('10') AS "s"
+      toInt64OrNull('5') + toInt64OrNull('10') AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/to_float_string_literal_ornull_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_float_string_literal_ornull_880__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      toFloat64OrNull('xyz') AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/to_float_string_literal_ornull_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_float_string_literal_ornull_880__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      double('xyz') AS `s`

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_column_unknown_plain_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_column_unknown_plain_880__clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      toInt64(u.full_name) AS "s"
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_column_unknown_plain_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_column_unknown_plain_880__databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      bigint(u.full_name) AS `s`
+FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_numeric_literal_plain_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_numeric_literal_plain_880__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      toInt64(3.9) AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_numeric_literal_plain_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_numeric_literal_plain_880__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      bigint(3.9) AS `s`

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_string_literal_ornull_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_string_literal_ornull_880__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      toInt64OrNull('abc') AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_string_literal_ornull_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_string_literal_ornull_880__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      bigint('abc') AS `s`

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_tostring_arg_ornull_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_tostring_arg_ornull_880__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      toInt64OrNull(toString(42)) AS "s"

--- a/tests/rust/integration/golden/sql_ir/standard/to_integer_tostring_arg_ornull_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/to_integer_tostring_arg_ornull_880__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      bigint(string(42)) AS `s`

--- a/tests/rust/integration/golden/sql_ir/standard/vlp_where_to_integer_string_ornull_880__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/vlp_where_to_integer_string_ornull_880__clickhouse.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [tuple(rel.follower_id, rel.followed_id)] as path_edges
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE toInt64OrNull('7') = start_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.follower_id, rel.followed_id)]) as path_edges
+    FROM vlp_a_b vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.follower_id, rel.followed_id))
+)
+SELECT 
+      t.end_id AS "b.user_id"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/sql_ir/standard/vlp_where_to_integer_string_ornull_880__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/vlp_where_to_integer_string_ornull_880__databricks.sql
@@ -1,0 +1,29 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(struct(rel.follower_id, rel.followed_id)) as path_edges
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE bigint('7') = start_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.follower_id, rel.followed_id))) as path_edges
+    FROM vlp_a_b vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.follower_id, rel.followed_id))
+)
+SELECT 
+      t.end_id AS `b.user_id`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -135,7 +135,10 @@ const CORPUS: &[(&str, &str)] = &[
     ),
     // #871 negative controls: numeric-returning function operands must STAY the
     // numeric `+` path (never misroute to concat). `toFloat`/`toInteger` classify
-    // as Float/Integer, so the concat gate does not fire.
+    // as Float/Integer, so the concat gate does not fire — the operator stays `+`.
+    // NOTE (#880): the string-literal args make these `toFloat64OrNull(...)` /
+    // `toInt64OrNull(...)` (parse-or-null on a string arg); the load-bearing
+    // #871 assertion is that the OPERATOR is `+`, not `concat`.
     (
         "numeric_add_tofloat_stays_plus_871",
         "RETURN toFloat('1') + toFloat('2') AS s",
@@ -143,6 +146,25 @@ const CORPUS: &[(&str, &str)] = &[
     (
         "numeric_add_tointeger_stays_plus_871",
         "RETURN toInteger('5') + toInteger('10') AS s",
+    ),
+    // #880: `toInteger`/`toFloat` on an unparseable STRING must return NULL, not
+    // throw. CH `toInt64`/`toFloat64` throw (Code 6) on a bad string, so a
+    // string-typed arg dispatches to `toInt64OrNull`/`toFloat64OrNull` (Spark
+    // `bigint`/`double` are already null-on-failure). A string literal and a
+    // `toString(...)` result are both string-typed.
+    ("to_integer_string_literal_ornull_880", "RETURN toInteger('abc') AS s"),
+    ("to_float_string_literal_ornull_880", "RETURN toFloat('xyz') AS s"),
+    (
+        "to_integer_tostring_arg_ornull_880",
+        "RETURN toInteger(toString(42)) AS s",
+    ),
+    // #880 negative controls: a numeric arg must keep the plain (never-throwing)
+    // cast — `toInteger(3.9)` = 3 (truncation), never OrNull. A column of unknown
+    // type also stays plain (conservative-None → no OrNull).
+    ("to_integer_numeric_literal_plain_880", "RETURN toInteger(3.9) AS s"),
+    (
+        "to_integer_column_unknown_plain_880",
+        "MATCH (u:User) RETURN toInteger(u.name) AS s",
     ),
     (
         "case_expr",

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -223,6 +223,14 @@ const CORPUS: &[(&str, &str)] = &[
         "vlp_where_string_concat_both_fn_calls_871",
         "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) WHERE toString(a.user_id) + toString(a.user_id) = 'x' RETURN b.user_id",
     ),
+    // #880 (VLP-filter path): toInteger/toFloat on a string-typed arg inside a
+    // VLP bound-node WHERE must dispatch to toInt64OrNull/toFloat64OrNull, same
+    // as the projection path. Renders through `cte_extraction::render_expr_to_sql_string`
+    // ("Path C") — the review-caught second-renderer gap in the first #880 cut.
+    (
+        "vlp_where_to_integer_string_ornull_880",
+        "MATCH (a:User)-[:FOLLOWS*1..3]->(b:User) WHERE toInteger('7') = a.user_id RETURN b.user_id",
+    ),
     ("whole_entity", "MATCH (u:User) RETURN u"),
     // List slicing -> arraySlice (CH) / slice (Spark). Both the 3-arg bounded
     // form and the 2-arg open-ended form (Spark needs a computed length).


### PR DESCRIPTION
## Summary

**PR2 of the operand-typing design cycle** (#871 → #880 → #854), built on PR1's (#889) render-site type classifier.

Neo4j `toInteger('abc')` / `toFloat('xyz')` return **null** for an unparseable string. ClickGraph mapped them to CH `toInt64`/`toFloat64`, which **throw** (Code 6 CANNOT_PARSE_TEXT) — failing the whole query. The obvious swap to `toInt64OrNull`/`toFloat64OrNull` doesn't work uniformly: those variants accept **only a String argument**. So the fix must dispatch on the argument's static type.

## The fix

Special-case `tointeger`/`tofloat` in the `ScalarFnCall` render arm (before the generic registry mapping, like `round`/`duration`). When `infer_render_type(arg0) == String`, emit the dialect's parse-or-null cast via two new `FunctionMapper` methods (Rule #7):

| Dialect | plain | OrNull (string arg) |
|---|---|---|
| ClickHouse | `toInt64` / `toFloat64` | `toInt64OrNull` / `toFloat64OrNull` |
| Databricks | `bigint` / `double` | `bigint` / `double` (Spark cast is already null-on-failure → byte-identical) |

| Query | Before | After |
|---|---|---|
| `toInteger('abc')` | `toInt64('abc')` (Code 6) | `toInt64OrNull('abc')` |
| `toFloat('xyz')` | `toFloat64('xyz')` (Code 6) | `toFloat64OrNull('xyz')` |
| `toInteger(toString(42))` | `toInt64(toString(42))` | `toInt64OrNull(toString(42))` |

### Negative controls (unchanged — conservative-None)
- `toInteger(3.9)` → stays `toInt64(3.9)` (numeric literal; preserves `=3` truncation, never throws)
- `toInteger(u.name)` (column, unknown type) → stays `toInt64(...)` (safe; never mis-parses a numeric column)

## Testing

- **5 new fail-when-reverted #880 goldens** (string-literal → OrNull ×2, `toString`-arg → OrNull, numeric-literal → plain, unknown-column → plain).
- 2 pre-existing #871 negative-control goldens updated: `toFloat('1')+toFloat('2')` now `toFloat64OrNull('1') + toFloat64OrNull('2')` — the string-literal args are genuinely string-typed, and the #871 property (the **operator** stays `+`, not `concat`) still holds.
- **corpus_sweep** 0-churn; **ratchet** net-zero; full gate green (`fmt`/`clippy`/`test`).
- No live ClickHouse — correctness bar is SQL shape (verified against the CH forms #880 cites) + byte goldens + full gate.

Closes #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)