### PR TITLE
fix(#806): flat VLP edge identity uses schema composite edge_id

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -466,7 +466,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **Phase 3 #806 fixed**)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -474,13 +474,18 @@ fixed stats fixture.
   self-spawning residual chain #606/#628/#710/#806/#808. **Phase 0 SHIPPED
   (#890, `1c3bce85`)**: deleted the test-only `CteStrategy` dispatch cluster (the
   5 `analyze_pattern` strategies were corpus-unreachable — sole caller inside
-  `#[cfg(test)]`), −2290 lines, byte-identical corpus sweep, APPROVE-0. Remaining:
+  `#[cfg(test)]`), −2290 lines, byte-identical corpus sweep, APPROVE-0.
+  **Phase 3 (#806) SHIPPED**: flat exact-bound pairwise guard now spells edge
+  identity with the schema `edge_id` (composite-aware, #617-orientation-correct),
+  matching the recursive path — parallel edges no longer collapse. 26 goldens
+  regenerated (guard line only), live-verified no regression + fix confirmed on a
+  parallel-edge fixture. Remaining:
   Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical)
-  then Phases 3–4 fix #806/#628 with regenerated goldens + live oracle. A
-  **design-cycle commitment** (~3 more refactor PRs before the first behavior
-  fix) — pick up when there's appetite for a multi-PR arc, or when a new corpus
-  makes a latent node-unique arm reachable. Explicitly NOT this cluster:
-  #643/#840/#627/#683 (different subsystems).
+  then Phase 4 fixes #628 (`*0..N` closed cycle) with regenerated goldens + live
+  oracle. Explicitly NOT this cluster:
+  #643/#840/#627/#683 (different subsystems). Adjacent bug found during #806 and
+  filed separately (NOT folded in): flat exact-bound polymorphic VLP drops the
+  `interaction_type` discriminator (`FOLLOWS*2` counts other edge types too).
 
 ## 3. Capacity split (guideline)
 
@@ -490,7 +495,25 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
-<<<<<<< HEAD
+- 2026-08-02: **P-6 — flat VLP composite edge-identity (#806, #887 Phase 3)**
+  (branch `fix/806-flat-vlp-composite-edge-id`). The flat exact-bound pairwise
+  relationship-uniqueness guard spelled "the same edge" as the `(from, to)` node
+  pair only, so two PARALLEL edges (same node pair, distinct `edge_id` column such
+  as a timestamp) collapsed into one relationship and every trail through them was
+  dropped (silent under-count). The recursive-CTE path was already correct via
+  `build_edge_tuple_recursive`. Fix threads the schema `edge_id` into
+  `generate_cycle_prevention_filters_composite` (new `edge_id_cols: Option<&[&str]>`
+  param); the caller (`filter_builder.rs`) resolves `rel_schema.edge_id` and
+  applies the #617 doubled-edge orientation correction (from/to →
+  `__cg_orig_from/to`; other identity columns pass through). No `edge_id` declared
+  → falls back to `(from, to)` (byte-identical for edge_id-less schemas). 26
+  goldens regenerated (single guard line each, all on `edge_id`-declaring schemas).
+  Live-verified: old vs new guard IDENTICAL on non-parallel data (standard 35=35,
+  composite_id 8=8, #617 undirected 122=122 — no regression); parallel-edge fixture
+  `FOLLOWS*2` now 2 (was 0), undirected 8 = oracle. Ratchet green. Unit regression
+  `flat_cycle_prevention_uses_composite_edge_id_806`. Adjacent bug filed separately
+  (NOT folded in): flat exact-bound polymorphic VLP drops the `interaction_type`
+  discriminator.
 - 2026-08-02: **P-1 — temporal component access / duration arithmetic on a native
   Date column threw CH Code 43** (branch `fix/854-temporal-date-epoch-wrap`,
   closes #854). PR3 (final) of the operand-typing design cycle. `year(x)`/`month(x)`

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -269,16 +269,40 @@ policy calls. Goldens byte-identical (asserts from Phase 1 guarantee it). Retire
 the second `uses_edge_uniqueness` copy by making CM Denormalized consume the same
 policy.
 
-### Phase 3 — fix #806 (flat-path identity) → behavior change, goldens regenerated
-Now that the flat pairwise guard reads `EdgeIdentity` (schema `edge_id`), the
-`(from,to)`-only collapse is fixed by construction. Regenerate the (small) set
-of goldens for parallel-edge schemas; live-verify the count against the trail
-oracle (`scratchpad/vlp_oracle.py`, per #606).
+### Phase 3 — fix #806 (flat-path identity) → **DONE (PR #TBD)** — behavior change, goldens regenerated
+**Shipped ahead of the full policy landing** (the fix is small and self-contained,
+so it did not need Phase 2's policy type first). The flat exact-bound pairwise
+guard (`generate_cycle_prevention_filters_composite`, `cte_extraction.rs`) now
+takes an `edge_id_cols: Option<&[&str]>` and, when the relationship schema
+declares an `edge_id`, spells the per-hop-pair inequality over that FULL identity
+column set — matching the recursive path's `build_edge_tuple_recursive`. The
+caller (`filter_builder.rs`) resolves `rel_schema.edge_id` (schema already in
+hand via `get_current_schema_with_fallback`) and applies the #617 doubled-edge
+orientation correction (from/to → `__cg_orig_from/to`; non-from/to identity
+columns pass through unchanged). When no `edge_id` is declared, identity falls
+back to the `(from, to)` node pair — byte-identical to the pre-#806 behaviour.
+Consulted only on the Normal/Polymorphic pairwise path; the legacy
+FkEdge/multi-type start != end guard ignores it. **26 goldens regenerated**
+(single-line guard change each — 13 entries × 2 dialects, all on
+`edge_id`-declaring schemas: social_integration `follow_id`, social_polymorphic
+composite, composite_id `transfer_id`, standard/#617 `follow_id`). **Live-verified
+no regression** (old vs new guard identical on non-parallel data: standard 35=35,
+composite_id 8=8, #617 undirected 122=122) and **fix confirmed** on a controlled
+parallel-edge fixture (`db_806_test`: two parallel FOLLOWS self-loops → `FOLLOWS*2`
+now returns 2, was 0; undirected returns 8 = oracle). Ratchet green (no raw
+axis-flag branching — routes through `rel_schema.edge_id`). Unit regression
+`flat_cycle_prevention_uses_composite_edge_id_806`.
+
+**Separate bug discovered during this phase (filed, NOT folded in — scope
+discipline §7):** the flat exact-bound POLYMORPHIC path drops the
+`interaction_type` type discriminator entirely (`FOLLOWS*2` counts LIKES chains
+too). That is a filter/join axis, not the edge-identity axis, so it gets its own
+issue rather than being mixed into #806.
 
 ### Phase 4 — fix #628 (`*0..N` closed cycle) → behavior change
 With the policy owning "zero-hop base is node-tracked, hop≥1 is edge-unique,"
 route the closed `*0..N` recursive arm to edge-uniqueness so real cycles survive
-(`(a)-[:FOLLOWS*0..2]->(a)` → 14, not 8). Live-verify.
+(`(a)-[:FOLLOWS*0..2]->(a)` → 14, not 8). Live-verify. **NEXT.**
 
 ### Phase 5 (optional) — #710 parallel-edge denorm
 Only if a real parallel-edge denorm schema is in scope. Needs a synthetic

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -8279,6 +8279,7 @@ pub fn generate_cycle_prevention_filters(
         start_alias,
         end_alias,
         use_legacy_start_end_guard,
+        None,
     )
 }
 
@@ -8307,6 +8308,18 @@ pub fn generate_cycle_prevention_filters(
 /// * `end_alias` - Alias for end node (e.g., "c")
 /// * `use_legacy_start_end_guard` - true for FkEdge / multi-type VLP (preserve
 ///   legacy start != end guard instead of pairwise rel-uniqueness)
+/// * `edge_id_cols` - #806: when the relationship schema declares a composite
+///   `edge_id` (e.g. `[from_id, to_id, interaction_type, timestamp]`), the FULL
+///   ordered identity column set to compare per hop-pair — matching the
+///   recursive path's `build_edge_tuple_recursive`. Two parallel edges sharing a
+///   `(from, to)` node pair but differing in a later identity column (a distinct
+///   timestamp) are then correctly treated as DISTINCT relationships. When
+///   `None`, the identity falls back to `from_cols ++ to_cols` (the `(from, to)`
+///   node pair), byte-identical to the pre-#806 behaviour for schemas without a
+///   declared `edge_id`. The caller applies the #617 doubled-edge orientation
+///   correction (from/to → `__cg_orig_from/to`) before passing these columns.
+///   Consulted only on the Normal/Polymorphic (`!use_legacy_start_end_guard`)
+///   pairwise path; the legacy FkEdge/multi-type start != end guard ignores it.
 ///
 /// # Returns
 /// RenderExpr combining all uniqueness conditions with AND
@@ -8320,6 +8333,7 @@ pub fn generate_cycle_prevention_filters_composite(
     start_alias: &str,
     end_alias: &str,
     use_legacy_start_end_guard: bool,
+    edge_id_cols: Option<&[&str]>,
 ) -> Option<RenderExpr> {
     use super::render_expr::{
         Operator, OperatorApplication, PropertyAccess, RenderExpr, TableAlias,
@@ -8433,23 +8447,33 @@ pub fn generate_cycle_prevention_filters_composite(
         // be a DISTINCT physical edge. A path IS allowed to return to its start
         // (e.g. 1→2→1 is a valid 2-path with a == b), so we deliberately do NOT
         // emit a start != end guard. For each pair of hops i<j emit
-        //   NOT (r_i.from = r_j.from AND r_i.to = r_j.to)
+        //   NOT (r_i.<id> = r_j.<id> AND ...)
         // which forbids reusing the same physical edge. This is the same rule as
         // the fixed multi-hop path in graph_join/cross_branch.rs. A single hop
         // (exact_hops < 2) has no pair, hence no constraint.
         if exact_hops < 2 {
             return None;
         }
-        // edge_cols = from_cols ++ to_cols → generate_composite_not_equal emits
-        // NOT (r_i.from = r_j.from AND r_i.to = r_j.to) (widened for composite IDs).
-        let edge_cols: Vec<&str> = from_cols.iter().chain(to_cols.iter()).copied().collect();
+        // #806: the physical edge's identity is the schema `edge_id` when one is
+        // declared (e.g. a polymorphic `interactions` table with
+        // `edge_id: [from_id, to_id, interaction_type, timestamp]`), matching the
+        // recursive path's `build_edge_tuple_recursive`. Comparing only the
+        // (from, to) node pair collapses two PARALLEL edges (same node pair,
+        // distinct later identity column) into one relationship and drops valid
+        // trails (under-count). When no `edge_id` is declared, identity is the
+        // `(from, to)` node pair (`edge_cols = from_cols ++ to_cols`) — the
+        // pre-#806 behaviour, byte-identical for edge_id-less schemas.
+        let default_edge_cols: Vec<&str> =
+            from_cols.iter().chain(to_cols.iter()).copied().collect();
+        let edge_cols: &[&str] = match edge_id_cols {
+            Some(cols) if !cols.is_empty() => cols,
+            _ => &default_edge_cols,
+        };
         for i in 1..exact_hops {
             for j in (i + 1)..=exact_hops {
                 let ri = format!("r{i}");
                 let rj = format!("r{j}");
-                filters.push(generate_composite_not_equal(
-                    &ri, &edge_cols, &rj, &edge_cols,
-                ));
+                filters.push(generate_composite_not_equal(&ri, edge_cols, &rj, edge_cols));
             }
         }
     }
@@ -8508,6 +8532,95 @@ mod tests {
         assert_eq!(
             render_in_list_rhs(&nn, "x", false, &[]).unwrap(),
             "x IN (1, 2)"
+        );
+    }
+
+    /// #806: the flat exact-bound pairwise relationship-uniqueness guard must
+    /// spell "the same edge" using the schema-declared composite `edge_id` when
+    /// one is passed, so two PARALLEL edges (same `(from, to)` node pair, distinct
+    /// later identity column such as a timestamp) are treated as DISTINCT
+    /// relationships instead of collapsing to one (which silently under-counts).
+    #[test]
+    fn flat_cycle_prevention_uses_composite_edge_id_806() {
+        // *2 with a composite edge_id [from_id, to_id, interaction_type,
+        // timestamp] — the guard compares the FULL identity, not just (from,to).
+        let edge_id_cols = ["from_id", "to_id", "interaction_type", "timestamp"];
+        let expr = generate_cycle_prevention_filters_composite(
+            2,
+            &["user_id"],
+            &["to_id"],
+            &["from_id"],
+            &["user_id"],
+            "a",
+            "b",
+            false,
+            Some(&edge_id_cols),
+        )
+        .expect("2-hop guard is non-empty");
+        assert_eq!(
+            render_expr_to_sql_string(&expr, &[]),
+            "NOT ((((r1.from_id = r2.from_id AND r1.to_id = r2.to_id) \
+             AND r1.interaction_type = r2.interaction_type) \
+             AND r1.timestamp = r2.timestamp))"
+        );
+
+        // A single composite-id column (e.g. `edge_id: follow_id`) collapses to
+        // the simple `<>` form — the strictest and cheapest edge identity.
+        let single = ["follow_id"];
+        let expr = generate_cycle_prevention_filters_composite(
+            2,
+            &["user_id"],
+            &["followed_id"],
+            &["follower_id"],
+            &["user_id"],
+            "a",
+            "b",
+            false,
+            Some(&single),
+        )
+        .expect("2-hop guard is non-empty");
+        assert_eq!(
+            render_expr_to_sql_string(&expr, &[]),
+            "r1.follow_id != r2.follow_id"
+        );
+
+        // No edge_id declared (None) → byte-identical to the pre-#806 (from,to)
+        // node-pair identity, so edge_id-less schemas are unaffected.
+        let expr = generate_cycle_prevention_filters_composite(
+            2,
+            &["user_id"],
+            &["followed_id"],
+            &["follower_id"],
+            &["user_id"],
+            "a",
+            "b",
+            false,
+            None,
+        )
+        .expect("2-hop guard is non-empty");
+        assert_eq!(
+            render_expr_to_sql_string(&expr, &[]),
+            "NOT ((r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id))"
+        );
+
+        // The legacy FkEdge / multi-type start != end guard IGNORES edge_id
+        // (those paths have no r1..rN edge-table aliases) — passing edge_id_cols
+        // must not change the emitted start != end node guard.
+        let expr = generate_cycle_prevention_filters_composite(
+            2,
+            &["user_id"],
+            &["followed_id"],
+            &["follower_id"],
+            &["user_id"],
+            "a",
+            "b",
+            true, // use_legacy_start_end_guard
+            Some(&edge_id_cols),
+        )
+        .expect("2-hop legacy guard is non-empty");
+        assert_eq!(
+            render_expr_to_sql_string(&expr, &[]),
+            "a.user_id != b.user_id"
         );
     }
 

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -624,6 +624,70 @@ impl FilterBuilder for LogicalPlan {
                                 start_id_cols.iter().map(String::as_str).collect();
                             let end_id_refs: Vec<&str> =
                                 end_id_cols.iter().map(String::as_str).collect();
+                            // #806: a schema-declared composite `edge_id` (e.g. a
+                            // polymorphic `interactions` table keyed
+                            // `[from_id, to_id, interaction_type, timestamp]`) is
+                            // the true physical-edge identity. The flat pairwise
+                            // uniqueness guard must compare that full column set —
+                            // matching the recursive path's
+                            // `build_edge_tuple_recursive` — or two PARALLEL edges
+                            // (same node pair, distinct timestamp) collapse into
+                            // one relationship and every trail through them is
+                            // dropped (under-count). Consulted only on the
+                            // Normal/Polymorphic pairwise path; the legacy
+                            // FkEdge/multi-type start != end guard has no edge
+                            // table and ignores it (kept None there).
+                            //
+                            // #617: on the doubled-edge undirected walk the from/to
+                            // columns are SWAPPED in reverse-orientation rows, so we
+                            // apply the same orientation correction the recursive
+                            // path uses — replace the schema from/to columns with
+                            // the original-orientation `__cg_orig_from/to` columns
+                            // the doubled CTE projects. Any non-from/to identity
+                            // column (interaction_type, timestamp) is
+                            // orientation-independent and passes through unchanged.
+                            let edge_id_cols_owned: Option<Vec<String>> =
+                                (!use_legacy_start_end_guard)
+                                    .then(|| {
+                                        schema_for_ids.as_ref().and_then(|schema| {
+                                            graph_rel.labels.as_ref().and_then(|labels| {
+                                                labels.first().and_then(|label| {
+                                                    schema
+                                                        .get_rel_schema(label)
+                                                        .ok()
+                                                        .and_then(|rs| rs.edge_id.clone())
+                                                })
+                                            })
+                                        })
+                                    })
+                                    .flatten()
+                                    .map(|edge_id| {
+                                        use crate::sql_generator::emitters::clickhouse::variable_length_cte as vlc;
+                                        let (from_key, to_key) = (
+                                            rel_cols.from_id.columns(),
+                                            rel_cols.to_id.columns(),
+                                        );
+                                        edge_id
+                                            .columns()
+                                            .iter()
+                                            .map(|c| {
+                                                if undirected_doubled {
+                                                    if from_key.iter().any(|k| k == c) {
+                                                        return vlc::DOUBLED_EDGES_ORIG_FROM
+                                                            .to_string();
+                                                    }
+                                                    if to_key.iter().any(|k| k == c) {
+                                                        return vlc::DOUBLED_EDGES_ORIG_TO
+                                                            .to_string();
+                                                    }
+                                                }
+                                                c.to_string()
+                                            })
+                                            .collect::<Vec<String>>()
+                                    });
+                            let edge_id_refs: Option<Vec<&str>> = edge_id_cols_owned
+                                .as_ref()
+                                .map(|cols| cols.iter().map(String::as_str).collect());
                             // Generate relationship-uniqueness filters
                             if let Some(cycle_filter) = crate::render_plan::cte_extraction::generate_cycle_prevention_filters_composite(
                                 exact_hops,
@@ -634,6 +698,7 @@ impl FilterBuilder for LogicalPlan {
                                 &graph_rel.left_connection,
                                 &graph_rel.right_connection,
                                 use_legacy_start_end_guard,
+                                edge_id_refs.as_deref(),
                             ) {
                                 crate::debug_println!("DEBUG: extract_filters - Generated relationship-uniqueness filter");
                                 all_predicates.push(cycle_filter);

--- a/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.clickhouse.sql
@@ -5,4 +5,4 @@ FROM db_composite_id.accounts AS a
 INNER JOIN db_composite_id.transfers AS r1 ON a.bank_id = r1.from_bank_id AND a.account_number = r1.from_account_number
 INNER JOIN db_composite_id.transfers AS r2 ON r1.to_bank_id = r2.from_bank_id AND r1.to_account_number = r2.from_account_number
 INNER JOIN db_composite_id.accounts AS b ON r2.to_bank_id = b.bank_id AND r2.to_account_number = b.account_number
-WHERE NOT (((r1.from_bank_id = r2.from_bank_id AND r1.from_account_number = r2.from_account_number) AND r1.to_bank_id = r2.to_bank_id) AND r1.to_account_number = r2.to_account_number)
+WHERE r1.transfer_id <> r2.transfer_id

--- a/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_id/test_604_composite_normal_exact_two_hop.databricks.sql
@@ -5,4 +5,4 @@ FROM db_composite_id.accounts AS a
 INNER JOIN db_composite_id.transfers AS r1 ON a.bank_id = r1.from_bank_id AND a.account_number = r1.from_account_number
 INNER JOIN db_composite_id.transfers AS r2 ON r1.to_bank_id = r2.from_bank_id AND r1.to_account_number = r2.from_account_number
 INNER JOIN db_composite_id.accounts AS b ON r2.to_bank_id = b.bank_id AND r2.to_account_number = b.account_number
-WHERE NOT (((r1.from_bank_id = r2.from_bank_id AND r1.from_account_number = r2.from_account_number) AND r1.to_bank_id = r2.to_bank_id) AND r1.to_account_number = r2.to_account_number)
+WHERE r1.transfer_id <> r2.transfer_id

--- a/tests/rust/integration/golden/corpus/social_integration/test_605_open_exact_vlp_stays_flat_sentinel.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_605_open_exact_vlp_stays_flat_sentinel.clickhouse.sql
@@ -3,4 +3,4 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id

--- a/tests/rust/integration/golden/corpus/social_integration/test_605_open_exact_vlp_stays_flat_sentinel.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_605_open_exact_vlp_stays_flat_sentinel.databricks.sql
@@ -3,4 +3,4 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMixedRecursiveNonRecursive_test_follows_continues_after_follows.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMixedRecursiveNonRecursive_test_follows_continues_after_follows.clickhouse.sql
@@ -3,4 +3,4 @@ SELECT
 FROM test_integration.users_test AS u
 INNER JOIN test_integration.user_follows_test AS r1 ON u.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE (u.user_id = 1 AND NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id))
+WHERE (u.user_id = 1 AND r1.follow_id <> r2.follow_id)

--- a/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMixedRecursiveNonRecursive_test_follows_continues_after_follows.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_graphrag_multi_type__TestMixedRecursiveNonRecursive_test_follows_continues_after_follows.databricks.sql
@@ -3,4 +3,4 @@ SELECT
 FROM test_integration.users_test AS u
 INNER JOIN test_integration.user_follows_test AS r1 ON u.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE (u.user_id = 1 AND NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id))
+WHERE (u.user_id = 1 AND r1.follow_id <> r2.follow_id)

--- a/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_length_exact_is_two.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_length_exact_is_two.clickhouse.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_length_exact_is_two.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_length_exact_is_two.databricks.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_standalone_exact_stays_flat.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_standalone_exact_stays_flat.clickhouse.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_standalone_exact_stays_flat.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_issue_623__TestFlatExactVlp_test_623_standalone_exact_stays_flat.databricks.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_0.clickhouse.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_0.databricks.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_1.clickhouse.sql
@@ -4,5 +4,5 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_1.databricks.sql
@@ -4,5 +4,5 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_2.clickhouse.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_vlp_exact_2.databricks.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_0.clickhouse.sql
@@ -4,5 +4,5 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_0.databricks.sql
@@ -4,5 +4,5 @@ SELECT
 FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_1.clickhouse.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_schema_matrix__TestStandardSchema_test_vlp_exact_1.databricks.sql
@@ -5,5 +5,5 @@ FROM test_integration.users_test AS a
 INNER JOIN test_integration.user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.follower_id = r2.follower_id AND r1.followed_id = r2.followed_id)
+WHERE r1.follow_id <> r2.follow_id
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_0.clickhouse.sql
@@ -5,5 +5,5 @@ FROM brahmand.users_bench AS a
 INNER JOIN brahmand.interactions AS r1 ON a.user_id = r1.from_id
 INNER JOIN brahmand.interactions AS r2 ON r1.to_id = r2.from_id
 INNER JOIN brahmand.users_bench AS b ON r2.to_id = b.user_id
-WHERE NOT (r1.from_id = r2.from_id AND r1.to_id = r2.to_id)
+WHERE NOT (((r1.from_id = r2.from_id AND r1.to_id = r2.to_id) AND r1.interaction_type = r2.interaction_type) AND r1.timestamp = r2.timestamp)
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_0.databricks.sql
@@ -5,5 +5,5 @@ FROM brahmand.users_bench AS a
 INNER JOIN brahmand.interactions AS r1 ON a.user_id = r1.from_id
 INNER JOIN brahmand.interactions AS r2 ON r1.to_id = r2.from_id
 INNER JOIN brahmand.users_bench AS b ON r2.to_id = b.user_id
-WHERE NOT (r1.from_id = r2.from_id AND r1.to_id = r2.to_id)
+WHERE NOT (((r1.from_id = r2.from_id AND r1.to_id = r2.to_id) AND r1.interaction_type = r2.interaction_type) AND r1.timestamp = r2.timestamp)
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_2.clickhouse.sql
@@ -5,5 +5,5 @@ FROM brahmand.users_bench AS a
 INNER JOIN brahmand.interactions AS r1 ON a.user_id = r1.from_id
 INNER JOIN brahmand.interactions AS r2 ON r1.to_id = r2.from_id
 INNER JOIN brahmand.users_bench AS b ON r2.to_id = b.user_id
-WHERE NOT (r1.from_id = r2.from_id AND r1.to_id = r2.to_id)
+WHERE NOT (((r1.from_id = r2.from_id AND r1.to_id = r2.to_id) AND r1.interaction_type = r2.interaction_type) AND r1.timestamp = r2.timestamp)
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_vlp_exact_2.databricks.sql
@@ -5,5 +5,5 @@ FROM brahmand.users_bench AS a
 INNER JOIN brahmand.interactions AS r1 ON a.user_id = r1.from_id
 INNER JOIN brahmand.interactions AS r2 ON r1.to_id = r2.from_id
 INNER JOIN brahmand.users_bench AS b ON r2.to_id = b.user_id
-WHERE NOT (r1.from_id = r2.from_id AND r1.to_id = r2.to_id)
+WHERE NOT (((r1.from_id = r2.from_id AND r1.to_id = r2.to_id) AND r1.interaction_type = r2.interaction_type) AND r1.timestamp = r2.timestamp)
 LIMIT 10

--- a/tests/rust/integration/golden/corpus/standard/test_undirected_vlp__Test617SingleWalk_test_exact_flat_doubled_chain.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_undirected_vlp__Test617SingleWalk_test_exact_flat_doubled_chain.clickhouse.sql
@@ -10,5 +10,5 @@ FROM test_integration.users_test AS a
 INNER JOIN undir_edges_a_b_test_integration_user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN undir_edges_a_b_test_integration_user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.__cg_orig_from = r2.__cg_orig_from AND r1.__cg_orig_to = r2.__cg_orig_to)
+WHERE r1.follow_id <> r2.follow_id
 ORDER BY a.full_name ASC, b.full_name ASC

--- a/tests/rust/integration/golden/corpus/standard/test_undirected_vlp__Test617SingleWalk_test_exact_flat_doubled_chain.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_undirected_vlp__Test617SingleWalk_test_exact_flat_doubled_chain.databricks.sql
@@ -10,5 +10,5 @@ FROM test_integration.users_test AS a
 INNER JOIN undir_edges_a_b_test_integration_user_follows_test AS r1 ON a.user_id = r1.follower_id
 INNER JOIN undir_edges_a_b_test_integration_user_follows_test AS r2 ON r1.followed_id = r2.follower_id
 INNER JOIN test_integration.users_test AS b ON r2.followed_id = b.user_id
-WHERE NOT (r1.__cg_orig_from = r2.__cg_orig_from AND r1.__cg_orig_to = r2.__cg_orig_to)
+WHERE r1.follow_id <> r2.follow_id
 ORDER BY a.full_name ASC, b.full_name ASC


### PR DESCRIPTION
## Summary

Fixes **#806**. The flat exact-bound variable-length-path (VLP) pairwise relationship-uniqueness guard identified "the same edge" by its `(from, to)` node pair only, ignoring a schema-declared composite `edge_id`. Two **parallel edges** — same node pair, distinct later identity column (e.g. a timestamp) — therefore collapsed into one relationship, and every trail through them was dropped as an edge-reuse (**silent under-count**). The recursive-CTE path was already correct via `build_edge_tuple_recursive`.

This is **Phase 3** of the #887 VLP edge-identity unification (design: `docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`).

## Repro (live, before)

Two parallel `FOLLOWS` self-loops `3→3` at distinct timestamps:
- `MATCH (a:User)-[:FOLLOWS*2]->(b:User) RETURN count(*)` → **0** (correct: **2** — the two parallel edges form a valid 2-trail each way).

Generated guard (before): `WHERE NOT (r1.from_id = r2.from_id AND r1.to_id = r2.to_id)` — collapses the parallel edges.

## Fix

Thread the schema `edge_id` into the flat guard:
- `generate_cycle_prevention_filters_composite` gains `edge_id_cols: Option<&[&str]>`. When `Some`, the per-hop-pair inequality compares that **full** identity column set. When `None`, identity is the `(from, to)` node pair — **byte-identical** to the pre-#806 behaviour, so `edge_id`-less schemas are unaffected.
- The caller (`filter_builder.rs`) resolves `rel_schema.edge_id` (schema already in hand) only on the Normal/Polymorphic pairwise path (the legacy FkEdge/multi-type `start != end` guard keeps `None`), and applies the **#617** doubled-edge orientation correction (from/to → `__cg_orig_from/to`; `interaction_type`/`timestamp` pass through unchanged).

Routes through `rel_schema.edge_id` (schema-catalog API), not a raw flag — **ratchet green**.

## Verification

- **26 goldens regenerated** — exactly one uniqueness-guard line each, all on `edge_id`-declaring corpus schemas (social_integration `follow_id`, social_polymorphic composite, composite_id `transfer_id`, standard/#617 `follow_id`).
- **Live, no regression**: old vs new guard produce identical counts on the non-parallel benchmark data — standard `35=35`, composite_id `8=8`, #617 undirected `122=122`.
- **Live, fix confirmed** on a controlled parallel-edge fixture: directed `FOLLOWS*2` now `2` (was `0`); undirected `8` = trail oracle.
- Unit regression `flat_cycle_prevention_uses_composite_edge_id_806` (composite / single / None / legacy start!=end cases).
- Full suite: `cargo fmt` / `clippy` clean; 1664 unit + 542 integration + ratchet + corpus_sweep all green.

## Scope discipline

An **adjacent** bug found during this work — the flat exact-bound *polymorphic* VLP drops the `interaction_type` type discriminator (`FOLLOWS*2` counts other edge types too) — is a filter/join axis, **not** the edge-identity axis, so it is filed separately rather than folded in (per #887 §7).

Also removes a stray `<<<<<<< HEAD` conflict marker accidentally committed in `PRIORITIES.md` by an earlier merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)