### PR TITLE
fix(#808/#606): mixed-access VLP arm enforces edge-uniqueness

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -466,7 +466,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **Phase 3 #806 + Phase 4 #628 + Phase 5 #710 fixed**)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -484,7 +484,7 @@ fixed stats fixture.
   `UnsupportedFeature` — now counts real cycles via edge-uniqueness (zero-hop base
   seeds empty `path_edges`), live-verified against the trail oracle; OPEN `*0..N`
   byte-unchanged.
-  **Phase 5 (#710) SHIPPED (PR #TBD)**: the DENORMALIZED VLP strategy
+  **Phase 5 (#710) SHIPPED (PR #905, `1d6c445b`)**: the DENORMALIZED VLP strategy
   (`DenormalizedCteStrategy::edge_tuple`) now consults the schema `edge_id`
   (resolved once via `resolve_edge_id`, spelled like `build_edge_tuple_recursive`:
   Composite→tuple / Single→scalar / None→byte-identical `(from,to)` fallback), so
@@ -493,16 +493,28 @@ fixed stats fixture.
   SQL-IR snapshot), every changed line an edge-identity line (`path_nodes`/joins
   byte-identical); live-verified length-3 parallel-edge trail = buggy 0 vs fixed 2
   (oracle 2), end-to-end through `cg`. Ratchet-clean (`edge_id` not a tracked
-  token). Remaining:
+  token); adversarial review APPROVE-2.
+  **#808 = #606 FIXED (PR #TBD)**: the mixed-access VLP arm
+  (`generate_mixed_{base,recursive}_case`, `new_mixed`) was proven **reachable**
+  (not dead) via a foreign-embedded self-loop with a one-sided role map — the
+  earlier "mixed ⊥ transitive" assumption was refuted. It emitted NODE-uniqueness
+  (`path_nodes`, no `path_edges`), the last reachable node-unique-where-edge-unique
+  site, silently dropping node-revisiting paths. Fix: seed/extend `path_edges` +
+  switch the cycle check to `emit_edge_cycle_check` gated by `uses_edge_uniqueness`,
+  matching every sibling arm. New schema `schemas/test/foreign_selfloop.yaml` +
+  2 corpus entries lock it (4 new goldens, ZERO existing-golden churn — the arm
+  was corpus-empty). Live-verified: `*2..3` over a 3-cycle = buggy 3 vs fixed 6
+  (oracle 6). Ratchet-clean. **This closes the covered-bug cluster** — #606, #628,
+  #710, #806, #808 all fixed.
+  Remaining #887:
   Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical
   design-cycle refactor). Explicitly NOT this cluster:
   #643/#840/#627/#683 (different subsystems). Adjacent bugs found during Phase 3/4/5
   and filed separately (NOT folded in): flat exact-bound polymorphic VLP drops the
   `interaction_type` discriminator (#897), an OPTIONAL-MATCH closed-VLP projection
   bug (`vt0.<prop>`, #899), FK-edge self-ref VLP degenerate recursive join (#902),
-  and #808 (mixed-access VLP arm is corpus-unreachable — resolve by adding one
-  mixed-schema VLP corpus entry, which will surface its node-uniqueness as
-  #606-inconsistent and convert it to edge-uniqueness).
+  and the mixed-arm denormalized-start-node non-id-property projection gap (#908,
+  surfaced while adding #808 coverage).
 
 ## 3. Capacity split (guideline)
 

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -125,6 +125,28 @@ Likewise **#808** already established via `eprintln!` + full corpus sweep that
 `generate_mixed_recursive_case`, `generate_heterogeneous_polymorphic_recursive_case`,
 and `generate_denormalized_recursive_case` (the VLC copies) get **0 hits**.
 
+> **CORRECTION (#808 resolved, PR #TBD)**: "0 corpus hits" is *coverage*, not
+> *reachability*. The `generate_mixed_{base,recursive}_case` arms turned out to
+> be **genuinely reachable** — the earlier "mixed-access and transitive-VLP are
+> mutually exclusive" hypothesis was refuted. A **foreign-embedded self-loop
+> with a one-sided role map** (node on its own table, a *different* edge table,
+> only `from_node_properties` declared, self-referencing relationship) makes the
+> same label denormalized in the from-role and standard in the to-role →
+> `start_is_denormalized XOR end_is_denormalized` → `new_mixed`; the transitivity
+> analyzer keys on label identity (self-loop) so `*2..N` is admitted; and the
+> same-table denorm validator that would reject the asymmetry only fires when
+> `node.table == edge.table`, leaving the foreign-embedded case unguarded. The
+> mixed arm emitted NODE-uniqueness (`emit_cycle_check`/`path_nodes`, no
+> `path_edges`), silently dropping node-revisiting paths — the last #606
+> inconsistency. **Fixed** (schema `schemas/test/foreign_selfloop.yaml` + corpus
+> entries lock it): the mixed arms now seed/extend `path_edges` and cycle-check
+> on it via `emit_edge_cycle_check`, gated by `uses_edge_uniqueness`, exactly
+> like the standard/FK/denorm arms. Live-verified against a 3-cycle fixture:
+> `*2..3` returns 6 relationship-unique trails vs the old node-unique 3. This
+> closes **#808 AND #606** (the mixed arm was the only remaining reachable
+> node-unique-where-edge-unique-required site). The hetero-poly and denorm VLC
+> copies remain genuinely dead (deleted in #860). The arms are NOT deletable.
+
 **Consequence:** a large share of the "cluster" is not a correctness fix at all
 — it is **dead-code deletion** (see Phase 0). Deleting it *first* shrinks the
 surface the real unification has to cover, and makes the ratchet debt fall
@@ -390,10 +412,13 @@ Ratchet baseline today, the 3 VLP files (`tests/rust/ratchet/baseline.txt`):
 `EdgeUniquenessPolicy` (constructed once from `PatternSchemaContext`), and the
 baseline **decreases** — the ratchet auto-ratchets down in the same PRs.
 
-Issue metric: #606, #628, #710, #806, #808 all close or convert to a documented
-non-bug. #710 is now **fixed** (denorm `edge_tuple` consults the schema
-`edge_id`), not a residual. No *new* uniqueness residual can be filed against an
-arm the policy owns, because there is one arm.
+Issue metric: #606, #628, #710, #806, #808 are **all fixed** (behavior). #806
+(flat composite edge_id), #628 (closed `*0..N` cycles), #710 (denorm parallel
+edges), and #808 = #606 (mixed-access arm edge-uniqueness) all landed as
+byte-scoped behavior fixes. No *new* uniqueness residual can be filed against an
+arm the policy owns, because once Phase 1–2 land there is one arm. What remains
+of #887 is the Phase 1–2 `EdgeUniquenessPolicy` consolidation — a pure
+design-cycle refactor, not a bug.
 
 ---
 

--- a/schemas/test/foreign_selfloop.yaml
+++ b/schemas/test/foreign_selfloop.yaml
@@ -1,0 +1,46 @@
+# Foreign-embedded self-loop schema — the shape that reaches the MIXED-access
+# VLP arm (#808/#606).
+#
+# Two independent schema properties combine here:
+#   1. `Person` is denormalized (declares `from_node_properties`) but lives on
+#      its OWN table `people`, DIFFERENT from the edge table `reports`
+#      ("foreign-embedded", graph_schema.rs `foreign_embedded` branch). Because
+#      only the from-role map is declared, `is_node_denormalized_on_edge`
+#      returns true for the from-role and false for the to-role of the SAME
+#      label → `classify_edge_table_pattern` = Mixed → one VLP endpoint is
+#      `EmbeddedInEdge`, the other `OwnTable` → `start_is_denormalized XOR
+#      end_is_denormalized` → the `new_mixed` VLP strategy.
+#   2. `REPORTS_TO` is self-referencing (from_node == to_node == Person), so the
+#      transitivity analyzer (which keys on LABEL identity, not denorm-ness)
+#      admits `*2..N` recursion.
+#
+# The same-table denorm validator (`validate_denormalized_nodes`) that would
+# reject a one-sided role map only fires when node.table == edge.table, so this
+# foreign-embedded case is unguarded — which is exactly why the mixed arm is
+# reachable. Used by the corpus sweep to lock the mixed arm's edge-uniqueness
+# (Cypher relationship-uniqueness) cycle check.
+name: foreign_selfloop_test
+version: "1.0"
+description: "Foreign-embedded self-loop: node table != edge table, one-sided role map -> reaches the mixed-access VLP arm (#808/#606)"
+
+graph_schema:
+  nodes:
+    - label: Person
+      database: testdb
+      table: people
+      node_id: pid
+      is_denormalized: true
+      property_mappings:
+        pid: pid
+        name: name
+      from_node_properties:
+        pid: mgr_id
+  edges:
+    - type: REPORTS_TO
+      database: testdb
+      table: reports
+      from_node: Person
+      to_node: Person
+      from_id: mgr_id
+      to_id: emp_id
+      property_mappings: {}

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -3420,6 +3420,23 @@ impl<'a> VariableLengthCteGenerator<'a> {
             arr(&format!("{}, {}", start_id_expr, end_id_expr))
         ));
 
+        // #808/#606: seed `path_edges` with this hop's edge-identity tuple so the
+        // recursive step can enforce Cypher's default RELATIONSHIP-uniqueness (an
+        // edge may not be reused, but a node MAY be revisited). The mixed arm
+        // previously carried only `path_nodes` and cycle-checked on the endpoint
+        // node id — NODE-uniqueness — which silently dropped every valid path
+        // that legitimately revisits a node, inconsistent with every sibling arm
+        // (standard/FK/denorm all use edge-uniqueness). `rel` is joined in both
+        // mixed FROM branches, so `build_edge_tuple_recursive` reads the edge_id
+        // (or `(from,to)`) tuple off it directly. Gated by `uses_edge_uniqueness`
+        // so shortestPath/zero-hop stay node-unique and byte-unchanged.
+        if self.uses_edge_uniqueness() {
+            select_items.push(format!(
+                "{} as path_edges",
+                arr(&self.build_edge_tuple_recursive(&self.relationship_alias))
+            ));
+        }
+
         // Add properties for non-denormalized nodes
         for prop in &self.properties {
             if prop.cypher_alias == self.start_cypher_alias && !self.start_is_denormalized {
@@ -3550,6 +3567,18 @@ impl<'a> VariableLengthCteGenerator<'a> {
             arr(&end_id_expr)
         ));
 
+        // #808/#606: extend `path_edges` with this hop's edge-identity tuple so
+        // the shape matches the base seed and the edge-uniqueness cycle check
+        // below (Cypher relationship-uniqueness). Gated identically to the base
+        // via `uses_edge_uniqueness` (shortestPath/zero-hop stay node-unique and
+        // never carry a `path_edges` column, so nothing to extend there).
+        if self.uses_edge_uniqueness() {
+            select_items.push(format!(
+                "{ac}(vp.path_edges, {}) as path_edges",
+                arr(&self.build_edge_tuple_recursive(&self.relationship_alias))
+            ));
+        }
+
         // Add properties - start from CTE, end from joined node (if not denorm)
         for prop in &self.properties {
             if prop.cypher_alias == self.start_cypher_alias && !self.start_is_denormalized {
@@ -3600,7 +3629,16 @@ impl<'a> VariableLengthCteGenerator<'a> {
             )
         };
 
-        let cycle_check = emit_cycle_check(&end_id_expr);
+        // #808/#606: enforce EDGE-uniqueness (an edge may not be reused, but a
+        // node MAY be revisited — Cypher's default) by testing the new hop's
+        // edge-identity tuple against `path_edges`, matching every sibling arm.
+        // Node-uniqueness (`NOT has(path_nodes, end_id)`) is retained only for
+        // shortestPath / zero-hop via `uses_edge_uniqueness`, byte-unchanged.
+        let cycle_check = if self.uses_edge_uniqueness() {
+            emit_edge_cycle_check(&self.build_edge_tuple_recursive(&self.relationship_alias))
+        } else {
+            emit_cycle_check(&end_id_expr)
+        };
 
         let mut where_conditions = vec![format!("vp.hop_count < {}", max_hops), cycle_check];
 
@@ -3817,6 +3855,69 @@ mod tests {
             "open *0..N must use node-uniqueness; got:\n{open_sql}"
         );
     }
+
+    /// #808/#606: the MIXED-access VLP arm (one endpoint denormalized, the other
+    /// standard — reached via a foreign-embedded self-loop with a one-sided role
+    /// map) previously carried only `path_nodes` and cycle-checked on the
+    /// endpoint node id (NODE-uniqueness), silently dropping every valid path
+    /// that legitimately revisits a node. It must now enforce Cypher's default
+    /// RELATIONSHIP-uniqueness on `path_edges`, consistent with the standard /
+    /// FK / denormalized arms. Live-verified against a 3-cycle fixture: `*2..3`
+    /// returns 6 relationship-unique trails (3 length-2 + 3 node-revisiting
+    /// length-3) versus the old node-unique 3.
+    #[test]
+    fn mixed_vlp_uses_edge_uniqueness_808() {
+        let schema = create_test_schema();
+        // Denorm→Standard mixed: start embedded-in-edge, end own-table.
+        let gen = VariableLengthCteGenerator::new_mixed(
+            &schema,
+            VariableLengthSpec::range(2, 3),
+            "people",  // start table (denorm start reads from rel; passed for shape)
+            "pid",     // start id col
+            "reports", // relationship table
+            "mgr_id",  // rel from col
+            "emp_id",  // rel to col
+            "people",  // end table (standard end own-table)
+            "pid",     // end id col
+            "a",
+            "b",
+            "",
+            vec![],
+            None, // shortest_path_mode
+            None, // start_node_filters
+            None, // end_node_filters
+            None, // relationship_filters
+            None, // path_variable
+            Some(vec!["REPORTS_TO".to_string()]),
+            None,  // edge_id (None → (from,to) identity)
+            true,  // start endpoint is the denormalized (embedded-in-edge) side
+            false, // end endpoint is the standard own-table side
+        );
+        assert!(
+            gen.uses_edge_uniqueness(),
+            "mixed range VLP (min_hops>=1, not shortestPath) must use edge-uniqueness"
+        );
+        let sql = gen.generate_recursive_sql();
+        // Base seeds and recursive extends path_edges with the (from,to) tuple.
+        assert!(
+            sql.contains("[tuple(rel.mgr_id, rel.emp_id)] as path_edges"),
+            "mixed base must seed path_edges with the edge tuple; got:\n{sql}"
+        );
+        assert!(
+            sql.contains("arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)])"),
+            "mixed recursive must extend path_edges with the edge tuple; got:\n{sql}"
+        );
+        // Cycle check is EDGE-unique on path_edges, NOT node-unique on the endpoint.
+        assert!(
+            sql.contains("NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))"),
+            "mixed cycle check must test edge-tuple membership; got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("NOT has(vp.path_nodes,"),
+            "mixed range VLP must no longer enforce node-uniqueness; got:\n{sql}"
+        );
+    }
+
     #[test]
     fn test_fixed_length_spec() {
         let spec = VariableLengthSpec::fixed(2);

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1231,3 +1231,5 @@
 {"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            WITH y AS z\n            RETURN count(z) AS c", "name": "test_886__chained_with_rename_of_unwind_scalar_count", "schema": "social_integration"}
 {"cypher": "WITH 1 AS one\n            WITH one AS two\n            RETURN count(two) AS c", "name": "test_886__chained_with_rename_of_literal_scalar_count", "schema": "social_integration"}
 {"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            WITH y AS z\n            WHERE z > 0\n            RETURN count(z) AS c", "name": "test_886__chained_with_rename_then_where_count", "schema": "social_integration"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) RETURN b.name", "name": "test_808__mixed_arm_vlp_uses_edge_uniqueness", "schema": "foreign_selfloop"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*1..2]->(b:Person) RETURN count(*) AS trails", "name": "test_808__mixed_arm_vlp_range_count", "schema": "foreign_selfloop"}

--- a/tests/corpus/schema_map.json
+++ b/tests/corpus/schema_map.json
@@ -35,6 +35,10 @@
     "subschema": null,
     "yaml": "schemas/examples/filesystem_single.yaml"
   },
+  "foreign_selfloop": {
+    "subschema": null,
+    "yaml": "schemas/test/foreign_selfloop.yaml"
+  },
   "ldbc_snb": {
     "subschema": "ldbc_snb",
     "yaml": "schemas/test/unified_test_multi_schema.yaml"

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_range_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_range_count.clickhouse.sql
@@ -1,0 +1,27 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [rel.mgr_id, end_node.pid] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.pid]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges
+    FROM vlp_a_b vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+)
+SELECT 
+      count(*) AS "trails"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_range_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_range_count.databricks.sql
@@ -1,0 +1,27 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(rel.mgr_id, end_node.pid) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.pid)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges
+    FROM vlp_a_b vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+)
+SELECT 
+      count(*) AS `trails`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_uses_edge_uniqueness.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_uses_edge_uniqueness.clickhouse.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [rel.mgr_id, end_node.pid] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.pid]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_uses_edge_uniqueness.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_808__mixed_arm_vlp_uses_edge_uniqueness.databricks.sql
@@ -1,0 +1,32 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(rel.mgr_id, end_node.pid) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.pid)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t


