### PR TITLE
fix(#910): keep the CTE column for any aggregate of a scalar property via WITH

### DIFF
--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1317,7 +1317,67 @@ impl ProjectionTagging {
                     };
 
                     if let Some(t_alias) = table_alias_opt {
+                        // #910: a scalar-valued aggregate argument — a WITH-scalar
+                        // alias (`WITH u.age AS a`), UNWIND element, or parameter —
+                        // is NOT a graph entity, so the per-label node/rel id-column
+                        // rewrite below does not apply. It must instead reference the
+                        // scalar CTE column directly (`ColumnAlias(a)` → `a.a`).
+                        // Leaving it as a bare `TableAlias(a)` makes the downstream
+                        // PropertyRequirements analyzer `require_all(a)` (meaningless
+                        // for a scalar, registers no concrete column), so the CTE
+                        // pruner strips the `u.age AS a` column → `SELECT *` and the
+                        // outer `<agg>(a.a)` references a column the CTE never exports
+                        // (Code 47). #903 fixed this for `count` only, inside the
+                        // count-specific block below; this hoists the SAME scalar
+                        // rewrite to ALL aggregates (sum/avg/min/max/collect/…).
+                        //
+                        // Two scalar shapes: (i) the analyzer typed the alias as a
+                        // scalar variable (`is_scalar()` — literals, UNWIND elements),
+                        // and (ii) a WITH property projection (`u.age AS a`) that types
+                        // as a Node (inheriting u's label) but whose underlying
+                        // projection expression is NOT a bare TableAlias rename — a
+                        // scalar in every meaningful sense (see #903). Both must
+                        // reference the CTE column, not the node-id form.
+                        let is_scalar_alias = plan_ctx
+                            .lookup_variable(t_alias)
+                            .is_some_and(|v| v.is_scalar())
+                            || (plan_ctx.is_projection_alias(t_alias)
+                                && plan_ctx.get_projection_alias_expr(t_alias).is_some_and(
+                                    |underlying| !matches!(underlying, LogicalExpr::TableAlias(_)),
+                                ));
+                        if is_scalar_alias {
+                            let col = LogicalExpr::ColumnAlias(
+                                crate::query_planner::logical_expr::ColumnAlias(
+                                    t_alias.to_string(),
+                                ),
+                            );
+                            let new_arg = if is_distinct {
+                                LogicalExpr::OperatorApplicationExp(OperatorApplication {
+                                    operator: Operator::Distinct,
+                                    operands: vec![col],
+                                })
+                            } else {
+                                col
+                            };
+                            item.expression = LogicalExpr::AggregateFnCall(AggregateFnCall {
+                                name: aggregate_fn_call.name.clone(),
+                                args: vec![new_arg],
+                            });
+                            return Ok(());
+                        }
+
                         if aggregate_fn_call.name.to_lowercase() == "count" {
+                            // NOTE (#910): the two scalar-alias sub-branches inside
+                            // this count block (the `is_scalar()` branch just below and
+                            // the `_ =>` projection-alias-with-scalar-underlying branch
+                            // from #903) are now SUPERSEDED by the aggregate-agnostic
+                            // `is_scalar_alias` rewrite hoisted above — which returns
+                            // early for every scalar arg, count included. They are kept
+                            // (unreachable-but-harmless) rather than deleted because
+                            // removing the `_ =>` arm would make the `match
+                            // underlying_expr` below non-exhaustive; the remaining
+                            // count-only logic here handles genuine graph-entity args
+                            // (node id-column / rel edge-id resolution).
                             // A scalar variable (UNWIND element, WITH-scalar alias,
                             // or parameter) is NOT a graph entity: it has no label or
                             // id column, so the per-label node/rel id-column rewrite

--- a/tests/rust/integration/golden/sql_ir/standard/avg_scalar_property_through_with_910__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/avg_scalar_property_through_with_910__clickhouse.sql
@@ -3,5 +3,5 @@ WITH with_a_cte_0 AS (SELECT
 FROM social.users_bench AS u
 )
 SELECT 
-      sum(a.a) AS "s"
+      avg(a.a) AS "s"
 FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/sql_ir/standard/avg_scalar_property_through_with_910__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/avg_scalar_property_through_with_910__databricks.sql
@@ -1,7 +1,7 @@
 WITH with_a_cte_0 AS (SELECT 
-      u.age AS "a"
+      u.age AS `a`
 FROM social.users_bench AS u
 )
 SELECT 
-      sum(a.a) AS "s"
+      avg(a.a) AS `s`
 FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/sql_ir/standard/collect_scalar_property_through_with_910__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/collect_scalar_property_through_with_910__clickhouse.sql
@@ -3,5 +3,5 @@ WITH with_a_cte_0 AS (SELECT
 FROM social.users_bench AS u
 )
 SELECT 
-      sum(a.a) AS "s"
+      groupArray(a.a) AS "s"
 FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/sql_ir/standard/collect_scalar_property_through_with_910__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/collect_scalar_property_through_with_910__databricks.sql
@@ -1,7 +1,7 @@
 WITH with_a_cte_0 AS (SELECT 
-      u.age AS "a"
+      u.age AS `a`
 FROM social.users_bench AS u
 )
 SELECT 
-      sum(a.a) AS "s"
+      collect_list(a.a) AS `s`
 FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/sql_ir/standard/sum_scalar_property_through_with_903__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/sum_scalar_property_through_with_903__databricks.sql
@@ -1,4 +1,5 @@
-WITH with_a_cte_0 AS (SELECT *
+WITH with_a_cte_0 AS (SELECT 
+      u.age AS `a`
 FROM social.users_bench AS u
 )
 SELECT 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -579,19 +579,27 @@ const CORPUS: &[(&str, &str)] = &[
         "count_distinct_scalar_property_through_with_903",
         "MATCH (u:User) WITH u.age AS a RETURN count(DISTINCT a) AS c",
     ),
-    // #903 scope guard: sum() of the same scalar-property alias is NOT touched by
-    // this fix (it never enters the count-arg block in projection_tagging.rs), so
-    // it stays byte-identical to main — which PINS a KNOWN-BROKEN render: the CTE
-    // degenerates to `SELECT *` and the outer `sum(a.a)` references a column the
-    // CTE never exports (ClickHouse Code 47). sum/avg/min/max/collect through a
-    // scalar-property WITH share the exact root cause the count fix addresses but
-    // via a different property-requirement path, and are still broken → filed as a
-    // follow-up (#910). This golden is intentionally locked to document that the
-    // count fix is SCOPED to count() and did not incidentally change (or fix) the
-    // sibling aggregates — NOT to assert the SQL is valid.
+    // #910: sum()/avg()/min()/max()/collect() of a scalar-property alias through a
+    // WITH barrier now keeps the CTE column (was `SELECT *` + `sum(a.a)` = Code 47,
+    // the sibling of the #903 count() bug via the same property-requirement path).
+    // Fix hoisted the scalar-alias arg rewrite (`TableAlias(a)` → `ColumnAlias(a)`)
+    // out of the count-only block in projection_tagging.rs to ALL aggregates, so
+    // the arg references the CTE column, registers the requirement, and the column
+    // survives pruning. Must render CTE `SELECT u.age AS "a"` + outer `sum(a.a)`.
     (
         "sum_scalar_property_through_with_903",
         "MATCH (u:User) WITH u.age AS a RETURN sum(a) AS s",
+    ),
+    // #910: the rest of the aggregate family — avg and collect — through the same
+    // scalar-property WITH barrier. avg → `avg(a.a)`, collect → `groupArray(a.a)`,
+    // both over CTE `SELECT u.age AS "a"`.
+    (
+        "avg_scalar_property_through_with_910",
+        "MATCH (u:User) WITH u.age AS a RETURN avg(a) AS s",
+    ),
+    (
+        "collect_scalar_property_through_with_910",
+        "MATCH (u:User) WITH u.age AS a RETURN collect(a) AS s",
     ),
     (
         "optional_match",


### PR DESCRIPTION
## Summary

`MATCH (u:User) WITH u.age AS a RETURN sum(a)` (and avg/min/max/collect) rendered `SELECT *` in the CTE body + outer `sum(a.a)` = ClickHouse **Code 47** (`a.a` references a column the CTE never exported). Sibling of #903, which fixed the same shape for `count` only.

## Root cause (same family as #903)

The aggregate arg is a scalar CTE-property alias, but a bare `TableAlias(a)` arg makes the PropertyRequirements analyzer `require_all(a)` — meaningless for a scalar, registers no concrete column — so the CTE pruner strips `u.age AS a` → `SELECT *`. #903 rewrote the arg to `ColumnAlias(a)` (so it references the CTE column and the requirement is kept) but **only inside the `count`-specific block** in `projection_tagging.rs`.

## Fix

Hoist that scalar-alias rewrite **out** of the count block to an aggregate-agnostic `is_scalar_alias` check that fires for **every** aggregate. It covers both scalar shapes:
- `is_scalar()` variables (UNWIND elements, literals), and
- a WITH property/expression projection whose underlying expr is not a bare `TableAlias` rename (#903's insight — these type as Node but are semantically scalar).

The arg then references the CTE column, registers the requirement, and the column survives pruning (`sum(a.a)` / `groupArray(a.a)` over `SELECT u.age AS "a"`).

The count block's two now-superseded scalar sub-branches are kept unreachable-but-harmless (a NOTE explains why): removing the `_ =>` arm would make the inner match non-exhaustive; the count-only logic there still handles genuine graph-entity args (node id-column / rel edge-id resolution).

## Review & safety

Adversarial review — **recommend merge, 0 HIGH/MEDIUM**:
- **Node/rel aggregates NOT misclassified**: `count(u)`→`count(u.user_id)`, `collect(u)`→`groupArray(u.user_id)`, `count(r)`→`count(r.follower_id)`; whole-node `WITH u AS v` has underlying `TableAlias(u)`, correctly excluded (verified on standard + polymorphic schemas).
- **DISTINCT preserved** for all aggregates — `sum(DISTINCT a)` was also broken on main → now fixed.
- **Bonus**: the previously double-Code-47 `WITH u, u.age AS a RETURN u.name, sum(a)` is now valid.
- #865/#903 count goldens byte-unchanged; direct `sum(u.age)` (no WITH) unchanged.

## Tests & gate

- The #903 `sum_scalar_property_through_with_903` scope-guard golden (locked to known-broken output by #903) now renders valid SQL — regenerated + comment updated; +avg and collect goldens added. All fail-when-reverted.
- `corpus_sweep` 0-churn; `ratchet` net-zero; full gate green (lib 1676, integration 549). Shared analyzer path — no Path-C duplicate.

## Out of scope (confirmed not introduced)

Chained double-WITH `WITH u.age AS a WITH a AS b RETURN sum(b)` and whole-node WITH rename with a non-count aggregate still `SELECT *` (same class; count is handled).

Closes #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)