### PR TITLE
fix(#876): flip expression-wrapped buried grouping key per denorm union arm

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -499,6 +499,31 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — expression-WRAPPED buried grouping key now flips per arm
+  on a denorm undirected union** (branch `fix/876-wrapped-buried-groupby-key`,
+  closes #876; #844 residual). #844 restored the per-arm origin/dest flip for a
+  grouping key buried in an aggregate-bearing RETURN item
+  (`a.code + toString(count(r))`) on a bidirectional-union denorm match, but
+  gated the per-arm override on the key being a bare `PropertyAccessExp`/`Column`.
+  A key WRAPPED in a scalar fn (`toUpper(a.code) + toString(count(r))`,
+  `coalesce(a.code,'x') + …`) is a `ScalarFnCall`, so it skipped the override and
+  both arms baked the origin column → the identical **silent under-count** #844
+  fixed. **Fix:** in `build_branch_inner_select_with_own_items`
+  (`to_sql_query.rs`), instead of gating on the whole key being a bare column,
+  walk the key with `collect_property_access_sql` for the denorm COMPONENT columns
+  it references and record a per-COMPONENT override — the inner SELECT already
+  exports those component columns and the emission side already looks them up by
+  component SQL, so the map just needed component-level keys. For a bare key the
+  component IS the key → #844 path byte-identical. Both wrapped arms now correctly
+  read `r.origin_code`/`r.dest_code AS "r.origin_code"`. 4 dual-dialect goldens
+  (upper, coalesce × CH/Databricks), all fail-when-reverted; #844 bare+buried
+  goldens byte-unchanged. corpus_sweep 0-churn; ratchet net-zero; full gate green.
+  SQL-shape-verified both dialects (no live CH). **Out of scope / filed separately:
+  #906** — the CASE-buried form (`CASE WHEN count(r)>5 THEN a.code ELSE 'x' END`)
+  has an upstream property-mapping defect (the denorm column leaks unmapped as a
+  phantom `r.code`, so no real column reaches the flip); byte-identical on main
+  and here (not a regression), rooted in grouping-key extraction
+  (`groupby-three-split-sites` class), not the union override.
 - 2026-08-02: **Fix — chained double-WITH rename of a scalar no longer drops
   the alias** (branch `fix/886-chained-with-rename`, closes #886; follow-up to
   #864). `UNWIND [1,2,3] AS x WITH x AS y WITH y AS z RETURN count(z)` (and the

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4589,45 +4589,62 @@ fn build_branch_inner_select_with_own_items(
     let mut key_branch_overrides: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     for g in group_by_exprs {
-        // Only qualified column/property keys are exported into the inner SELECT
-        // (see `collect_property_access_sql`); bare keys aren't, so skip them.
-        if !matches!(g, RenderExpr::PropertyAccessExp(_) | RenderExpr::Column(_)) {
-            continue;
-        }
-        let g_sql = g.to_sql();
-        if !g_sql.contains('.') {
-            continue;
-        }
-        // If a standalone non-agg outer item already exports this key, the normal
-        // per-branch projection handles the flip (the bare-key path) — no override.
-        if outer_select.items.iter().any(|it| {
-            !render_expr_contains_aggregate(&it.expression) && it.expression.to_sql() == g_sql
-        }) {
-            continue;
-        }
-        // Buried key: find the aggregate-bearing outer item whose tree contains it,
-        // then the same-alias branch item, then this arm's corresponding column.
-        let Some(outer_item) = outer_select.items.iter().find(|it| {
-            render_expr_contains_aggregate(&it.expression)
-                && corresponding_branch_subexpr(&it.expression, &it.expression, &g_sql).is_some()
-        }) else {
-            continue;
-        };
-        let Some(branch_item) = branch_select
-            .items
-            .iter()
-            .find(|it| it.col_alias == outer_item.col_alias)
-        else {
-            continue;
-        };
-        if let Some(bcol) =
-            corresponding_branch_subexpr(&outer_item.expression, &branch_item.expression, &g_sql)
-        {
-            let bcol_sql = bcol.to_sql();
-            // Only record a real flip; when this arm's column already equals the
-            // key (arm0, or any non-denorm schema) the emission is unchanged.
-            if bcol_sql != g_sql {
-                key_branch_overrides.insert(g_sql, bcol_sql);
+        // Resolve the per-arm flip against each denorm COLUMN the key references,
+        // not the key as a whole. A bare key (`r.origin_code`, #844) references
+        // exactly itself; an expression-WRAPPED key (`upper(r.origin_code)`,
+        // `coalesce(r.origin_code,'x')`, #876) references the same column as a
+        // sub-expression. The inner SELECT exports those component columns (see
+        // `collect_property_access_sql` on `extra_required_exprs` in
+        // `build_union_inner_select`) and looks up the override by the component
+        // column's SQL — so the map must be keyed by component column, which for
+        // a bare key collapses to the #844 behavior (byte-identical).
+        let mut key_cols: Vec<String> = Vec::new();
+        collect_property_access_sql(g, &mut key_cols);
+        for g_sql in key_cols {
+            // Only qualified column refs are exported into the inner SELECT.
+            if !g_sql.contains('.') {
+                continue;
+            }
+            if key_branch_overrides.contains_key(&g_sql) {
+                continue;
+            }
+            // If a standalone non-agg outer item already exports this column, the
+            // normal per-branch projection handles the flip (the bare-key path) —
+            // no override.
+            if outer_select.items.iter().any(|it| {
+                !render_expr_contains_aggregate(&it.expression) && it.expression.to_sql() == g_sql
+            }) {
+                continue;
+            }
+            // Buried column: find the aggregate-bearing outer item whose tree
+            // contains it, then the same-alias branch item, then this arm's
+            // corresponding column.
+            let Some(outer_item) = outer_select.items.iter().find(|it| {
+                render_expr_contains_aggregate(&it.expression)
+                    && corresponding_branch_subexpr(&it.expression, &it.expression, &g_sql)
+                        .is_some()
+            }) else {
+                continue;
+            };
+            let Some(branch_item) = branch_select
+                .items
+                .iter()
+                .find(|it| it.col_alias == outer_item.col_alias)
+            else {
+                continue;
+            };
+            if let Some(bcol) = corresponding_branch_subexpr(
+                &outer_item.expression,
+                &branch_item.expression,
+                &g_sql,
+            ) {
+                let bcol_sql = bcol.to_sql();
+                // Only record a real flip; when this arm's column already equals
+                // the key (arm0, or any non-denorm schema) the emission is
+                // unchanged.
+                if bcol_sql != g_sql {
+                    key_branch_overrides.insert(g_sql, bcol_sql);
+                }
             }
         }
     }

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_coalesce_876__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_coalesce_876__clickhouse.sql
@@ -1,0 +1,12 @@
+SELECT concat(coalesce(`r.origin_code`, 'x'), toString(count(`r.flight_id`))) AS "m" FROM (
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.origin_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.dest_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY coalesce(r.origin_code, 'x')

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_coalesce_876__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_coalesce_876__databricks.sql
@@ -1,0 +1,12 @@
+SELECT concat(coalesce(`r.origin_code`, 'x'), string(count(`r.flight_id`))) AS `m` FROM (
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.origin_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.dest_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY coalesce(r.origin_code, 'x')

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_upper_876__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_upper_876__clickhouse.sql
@@ -1,0 +1,12 @@
+SELECT concat(upper(`r.origin_code`), toString(count(`r.flight_id`))) AS "m" FROM (
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.origin_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.dest_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY upper(r.origin_code)

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_upper_876__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_wrapped_buried_agg_key_upper_876__databricks.sql
@@ -1,0 +1,12 @@
+SELECT concat(upper(`r.origin_code`), string(count(`r.flight_id`))) AS `m` FROM (
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.origin_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.dest_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY upper(r.origin_code)

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -1291,6 +1291,23 @@ const DENORM_CORPUS: &[(&str, &str)] = &[
         "undirected_buried_agg_key_844",
         "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN a.code + toString(count(r)) AS m",
     ),
+    // #876 (#844 residual): the buried grouping key wrapped in a scalar function
+    // (`toUpper(a.code)`, `coalesce(a.code,'x')`) must STILL flip per arm — the
+    // flip-able denorm column (`r.origin_code`) sits as a sub-expression of the
+    // group key, so the per-arm override must target the component column, not the
+    // key as a whole. Regression: the override gated on the key being a bare
+    // `PropertyAccessExp`/`Column`, so a wrapped key skipped the flip and both arms
+    // baked the origin column (silent under-count, identical to the #844 bug).
+    // Both arms must read `r.origin_code AS "r.origin_code"` / `r.dest_code AS
+    // "r.origin_code"` exactly like the bare-key sibling.
+    (
+        "undirected_wrapped_buried_agg_key_upper_876",
+        "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN toUpper(a.code) + toString(count(r)) AS m",
+    ),
+    (
+        "undirected_wrapped_buried_agg_key_coalesce_876",
+        "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN coalesce(a.code, 'x') + toString(count(r)) AS m",
+    ),
     // #844 byte-lock guard: the bare-key form (grouping key as its own SELECT
     // item) was ALWAYS correct and must stay byte-identical — the fix is scoped
     // to the buried-key shape only.


### PR DESCRIPTION
## Summary

Residual of #844. On a **denormalized undirected** (bidirectional-union) match, a grouping key buried in an aggregate-bearing RETURN item must flip its denorm column per arm (origin on the outgoing arm, dest on the incoming arm). #844 fixed this for a **bare-column** key but gated the per-arm override on the key being a bare `PropertyAccessExp`/`Column`. A key **wrapped in a scalar fn** skipped the override, so both UNION arms baked the origin column → the identical **silent under-count** #844 fixed:

```cypher
MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN toUpper(a.code) + toString(count(r)) AS m
MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN coalesce(a.code,'x') + toString(count(r)) AS m
```

## Fix

In `build_branch_inner_select_with_own_items` (`to_sql_query.rs`), instead of gating on the whole key being a bare column, walk the key with `collect_property_access_sql` for the denorm **component** columns it references and record a **per-component** override. The inner SELECT already exports those component columns and the emission side (`build_union_inner_select`) already looks them up by component SQL — only the override-building loop needed component-level keys.

- **Bare key (#844)** → component IS the key → **byte-identical**.
- **Multiple denorm columns in one key** (`a.code + b.code`) → each flips independently.
- The emission side is unchanged; an override for a non-exported column is a **dead map entry**, never a new column reference — so the fix **can never emit invalid SQL** and is strictly ≥ main.

## Tests & gate

- 4 dual-dialect goldens (upper, coalesce × CH/Databricks), all **fail-when-reverted**.
- #844 bare + buried goldens **byte-unchanged**.
- `corpus_sweep` 0-churn; `ratchet` net-zero; full gate green (lib 1673, integration 547). SQL-shape-verified both dialects (no live CH).
- Adversarial review: **safe to merge**, 0 HIGH/MEDIUM across 8 vectors.

## Out of scope

- **#906** — the CASE-buried form (`CASE WHEN count(r)>5 THEN a.code ELSE 'x' END`) has a **separate upstream property-mapping defect** (the denorm column leaks unmapped as a phantom `r.code`); byte-identical on main and here, rooted in grouping-key extraction, not the union override.
- Keys buried in `CASE`/`List`/`ArraySubscript`/`Reduce`/`Map` still under-count — a **safe pre-existing gap** (same as main, never invalid SQL).

Closes #876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)