### PR TITLE
fix(#710): denormalized VLP edge identity uses schema composite edge_id

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -466,7 +466,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **Phase 3 #806 + Phase 4 #628 fixed**)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **Phase 3 #806 + Phase 4 #628 + Phase 5 #710 fixed**)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -483,13 +483,26 @@ fixed stats fixture.
   **Phase 4 (#628) SHIPPED**: closed `*0..N` (`(a)-[*0..N]->(a)`) — was a loud
   `UnsupportedFeature` — now counts real cycles via edge-uniqueness (zero-hop base
   seeds empty `path_edges`), live-verified against the trail oracle; OPEN `*0..N`
-  byte-unchanged. Remaining:
-  Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical),
-  then Phase 5 (optional, #710 parallel-edge denorm). Explicitly NOT this cluster:
-  #643/#840/#627/#683 (different subsystems). Adjacent bugs found during Phase 3/4
+  byte-unchanged.
+  **Phase 5 (#710) SHIPPED (PR #TBD)**: the DENORMALIZED VLP strategy
+  (`DenormalizedCteStrategy::edge_tuple`) now consults the schema `edge_id`
+  (resolved once via `resolve_edge_id`, spelled like `build_edge_tuple_recursive`:
+  Composite→tuple / Single→scalar / None→byte-identical `(from,to)` fallback), so
+  parallel denorm edges keyed by e.g. `flight_id` no longer collapse into one
+  `(from,to)` tuple and under-count trails. 78 goldens regenerated (72 corpus + 6
+  SQL-IR snapshot), every changed line an edge-identity line (`path_nodes`/joins
+  byte-identical); live-verified length-3 parallel-edge trail = buggy 0 vs fixed 2
+  (oracle 2), end-to-end through `cg`. Ratchet-clean (`edge_id` not a tracked
+  token). Remaining:
+  Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical
+  design-cycle refactor). Explicitly NOT this cluster:
+  #643/#840/#627/#683 (different subsystems). Adjacent bugs found during Phase 3/4/5
   and filed separately (NOT folded in): flat exact-bound polymorphic VLP drops the
-  `interaction_type` discriminator (`FOLLOWS*2` counts other edge types), and an
-  OPTIONAL-MATCH closed-VLP projection bug (`vt0.<prop>`, #899).
+  `interaction_type` discriminator (#897), an OPTIONAL-MATCH closed-VLP projection
+  bug (`vt0.<prop>`, #899), FK-edge self-ref VLP degenerate recursive join (#902),
+  and #808 (mixed-access VLP arm is corpus-unreachable — resolve by adding one
+  mixed-schema VLP corpus entry, which will surface its node-uniqueness as
+  #606-inconsistent and convert it to edge-uniqueness).
 
 ## 3. Capacity split (guideline)
 

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -58,7 +58,7 @@ the **schema shape**, and this is the axis that is currently duplicated:
 |---|---|---|
 | Standard / polymorphic | schema `edge_id` if declared, else `(from,to)` | a real edge table row |
 | FK-edge (edge = FK column on node) | ordered node-id pair `(from_id, to_id)` | no edge table; the node pair *is* the edge |
-| Denormalized (both nodes virtual) | `(from,to)` tuple | no edge-id column (residual #710: parallel edges) |
+| Denormalized (both nodes virtual) | schema `edge_id` if declared, else `(from,to)` | #710 fixed: parallel edges use the declared `edge_id` |
 | Undirected doubled-edge (#617) | original-orientation `(__cg_orig_from,__cg_orig_to)` | so reverse rows share identity |
 | shortestPath / weighted / hetero-poly / zero-hop | none (node-unique) | node-uniqueness by design |
 
@@ -339,9 +339,26 @@ exposes a pre-existing OPTIONAL-MATCH projection bug (`vt0.<prop>` — anchor
 property wrongly bound to the VLP CTE alias). Reproduces on `*1..` on the old
 binary, so it is independent of #628.
 
-### Phase 5 (optional) — #710 parallel-edge denorm
-Only if a real parallel-edge denorm schema is in scope. Needs a synthetic
-per-row edge key threaded into `path_edges`. Low priority; documented residual.
+### Phase 5 — #710 parallel-edge denorm → **DONE (PR #TBD)** — behavior change, goldens regenerated
+`DenormalizedCteStrategy::edge_tuple` (CM) now consults the relationship's
+schema `edge_id` (resolved once at construction via `resolve_edge_id`), spelled
+identically to the standard emitter's `build_edge_tuple_recursive`:
+`Composite → tuple(alias.c1, …)`, `Single → alias.col`, `None →` the historical
+`(from, to)` pair (byte-identical fallback). Parallel edges that share one
+`(from, to)` node pair (e.g. two flights on the same route keyed by
+`flight_id`) are no longer collapsed → no more silent trail under-count. The
+denorm VLP is a single directional recursive self-join (no #617 doubled-edge
+CTE), so no orientation swap is needed.
+
+Live-verified against a parallel-edge fixture (LAX⇉ATL two edges + ATL→LAX
+return): a length-3 trail LAX→ATL→LAX→ATL returned **0** under the buggy
+`(origin,dest)` key (both valid trails dropped when hop 3 "reused" the node
+pair) versus **2** under the `flight_id` key (oracle = 2), end-to-end through
+`cg`. 78 goldens regenerated (72 corpus + 6 SQL-IR snapshot), every changed line
+an edge-identity line; `path_nodes`/joins/projections byte-identical. Denorm
+schemas without `edge_id` are unchanged (fallback). Ratchet-clean (`edge_id` is
+not a tracked axis token; the fix reads it via the canonical
+`schema.get_rel_schema(label).edge_id` route).
 
 **#808's mixed/hetero-poly "fix" is deliberately NOT a phase**: they are
 corpus-unreachable (Phase 0 either deletes them or, if a reachable shape later
@@ -373,8 +390,9 @@ Ratchet baseline today, the 3 VLP files (`tests/rust/ratchet/baseline.txt`):
 `EdgeUniquenessPolicy` (constructed once from `PatternSchemaContext`), and the
 baseline **decreases** — the ratchet auto-ratchets down in the same PRs.
 
-Issue metric: #606, #628, #710, #806, #808 all close or convert to a single
-documented residual (#710). No *new* uniqueness residual can be filed against an
+Issue metric: #606, #628, #710, #806, #808 all close or convert to a documented
+non-bug. #710 is now **fixed** (denorm `edge_tuple` consults the schema
+`edge_id`), not a residual. No *new* uniqueness residual can be filed against an
 arm the policy owns, because there is one arm.
 
 ---

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -9,8 +9,8 @@ use crate::clickhouse_query_generator::variable_length_cte::{
     NodeProperty, VariableLengthCteGenerator,
 };
 use crate::graph_catalog::{
-    graph_schema::GraphSchema, EdgeAccessStrategy, JoinStrategy, NodeAccessStrategy,
-    PatternSchemaContext,
+    config::Identifier, graph_schema::GraphSchema, EdgeAccessStrategy, JoinStrategy,
+    NodeAccessStrategy, PatternSchemaContext,
 };
 use crate::query_planner::join_context::{
     VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
@@ -342,6 +342,14 @@ pub struct DenormalizedCteStrategy {
     from_col: String,
     to_col: String,
     schema: Arc<GraphSchema>,
+    /// Schema-declared composite edge identity (`edge_id:` in YAML), if any.
+    /// When present it uniquely distinguishes parallel edges that share the
+    /// same `(from, to)` node pair (e.g. two flights on the same route keyed by
+    /// `flight_id`); when `None` the edge identity degrades to the `(from, to)`
+    /// pair. Resolved once at construction from the relationship's schema so
+    /// [`Self::edge_tuple`] can spell the correct trail-uniqueness key (#710,
+    /// the denormalized counterpart of #806/#606's flat/recursive paths).
+    edge_id: Option<Identifier>,
 }
 
 // ===== DenormalizedCteStrategy =====
@@ -374,12 +382,30 @@ impl DenormalizedCteStrategy {
                 table: table.clone(),
                 from_col: Self::get_from_column(pattern_ctx)?,
                 to_col: Self::get_to_column(pattern_ctx)?,
+                edge_id: Self::resolve_edge_id(pattern_ctx, &schema),
                 schema,
             }),
             _ => Err(CteError::InvalidStrategy(
                 "DenormalizedCteStrategy requires JoinStrategy::SingleTableScan".into(),
             )),
         }
+    }
+
+    /// Resolve the relationship's schema-declared composite `edge_id`, if any,
+    /// from its first relationship type. Mirrors the emitter's resolution at
+    /// `cte_extraction.rs` (`schema.get_rel_schema(label).edge_id`), so the
+    /// denormalized path spells edge identity the same way the flat/recursive
+    /// paths do (#710/#806/#606). Returns `None` when there is no rel type or
+    /// the schema declares no `edge_id` — the historical `(from, to)` behavior.
+    fn resolve_edge_id(
+        pattern_ctx: &PatternSchemaContext,
+        schema: &GraphSchema,
+    ) -> Option<Identifier> {
+        pattern_ctx
+            .rel_types
+            .first()
+            .and_then(|label| schema.get_rel_schema(label).ok())
+            .and_then(|rel_schema| rel_schema.edge_id.clone())
     }
 
     fn get_from_column(pattern_ctx: &PatternSchemaContext) -> Result<String, CteError> {
@@ -418,23 +444,50 @@ impl DenormalizedCteStrategy {
     ///   cannot seed a 1-hop `path_edges` tuple; seeding it only in the
     ///   ordinary base would diverge from the zero-hop base's column shape.
     ///
-    /// A denormalized edge has no separate edge-id column, so its edge identity
-    /// is the `(from_col, to_col)` pair — see [`Self::edge_tuple`].
+    /// A denormalized edge's identity is its schema-declared `edge_id` when one
+    /// is present, else the `(from_col, to_col)` node pair — see
+    /// [`Self::edge_tuple`] (#710).
     fn uses_edge_uniqueness(&self, context: &CteGenerationContext) -> bool {
         context.shortest_path_mode.is_none() && context.spec.effective_min_hops() >= 1
     }
 
-    /// The `(from, to)` edge-identity tuple for one hop, read off `rel_alias`
-    /// (base case) or `next` (recursive case). Denormalized edges carry no
-    /// dedicated edge-id column, so the ordered endpoint pair uniquely
-    /// identifies the physical edge row for trail-uniqueness.
+    /// The edge-identity value for one hop, read off `rel_alias` (base case) or
+    /// `next` (recursive case), seeded into / matched against `path_edges` for
+    /// trail-uniqueness.
+    ///
+    /// When the relationship schema declares an `edge_id` (#710, the
+    /// denormalized counterpart of #806/#606), that column (or composite tuple)
+    /// IS the edge identity — this distinguishes parallel edges that share the
+    /// same `(from, to)` node pair (e.g. two flights on one route keyed by
+    /// `flight_id`), which the `(from, to)` pair alone would collapse into a
+    /// single edge and under-count. Spelled identically to the standard
+    /// emitter's [`VariableLengthCteGenerator::build_edge_tuple_recursive`]:
+    ///
+    /// - `Single(col)` → bare `rel_alias.col` (scalar element),
+    /// - `Composite(cols)` → `tuple(rel_alias.c1, rel_alias.c2, …)`,
+    /// - `None` → the historical `tuple(rel_alias.from, rel_alias.to)` pair
+    ///   (byte-identical to the pre-#710 behavior).
+    ///
+    /// A denormalized VLP is a single directional recursive self-join over the
+    /// edge table (no #617 doubled-edge CTE), so no from/to orientation swap is
+    /// needed — the identity columns are read verbatim.
     fn edge_tuple(&self, rel_alias: &str) -> String {
         let tuple_ctor =
             crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor();
-        format!(
-            "{}({}.{}, {}.{})",
-            tuple_ctor, rel_alias, self.from_col, rel_alias, self.to_col
-        )
+        match &self.edge_id {
+            Some(Identifier::Single(col)) => format!("{}.{}", rel_alias, col),
+            Some(Identifier::Composite(cols)) => {
+                let elems: Vec<String> = cols
+                    .iter()
+                    .map(|col| format!("{}.{}", rel_alias, col))
+                    .collect();
+                format!("{}({})", tuple_ctor, elems.join(", "))
+            }
+            None => format!(
+                "{}({}.{}, {}.{})",
+                tuple_ctor, rel_alias, self.from_col, rel_alias, self.to_col
+            ),
+        }
     }
 
     pub fn generate_sql(
@@ -1444,6 +1497,7 @@ impl VariableLengthCteStrategy {
                 table: self.rel_table.clone(),
                 from_col: self.rel_from_col.clone(),
                 to_col: self.rel_to_col.clone(),
+                edge_id: DenormalizedCteStrategy::resolve_edge_id(&self.pattern_ctx, schema),
                 schema: Arc::new(schema.clone()),
             };
 
@@ -1758,6 +1812,105 @@ mod tests {
         assert!(
             !sql.contains("has(vp.path_edges"),
             "Databricks SQL leaked ClickHouse `has(...)` cycle check; got:\n{sql}"
+        );
+    }
+
+    /// Build a denormalized strategy with an explicit `edge_id`, bypassing the
+    /// schema round-trip so `edge_tuple`'s three arms can be exercised directly.
+    fn denorm_strategy_with_edge_id(edge_id: Option<Identifier>) -> DenormalizedCteStrategy {
+        let pattern_ctx = denormalized_flights_pattern_ctx();
+        let schema = Arc::new(GraphSchema::build(
+            1,
+            "test".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        ));
+        DenormalizedCteStrategy {
+            pattern_ctx,
+            table: "flights".to_string(),
+            from_col: "Origin".to_string(),
+            to_col: "Dest".to_string(),
+            edge_id,
+            schema,
+        }
+    }
+
+    /// #710: a denormalized VLP's edge identity must consult the schema
+    /// `edge_id` so parallel edges sharing one `(from, to)` node pair are not
+    /// collapsed (silent under-count). `edge_tuple` mirrors the standard
+    /// emitter's `build_edge_tuple_recursive`:
+    ///   - `Composite` → `tuple(alias.c1, alias.c2, …)`,
+    ///   - `Single`    → bare scalar `alias.col`,
+    ///   - `None`      → the historical `(from, to)` pair (byte-identical).
+    #[test]
+    fn denorm_edge_tuple_uses_schema_edge_id_710() {
+        // Composite edge_id — the parallel-edge case (e.g. flight_id + number).
+        let composite = denorm_strategy_with_edge_id(Some(Identifier::Composite(vec![
+            "flight_id".to_string(),
+            "flight_number".to_string(),
+        ])));
+        assert_eq!(
+            composite.edge_tuple("next"),
+            "tuple(next.flight_id, next.flight_number)",
+            "composite edge_id must spell the full ordered tuple (#710)"
+        );
+
+        // Single-column edge_id — bare scalar element (matches the emitter's
+        // Single arm; `arr(...)` wraps it into a scalar `path_edges` array).
+        let single = denorm_strategy_with_edge_id(Some(Identifier::Single("evt_id".to_string())));
+        assert_eq!(
+            single.edge_tuple("next"),
+            "next.evt_id",
+            "single-column edge_id must render as a bare scalar (#710)"
+        );
+
+        // No edge_id — byte-identical to the pre-#710 `(from, to)` behavior.
+        let none = denorm_strategy_with_edge_id(None);
+        assert_eq!(
+            none.edge_tuple("next"),
+            "tuple(next.Origin, next.Dest)",
+            "absent edge_id must preserve the historical node-pair identity"
+        );
+        // ...and on the base-case alias too.
+        assert_eq!(none.edge_tuple("f"), "tuple(f.Origin, f.Dest)");
+    }
+
+    /// #710: end-to-end — a composite `edge_id` must appear on ALL THREE
+    /// edge-identity sites of the generated recursive CTE (base seed, recursive
+    /// append, cycle check), and the collapsing `(Origin, Dest)` node pair must
+    /// be gone from `path_edges`.
+    #[test]
+    fn denorm_vlp_composite_edge_id_in_generated_sql_710() {
+        let composite =
+            Identifier::Composite(vec!["flight_id".to_string(), "flight_number".to_string()]);
+        let strategy = denorm_strategy_with_edge_id(Some(composite));
+        let context = CteGenerationContext::new().with_spec(VariableLengthSpec {
+            min_hops: Some(1),
+            max_hops: Some(3),
+        });
+        let sql = strategy
+            .generate_sql(&context, &[], &empty_filters())
+            .unwrap()
+            .sql;
+        // Base seed.
+        assert!(
+            sql.contains("[tuple(flights.flight_id, flights.flight_number)] as path_edges"),
+            "base seed must use the composite edge_id; got:\n{sql}"
+        );
+        // Recursive append.
+        assert!(
+            sql.contains("arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)])"),
+            "recursive append must use the composite edge_id; got:\n{sql}"
+        );
+        // Cycle check.
+        assert!(
+            sql.contains("NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))"),
+            "cycle check must use the composite edge_id; got:\n{sql}"
+        );
+        // The collapsing node-pair identity must no longer key path_edges.
+        assert!(
+            !sql.contains("tuple(next.Origin, next.Dest)"),
+            "node-pair (Origin, Dest) must not key path_edges once edge_id exists; got:\n{sql}"
         );
     }
 

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1857,6 +1857,9 @@ mod tests {
 
         // Single-column edge_id — bare scalar element (matches the emitter's
         // Single arm; `arr(...)` wraps it into a scalar `path_edges` array).
+        // Live-reachable via single-column denorm `edge_id` schemas such as
+        // `schemas/test/denorm_selfloop_multitype.yaml` (`edge_id: evt_id`),
+        // though no golden-corpus VLP currently exercises it.
         let single = denorm_strategy_with_edge_id(Some(Identifier::Single("evt_id".to_string())));
         assert_eq!(
             single.edge_tuple("next"),

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_distinct_endpoint.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_optional_vlp_count_far_endpoint.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_required_vlp_count_far_endpoint.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_id_projection_control.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_659_denorm_vlp_endpoint_prop_projection_control.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.clickhouse.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_683_denorm_optional_vlp_anchor_count_distinct.databricks.sql
@@ -23,7 +23,7 @@ vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -33,12 +33,12 @@ vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [tuple(f.Origin, f.Dest)] as path_edges,
+        [tuple(f.flight_id, f.flight_number)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         f."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL' AND hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_composite_id_prevents_duplicate_edges.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(struct(f.Origin, f.Dest)) as path_edges,
+        array(struct(f.flight_id, f.flight_number)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         f.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL' AND hop_count >= 2

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [tuple(f.Origin, f.Dest)] as path_edges,
+        [tuple(f.flight_id, f.flight_number)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         [] as path_relationships,
         f."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       count(DISTINCT t.end_Dest) AS "dest_count"

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestCompositeEdgeIds_test_variable_path_with_composite_edge_id.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(struct(f.Origin, f.Dest)) as path_edges,
+        array(struct(f.flight_id, f.flight_number)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array() as path_relationships,
         f.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       count(DISTINCT t.end_Dest) AS `dest_count`

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [tuple(f.Origin, f.Dest)] as path_edges,
+        [tuple(f.flight_id, f.flight_number)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         [] as path_relationships,
         f."DestCityName" as "end_DestCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."DestCityName" as "end_DestCityName"
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_DestCityName AS "dest.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_cte_uses_denormalized_props.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(struct(f.Origin, f.Dest)) as path_edges,
+        array(struct(f.flight_id, f.flight_number)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array() as path_relationships,
         f.`DestCityName` as `end_DestCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_origin_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_origin_dest vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_DestCityName AS `dest.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        [tuple(f.Origin, f.Dest)] as path_edges,
+        [tuple(f.flight_id, f.flight_number)] as path_edges,
         [f.Origin, f.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         f."OriginCityName" as "start_OriginCityName",
@@ -16,7 +16,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
@@ -24,7 +24,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         next."Dest" as "end_Dest"
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL'

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_denormalized_edges__TestDenormalizedVariableLengthPaths_test_variable_path_with_denormalized_properties.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         f.Origin as start_id,
         f.Dest as end_id,
         1 as hop_count,
-        array(struct(f.Origin, f.Dest)) as path_edges,
+        array(struct(f.flight_id, f.flight_number)) as path_edges,
         array(f.Origin, f.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         f.`OriginCityName` as `start_OriginCityName`,
@@ -16,7 +16,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
@@ -24,7 +24,7 @@ WITH RECURSIVE vlp_origin_dest_inner AS (
         next.`Dest` as `end_Dest`
     FROM vlp_origin_dest_inner vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_origin_dest AS (
     SELECT * FROM vlp_origin_dest_inner WHERE end_Dest = 'ATL'

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       count(*) AS "paths"

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_schema_variations_comprehensive__TestDenormalizedEdgeCases_test_denorm_variable_length_path_with_denorm.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       count(*) AS `paths`

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -17,7 +17,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
@@ -26,7 +26,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         next."DestState" as "end_DestState"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_multiple_properties.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -17,7 +17,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
@@ -26,7 +26,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         next.`DestState` as `end_DestState`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_collect.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS "a1.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_groupby.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS `a1.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."DestCityName" as "end_DestCityName"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_DestCityName AS "a2.city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_crossfunctional__TestDenormalizedVLPCrossFunctional_test_denormalized_vlp_with_where_and_groupby.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a1_a2 AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`DestCityName` as `end_DestCityName`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a1_a2 AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a1_a2 vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_DestCityName AS `a2.city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ), 
 with_a_b_hops_cte_0 AS (SELECT 
       start_city AS "p1_a_city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_length_path_in_with.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ), 
 with_a_b_hops_cte_0 AS (SELECT 
       start_city AS `p1_a_city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ), 
 with_a_b_hops_path_nodes_cte_0 AS (SELECT 
       start_city AS "p1_a_city", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_nodes_path_in_with.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ), 
 with_a_b_hops_path_nodes_cte_0 AS (SELECT 
       start_city AS `p1_a_city`, 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ), 
 with_dest_dest_state_hops_origin_cte_0 AS (SELECT 
       t.start_city AS "origin", 

--- a/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights_test/test_vlp_with_comprehensive__TestVLPWithDenormalizedSchema_test_denorm_with_properties_and_path.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM test_integration.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN test_integration.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ), 
 with_dest_dest_state_hops_origin_cte_0 AS (SELECT 
       t.start_city AS `origin`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_airport AS "a.airport", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_airport AS `a.airport`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginState AS "a.state", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginState AS `a.state`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS "a.city", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS `a.city`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_exact_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b_inner AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 ),
 vlp_a_b AS (
     SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_path_var_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM default.flights AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."Origin" as "start_Origin",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_Origin" as "start_Origin",
         next."Dest" as "end_Dest"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_Origin AS "a.code", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_0.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`Origin` as `start_Origin`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_Origin` as `start_Origin`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_Origin AS `a.code`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginCityName" as "start_OriginCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginCityName" as "start_OriginCityName",
         next."DestCityName" as "end_DestCityName"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS "a.city", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_1.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginCityName` as `start_OriginCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginCityName` as `start_OriginCityName`,
         next.`DestCityName` as `end_DestCityName`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginCityName AS `a.city`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."OriginState" as "start_OriginState",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         vp."start_OriginState" as "start_OriginState",
         next."DestState" as "end_DestState"
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginState AS "a.state", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_vlp_range_2.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`OriginState` as `start_OriginState`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         vp.`start_OriginState` as `start_OriginState`,
         next.`DestState` as `end_DestState`
     FROM vlp_a_b vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 3 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_OriginState AS `a.state`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         ['FLIGHT'] as path_relationships,
         t0."Dest" as "end_Dest"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
         next."Dest" as "end_Dest"
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS "length(p)", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_graphrag_expansion.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array('FLIGHT') as path_relationships,
         t0.`Dest` as `end_Dest`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
         next.`Dest` as `end_Dest`
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.hop_count AS `length(p)`, 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        [tuple(t0.Origin, t0.Dest)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
         [] as path_relationships,
         t0."DestCityName" as "end_DestCityName",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.Origin, next.Dest)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.Dest]),
         [] as path_relationships,
         next."DestCityName" as "end_DestCityName",
         next."Dest" as "end_Dest"
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT DISTINCT 
       t.end_Dest AS "dest.code", 

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_schema_variations__TestDenormalizedSchema_test_vlp_flights.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_dest AS (
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
-        array(struct(t0.Origin, t0.Dest)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
         array() as path_relationships,
         t0.`DestCityName` as `end_DestCityName`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_dest AS (
         vp.start_id as start_id,
         next.Dest as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.Origin, next.Dest))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.Dest)),
         array() as path_relationships,
         next.`DestCityName` as `end_DestCityName`,
         next.`Dest` as `end_Dest`
     FROM vlp_a_dest vp
     JOIN default.flights next ON next.Origin = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT DISTINCT 
       t.end_Dest AS `dest.code`, 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."origin_code" as "start_origin_code",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         vp."start_origin_code" as "start_origin_code",
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_origin_code AS "a.code", 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestCrossSchemaPatterns_test_vlp_pattern__denormalized_MATCH_a_Airport_FLIGHT_1_2_b_Airport_RETURN_a_code_b_code.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`origin_code` as `start_origin_code`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         vp.`start_origin_code` as `start_origin_code`,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.start_origin_code AS `a.code`, 

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."dest_city" as "end_dest_city"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         next."dest_city" as "end_dest_city"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_dest_city AS "b.city"

--- a/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.databricks.sql
+++ b/tests/rust/integration/golden/corpus/sqlgen_denormalized/test_schema_sql_generation__TestDenormalizedSchema_test_denorm_vlp.databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`dest_city` as `end_dest_city`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         next.`dest_city` as `end_dest_city`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_dest_city AS `b.city`

--- a/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         ['FLIGHT'] as path_relationships
     FROM db_denormalized.flights_denorm AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       tuple(t.path_nodes, t.path_relationships, t.hop_count) AS "p"

--- a/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/dn_path_vlp__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array('FLIGHT') as path_relationships
     FROM db_denormalized.flights_denorm AS t0
@@ -13,12 +13,12 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.dest_code)),
         concat(vp.path_relationships, array('FLIGHT')) as path_relationships
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       struct(t.path_nodes, t.path_relationships, t.hop_count) AS `p`

--- a/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."origin_code" as "start_origin_code",
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         vp."start_origin_code" as "start_origin_code",
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t1.origin_code AS "x.code", 

--- a/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/fixed_hop_then_vlp_hop_559__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`origin_code` as `start_origin_code`,
@@ -15,14 +15,14 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         vp.`start_origin_code` as `start_origin_code`,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t1.origin_code AS `x.code`, 

--- a/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__clickhouse.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        [tuple(t0.origin_code, t0.dest_code)] as path_edges,
+        [tuple(t0.flight_id, t0.flight_number)] as path_edges,
         [t0.origin_code, t0.dest_code] as path_nodes,
         [] as path_relationships,
         t0."dest_code" as "end_dest_code"
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)]),
+        arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)]),
         arrayConcat(vp.path_nodes, [next.dest_code]),
         [] as path_relationships,
         next."dest_code" as "end_dest_code"
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_dest_code AS "b.code"

--- a/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/vlp_recursive__databricks.sql
@@ -3,7 +3,7 @@ WITH RECURSIVE vlp_a_b AS (
         t0.origin_code as start_id,
         t0.dest_code as end_id,
         1 as hop_count,
-        array(struct(t0.origin_code, t0.dest_code)) as path_edges,
+        array(struct(t0.flight_id, t0.flight_number)) as path_edges,
         array(t0.origin_code, t0.dest_code) as path_nodes,
         array() as path_relationships,
         t0.`dest_code` as `end_dest_code`
@@ -14,13 +14,13 @@ WITH RECURSIVE vlp_a_b AS (
         vp.start_id as start_id,
         next.dest_code as end_id,
         vp.hop_count + 1,
-        concat(vp.path_edges, array(struct(next.origin_code, next.dest_code))),
+        concat(vp.path_edges, array(struct(next.flight_id, next.flight_number))),
         concat(vp.path_nodes, array(next.dest_code)),
         array() as path_relationships,
         next.`dest_code` as `end_dest_code`
     FROM vlp_a_b vp
     JOIN db_denormalized.flights_denorm next ON next.origin_code = vp.end_id
-    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.origin_code, next.dest_code))
+    WHERE vp.hop_count < 2 AND NOT array_contains(vp.path_edges, struct(next.flight_id, next.flight_number))
 )
 SELECT 
       t.end_dest_code AS `b.code`

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -9009,15 +9009,16 @@ async fn relationship_uniqueness_guard_skips_unrelated_types_and_optional_518() 
 /// walk, silently dropping every valid path that legitimately revisits a node.
 /// Cypher's default is RELATIONSHIP-uniqueness: a physical edge may not repeat,
 /// but a node MAY be revisited. This mirrors the standard emitter's #598 part-2
-/// fix into the denormalized strategy: `path_edges` now seeds and extends the
-/// `(from, to)` edge-identity tuple, and the cycle check tests that tuple.
+/// fix into the denormalized strategy: `path_edges` now seeds and extends an
+/// edge-identity tuple, and the cycle check tests that tuple.
 ///
-/// A denormalized edge carries no dedicated edge-id column, so the ordered
-/// endpoint pair IS the edge identity. Live-verified against a cyclic fixture
-/// (edges A→B, B→A, B→C, C→A): the edge-unique walk returns 14 trails over
-/// `*1..3` (including node-revisiting trails like A→B→A and C→A→B→A) versus the
-/// old node-unique walk's 7 — exactly the 7 valid paths that were being
-/// silently dropped, with no edge ever reused.
+/// #710: the edge identity is the schema-declared `edge_id` when present — for
+/// `flights_denormalized.yaml` that is the composite `(flight_id,
+/// flight_number)`, which distinguishes parallel edges sharing one
+/// `(origin, dest)` node pair (two flights on the same route). Before #710 the
+/// tuple was the `(origin_code, dest_code)` node pair, which collapsed such
+/// parallel edges and under-counted trails. The `None`-`edge_id` denormalized
+/// schema still falls back to the `(from, to)` pair.
 #[tokio::test]
 async fn denormalized_vlp_range_uses_edge_uniqueness_606() {
     let schema = load_schema(SchemaId::Denormalized.yaml_path());
@@ -9029,27 +9030,35 @@ async fn denormalized_vlp_range_uses_edge_uniqueness_606() {
         "MATCH (a:Airport)-[:FLIGHT*2..3]->(b:Airport) RETURN a.code, b.code",
     ] {
         let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
-        // Base seed + recursive extend carry the (origin, dest) edge tuple.
+        // #710: base seed + recursive extend carry the schema `edge_id`
+        // composite tuple (flight_id, flight_number), NOT the collapsing
+        // (origin, dest) node pair.
         assert!(
             sql.contains("[tuple(t")
-                && sql.contains("origin_code")
-                && sql.contains("dest_code")
+                && sql.contains("flight_id")
+                && sql.contains("flight_number")
                 && sql.contains(
-                    "arrayConcat(vp.path_edges, [tuple(next.origin_code, next.dest_code)])"
+                    "arrayConcat(vp.path_edges, [tuple(next.flight_id, next.flight_number)])"
                 ),
-            "[{cypher}] #606: denorm range VLP must seed/extend path_edges with \
-             the (from,to) edge tuple; got:\n{sql}"
+            "[{cypher}] #710: denorm range VLP must seed/extend path_edges with \
+             the schema edge_id (flight_id, flight_number) tuple; got:\n{sql}"
         );
-        // Cycle check is edge-unique on the tuple, NOT node-unique on the endpoint.
+        // Cycle check is edge-unique on the edge_id tuple, NOT node-unique on
+        // the endpoint, and NOT keyed on the collapsing node pair.
         assert!(
-            sql.contains("NOT has(vp.path_edges, tuple(next.origin_code, next.dest_code))"),
-            "[{cypher}] #606: denorm range VLP cycle check must test edge-tuple \
-             membership in path_edges; got:\n{sql}"
+            sql.contains("NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))"),
+            "[{cypher}] #710: denorm range VLP cycle check must test the edge_id \
+             tuple membership in path_edges; got:\n{sql}"
         );
         assert!(
             !sql.contains("NOT has(vp.path_nodes, next.dest_code)"),
             "[{cypher}] #606: denorm range VLP must no longer enforce \
              node-uniqueness; got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("tuple(next.origin_code, next.dest_code)"),
+            "[{cypher}] #710: the collapsing (origin, dest) node pair must not \
+             key path_edges once the schema declares an edge_id; got:\n{sql}"
         );
     }
 


### PR DESCRIPTION
## Summary

The denormalized VLP strategy (`DenormalizedCteStrategy::edge_tuple`) identified an edge by its `(from_col, to_col)` node pair only, **ignoring a schema-declared composite `edge_id`**. Parallel denorm edges sharing one `(from, to)` node pair (e.g. two flights on the same route keyed by `flight_id`) collapsed into a single edge identity, so a variable-length trail that legitimately traverses (or revisits a node via) such an edge was **silently dropped** by the relationship-uniqueness cycle check — a trail under-count.

This is the **denormalized counterpart of #806/#606**. `edge_tuple` now consults the relationship's schema `edge_id` (resolved once at construction via `resolve_edge_id`), spelled identically to the standard emitter's `build_edge_tuple_recursive`:

| `edge_id` | rendered identity |
|---|---|
| `Composite(cols)` | `tuple(alias.c1, alias.c2, …)` |
| `Single(col)` | bare scalar `alias.col` |
| `None` | `tuple(alias.from, alias.to)` — **byte-identical fallback** |

A denormalized VLP is a single directional recursive self-join over the edge table (no #617 doubled-edge CTE), so no from/to orientation swap is needed.

## Live verification (the silent-wrong proof)

Parallel-edge fixture: LAX⇉ATL (two edges, distinct `flight_id`) + ATL→LAX return. Counting length-3 trails `LAX→ATL→LAX→ATL` (must alternate the two parallel edges):

| edge-identity key | result | correct? |
|---|---|---|
| buggy `(origin, dest)` node pair | **0** (both valid trails dropped — hop 3 "reused" the `(LAX,ATL)` tuple) | ✗ |
| fixed `flight_id` | **2** | ✓ (oracle = 2) |

End-to-end through `cg` against live ClickHouse returns **2**.

## Golden churn

78 goldens regenerated (72 corpus + 6 SQL-IR snapshot). **Every changed line is an edge-identity line** (`path_edges` seed / append / cycle-check); `path_nodes`, JOINs, and projections are byte-identical everywhere. Only denorm schemas that declare `edge_id` (the flight schemas) changed; denorm schemas without `edge_id` are untouched (fallback).

```diff
-        [tuple(f.Origin, f.Dest)] as path_edges,
+        [tuple(f.flight_id, f.flight_number)] as path_edges,
-    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.Origin, next.Dest))
+    WHERE vp.hop_count < 2 AND NOT has(vp.path_edges, tuple(next.flight_id, next.flight_number))
```

The corpus test whose name literally claims `test_composite_id_prevents_duplicate_edges` now actually does.

## Tests

- 2 new unit tests: `denorm_edge_tuple_uses_schema_edge_id_710` (all three arms) + `denorm_vlp_composite_edge_id_in_generated_sql_710` (end-to-end SQL).
- Updated the stale `denormalized_vlp_range_uses_edge_uniqueness_606` assertions (were locking the pre-#710 node-pair spelling) to the composite `edge_id` spelling.
- `cargo fmt` / `clippy --all-targets` / `cargo test` (1675 lib + 544 integration) / `--test ratchet` all green.

## Rule #7 / ratchet

Ratchet-clean: `edge_id` is not a tracked axis token, and the fix reads it via the canonical `schema.get_rel_schema(label).edge_id` dispatch route (same as `cte_extraction.rs`). No baseline bump.

## Scope discipline (#887 §7)

Adjacent bug **not** folded in: **#808** — the mixed-access VLP arm (`generate_mixed_*`) is corpus-unreachable and still node-unique; resolve separately by adding one mixed-schema VLP corpus entry, which will surface the inconsistency.

Closes #710. Part of #887 Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)