### PR DESCRIPTION
## Summary

The **mixed-access VLP arm** (`generate_mixed_base_case` / `generate_mixed_recursive_case`, dispatched via `new_mixed` when exactly one VLP endpoint is denormalized) carried only a `path_nodes` array and cycle-checked on the endpoint node id — **NODE-uniqueness**. Cypher's default is **relationship-uniqueness** (an edge may not be reused, but a node MAY be revisited), which every sibling arm (standard, FK-edge, denormalized) already enforces on `path_edges`. So the mixed arm **silently dropped every valid path that revisits a node** — a trail under-count. This was the last reachable node-unique-where-edge-unique-required VLP site, so fixing it closes **both #808 and #606**.

## Reachability (the surprising part)

The arm was believed corpus-unreachable / possibly dead. It is **genuinely reachable** — the "mixed-access ⊥ transitive-VLP" hypothesis was refuted. A **foreign-embedded self-loop with a one-sided role map** reaches it:

- A node on its OWN table, a self-referencing relationship on a **different** edge table, with only `from_node_properties` declared, makes the *same* label **denormalized in the from-role and standard in the to-role** (`is_node_denormalized_on_edge` reads different `NodeSchema` fields per role) → `start_is_denormalized XOR end_is_denormalized` → `new_mixed`.
- The transitivity analyzer keys on label identity (self-loop) → `*2..N` admitted.
- The same-table denorm validator that would reject the asymmetry only fires when `node.table == edge.table`, leaving the foreign-embedded case unguarded.

