### PR TITLE
feat(#866): lower list comprehension in projection to arrayMap/arrayFilter

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -503,24 +503,44 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   so ZERO new CH render code. **Conservative guard:** a WHERE holding a graph
   pattern (`[p IN posts WHERE (p)-[:R]->()]`) has no scalar lowering — it keeps
   returning `ListComprehensionNotRewritten` (routed elsewhere inside
-  `size()`/`length()`, so #612/#629 are byte-unchanged). Two supporting fixes:
+  `size()`/`length()`, so #612/#629 are byte-unchanged). **The guard is
+  exhaustive** — it recurses through every pattern-bearing `Expression` variant
+  (CASE, function args, EXISTS, nested comprehensions) in BOTH the WHERE and the
+  projection, because a pattern hidden in e.g. a CASE would otherwise lower into
+  a lambda body that renders a pattern in expression context — a pre-existing
+  `unimplemented!` PANIC at `render_expr.rs` (a clean error on main → a crash;
+  now kept a clean error). Two supporting fixes:
   (1) **Databricks/Spark mapping** — registered `arrayFilter`→`filter`,
   `arrayMap`→`transform` in `function_registry.rs` with a dialect-gated arg swap
   (Spark HOFs take `(collection, lambda)`, CH takes `(lambda, collection)`;
   swap Databricks-only, like `split`), routed through `FunctionMapper`/`Dialect`
-  (Rule #7); CH byte-identical. (2) **Latent lambda-param bug fixed** — the
+  (Rule #7); CH byte-identical. **Applied to BOTH renderers** — Path A
+  (`to_sql_query.rs`, final SELECT / WITH→CTE) AND Path C
+  (`cte_extraction.rs::render_expr_to_sql_string`, reached by a `size([…])`
+  comprehension inside a VLP WHERE filter) via a shared `list_higher_order_fn_sql`
+  helper in `common.rs`; `dialect_function_name` skips `arg_transform` entries, so
+  without the Path-C fix a VLP-embedded comprehension leaked raw
+  `arrayFilter`/`arrayMap` + CH arg order on Spark (the recurring Path-A-only bug
+  class caught on #871/#880 — caught here by adversarial review too).
+  (2) **Latent lambda-param bug fixed** — the
   `projection_tagging.rs` `Lambda` arm documented "params are local variables
   (don't resolve them)" but tagged the whole body, so a bound param `x` (a
   `TableAlias`) errored `No table context for alias 'x'` — which broke even
   explicit `ch.arrayFilter(x -> …, …)` today. Now the arm registers each param
   as a projection alias for the duration of body tagging (save/restore to honor
-  shadowing), so the param stays a local. 10 new dual-dialect goldens (5 shapes ×
-  CH/Databricks: WHERE-only, map-only, both, WITH-bound list, nested) + 6
-  `ast_conversion` unit tests (4 lowering shapes + 2 pattern-predicate loud-fail
-  negative controls); updated the #612 "errors-not-panics" regression to
-  "lowers-not-panics". corpus_sweep 0-churn; sql_golden +10; ratchet net-zero;
-  full gate green (lib 1669, integration 542). SQL-shape-verified both dialects
-  (no live CH). Entirely outside the VLP files bronco owns (#887).
+  shadowing), so the param stays a local. 12 new dual-dialect goldens (6 shapes ×
+  CH/Databricks: WHERE-only, map-only, both, WITH-bound list, nested, +VLP-WHERE
+  Path-C) + 8 `ast_conversion` unit tests (4 lowering shapes + 4 pattern-loud-fail
+  controls incl. CASE-nested + projection-side) + a full-planner panic-guard
+  integration test; updated the #612 "errors-not-panics" regression to
+  "lowers-not-panics". corpus_sweep 0-churn; sql_golden +12; ratchet net-zero;
+  full gate green (lib 1671, integration 543). SQL-shape-verified both dialects
+  (no live CH). Adversarial review verdict fix-then-ship (2 HIGH: exhaustive
+  guard, Path-C Databricks leak); both fixed pre-merge. Entirely outside the VLP
+  files bronco owns (#887). Pre-existing out-of-scope gaps noted: a graph pattern
+  in a CASE/expression context still `unimplemented!`-panics on main independent
+  of comprehensions (filed separately); property access on a lambda-bound scalar
+  param (`p.foo`) errors cleanly on both main and here (not a #866 target).
 - 2026-08-02: **P-1 — temporal component access / duration arithmetic on a native
   Date column threw CH Code 43** (branch `fix/854-temporal-date-epoch-wrap`,
   closes #854). PR3 (final) of the operand-typing design cycle. `year(x)`/`month(x)`

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -490,7 +490,37 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
-<<<<<<< HEAD
+- 2026-08-02: **Feature — list comprehension in RETURN/WITH projection now
+  supported** (branch `feature/866-list-comprehension-lowering`, closes #866).
+  A plain `[x IN list WHERE p | e]` in projection position failed loud
+  (`ListComprehensionNotRewritten`) — no rewrite pass lowered it. Fix, mirroring
+  how `reduce(...)` lowers to `arrayFold`: a pure `ast_conversion.rs` lowering
+  (Option A — NO new `LogicalExpr`/`RenderExpr` variant) builds nested
+  CH-native `ScalarFnCall`s carrying `Lambda` args —
+  `[x IN l WHERE p | e]` → `arrayMap(x -> e, arrayFilter(x -> p, l))`; WHERE-only
+  → `arrayFilter`; `|`-only → `arrayMap`; identity → the bare list. Reuses the
+  existing `ScalarFnCall`+`Lambda` render paths (Path A and the WITH→CTE path),
+  so ZERO new CH render code. **Conservative guard:** a WHERE holding a graph
+  pattern (`[p IN posts WHERE (p)-[:R]->()]`) has no scalar lowering — it keeps
+  returning `ListComprehensionNotRewritten` (routed elsewhere inside
+  `size()`/`length()`, so #612/#629 are byte-unchanged). Two supporting fixes:
+  (1) **Databricks/Spark mapping** — registered `arrayFilter`→`filter`,
+  `arrayMap`→`transform` in `function_registry.rs` with a dialect-gated arg swap
+  (Spark HOFs take `(collection, lambda)`, CH takes `(lambda, collection)`;
+  swap Databricks-only, like `split`), routed through `FunctionMapper`/`Dialect`
+  (Rule #7); CH byte-identical. (2) **Latent lambda-param bug fixed** — the
+  `projection_tagging.rs` `Lambda` arm documented "params are local variables
+  (don't resolve them)" but tagged the whole body, so a bound param `x` (a
+  `TableAlias`) errored `No table context for alias 'x'` — which broke even
+  explicit `ch.arrayFilter(x -> …, …)` today. Now the arm registers each param
+  as a projection alias for the duration of body tagging (save/restore to honor
+  shadowing), so the param stays a local. 10 new dual-dialect goldens (5 shapes ×
+  CH/Databricks: WHERE-only, map-only, both, WITH-bound list, nested) + 6
+  `ast_conversion` unit tests (4 lowering shapes + 2 pattern-predicate loud-fail
+  negative controls); updated the #612 "errors-not-panics" regression to
+  "lowers-not-panics". corpus_sweep 0-churn; sql_golden +10; ratchet net-zero;
+  full gate green (lib 1669, integration 542). SQL-shape-verified both dialects
+  (no live CH). Entirely outside the VLP files bronco owns (#887).
 - 2026-08-02: **P-1 — temporal component access / duration arithmetic on a native
   Date column threw CH Code 43** (branch `fix/854-temporal-date-epoch-wrap`,
   closes #854). PR3 (final) of the operand-typing design cycle. `year(x)`/`month(x)`

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1908,12 +1908,43 @@ impl ProjectionTagging {
                 // Lambda expressions need special handling:
                 // - Lambda parameters are local variables (don't resolve them)
                 // - Lambda body may contain references that need resolution
-                // We recursively transform the body expression
+                //
+                // #866: to honor "don't resolve the params", register each param
+                // name as a projection alias for the duration of body tagging.
+                // The `TableAlias` arm returns early for projection aliases
+                // (keeping the bare name as-is), so a param reference like `x` in
+                // `arrayFilter(x -> x > 1, list)` is no longer resolved as a
+                // graph alias (which errored `No table context for alias 'x'`).
+                // Params are removed afterwards, and any pre-existing alias of
+                // the same name is saved and restored so an outer binding that a
+                // param shadows is not clobbered.
+                let mut shadowed: Vec<(String, Option<LogicalExpr>)> = Vec::new();
+                for param in &lambda_expr.params {
+                    let prev = plan_ctx.remove_projection_alias(param);
+                    plan_ctx.register_projection_alias(
+                        param.clone(),
+                        LogicalExpr::TableAlias(TableAlias(param.clone())),
+                    );
+                    shadowed.push((param.clone(), prev));
+                }
+
                 let mut body_item = ProjectionItem {
                     expression: (*lambda_expr.body).clone(),
                     col_alias: None,
                 };
-                Self::tag_projection(&mut body_item, plan_ctx, graph_schema, input_plan)?;
+                let result =
+                    Self::tag_projection(&mut body_item, plan_ctx, graph_schema, input_plan);
+
+                // Restore prior alias state regardless of tagging outcome.
+                for (param, prev) in shadowed.into_iter().rev() {
+                    match prev {
+                        Some(expr) => plan_ctx.register_projection_alias(param, expr),
+                        None => {
+                            plan_ctx.remove_projection_alias(&param);
+                        }
+                    }
+                }
+                result?;
 
                 item.expression = LogicalExpr::Lambda(LambdaExpr {
                     params: lambda_expr.params.clone(),

--- a/src/query_planner/logical_expr/ast_conversion.rs
+++ b/src/query_planner/logical_expr/ast_conversion.rs
@@ -699,15 +699,27 @@ impl<'a> std::convert::TryFrom<open_cypher_parser::ast::Expression<'a>> for Logi
                 //   [x IN l WHERE p]     -> arrayFilter(x->p, l)
                 //   [x IN l | e]         -> arrayMap(x->e, l)
                 //   [x IN l]             -> l              (identity)
-                // CONSERVATIVE GUARD: a WHERE holding a graph pattern
-                // (`[p IN posts WHERE (p)-[:R]->()]`) has NO scalar lowering and
-                // is handled upstream inside `size()`/`length()`
-                // (with_clause.rs). Such a bare pattern-predicate comprehension
-                // keeps failing loud here so #612/#629 routing is byte-unchanged.
-                if let Some(ref where_expr) = lc.where_clause {
-                    if list_comprehension_where_has_pattern(where_expr) {
-                        return Err(errors::LogicalExprError::ListComprehensionNotRewritten);
-                    }
+                // CONSERVATIVE GUARD: a graph pattern anywhere in the WHERE or
+                // projection (`[p IN posts WHERE (p)-[:R]->()]`, or hidden inside
+                // a CASE / exists() / function arg) has NO scalar per-element
+                // lowering — the pattern is a graph traversal, not an array
+                // predicate. Such comprehensions keep failing loud here
+                // (`ListComprehensionNotRewritten`) rather than lowering into a
+                // lambda body that renders a pattern in expression context (a
+                // pre-existing `unimplemented!` panic at
+                // render_expr.rs). `size([...])`-wrapped pattern comprehensions
+                // are already intercepted upstream (with_clause.rs, #612/#629),
+                // so this is the guard for the BARE projection-position form.
+                if lc
+                    .where_clause
+                    .as_deref()
+                    .is_some_and(expr_contains_path_pattern)
+                    || lc
+                        .projection
+                        .as_deref()
+                        .is_some_and(expr_contains_path_pattern)
+                {
+                    return Err(errors::LogicalExprError::ListComprehensionNotRewritten);
                 }
 
                 let var = lc.variable.to_string();
@@ -761,20 +773,79 @@ impl<'a> std::convert::TryFrom<open_cypher_parser::ast::Expression<'a>> for Logi
     }
 }
 
-/// #866: returns true if a list-comprehension WHERE clause contains a graph
-/// pattern (`(p)-[:R]->()`), recursing through operator operands (AND/OR/NOT).
-/// A pattern-predicate comprehension has no scalar `arrayFilter` lowering — it
-/// is handled upstream inside `size()`/`length()` (with_clause.rs) — so we keep
-/// it failing loud rather than emit wrong SQL. Mirrors
-/// `extract_path_pattern_from_expression` in `logical_plan::with_clause`.
-fn list_comprehension_where_has_pattern(expr: &open_cypher_parser::ast::Expression<'_>) -> bool {
+/// #866: returns true if a list-comprehension WHERE or projection expression
+/// contains a graph pattern anywhere — a bare `PathPattern`, or one nested
+/// inside an operator / CASE / function arg / EXISTS / pattern-comprehension /
+/// another comprehension. Such an expression has no scalar per-element
+/// `arrayFilter`/`arrayMap` lowering (the pattern is a graph traversal, not an
+/// array predicate), so the comprehension keeps failing loud
+/// (`ListComprehensionNotRewritten`) instead of lowering into a lambda body
+/// that renders a pattern in expression context — a pre-existing
+/// `unimplemented!` panic at `render_expr.rs`.
+///
+/// The match is exhaustive (no catch-all) so a new `Expression` variant that
+/// could carry a pattern is a compile error here until it is classified,
+/// rather than silently slipping a pattern through to the panic path.
+fn expr_contains_path_pattern(expr: &open_cypher_parser::ast::Expression<'_>) -> bool {
     use open_cypher_parser::ast::Expression;
     match expr {
-        Expression::PathPattern(_) => true,
+        // Directly a pattern, or a node whose very presence implies a pattern.
+        Expression::PathPattern(_)
+        | Expression::ExistsExpression(_)
+        | Expression::PatternComprehension(_) => true,
+
+        // Recurse through every expression-bearing child.
+        Expression::List(items) => items.iter().any(expr_contains_path_pattern),
+        Expression::FunctionCallExp(fc) => fc.args.iter().any(expr_contains_path_pattern),
         Expression::OperatorApplicationExp(op) => {
-            op.operands.iter().any(list_comprehension_where_has_pattern)
+            op.operands.iter().any(expr_contains_path_pattern)
         }
-        _ => false,
+        Expression::Case(case) => {
+            case.expr.as_deref().is_some_and(expr_contains_path_pattern)
+                || case
+                    .when_then
+                    .iter()
+                    .any(|(w, t)| expr_contains_path_pattern(w) || expr_contains_path_pattern(t))
+                || case
+                    .else_expr
+                    .as_deref()
+                    .is_some_and(expr_contains_path_pattern)
+        }
+        Expression::ReduceExp(r) => {
+            expr_contains_path_pattern(&r.initial_value)
+                || expr_contains_path_pattern(&r.list)
+                || expr_contains_path_pattern(&r.expression)
+        }
+        Expression::MapLiteral(entries) => {
+            entries.iter().any(|(_, v)| expr_contains_path_pattern(v))
+        }
+        Expression::Lambda(l) => expr_contains_path_pattern(&l.body),
+        Expression::ListComprehension(lc) => {
+            expr_contains_path_pattern(&lc.list_expr)
+                || lc
+                    .where_clause
+                    .as_deref()
+                    .is_some_and(expr_contains_path_pattern)
+                || lc
+                    .projection
+                    .as_deref()
+                    .is_some_and(expr_contains_path_pattern)
+        }
+        Expression::ArraySubscript { array, index } => {
+            expr_contains_path_pattern(array) || expr_contains_path_pattern(index)
+        }
+        Expression::ArraySlicing { array, from, to } => {
+            expr_contains_path_pattern(array)
+                || from.as_deref().is_some_and(expr_contains_path_pattern)
+                || to.as_deref().is_some_and(expr_contains_path_pattern)
+        }
+
+        // Leaves that cannot contain a pattern.
+        Expression::Literal(_)
+        | Expression::Variable(_)
+        | Expression::Parameter(_)
+        | Expression::PropertyAccessExp(_)
+        | Expression::LabelExpression { .. } => false,
     }
 }
 
@@ -935,6 +1006,63 @@ mod listcomp_lowering_tests {
             list_expr: Box::new(Expression::Variable("posts")),
             where_clause: Some(Box::new(where_clause)),
             projection: None,
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            errors::LogicalExprError::ListComprehensionNotRewritten
+        ));
+    }
+
+    #[test]
+    fn pattern_hidden_in_case_fails_loud_not_panics() {
+        // A pattern buried in a CASE inside the WHERE
+        // (`[p IN l WHERE CASE WHEN (p)-[:R]->() THEN … END]`) has no scalar
+        // lowering. Before the guard recursed into CASE, this lowered and then
+        // PANICKED at render_expr.rs (pattern in expression context is
+        // `unimplemented!`). It must fail loud instead.
+        let pattern = Expression::PathPattern(AstPathPattern::Node(NodePattern {
+            name: Some("p"),
+            labels: None,
+            properties: None,
+        }));
+        let case = Expression::Case(crate::open_cypher_parser::ast::Case {
+            expr: None,
+            when_then: vec![(pattern, Expression::Literal(AstLiteral::Boolean(true)))],
+            else_expr: Some(Box::new(Expression::Literal(AstLiteral::Boolean(false)))),
+        });
+        let err = lower(ListComprehension {
+            variable: "p",
+            list_expr: Box::new(Expression::Variable("posts")),
+            where_clause: Some(Box::new(case)),
+            projection: None,
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            errors::LogicalExprError::ListComprehensionNotRewritten
+        ));
+    }
+
+    #[test]
+    fn pattern_in_projection_fails_loud() {
+        // The guard also covers the projection (`| …`), not just the WHERE:
+        // `[p IN l | CASE WHEN (p)-[:R]->() THEN 1 ELSE 0 END]` must fail loud.
+        let pattern = Expression::PathPattern(AstPathPattern::Node(NodePattern {
+            name: Some("p"),
+            labels: None,
+            properties: None,
+        }));
+        let projection = Expression::Case(crate::open_cypher_parser::ast::Case {
+            expr: None,
+            when_then: vec![(pattern, Expression::Literal(AstLiteral::Integer(1)))],
+            else_expr: Some(Box::new(Expression::Literal(AstLiteral::Integer(0)))),
+        });
+        let err = lower(ListComprehension {
+            variable: "p",
+            list_expr: Box::new(list_123()),
+            where_clause: None,
+            projection: Some(Box::new(projection)),
         })
         .unwrap_err();
         assert!(matches!(

--- a/src/query_planner/logical_expr/ast_conversion.rs
+++ b/src/query_planner/logical_expr/ast_conversion.rs
@@ -690,8 +690,59 @@ impl<'a> std::convert::TryFrom<open_cypher_parser::ast::Expression<'a>> for Logi
             Expression::PatternComprehension(_) => {
                 Err(errors::LogicalExprError::PatternComprehensionNotRewritten)
             }
-            Expression::ListComprehension(_) => {
-                Err(errors::LogicalExprError::ListComprehensionNotRewritten)
+            Expression::ListComprehension(lc) => {
+                // #866: lower a plain (scalar) list comprehension in projection
+                // position to nested ClickHouse `arrayMap`/`arrayFilter` calls,
+                // mirroring how `reduce(...)` lowers to `arrayFold`. The four
+                // shapes:
+                //   [x IN l WHERE p | e] -> arrayMap(x->e, arrayFilter(x->p, l))
+                //   [x IN l WHERE p]     -> arrayFilter(x->p, l)
+                //   [x IN l | e]         -> arrayMap(x->e, l)
+                //   [x IN l]             -> l              (identity)
+                // CONSERVATIVE GUARD: a WHERE holding a graph pattern
+                // (`[p IN posts WHERE (p)-[:R]->()]`) has NO scalar lowering and
+                // is handled upstream inside `size()`/`length()`
+                // (with_clause.rs). Such a bare pattern-predicate comprehension
+                // keeps failing loud here so #612/#629 routing is byte-unchanged.
+                if let Some(ref where_expr) = lc.where_clause {
+                    if list_comprehension_where_has_pattern(where_expr) {
+                        return Err(errors::LogicalExprError::ListComprehensionNotRewritten);
+                    }
+                }
+
+                let var = lc.variable.to_string();
+                let list = Self::try_from(*lc.list_expr)?;
+
+                // Inner: filter, only when a (scalar) WHERE is present.
+                let filtered = match lc.where_clause {
+                    Some(where_expr) => LogicalExpr::ScalarFnCall(ScalarFnCall {
+                        name: "arrayFilter".to_string(),
+                        args: vec![
+                            LogicalExpr::Lambda(LambdaExpr {
+                                params: vec![var.clone()],
+                                body: Box::new(Self::try_from(*where_expr)?),
+                            }),
+                            list,
+                        ],
+                    }),
+                    None => list,
+                };
+
+                // Outer: map, only when a projection (`| expr`) is present.
+                // `None` = identity projection, so the filtered list is the result.
+                match lc.projection {
+                    Some(proj) => Ok(LogicalExpr::ScalarFnCall(ScalarFnCall {
+                        name: "arrayMap".to_string(),
+                        args: vec![
+                            LogicalExpr::Lambda(LambdaExpr {
+                                params: vec![var],
+                                body: Box::new(Self::try_from(*proj)?),
+                            }),
+                            filtered,
+                        ],
+                    })),
+                    None => Ok(filtered),
+                }
             }
             Expression::ArraySubscript { array, index } => Ok(LogicalExpr::ArraySubscript {
                 array: Box::new(LogicalExpr::try_from(*array)?),
@@ -707,5 +758,188 @@ impl<'a> std::convert::TryFrom<open_cypher_parser::ast::Expression<'a>> for Logi
                     .transpose()?,
             }),
         }
+    }
+}
+
+/// #866: returns true if a list-comprehension WHERE clause contains a graph
+/// pattern (`(p)-[:R]->()`), recursing through operator operands (AND/OR/NOT).
+/// A pattern-predicate comprehension has no scalar `arrayFilter` lowering — it
+/// is handled upstream inside `size()`/`length()` (with_clause.rs) — so we keep
+/// it failing loud rather than emit wrong SQL. Mirrors
+/// `extract_path_pattern_from_expression` in `logical_plan::with_clause`.
+fn list_comprehension_where_has_pattern(expr: &open_cypher_parser::ast::Expression<'_>) -> bool {
+    use open_cypher_parser::ast::Expression;
+    match expr {
+        Expression::PathPattern(_) => true,
+        Expression::OperatorApplicationExp(op) => {
+            op.operands.iter().any(list_comprehension_where_has_pattern)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod listcomp_lowering_tests {
+    //! #866: a plain (scalar) list comprehension in projection position lowers
+    //! to nested `arrayMap`/`arrayFilter` `ScalarFnCall`s carrying `Lambda`
+    //! args. A pattern-predicate WHERE has no scalar lowering and keeps failing
+    //! loud (routed elsewhere for `size([...])`).
+    use super::*;
+    use crate::open_cypher_parser::ast::{
+        Expression, ListComprehension, Literal as AstLiteral, NodePattern, Operator,
+        OperatorApplication, PathPattern as AstPathPattern,
+    };
+
+    /// `[1, 2, 3]` as an AST list expression.
+    fn list_123<'a>() -> Expression<'a> {
+        Expression::List(vec![
+            Expression::Literal(AstLiteral::Integer(1)),
+            Expression::Literal(AstLiteral::Integer(2)),
+            Expression::Literal(AstLiteral::Integer(3)),
+        ])
+    }
+
+    /// `x <op> <int>` scalar predicate/projection over the iteration var.
+    fn bin_x<'a>(op: Operator, rhs: i64) -> Expression<'a> {
+        Expression::OperatorApplicationExp(OperatorApplication {
+            operator: op,
+            operands: vec![
+                Expression::Variable("x"),
+                Expression::Literal(AstLiteral::Integer(rhs)),
+            ],
+        })
+    }
+
+    fn lower(lc: ListComprehension<'_>) -> Result<LogicalExpr, errors::LogicalExprError> {
+        LogicalExpr::try_from(Expression::ListComprehension(lc))
+    }
+
+    fn scalar_fn(expr: &LogicalExpr) -> &ScalarFnCall {
+        match expr {
+            LogicalExpr::ScalarFnCall(f) => f,
+            other => panic!("expected ScalarFnCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn where_only_lowers_to_array_filter() {
+        // [x IN [1,2,3] WHERE x > 1] -> arrayFilter(x -> x > 1, [1,2,3])
+        let lowered = lower(ListComprehension {
+            variable: "x",
+            list_expr: Box::new(list_123()),
+            where_clause: Some(Box::new(bin_x(Operator::GreaterThan, 1))),
+            projection: None,
+        })
+        .unwrap();
+        let f = scalar_fn(&lowered);
+        assert_eq!(f.name, "arrayFilter");
+        assert_eq!(f.args.len(), 2);
+        match &f.args[0] {
+            LogicalExpr::Lambda(l) => assert_eq!(l.params, vec!["x".to_string()]),
+            other => panic!("expected Lambda, got {other:?}"),
+        }
+        assert!(matches!(&f.args[1], LogicalExpr::List(_)));
+    }
+
+    #[test]
+    fn map_only_lowers_to_array_map() {
+        // [x IN [1,2,3] | x * 2] -> arrayMap(x -> x * 2, [1,2,3])
+        let lowered = lower(ListComprehension {
+            variable: "x",
+            list_expr: Box::new(list_123()),
+            where_clause: None,
+            projection: Some(Box::new(bin_x(Operator::Multiplication, 2))),
+        })
+        .unwrap();
+        let f = scalar_fn(&lowered);
+        assert_eq!(f.name, "arrayMap");
+        assert_eq!(f.args.len(), 2);
+        assert!(matches!(&f.args[0], LogicalExpr::Lambda(_)));
+        assert!(matches!(&f.args[1], LogicalExpr::List(_)));
+    }
+
+    #[test]
+    fn where_and_map_nests_map_over_filter() {
+        // [x IN l WHERE p | e] -> arrayMap(x -> e, arrayFilter(x -> p, l))
+        let lowered = lower(ListComprehension {
+            variable: "x",
+            list_expr: Box::new(list_123()),
+            where_clause: Some(Box::new(bin_x(Operator::GreaterThan, 1))),
+            projection: Some(Box::new(bin_x(Operator::Multiplication, 10))),
+        })
+        .unwrap();
+        let outer = scalar_fn(&lowered);
+        assert_eq!(outer.name, "arrayMap");
+        // The map's collection arg is the inner arrayFilter.
+        let inner = scalar_fn(&outer.args[1]);
+        assert_eq!(inner.name, "arrayFilter");
+        assert!(matches!(&inner.args[1], LogicalExpr::List(_)));
+    }
+
+    #[test]
+    fn identity_lowers_to_bare_list() {
+        // [x IN [1,2,3]] -> [1,2,3] (no filter, no map)
+        let lowered = lower(ListComprehension {
+            variable: "x",
+            list_expr: Box::new(list_123()),
+            where_clause: None,
+            projection: None,
+        })
+        .unwrap();
+        assert!(
+            matches!(&lowered, LogicalExpr::List(items) if items.len() == 3),
+            "expected bare List, got {lowered:?}"
+        );
+    }
+
+    #[test]
+    fn pattern_predicate_where_keeps_failing_loud() {
+        // A graph-pattern WHERE has no scalar lowering — it must return the
+        // ListComprehensionNotRewritten error unchanged (routed elsewhere for
+        // `size([...])`, #612/#629), never silently emit wrong SQL. The guard
+        // fires on any `Expression::PathPattern` in the WHERE; the inner pattern
+        // shape is irrelevant, so a bare `PathPattern::Node` suffices here.
+        let pattern = Expression::PathPattern(AstPathPattern::Node(NodePattern {
+            name: Some("p"),
+            labels: None,
+            properties: None,
+        }));
+        let err = lower(ListComprehension {
+            variable: "p",
+            list_expr: Box::new(Expression::Variable("posts")),
+            where_clause: Some(Box::new(pattern)),
+            projection: None,
+        })
+        .unwrap_err();
+        assert!(
+            matches!(err, errors::LogicalExprError::ListComprehensionNotRewritten),
+            "expected ListComprehensionNotRewritten, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn pattern_predicate_nested_in_operator_still_fails_loud() {
+        // The guard recurses through operator operands, so a pattern buried in
+        // `AND`/`NOT`/`OR` (`WHERE x > 0 AND (p)-[...]->()`) is still caught.
+        let pattern = Expression::PathPattern(AstPathPattern::Node(NodePattern {
+            name: Some("p"),
+            labels: None,
+            properties: None,
+        }));
+        let where_clause = Expression::OperatorApplicationExp(OperatorApplication {
+            operator: Operator::And,
+            operands: vec![bin_x(Operator::GreaterThan, 0), pattern],
+        });
+        let err = lower(ListComprehension {
+            variable: "p",
+            list_expr: Box::new(Expression::Variable("posts")),
+            where_clause: Some(Box::new(where_clause)),
+            projection: None,
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            errors::LogicalExprError::ListComprehensionNotRewritten
+        ));
     }
 }

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -331,6 +331,15 @@ impl PlanCtx {
         self.projection_aliases.contains_key(alias)
     }
 
+    /// Remove a projection alias, returning its expression if it was present.
+    /// Used to scope lambda-bound parameter names to the lambda body during
+    /// projection tagging (#866): the param is registered before tagging the
+    /// body and removed after, so a bare param reference is kept as-is (a local
+    /// variable) instead of being resolved as a graph alias.
+    pub fn remove_projection_alias(&mut self, alias: &str) -> Option<LogicalExpr> {
+        self.projection_aliases.remove(alias)
+    }
+
     /// Get the original expression for a projection alias
     pub fn get_projection_alias_expr(&self, alias: &str) -> Option<&LogicalExpr> {
         self.projection_aliases.get(alias)

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1939,6 +1939,22 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                     mapper.cast_float64_or_null(&args[0])
                 };
             }
+            // #866: arrayFilter/arrayMap (list-comprehension lowering) need the
+            // dialect name + arg swap on this Path-C renderer too. Spark's
+            // filter/transform take (collection, lambda); CH's arrayFilter/
+            // arrayMap take (lambda, collection). `dialect_function_name` below
+            // deliberately SKIPS registry entries that carry an `arg_transform`
+            // (it can't rewrite args), so without this a list comprehension
+            // reaching Path C — e.g. `size([x IN l WHERE p])` inside a VLP WHERE
+            // filter — would emit the raw CH name + CH arg order on Spark
+            // (invalid). The shared helper applies BOTH, matching Path A
+            // (to_sql_query.rs), routing through the registry (no inline dialect
+            // branch here — Rule #7).
+            if let Some(sql) =
+                crate::clickhouse_query_generator::list_higher_order_fn_sql(&fn_lower, &args)
+            {
+                return sql;
+            }
             // Map dialect-divergent names (e.g. tuple -> Spark struct) via the registry.
             let name = crate::clickhouse_query_generator::dialect_function_name(&func.name);
             format!("{}({})", name, args.join(", "))

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -325,6 +325,32 @@ pub fn dialect_function_name(name: &str) -> String {
     }
 }
 
+/// #866: render `arrayFilter`/`arrayMap` (the list-comprehension lowering) for
+/// the duplicate generic `ScalarFnCall` renderers (Path C in `render_plan`,
+/// e.g. `cte_extraction`). These registry entries carry an `arg_transform`
+/// (the CH↔Spark arg swap), so `dialect_function_name` deliberately leaves them
+/// raw — this shim applies BOTH the dialect name and the transform, matching
+/// the canonical Path-A `RenderExpr::to_sql` arm. Returns `None` for any other
+/// function so the caller keeps its existing `dialect_function_name` path.
+/// `rendered_args` are already-rendered SQL strings (the transform operates on
+/// strings, like the Path-A `arg_transform` application).
+pub fn list_higher_order_fn_sql(fn_lower: &str, rendered_args: &[String]) -> Option<String> {
+    if fn_lower != "arrayfilter" && fn_lower != "arraymap" {
+        return None;
+    }
+    let mapping = super::function_registry::get_function_mapping(fn_lower)?;
+    let dialect = crate::server::query_context::get_current_dialect();
+    let args = match mapping.arg_transform {
+        Some(t) => t(rendered_args),
+        None => rendered_args.to_vec(),
+    };
+    Some(format!(
+        "{}({})",
+        mapping.name_for(dialect),
+        args.join(", ")
+    ))
+}
+
 /// Intercept the openCypher percentile aggregates and render them through
 /// `FunctionMapper::percentile_aggregate`, honoring the percentile argument
 /// (#639). Returns `Some(sql)` for `percentileCont`/`percentileDisc` called

--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -58,6 +58,20 @@ fn wrap_epoch_millis_arg(args: &[String]) -> Vec<String> {
 /// Argument transformation: maps SQL-string args to (possibly rewritten) SQL-string args.
 pub type ArgTransform = fn(&[String]) -> Vec<String>;
 
+/// #866: arg transform shared by the `arrayFilter`/`arrayMap` mappings.
+/// ClickHouse higher-order array functions take `(lambda, collection)`; Spark's
+/// `filter`/`transform` take `(collection, lambda)`. The list-comprehension
+/// lowering builds the CH order, so swap the two args on Databricks only. CH is
+/// left byte-identical. Non-2-arg calls are passed through untouched.
+fn list_higher_order_arg_transform(args: &[String]) -> Vec<String> {
+    let dialect = crate::server::query_context::get_current_dialect();
+    if dialect == crate::sql_generator::SqlDialect::Databricks && args.len() == 2 {
+        vec![args[1].clone(), args[0].clone()]
+    } else {
+        args.to_vec()
+    }
+}
+
 /// Cypher-semantic return kind of a function, used by the render-site type
 /// classifier ([`super::type_inference::infer_render_type`]) to decide things
 /// like string `+` → `concat` (#871), `toInteger`/`toFloat` OrNull dispatch
@@ -884,15 +898,28 @@ lazy_static::lazy_static! {
         // reduce() - complex, needs special handling but add placeholder
         // Note: ClickHouse has arrayReduce() but syntax differs significantly
 
-        // filter() -> arrayFilter() [list comprehension style]
-        // Neo4j: [x IN list WHERE x > 0] or filter(x IN list WHERE x > 0)
-        // ClickHouse: arrayFilter(x -> x > 0, list)
-        // This requires special AST handling, placeholder for now
-
-        // extract() -> arrayMap() for extracting properties
-        // Neo4j: [x IN list | x.prop] or extract(x IN list | x.prop)
-        // ClickHouse: arrayMap(x -> x.prop, list)
-        // This requires special AST handling, placeholder for now
+        // #866: list-comprehension lowering emits CH-native `arrayFilter`/
+        // `arrayMap` (see ast_conversion.rs). These entries carry those CH names
+        // through unchanged AND supply the Databricks/Spark mapping:
+        //   [x IN l WHERE p]  -> CH   arrayFilter(x -> p, l)      (lambda, list)
+        //                        Spark filter(l, x -> p)          (list, lambda)
+        //   [x IN l | e]      -> CH   arrayMap(x -> e, l)         (lambda, list)
+        //                        Spark transform(l, x -> e)       (list, lambda)
+        // Spark's higher-order functions take (collection, lambda) — the reverse
+        // of CH — so the arg swap is Databricks-only (dialect-gated, like
+        // `split`). CH keeps its native order byte-identical.
+        m.insert("arrayfilter", FunctionMapping {
+            neo4j_name: "arrayFilter",
+            clickhouse_name: "arrayFilter",
+            databricks_name: Some("filter"),
+            arg_transform: Some(list_higher_order_arg_transform),
+        });
+        m.insert("arraymap", FunctionMapping {
+            neo4j_name: "arrayMap",
+            clickhouse_name: "arrayMap",
+            databricks_name: Some("transform"),
+            arg_transform: Some(list_higher_order_arg_transform),
+        });
 
         // all() -> arrayAll() - check if all elements match predicate
         m.insert("all", FunctionMapping {

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -21,8 +21,8 @@ pub use write_to_sql::write_render_to_sql;
 mod where_clause_tests;
 
 pub use common::{
-    contains_predicate, dialect_function_name, ends_with_predicate, qualified_column,
-    quote_identifier, reduce_fold_sql, regex_match_predicate, round_half_up_sql,
+    contains_predicate, dialect_function_name, ends_with_predicate, list_higher_order_fn_sql,
+    qualified_column, quote_identifier, reduce_fold_sql, regex_match_predicate, round_half_up_sql,
     starts_with_predicate,
 };
 pub use errors::ClickhouseQueryGeneratorError;

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_in_vlp_where_path_c_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_in_vlp_where_path_c_866__clickhouse.sql
@@ -1,0 +1,30 @@
+WITH RECURSIVE vlp_u_v AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [tuple(rel.follower_id, rel.followed_id)] as path_edges
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE length(arrayFilter(x -> x > 1, [1, 2, 3])) > 0
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.follower_id, rel.followed_id)]) as path_edges
+    FROM vlp_u_v vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.follower_id, rel.followed_id))
+      AND length(arrayFilter(x -> x > 1, [1, 2, 3])) > 0
+)
+SELECT 
+      t.start_id AS "u.user_id"
+FROM vlp_u_v AS t

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_in_vlp_where_path_c_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_in_vlp_where_path_c_866__databricks.sql
@@ -1,0 +1,30 @@
+WITH RECURSIVE vlp_u_v AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(struct(rel.follower_id, rel.followed_id)) as path_edges
+    FROM social.users_bench AS start_node
+    JOIN social.user_follows_bench AS rel ON start_node.user_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE length(filter(array(1, 2, 3), x -> x > 1)) > 0
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.follower_id, rel.followed_id))) as path_edges
+    FROM vlp_u_v vp
+    JOIN social.user_follows_bench AS rel ON vp.end_id = rel.follower_id
+    JOIN social.users_bench AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.follower_id, rel.followed_id))
+      AND length(filter(array(1, 2, 3), x -> x > 1)) > 0
+)
+SELECT 
+      t.start_id AS `u.user_id`
+FROM vlp_u_v AS t

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_map_only_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_map_only_866__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      arrayMap(x -> x * 2, [1, 2, 3]) AS "c"

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_map_only_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_map_only_866__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      transform(array(1, 2, 3), x -> x * 2) AS `c`

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_nested_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_nested_866__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      arrayMap(x -> arrayMap(y -> y, range(1, (x) + 1)), range(1, (3) + 1)) AS "c"

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_nested_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_nested_866__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      transform(sequence(1, 3), x -> transform(sequence(1, x), y -> y)) AS `c`

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_where_and_map_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_where_and_map_866__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      arrayMap(x -> x * 10, arrayFilter(x -> x % 2 = 0, range(1, (5) + 1))) AS "c"

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_where_and_map_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_where_and_map_866__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      transform(filter(sequence(1, 5), x -> x % 2 = 0), x -> x * 10) AS `c`

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_where_only_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_where_only_866__clickhouse.sql
@@ -1,0 +1,2 @@
+SELECT 
+      arrayFilter(x -> x > 1, [1, 2, 3]) AS "c"

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_where_only_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_where_only_866__databricks.sql
@@ -1,0 +1,2 @@
+SELECT 
+      filter(array(1, 2, 3), x -> x > 1) AS `c`

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_with_bound_list_866__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_with_bound_list_866__clickhouse.sql
@@ -1,0 +1,6 @@
+WITH with_lst_cte_0 AS (SELECT 
+      [1, 2, 3, 4] AS "lst"
+)
+SELECT 
+      arrayFilter(x -> x > 2, lst.lst) AS "c"
+FROM with_lst_cte_0 AS lst

--- a/tests/rust/integration/golden/sql_ir/standard/listcomp_with_bound_list_866__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/listcomp_with_bound_list_866__databricks.sql
@@ -1,0 +1,6 @@
+WITH with_lst_cte_0 AS (SELECT 
+      array(1, 2, 3, 4) AS `lst`
+)
+SELECT 
+      filter(lst.lst, x -> x > 2) AS `c`
+FROM with_lst_cte_0 AS lst

--- a/tests/rust/integration/parameter_function_test.rs
+++ b/tests/rust/integration/parameter_function_test.rs
@@ -427,19 +427,27 @@ fn test_function_on_parameter_in_return() {
 }
 
 #[test]
-fn test_list_comprehension_in_return_errors_not_panics() {
-    // Regression: a list comprehension in RETURN reaches ProjectionItem
-    // conversion without any rewrite pass having lowered it. That conversion
-    // used to `.expect()` on the failing `LogicalExpr::try_from`, PANICKING the
-    // worker thread and taking down the whole server on otherwise-valid Cypher.
-    // It must now surface as a clean planning error (Err), not a panic.
+fn test_list_comprehension_in_return_lowers_not_panics() {
+    // #866: a scalar list comprehension in RETURN now lowers to nested
+    // arrayMap/arrayFilter (previously it reached ProjectionItem conversion with
+    // no rewrite pass having lowered it — first PANICKING the worker thread on
+    // otherwise-valid Cypher, then #612 downgraded it to a clean planning Err,
+    // and #866 finally supports it). It must plan successfully AND never panic.
     let query = "MATCH (n:User) RETURN [x IN [1, 2, 3, 4] WHERE x > 2] AS r";
     let ast = parse_query(query).expect("Failed to parse query");
     let schema = create_test_schema();
 
-    let result = build_logical_plan(&ast, &schema, None, None, None);
+    let (logical_plan, plan_ctx) =
+        build_logical_plan(&ast, &schema, None, None, None).expect("should plan, not error/panic");
+    let render_plan =
+        logical_plan_to_render_plan_with_ctx((*logical_plan).clone(), &schema, Some(&plan_ctx))
+            .expect("Failed to render SQL");
+    let sql = render_plan.to_sql();
+
+    // Lowered to CH arrayFilter(x -> x > 2, [1,2,3,4]) — no lingering raw
+    // comprehension, and the lambda-bound `x` stays local (not a graph alias).
     assert!(
-        result.is_err(),
-        "list comprehension in RETURN should return a planning error, not panic"
+        sql.contains("arrayFilter(x -> x > 2"),
+        "expected arrayFilter lowering, got:\n{sql}"
     );
 }

--- a/tests/rust/integration/parameter_function_test.rs
+++ b/tests/rust/integration/parameter_function_test.rs
@@ -451,3 +451,23 @@ fn test_list_comprehension_in_return_lowers_not_panics() {
         "expected arrayFilter lowering, got:\n{sql}"
     );
 }
+
+#[test]
+fn test_list_comprehension_with_hidden_pattern_errors_not_panics() {
+    // #866 guard: a graph pattern hidden in a CASE inside the comprehension
+    // WHERE has no scalar per-element lowering. It must surface as a clean
+    // planning Err (ListComprehensionNotRewritten), NOT lower into a lambda body
+    // that renders a pattern in expression context — a pre-existing
+    // `unimplemented!` PANIC at render_expr.rs. Locks the no-panic behavior at
+    // the full-planner level (the classifier guard recurses into CASE/exists/…).
+    let query = "MATCH (n:User) WITH collect(n) AS ns \
+                 RETURN [p IN ns WHERE CASE WHEN (p)-[:FOLLOWS]->() THEN true ELSE false END] AS r";
+    let ast = parse_query(query).expect("Failed to parse query");
+    let schema = create_test_schema();
+
+    let result = build_logical_plan(&ast, &schema, None, None, None);
+    assert!(
+        result.is_err(),
+        "a pattern hidden in a list-comprehension CASE should error, not panic"
+    );
+}

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -722,6 +722,16 @@ const CORPUS: &[(&str, &str)] = &[
         "listcomp_nested_866",
         "RETURN [x IN range(1, 3) | [y IN range(1, x) | y]] AS c",
     ),
+    // #866 Path C: a list comprehension inside a VLP WHERE filter renders through
+    // the CTE-build renderer (cte_extraction.rs::render_expr_to_sql_string), NOT
+    // the final-SELECT Path A. Locks that the Databricks name+arg swap
+    // (arrayFilter -> filter(collection, lambda)) is applied there too — without
+    // the Path-C fix this leaked raw `arrayFilter(lambda, collection)` on Spark
+    // (invalid). CH stays native `arrayFilter(lambda, collection)`.
+    (
+        "listcomp_in_vlp_where_path_c_866",
+        "MATCH (u:User)-[:FOLLOWS*1..3]->(v:User) WHERE size([x IN [1, 2, 3] WHERE x > 1]) > 0 RETURN u.user_id",
+    ),
     // NOTE: Path D coverage (EXISTS / pattern-predicate, e.g.
     // `WHERE (u)-[:AUTHORED]->(:Post)`) is intentionally absent — that path
     // currently hits `unimplemented!` in render_expr for anonymous pattern

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -690,6 +690,38 @@ const CORPUS: &[(&str, &str)] = &[
         "pattern_comp_projection_corrvar_fallback_863",
         "MATCH (u:User) RETURN [(u)-[:FOLLOWS]->(v:User) | u.age + v.age] AS x",
     ),
+    // #866: plain list comprehension in projection position lowers to nested
+    // ClickHouse `arrayMap`/`arrayFilter` (Spark `transform`/`filter` with the
+    // args swapped, since Spark HOFs take (collection, lambda) and CH takes
+    // (lambda, collection)). Four shapes:
+    //   WHERE only  -> arrayFilter(x -> p, l)          / filter(l, x -> p)
+    //   `|` only    -> arrayMap(x -> e, l)             / transform(l, x -> e)
+    //   both        -> arrayMap(x -> e, arrayFilter(x -> p, l)) / nested Spark
+    //   identity    -> the bare list (no wrap)
+    // The lambda-bound var is kept as a local variable (projection tagging
+    // shadows it — see projection_tagging.rs Lambda arm), NOT resolved as a
+    // graph alias.
+    (
+        "listcomp_where_only_866",
+        "RETURN [x IN [1, 2, 3] WHERE x > 1] AS c",
+    ),
+    ("listcomp_map_only_866", "RETURN [x IN [1, 2, 3] | x * 2] AS c"),
+    (
+        "listcomp_where_and_map_866",
+        "RETURN [x IN range(1, 5) WHERE x % 2 = 0 | x * 10] AS c",
+    ),
+    // The list source is a WITH-bound alias (resolves to the CTE column `lst.lst`
+    // inside the lambda's collection arg, while the lambda var `x` stays local).
+    (
+        "listcomp_with_bound_list_866",
+        "WITH [1, 2, 3, 4] AS lst RETURN [x IN lst WHERE x > 2] AS c",
+    ),
+    // Nested comprehension: the inner lambda var `y` and outer `x` are both local;
+    // the inner list `range(1, x)` references the outer lambda var.
+    (
+        "listcomp_nested_866",
+        "RETURN [x IN range(1, 3) | [y IN range(1, x) | y]] AS c",
+    ),
     // NOTE: Path D coverage (EXISTS / pattern-predicate, e.g.
     // `WHERE (u)-[:AUTHORED]->(:Post)`) is intentionally absent — that path
     // currently hits `unimplemented!` in render_expr for anonymous pattern


### PR DESCRIPTION
## Summary

Supports plain **list comprehensions in RETURN/WITH projection position** — `[x IN list WHERE p | e]` — which previously failed loud with `ListComprehensionNotRewritten`. Closes #866.

Lowered directly in `ast_conversion.rs` (no new `LogicalExpr`/`RenderExpr` variant), mirroring how `reduce(...)` lowers to `arrayFold`:

| Cypher | ClickHouse | Databricks/Spark |
|---|---|---|
| `[x IN l WHERE p \| e]` | `arrayMap(x -> e, arrayFilter(x -> p, l))` | `transform(filter(l, x -> p), x -> e)` |
| `[x IN l WHERE p]` | `arrayFilter(x -> p, l)` | `filter(l, x -> p)` |
| `[x IN l \| e]` | `arrayMap(x -> e, l)` | `transform(l, x -> e)` |
| `[x IN l]` | `l` (identity) | `l` |

Reuses the existing `ScalarFnCall` + `Lambda` render paths (projection path **and** WITH→CTE path), so **zero new ClickHouse render code**.

## Conservative guard

A WHERE holding a **graph pattern** (`[p IN posts WHERE (p)-[:R]->()]`) has no scalar lowering, so it keeps returning `ListComprehensionNotRewritten` — that shape is routed elsewhere inside `size()`/`length()`. **#612/#629 are byte-unchanged.**

## Two supporting fixes

1. **Databricks/Spark mapping** — registered `arrayFilter`→`filter`, `arrayMap`→`transform` in `function_registry.rs` with a dialect-gated arg swap (Spark HOFs take `(collection, lambda)`; CH takes `(lambda, collection)`). Swap is Databricks-only (like `split`), routed through `FunctionMapper`/`Dialect` (Rule #7). CH byte-identical.

2. **Latent lambda-param bug** — the `projection_tagging.rs` `Lambda` arm documented "params are local variables (don't resolve them)" but tagged the whole body, so a bound param `x` (a `TableAlias`) errored `No table context for alias 'x'`. This broke even explicit `ch.arrayFilter(x -> …, …)` today. The arm now registers each param as a projection alias for the duration of body tagging (save/restore to honor shadowing).

## Tests / gates

- 10 dual-dialect goldens (5 shapes × CH/Databricks: WHERE-only, map-only, both, WITH-bound list, nested).
- 6 `ast_conversion` unit tests (4 lowering shapes + 2 pattern-predicate loud-fail negative controls).
- Updated the #612 "errors-not-panics" regression to "lowers-not-panics".
- **corpus_sweep 0-churn; sql_golden +10; ratchet net-zero;** full gate green (lib 1669, integration 542, fmt/clippy clean).
- SQL-shape-verified both dialects (no live CH in env).

Entirely outside the VLP files bronco owns (#887) — no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)