### PR TITLE
fix(#901): return a clean error for a graph pattern in expression context

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -524,6 +524,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — graph pattern in scalar-expression context returns a clean
+  error instead of panicking** (branch `fix/901-pattern-in-expr-context-panic`,
+  closes #901). `MATCH (u:User) RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0
+  END` (and the WHERE-CASE form) panicked the tokio worker with `unimplemented!`
+  at `render_expr.rs:2036` — in server mode this took down the worker on
+  otherwise-valid Cypher. **Root cause:** `RenderExpr::try_from(LogicalExpr)` had
+  a catch-all `_ => unimplemented!(...)` (plus a nested `unimplemented!` for a
+  name/label-less `PathPattern::Node`); a relationship pattern in expression
+  context (`PathPattern::ConnectedPattern`) reached it — only the bare
+  `PathPattern::Node` label-check form was lowered. **Fix:** replace both
+  `unimplemented!` calls with a clean `RenderBuildError::UnsupportedFeature` Err
+  (the fn already returns `Result<_, RenderBuildError>`), naming the offending
+  variant and suggesting a top-level MATCH / `EXISTS { … }` workaround. Ground-
+  rule-1 safe: a panic becomes a loud error, never wrong SQL. The full lowering
+  (relationship pattern → correlated EXISTS subquery, the #574/#587 neighborhood)
+  is out of scope. Supported paths unchanged: `(u:User)` node-label pattern in a
+  CASE still lowers to `u.__label__ = 'User'`; normal `EXISTS { … }` unaffected.
+  2 fail-when-reverted panic-guard tests (RETURN + WHERE CASE forms) at the render
+  level; corpus_sweep 0-churn; ratchet net-zero; full gate green (lib 1676,
+  integration 549). Discovered while fixing #866.
 - 2026-08-02: **Fix — count() of a scalar property through a WITH barrier no
   longer collapses to count(\*)** (branch `fix/903-count-scalar-property-with`,
   closes #903). `MATCH (u:User) WITH u.age AS a RETURN count(a)` rendered the CTE

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -2030,10 +2030,30 @@ impl TryFrom<LogicalExpr> for RenderExpr {
                         ],
                     })
                 } else {
-                    unimplemented!("PathPattern::Node without name or label is not supported in expression context")
+                    // #901: a bare node pattern with neither name nor label in
+                    // expression context has no scalar lowering. Return a clean
+                    // error instead of panicking the worker.
+                    return Err(RenderBuildError::UnsupportedFeature(
+                        "a bare node pattern with neither variable nor label in \
+                         expression context (e.g. inside CASE/WHERE) is not supported"
+                            .to_string(),
+                    ));
                 }
             }
-            _ => unimplemented!("Conversion for this LogicalExpr variant is not implemented"),
+            // #901: a relationship pattern (or any other unhandled variant) in
+            // expression context — e.g. `CASE WHEN (u)-[:R]->() THEN … END` — has no
+            // scalar lowering yet (a correlated EXISTS-style subquery, the #574/#587
+            // neighborhood). Previously this hit a catch-all `unimplemented!` that
+            // PANICKED the tokio worker on otherwise-valid Cypher; return a clean,
+            // loud error instead (ground-rule-1 safe: never wrong SQL). Express such
+            // a pattern via a top-level MATCH or an EXISTS { … } subquery.
+            other => {
+                return Err(RenderBuildError::UnsupportedFeature(format!(
+                    "a graph pattern or unsupported expression in scalar-expression \
+                     context (e.g. inside CASE/WHERE) is not supported: {other:?}. \
+                     Express it as a top-level MATCH or an EXISTS {{ … }} subquery"
+                )));
+            }
         };
         Ok(expression)
     }

--- a/tests/rust/integration/parameter_function_test.rs
+++ b/tests/rust/integration/parameter_function_test.rs
@@ -471,3 +471,48 @@ fn test_list_comprehension_with_hidden_pattern_errors_not_panics() {
         "a pattern hidden in a list-comprehension CASE should error, not panic"
     );
 }
+
+#[test]
+fn test_relationship_pattern_in_case_return_errors_not_panics_901() {
+    // #901: a relationship pattern in scalar-expression context inside a CASE
+    // (`RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0 END`) has no scalar
+    // lowering. It plans fine but reaches `RenderExpr::try_from(LogicalExpr)`,
+    // where a catch-all `unimplemented!` used to PANIC the tokio worker on
+    // otherwise-valid Cypher (taking down the server). It must now surface as a
+    // clean render Err (UnsupportedFeature), never a panic.
+    let query = "MATCH (u:User) RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0 END AS c";
+    let ast = parse_query(query).expect("Failed to parse query");
+    let schema = create_test_schema();
+
+    let (logical_plan, plan_ctx) = build_logical_plan(&ast, &schema, None, None, None)
+        .expect("should plan (error is at render)");
+    let result =
+        logical_plan_to_render_plan_with_ctx((*logical_plan).clone(), &schema, Some(&plan_ctx));
+    assert!(
+        result.is_err(),
+        "a relationship pattern in a CASE expression must render-error, not panic"
+    );
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("UnsupportedFeature"),
+        "expected a clean UnsupportedFeature error, got: {err}"
+    );
+}
+
+#[test]
+fn test_relationship_pattern_in_where_case_errors_not_panics_901() {
+    // #901 (WHERE form): same panic path via a CASE predicate in WHERE.
+    let query = "MATCH (u:User) WHERE CASE WHEN (u)-[:FOLLOWS]->() THEN true ELSE false END \
+                 RETURN u.user_id";
+    let ast = parse_query(query).expect("Failed to parse query");
+    let schema = create_test_schema();
+
+    let (logical_plan, plan_ctx) = build_logical_plan(&ast, &schema, None, None, None)
+        .expect("should plan (error is at render)");
+    let result =
+        logical_plan_to_render_plan_with_ctx((*logical_plan).clone(), &schema, Some(&plan_ctx));
+    assert!(
+        result.is_err(),
+        "a relationship pattern in a WHERE CASE must render-error, not panic"
+    );
+}


### PR DESCRIPTION
## Summary

`MATCH (u:User) RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0 END` (and the WHERE-CASE form) **panicked the tokio worker** with `unimplemented!` at `render_expr.rs:2036` — in server mode this took down the worker on otherwise-valid Cypher.

## Root cause

`RenderExpr::try_from(LogicalExpr)` had a catch-all `_ => unimplemented!(...)` (plus a nested `unimplemented!` for a name/label-less `PathPattern::Node`). A relationship pattern in expression context (`PathPattern::ConnectedPattern`) reached it — only the bare `PathPattern::Node` label-check form was lowered.

## Fix

Replace both `unimplemented!` calls with a clean `RenderBuildError::UnsupportedFeature` Err (the fn already returns `Result<_, RenderBuildError>`), naming the offending variant and suggesting a top-level MATCH / `EXISTS { … }` workaround. **Ground-rule-1 safe: a panic becomes a loud error, never wrong SQL.**

The full lowering (relationship pattern → correlated EXISTS subquery, the #574/#587 neighborhood) is out of scope.

## Safety

- Supported paths unchanged: `(u:User)` node-label pattern in a CASE still lowers to `u.__label__ = 'User'`; normal `EXISTS { … }` unaffected.
- Verified a spectrum of valid CASE / arithmetic / list-comprehension / reduce / IN / coalesce expressions still render — the new Err does **not** over-catch.

## Tests & gate

- 2 fail-when-reverted panic-guard tests (RETURN + WHERE CASE forms) at the render level (they panic at `render_expr.rs:2036` without the fix).
- `corpus_sweep` 0-churn; `ratchet` net-zero; full gate green (lib 1676, integration 549).

Discovered while fixing #866.

Closes #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)