## Fix

Mirrors the standard arm's #598/#606 machinery, gated by `uses_edge_uniqueness` (so shortestPath/zero-hop stay node-unique, byte-unchanged):
- base seeds `path_edges` with `build_edge_tuple_recursive(rel)` (schema `edge_id` if declared, else `(from,to)`);
- recursive extends `path_edges` with the same tuple;
- the cycle check switches to `emit_edge_cycle_check(...)` on `path_edges`.

`new_mixed` already receives `context.edge_id`, so composite-`edge_id` schemas work for free — consistent with #710/#806/#628.

## Live verification (silent-wrong proof)

3-cycle fixture (edges `1→2`, `2→3`, `3→1`), `MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person)`:

| | result | correct? |
|---|---|---|
| buggy (node-unique) | **3** (drops all 3 node-revisiting length-3 trails) | ✗ |
| fixed (edge-unique) | **6** (3 length-2 + 3 length-3) | ✓ (oracle=6) |

End-to-end through `cg`. Both dialects render correctly (CH `has`/`tuple`, Spark `array_contains`/`struct`).

## Coverage & churn

- New `schemas/test/foreign_selfloop.yaml` — first foreign-embedded self-loop schema in the repo.
- 2 corpus entries + a `new_mixed` unit test lock the mixed arm's edge-uniqueness.
- **ZERO existing-golden churn** — the arm was corpus-empty, so no previously-covered query changes. 4 new goldens only.
- `cargo fmt` / `clippy` / `cargo test` (1676 lib + 547 integration) / `--test ratchet` all green. Ratchet-clean (routes through `uses_edge_uniqueness`; no raw axis tokens added).

## Scope discipline (#887 §7)

Filed **#908** separately (NOT folded in): the mixed arm doesn't project a denormalized START node's non-id property (`RETURN a.name` → Code 47) — a pre-existing projection gap surfaced by this coverage.

Closes #808. Closes #606. Part of #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)