### PR TITLE
fix(#886): keep chained WITH rename of a scalar from collapsing

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -499,6 +499,43 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — chained double-WITH rename of a scalar no longer drops
+  the alias** (branch `fix/886-chained-with-rename`, closes #886; follow-up to
+  #864). `UNWIND [1,2,3] AS x WITH x AS y WITH y AS z RETURN count(z)` (and the
+  literal/property scalar analogues `WITH 1 AS one WITH one AS two`,
+  `WITH u.age AS a WITH a AS b`) rendered a CTE body that degenerated to
+  `SELECT *` while the outer aggregate referenced a never-emitted renamed column
+  → ClickHouse Code 47. **Root cause (two compounding defects):**
+  (a) `is_simple_passthrough` in `try_collapse_passthrough_with`
+  (`with_to_cte/mod.rs`) matched only `TableAlias(_)` on the item expression and
+  ignored `col_alias`, so a RENAME (`WITH y AS z`, `col_alias: Some(z)`) was
+  indistinguishable from a genuine passthrough (`WITH y`, `col_alias: None`) —
+  the second hop was collapsed away and the CTE-column pruner then stripped the
+  now-unreferenced source column → `SELECT *`. (b) Even when the collapse is
+  suppressed (e.g. a trailing WHERE), the non-UNWIND `TableAlias` projection
+  branch in `build_with_projection_select_items` called
+  `expand_table_alias_to_select_items` (which names the output after the SOURCE
+  alias) and never honored the caller's `col_alias`, so the emitted column stayed
+  named `y` and was pruned. **Fix:** (a) require the item's `col_alias` to be
+  absent or equal the source alias for a passthrough (real renames fall through
+  to normal per-CTE rendering); (b) when the expansion yields a single column and
+  `col_alias` differs from the source, override the output name to the rename
+  target — mirroring the #864 UNWIND-alias branch's `out_name`, restricted to the
+  single-column case so multi-property node expansions are untouched. Both fixes
+  independently verified load-bearing (each alone leaves the headline case
+  failing). **Conservative:** rename-then-passthrough (`WITH x AS y WITH y`),
+  single-rename #864, and passthrough-passthrough all stay byte-identical
+  (regression-guarded). 6 new dual-dialect corpus goldens (3 shapes: UNWIND
+  chained, literal chained, chained+WHERE) + 3 focused assertion tests
+  (`sql_golden_tests.rs`, incl. the collapse-must-still-fire guard). corpus_sweep
+  0-churn on existing goldens; ratchet net-zero (no dialect/axis predicates); full
+  gate green. SQL-shape-verified both dialects (no live CH). Single renderer path
+  — no Path-C duplicate (`is_simple_passthrough` is the only WITH-passthrough
+  collapse predicate; grep-confirmed). Entirely outside the VLP files bronco owns
+  (#887). **Pre-existing out-of-scope gap filed separately:** the single-hop
+  property rename `MATCH (u) WITH u.age AS a RETURN count(a)` renders `SELECT *` +
+  `count(*)` identically on main (a scalar-property-into-CTE-column projection
+  bug, not a chained-rename defect) → **#903**.
 - 2026-08-02: **Feature — list comprehension in RETURN/WITH projection now
   supported** (branch `feature/866-list-comprehension-lowering`, closes #866).
   A plain `[x IN list WHERE p | e]` in projection position failed loud

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -6854,7 +6854,15 @@ fn try_collapse_passthrough_with(
 ) -> RenderPlanBuilderResult<bool> {
     if let LogicalPlan::WithClause(wc) = with_plan {
         if let Some(existing_cte) = is_cte_reference(&wc.input) {
-            // Check if this is a simple passthrough (same alias, no modifications)
+            // Check if this is a simple passthrough (same alias, no modifications).
+            // A RENAME (`WITH y AS z`) is NOT a passthrough: it carries the same
+            // `TableAlias` expression but a `col_alias` that differs from the source
+            // alias. Collapsing it would drop the rename (the collapse machinery only
+            // remaps the source alias onto the existing CTE, never the new output
+            // name), leaving downstream references to `z` dangling → `SELECT *` +
+            // Code 47 (#886). Require `col_alias` to be absent or equal to the source
+            // alias so only genuine passthroughs collapse; real renames fall through
+            // to normal per-CTE rendering, which honors the output name.
             let is_simple_passthrough = wc.items.len() == 1
                 && wc.order_by.is_none()
                 && wc.skip.is_none()
@@ -6863,7 +6871,11 @@ fn try_collapse_passthrough_with(
                 && wc.where_clause.is_none()  // CRITICAL: WHERE clause makes it not a passthrough!
                 && matches!(
                     &wc.items[0].expression,
-                    crate::query_planner::logical_expr::LogicalExpr::TableAlias(_)
+                    crate::query_planner::logical_expr::LogicalExpr::TableAlias(ta)
+                        if wc.items[0]
+                            .col_alias
+                            .as_ref()
+                            .is_none_or(|ca| ca.0 == ta.0)
                 );
 
             log::debug!("🔧 build_chained_with_match_cte_plan: Checking passthrough: items={}, order_by={}, skip={}, limit={}, distinct={}, where_clause={}, is_table_alias={}, is_passthrough={}",
@@ -7266,7 +7278,7 @@ fn build_with_projection_select_items(
                                 // This allows "WITH a, b, c" to find "a" and "b" from previous CTEs
                                 //
                                 // The unified helper automatically handles anyLast() wrapping when has_aggregation=true
-                                let expanded = expand_table_alias_to_select_items(
+                                let mut expanded = expand_table_alias_to_select_items(
                                     &alias.0,
                                     plan_to_render,
                                     cte_schemas,
@@ -7277,6 +7289,24 @@ fn build_with_projection_select_items(
                                 );
                                 log::debug!("🔧 build_chained_with_match_cte_plan: Expanded alias '{}' to {} items (aggregation={})",
                                            alias.0, expanded.len(), has_aggregation);
+
+                                // Honor a WITH rename of a CTE-scoped scalar
+                                // (`WITH y AS z`, where `y` is a prior WITH's exported
+                                // column). The expansion above names the output after
+                                // the SOURCE alias `y`; the outer query references the
+                                // rename target `z`, so without this the emitted column
+                                // (`y`) is pruned as dead → `SELECT *` + Code 47 (#886).
+                                // Restricted to the single-column case: a multi-property
+                                // node expansion legitimately keeps its per-property
+                                // names and has no single rename target. Mirrors the
+                                // UNWIND-alias branch's `out_name` logic (#864).
+                                if expanded.len() == 1 {
+                                    if let Some(col_alias) = &item.col_alias {
+                                        if col_alias.0 != alias.0 {
+                                            expanded[0].col_alias = Some(ColumnAlias(col_alias.0.clone()));
+                                        }
+                                    }
+                                }
 
                                 expanded
                             }

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1228,3 +1228,6 @@
 {"cypher": "MATCH (a:Member)-[:MENTORS|HELPS*1..3]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_one_to_three", "schema": "mt_multitype_uniqueness"}
 {"cypher": "MATCH (a:Member)-[:MENTORS|HELPS]->(b:Member) RETURN a.id, b.id", "name": "test_606_multitype_vlp_uniqueness_single_hop", "schema": "mt_multitype_uniqueness"}
 {"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            RETURN count(y) AS c", "name": "test_864__with_rename_of_unwind_scalar_count", "schema": "social_integration"}
+{"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            WITH y AS z\n            RETURN count(z) AS c", "name": "test_886__chained_with_rename_of_unwind_scalar_count", "schema": "social_integration"}
+{"cypher": "WITH 1 AS one\n            WITH one AS two\n            RETURN count(two) AS c", "name": "test_886__chained_with_rename_of_literal_scalar_count", "schema": "social_integration"}
+{"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            WITH y AS z\n            WHERE z > 0\n            RETURN count(z) AS c", "name": "test_886__chained_with_rename_then_where_count", "schema": "social_integration"}

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_literal_scalar_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_literal_scalar_count.clickhouse.sql
@@ -1,0 +1,10 @@
+WITH with_one_cte_0 AS (SELECT 
+      1 AS "one"
+), 
+with_two_cte_1 AS (SELECT 
+      one.one AS "two"
+FROM with_one_cte_0 AS one
+)
+SELECT 
+      count(two.two) AS "c"
+FROM with_two_cte_1 AS two

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_literal_scalar_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_literal_scalar_count.databricks.sql
@@ -1,0 +1,10 @@
+WITH with_one_cte_0 AS (SELECT 
+      1 AS `one`
+), 
+with_two_cte_1 AS (SELECT 
+      one.one AS `two`
+FROM with_one_cte_0 AS one
+)
+SELECT 
+      count(two.two) AS `c`
+FROM with_two_cte_1 AS two

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_unwind_scalar_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_unwind_scalar_count.clickhouse.sql
@@ -1,0 +1,12 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS "y"
+FROM system.one
+ARRAY JOIN [1, 2, 3] AS x
+), 
+with_z_cte_1 AS (SELECT 
+      y.y AS "z"
+FROM with_y_cte_0 AS y
+)
+SELECT 
+      count(z.z) AS "c"
+FROM with_z_cte_1 AS z

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_unwind_scalar_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_of_unwind_scalar_count.databricks.sql
@@ -1,0 +1,12 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS `y`
+FROM (SELECT 1) AS _unwind
+LATERAL VIEW explode(array(1, 2, 3)) AS x
+), 
+with_z_cte_1 AS (SELECT 
+      y.y AS `z`
+FROM with_y_cte_0 AS y
+)
+SELECT 
+      count(z.z) AS `c`
+FROM with_z_cte_1 AS z

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_then_where_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_then_where_count.clickhouse.sql
@@ -1,0 +1,13 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS "y"
+FROM system.one
+ARRAY JOIN [1, 2, 3] AS x
+), 
+with_z_cte_1 AS (SELECT 
+      y.y AS "z"
+FROM with_y_cte_0 AS y
+WHERE y.y > 0
+)
+SELECT 
+      count(z.z) AS "c"
+FROM with_z_cte_1 AS z

--- a/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_then_where_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_886__chained_with_rename_then_where_count.databricks.sql
@@ -1,0 +1,13 @@
+WITH with_y_cte_0 AS (SELECT 
+      x AS `y`
+FROM (SELECT 1) AS _unwind
+LATERAL VIEW explode(array(1, 2, 3)) AS x
+), 
+with_z_cte_1 AS (SELECT 
+      y.y AS `z`
+FROM with_y_cte_0 AS y
+WHERE y.y > 0
+)
+SELECT 
+      count(z.z) AS `c`
+FROM with_z_cte_1 AS z

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -15912,3 +15912,81 @@ async fn round_neo4j_faithful_dialect_spellings() {
         "Spark 2-arg round() must stay a plain call, got:\n{dbx_2}"
     );
 }
+
+/// #886: a CHAINED double-WITH rename of a scalar (`WITH x AS y WITH y AS z`)
+/// must emit a second CTE that preserves the rename, not collapse the second
+/// hop as if it were a passthrough. Before the fix, `is_simple_passthrough`
+/// mistook `WITH y AS z` for `WITH y` (both carry a `TableAlias(y)` expression),
+/// collapsed it away, and the CTE-column pruner then stripped the now-unreferenced
+/// `y` column → `SELECT *` + a dangling outer `count(z)` (ClickHouse Code 47).
+/// Follow-up to #864 (single-hop rename).
+#[tokio::test]
+async fn chained_with_rename_of_unwind_scalar_preserved_886() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let sql = render(
+        &schema,
+        "UNWIND [1, 2, 3] AS x WITH x AS y WITH y AS z RETURN count(z) AS c",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    // A second CTE must exist for the second rename hop, exporting `z`.
+    assert!(
+        sql.contains("with_z_cte_1") && sql.contains(r#"y.y AS "z""#),
+        "second rename hop must render its own CTE `SELECT y.y AS z`, got:\n{sql}"
+    );
+    // The outer aggregate resolves against the renamed CTE column, not a
+    // never-emitted one, and the CTE body must NOT have degenerated to SELECT *.
+    assert!(
+        sql.contains("count(z.z)"),
+        "outer count must resolve to the renamed CTE column z.z, got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("SELECT *"),
+        "no CTE should collapse to SELECT * (rename dropped), got:\n{sql}"
+    );
+}
+
+/// #886: the chained rename also applies to a bare-literal scalar
+/// (`WITH 1 AS one WITH one AS two`) — same collapse-mistakes-rename bug,
+/// different scalar source. The second hop must carry the rename into its CTE.
+#[tokio::test]
+async fn chained_with_rename_of_literal_scalar_preserved_886() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let sql = render(
+        &schema,
+        "WITH 1 AS one WITH one AS two RETURN count(two) AS c",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        sql.contains("with_two_cte_1") && sql.contains(r#"one.one AS "two""#),
+        "second rename hop must render its own CTE `SELECT one.one AS two`, got:\n{sql}"
+    );
+    assert!(
+        sql.contains("count(two.two)") && !sql.contains("SELECT *"),
+        "outer count must resolve to two.two with no SELECT * collapse, got:\n{sql}"
+    );
+}
+
+/// #886 (regression guard): a rename-then-PASSTHROUGH (`WITH x AS y WITH y`)
+/// is NOT a chained rename — the trailing `WITH y` is a genuine passthrough
+/// (no `col_alias`), so it must still collapse into the single `with_y_cte_0`
+/// exactly as before the fix. This guards the tightened `is_simple_passthrough`
+/// predicate against over-firing (it must only spare true renames).
+#[tokio::test]
+async fn rename_then_passthrough_still_collapses_886() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    let sql = render(
+        &schema,
+        "UNWIND [1, 2, 3] AS x WITH x AS y WITH y RETURN count(y) AS c",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        sql.contains("with_y_cte_0")
+            && !sql.contains("with_y_cte_1")
+            && sql.contains(r#"x AS "y""#)
+            && sql.contains("count(y.y)"),
+        "rename-then-passthrough must stay a single collapsed CTE, got:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #864. A **chained** double-WITH rename of a scalar dropped the alias and produced invalid SQL:

```cypher
UNWIND [1,2,3] AS x WITH x AS y WITH y AS z RETURN count(z)
```
rendered a CTE body of `SELECT *` while the outer `count(z)` referenced a never-emitted column → ClickHouse **Code 47**. Same for the literal (`WITH 1 AS one WITH one AS two`) and property (`WITH u.age AS a WITH a AS b`) scalar analogues.

## Root cause (two compounding defects in `src/render_plan/with_to_cte/mod.rs`)

**(a)** `is_simple_passthrough` in `try_collapse_passthrough_with` matched only `LogicalExpr::TableAlias(_)` on the item expression and **ignored `col_alias`**. So a rename (`WITH y AS z`, `col_alias: Some(z)`) was indistinguishable from a genuine passthrough (`WITH y`, `col_alias: None`). The rename hop was collapsed away, and the CTE-column pruner then stripped the now-unreferenced source column → `SELECT *`.

**(b)** Even with the collapse suppressed (e.g. a trailing `WHERE`), the non-UNWIND `TableAlias` projection branch in `build_with_projection_select_items` called `expand_table_alias_to_select_items` — which names the output after the **source** alias — and never honored the caller's `item.col_alias`, so the emitted column stayed named `y` and was pruned.

## Fix

- **(a)** Require `col_alias` to be absent or equal the source alias for a passthrough; real renames fall through to normal per-CTE rendering.
- **(b)** When the expansion yields a single column and `col_alias` differs from the source, override the output name to the rename target — mirroring the #864 UNWIND-alias branch's `out_name`, restricted to the single-column case so multi-property node expansions are untouched.

Both fixes independently verified **load-bearing** (each alone leaves the headline case failing).

## Conservative / byte-identical

`WITH x AS y WITH y` (rename-then-passthrough), single-rename #864, and passthrough-passthrough all stay byte-identical — regression-guarded by a dedicated test asserting the collapse must still fire.

## Tests & gate

- 6 dual-dialect corpus goldens (UNWIND chained, literal chained, chained+WHERE) + 3 focused assertion tests.
- Both fixes verified fail-when-reverted.
- `corpus_sweep` 0-churn on existing goldens; `ratchet` net-zero (no dialect/axis predicates); full gate green (lib 1672, integration 546). SQL-shape-verified both dialects (no live CH).
- **Single renderer path** — `is_simple_passthrough` is the only WITH-passthrough-collapse predicate (grep-confirmed); no Path-C duplicate.
- Adversarial review: **APPROVE**, 0 HIGH/MEDIUM across 7 attack vectors.

## Out of scope

The single-hop scalar-**property** rename (`MATCH (u) WITH u.age AS a RETURN count(a)` → `SELECT *` + `count(*)`) is pre-existing on main and independent — filed as **#903**.

Closes #886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)