### PR TITLE
fix(#914): follow WITH rename chain to a scalar origin for aggregate args

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -524,6 +524,31 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — chained double-WITH rename of a scalar PROPERTY consumed by
+  a NON-count aggregate no longer renders `SELECT *`** (branch
+  `fix/914-chained-with-rename-non-count-aggregate`, PR #915, closes #914;
+  follow-up to #910 single-hop and #886 chained-`count`).
+  `MATCH (u:User) WITH u.age AS a WITH a AS b RETURN sum(b)` (and avg/min/max/
+  collect) collapsed both CTE bodies to `SELECT *`; the outer `sum(b.b)`
+  referenced a never-exported column → ClickHouse Code 47. **Root cause:** the
+  #910 scalar-aggregate-arg rewrite (`projection_tagging.rs`) recognized a scalar
+  alias only ONE level deep — its shape-(ii) check required the alias's underlying
+  projection expr to be NON-`TableAlias`. On the second rename hop (`WITH a AS b`)
+  `b`'s underlying IS a bare `TableAlias(a)`, so the check was false, the rewrite
+  never fired, `sum(b)` kept a bare `TableAlias(b)` → `require_all(b)` → the CTE
+  column was pruned → `SELECT *`. **Fix:** replace the one-level check with
+  `resolves_to_scalar`, which follows the chain of `TableAlias` renames back to its
+  origin (any hop `is_scalar()`, or the innermost underlying is a non-`TableAlias`
+  scalar projection like `u.age`); a chain bottoming out in an unregistered alias
+  is a genuine graph entity → NOT scalar (falls through to node/rel id-column
+  logic). Bounded by `PlanCtx::projection_alias_count()` so a pathological
+  self-referential registration can't loop. Scope: the rewrite only fires for a
+  bare-`TableAlias` arg, so `sum(v.age)` (PropertyAccess) and whole-node
+  `collect(v)` are untouched. Live-verified (`test_integration.users_test`, 30
+  users, `sum(age)=889`): old binary → Code 47; fixed → 889 (matches oracle).
+  Zero existing-golden churn (554 corpus); 2 new corpus goldens (sum/collect ×
+  CH+Databricks) + unit test over sum/avg/min/max/collect, all fail-when-reverted;
+  ratchet net-zero (helper-routed).
 - 2026-08-02: **Fix — graph pattern in scalar-expression context returns a clean
   error instead of panicking** (branch `fix/901-pattern-in-expr-context-panic`,
   closes #901). `MATCH (u:User) RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -1338,13 +1338,45 @@ impl ProjectionTagging {
                         // projection expression is NOT a bare TableAlias rename — a
                         // scalar in every meaningful sense (see #903). Both must
                         // reference the CTE column, not the node-id form.
-                        let is_scalar_alias = plan_ctx
-                            .lookup_variable(t_alias)
-                            .is_some_and(|v| v.is_scalar())
-                            || (plan_ctx.is_projection_alias(t_alias)
-                                && plan_ctx.get_projection_alias_expr(t_alias).is_some_and(
-                                    |underlying| !matches!(underlying, LogicalExpr::TableAlias(_)),
-                                ));
+                        //
+                        // #914: a CHAINED rename (`WITH u.age AS a WITH a AS b`) makes
+                        // `b`'s underlying projection expr a bare `TableAlias(a)`, so
+                        // the shape-(ii) check above (which requires the underlying to
+                        // be NON-TableAlias) is FALSE at `b` and the rewrite misses —
+                        // `sum(b)` keeps a bare `TableAlias(b)` → pruned → `SELECT *` +
+                        // Code 47. Follow the chain of `TableAlias` renames back to its
+                        // origin: if any hop resolves to a scalar variable, or the
+                        // innermost underlying is a non-`TableAlias` scalar projection,
+                        // the whole chain is scalar. A rename that bottoms out in an
+                        // unregistered alias (a genuine graph entity from MATCH) is NOT
+                        // scalar and falls through to the node/rel id-column logic.
+                        fn resolves_to_scalar(plan_ctx: &PlanCtx, alias: &str) -> bool {
+                            let mut current = alias.to_string();
+                            // Bound the walk by the number of registered aliases so a
+                            // pathological self-referential registration can't loop.
+                            for _ in 0..plan_ctx.projection_alias_count() + 1 {
+                                if plan_ctx
+                                    .lookup_variable(&current)
+                                    .is_some_and(|v| v.is_scalar())
+                                {
+                                    return true;
+                                }
+                                match plan_ctx.get_projection_alias_expr(&current) {
+                                    // A rename hop — follow it to the source alias.
+                                    Some(LogicalExpr::TableAlias(TableAlias(src))) => {
+                                        current = src.clone();
+                                    }
+                                    // Bottoms out in a non-TableAlias projection expr
+                                    // (e.g. `u.age`): a scalar in every meaningful sense.
+                                    Some(_) => return true,
+                                    // Not a projection alias (unregistered) and not a
+                                    // scalar variable → a genuine graph entity.
+                                    None => return false,
+                                }
+                            }
+                            false
+                        }
+                        let is_scalar_alias = resolves_to_scalar(plan_ctx, t_alias);
                         if is_scalar_alias {
                             let col = LogicalExpr::ColumnAlias(
                                 crate::query_planner::logical_expr::ColumnAlias(

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -331,6 +331,13 @@ impl PlanCtx {
         self.projection_aliases.contains_key(alias)
     }
 
+    /// Number of registered projection aliases. Used to bound a walk over the
+    /// rename chain (#914) so a pathological self-referential registration
+    /// cannot loop forever.
+    pub fn projection_alias_count(&self) -> usize {
+        self.projection_aliases.len()
+    }
+
     /// Remove a projection alias, returning its expression if it was present.
     /// Used to scope lambda-bound parameter names to the lambda body during
     /// projection tagging (#866): the param is registered before tagging the

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1233,3 +1233,5 @@
 {"cypher": "UNWIND [1, 2, 3] AS x\n            WITH x AS y\n            WITH y AS z\n            WHERE z > 0\n            RETURN count(z) AS c", "name": "test_886__chained_with_rename_then_where_count", "schema": "social_integration"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) RETURN b.name", "name": "test_808__mixed_arm_vlp_uses_edge_uniqueness", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*1..2]->(b:Person) RETURN count(*) AS trails", "name": "test_808__mixed_arm_vlp_range_count", "schema": "foreign_selfloop"}
+{"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN sum(b) AS total", "name": "test_914__chained_with_rename_of_property_sum", "schema": "social_integration"}
+{"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN collect(b) AS ages", "name": "test_914__chained_with_rename_of_property_collect", "schema": "social_integration"}

--- a/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_collect.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_collect.clickhouse.sql
@@ -1,0 +1,11 @@
+WITH with_a_cte_0 AS (SELECT 
+      u.age AS "a"
+FROM test_integration.users_test AS u
+), 
+with_b_cte_1 AS (SELECT 
+      a.a AS "b"
+FROM with_a_cte_0 AS a
+)
+SELECT 
+      groupArray(b.b) AS "ages"
+FROM with_b_cte_1 AS b

--- a/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_collect.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_collect.databricks.sql
@@ -1,0 +1,11 @@
+WITH with_a_cte_0 AS (SELECT 
+      u.age AS `a`
+FROM test_integration.users_test AS u
+), 
+with_b_cte_1 AS (SELECT 
+      a.a AS `b`
+FROM with_a_cte_0 AS a
+)
+SELECT 
+      collect_list(b.b) AS `ages`
+FROM with_b_cte_1 AS b

--- a/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_sum.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_sum.clickhouse.sql
@@ -1,0 +1,11 @@
+WITH with_a_cte_0 AS (SELECT 
+      u.age AS "a"
+FROM test_integration.users_test AS u
+), 
+with_b_cte_1 AS (SELECT 
+      a.a AS "b"
+FROM with_a_cte_0 AS a
+)
+SELECT 
+      sum(b.b) AS "total"
+FROM with_b_cte_1 AS b

--- a/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_sum.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_914__chained_with_rename_of_property_sum.databricks.sql
@@ -1,0 +1,11 @@
+WITH with_a_cte_0 AS (SELECT 
+      u.age AS `a`
+FROM test_integration.users_test AS u
+), 
+with_b_cte_1 AS (SELECT 
+      a.a AS `b`
+FROM with_a_cte_0 AS a
+)
+SELECT 
+      sum(b.b) AS `total`
+FROM with_b_cte_1 AS b

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -16055,3 +16055,45 @@ async fn rename_then_passthrough_still_collapses_886() {
         "rename-then-passthrough must stay a single collapsed CTE, got:\n{sql}"
     );
 }
+
+/// #914: a chained WITH rename of a node PROPERTY consumed by a NON-count
+/// aggregate. Follow-up to #910 (single-hop) and #886 (chained rename for
+/// `count`). On the second hop (`WITH a AS b`), `b`'s underlying projection
+/// expr is a bare `TableAlias(a)`, so the #910 shape-(ii) guard (which required
+/// the underlying to be NON-TableAlias) was FALSE and the scalar-arg rewrite
+/// missed → `sum(b)` kept a bare `TableAlias(b)`, the CTE column was pruned →
+/// `SELECT *` + a dangling outer `sum(b.b)` (ClickHouse Code 47). The fix
+/// follows the rename chain back to the scalar origin (`u.age`).
+#[tokio::test]
+async fn chained_with_rename_of_property_non_count_aggregate_914() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    for func in ["sum", "avg", "min", "max", "collect"] {
+        let sql = render(
+            &schema,
+            &format!("MATCH (u:User) WITH u.age AS a WITH a AS b RETURN {func}(b) AS r"),
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        // First hop materializes the real property column; second hop renames it.
+        assert!(
+            sql.contains(r#"u.age AS "a""#) && sql.contains(r#"a.a AS "b""#),
+            "{func}: both rename hops must export a real column (u.age AS a, a.a AS b), got:\n{sql}"
+        );
+        // No CTE collapses to SELECT * (the rename-drop symptom).
+        assert!(
+            !sql.contains("SELECT *"),
+            "{func}: no CTE should collapse to SELECT *, got:\n{sql}"
+        );
+        // The outer aggregate resolves against the renamed CTE column `b.b`,
+        // NOT the node-id form (`b.p{N}_b_user_id`) — this is a scalar, not a node.
+        let rendered_fn = if func == "collect" {
+            "groupArray"
+        } else {
+            func
+        };
+        assert!(
+            sql.contains(&format!("{rendered_fn}(b.b)")),
+            "{func}: outer aggregate must resolve to the scalar CTE column b.b, got:\n{sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #914. A chained double-WITH rename of a node property consumed by a **non-count** aggregate rendered invalid SQL:

```cypher
MATCH (u:User) WITH u.age AS a WITH a AS b RETURN sum(b)
```
→ both CTE bodies collapsed to `SELECT *`, outer `sum(b.b)` referenced a never-exported column → ClickHouse **Code 47**. Same for avg/min/max/collect.

## Root cause

The #910 scalar-aggregate-arg rewrite (`projection_tagging.rs`) recognized a scalar alias only **one level deep**: its shape-(ii) check required the alias's underlying projection expr to be NON-`TableAlias`. On the second rename hop (`WITH a AS b`), `b`'s underlying IS a bare `TableAlias(a)`, so the check was false, the rewrite never fired, `sum(b)` kept a bare `TableAlias(b)` → `require_all(b)` → CTE column pruned → `SELECT *`.

## Fix

Replace the one-level check with `resolves_to_scalar`, which **follows the chain of `TableAlias` renames** back to its origin:
- any hop is a scalar variable (`is_scalar()`), or
- the innermost underlying is a non-`TableAlias` scalar projection (e.g. `u.age`) → scalar (reference the CTE column `b.b`).
- chain bottoms out in an unregistered alias → genuine graph entity → NOT scalar (falls through to node/rel id-column logic).

Bounded by `PlanCtx::projection_alias_count()` so a pathological self-referential registration can't loop.

## Scope discipline

The aggregate-arg rewrite only fires for a **bare-`TableAlias`** arg, so `sum(v.age)` (PropertyAccess) and whole-node `collect(v)` are untouched — those render identically with/without the rename (pre-existing whole-node behavior, out of scope, noted in the issue).

## Verification

- **Live** (`test_integration.users_test`, 30 users, `sum(age)=889`): old binary → Code 47 `b.b cannot be resolved`; fixed → **889** (matches oracle). collect → 30 ages.
- **Zero existing-golden churn** across all 553 corpus entries — the property-rename chain had no prior coverage; the #886 UNWIND/literal entries route through `is_scalar()` and are unchanged.
- 2 new corpus entries (sum + collect) + 4 goldens; unit test over sum/avg/min/max/collect.
- `cargo fmt` / `clippy --all-targets` / `cargo test -p clickgraph` (1676 + 550) / ratchet — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)