### PR TITLE
fix(#613): resolve size() pattern-count correlation CTE-aware after a WITH barrier

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -524,7 +524,34 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
-<<<<<<< Updated upstream
+- 2026-08-02: **Fix — `size((pattern))` in RETURN position after a WITH barrier
+  now resolves its correlation column CTE-aware** (branch
+  `fix/613-size-pattern-count-after-with`, closes #613; found during #599's
+  adversarial review, pre-existing on main). `MATCH (a:User) WITH a RETURN
+  a.user_id, size((a)-[:FOLLOWS]->()) AS c` emitted a correlated `COUNT(*)`
+  subquery whose `WHERE user_follows.follower_id = a.user_id` referenced the raw
+  schema column, but after the WITH the outer anchor `a` is a CTE exposing only
+  `p1_a_user_id` → ClickHouse Code 47 UNKNOWN_IDENTIFIER (loud, ground-rule-1
+  safe; violates the forward-through-scope rule, CLAUDE.md §2). **Root cause:**
+  `generate_pattern_count_sql` (single-hop) and
+  `generate_multi_hop_pattern_count_sql` (multi-hop) baked the start-node id via
+  `node_schema.node_id.sql_tuple(start_alias)` — the raw form — instead of the
+  CTE-aware `resolve_correlation_id_sql` that `generate_exists_graph_rel_sql`
+  already uses (the #596 EXISTS template). **Fix:** route both start-id
+  resolutions through `resolve_correlation_id_sql`, which returns the CTE column
+  when the anchor is CTE-scoped and falls back to the raw `sql_tuple` for a fresh
+  MATCH (byte-identical). Only the START node is correlated (named end nodes are
+  internal to the pattern); `_end_id_sql` was already unused. Contrast:
+  WHERE-position size() after WITH already worked (the predicate folds inside the
+  CTE where the raw column is still in scope). Verified all directions
+  (out/in/undirected) + multi-hop after WITH resolve `a.p1_a_user_id`; fresh
+  MATCH stays `a.user_id` byte-identical; corpus_sweep 0-churn (no prior coverage
+  of size()-after-WITH), 2 new dual-dialect corpus goldens + unit test, all
+  fail-when-reverted; ratchet net-zero (shared helper, no axis predicates); full
+  gate green. No live CH (SQL-shape + byte goldens). Composite-id start nodes are
+  unaffected (the correlation falls back to the raw tuple when not all id columns
+  resolve to CTE columns — byte-identical to main; the pre-existing composite LHS
+  malformation is separate and worth a follow-up).
 - 2026-08-02: **Fix — chained double-WITH rename of a scalar PROPERTY consumed by
   a NON-count aggregate no longer renders `SELECT *`** (branch
   `fix/914-chained-with-rename-non-count-aggregate`, PR #915, closes #914;
@@ -550,25 +577,6 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   Zero existing-golden churn (554 corpus); 2 new corpus goldens (sum/collect ×
   CH+Databricks) + unit test over sum/avg/min/max/collect, all fail-when-reverted;
   ratchet net-zero (helper-routed).
-=======
-- 2026-08-02: **Fix — chained WITH rename of a property consumed by a non-count
-  aggregate** (branch `fix/914-chained-with-rename-non-count-aggregate`, PR #915,
-  `05b57045`, closes #914). `MATCH (u:User) WITH u.age AS a WITH a AS b RETURN
-  sum(b)` (and avg/min/max/collect) rendered `SELECT *` in both CTE bodies + an
-  outer `sum(b.b)` referencing a never-exported column → ClickHouse Code 47.
-  **Root cause:** the #910 scalar-aggregate-arg rewrite recognized a scalar alias
-  only one level deep (shape-(ii) required the alias's underlying projection expr
-  to be NON-`TableAlias`); on the second rename hop `b`'s underlying IS a bare
-  `TableAlias(a)`, so the rewrite missed and `sum(b)` kept a bare `TableAlias(b)` →
-  `require_all(b)` → CTE column pruned → `SELECT *`. **Fix:** `resolves_to_scalar`
-  follows the chain of `TableAlias` renames back to its origin (scalar variable, or
-  innermost non-`TableAlias` scalar projection); bottoms out in an unregistered
-  alias → genuine graph entity → NOT scalar. Bounded by new
-  `PlanCtx::projection_alias_count()`. Whole-node `collect(v)` / `sum(v.age)` are
-  untouched (rewrite only fires for a bare-`TableAlias` arg). ZERO existing-golden
-  churn; live-verified sum(age)=889 (old → Code 47). Review APPROVE-0.
-
->>>>>>> Stashed changes
 - 2026-08-02: **Fix — graph pattern in scalar-expression context returns a clean
   error instead of panicking** (branch `fix/901-pattern-in-expr-context-panic`,
   closes #901). `MATCH (u:User) RETURN CASE WHEN (u)-[:FOLLOWS]->() THEN 1 ELSE 0

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -885,7 +885,9 @@ fn generate_multi_hop_pattern_count_sql(
     let start_node_schema = schema
         .node_schema_opt(&start_node_label)
         .ok_or_else(|| RenderBuildError::NodeSchemaNotFound(start_node_label.clone()))?;
-    let start_id_sql = start_node_schema.node_id.sql_tuple(start_alias);
+    // #613: CTE-aware correlation id (see the single-hop path). Falls back to the
+    // raw `sql_tuple` for a fresh MATCH, so non-WITH multi-hop is byte-identical.
+    let start_id_sql = resolve_correlation_id_sql(start_alias, start_node_schema);
 
     // Build FROM clause with JOINs
     let first_table = if !first_rel_schema.database.is_empty() {
@@ -1095,20 +1097,28 @@ fn generate_pattern_count_sql(pattern: &PathPattern) -> Result<String, RenderBui
                     let from_col = &rel_schema.from_id;
                     let to_col = &rel_schema.to_id;
 
-                    // Get the start node's ID column
-                    // First try the explicit label from the pattern, then fall back to relationship schema
+                    // Get the start node's ID column.
+                    // First try the explicit label from the pattern, then fall back to relationship schema.
+                    //
+                    // #613: resolve the correlation id CTE-aware (mirrors
+                    // `generate_exists_graph_rel_sql`). After a WITH barrier the outer
+                    // anchor `a` is a CTE exposing only the renamed column
+                    // `p{N}_a_user_id`, so a raw `a.user_id` reference is an unknown
+                    // identifier (Code 47). `resolve_correlation_id_sql` returns the
+                    // CTE column when `a` is CTE-scoped and falls back to the raw
+                    // `sql_tuple` for a fresh MATCH (byte-identical to prior behavior).
                     let start_id_sql = if let Some(label) = &conn.start_node.label {
                         let node_schema = schema
                             .node_schema_opt(label)
                             .ok_or_else(|| RenderBuildError::NodeSchemaNotFound(label.clone()))?;
-                        node_schema.node_id.sql_tuple(start_alias)
+                        resolve_correlation_id_sql(start_alias, node_schema)
                     } else {
                         // No label in pattern - infer from relationship's from_node
                         let node_type = &rel_schema.from_node;
                         let node_schema = schema.node_schema_opt(node_type).ok_or_else(|| {
                             RenderBuildError::NodeSchemaNotFound(node_type.clone())
                         })?;
-                        node_schema.node_id.sql_tuple(start_alias)
+                        resolve_correlation_id_sql(start_alias, node_schema)
                     };
 
                     // Get end node's ID column

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -6239,8 +6239,9 @@ fn publish_cte_alias_scopes(
         // correlation variable that must resolve through the CTE scope
         // active *at this exact point* in `build_chained_with_match_cte_plan`,
         // before the variable moves on to a later WITH clause's CTE. It
-        // is written only here and read only by `generate_exists_sql`'s
-        // `GraphRel` branch, so it cannot affect any other resolution.
+        // is written only here and read by `resolve_correlation_id_sql`
+        // (EXISTS `GraphRel` correlation and, since #613, `size()`
+        // pattern-count correlation), so it cannot affect any other resolution.
         crate::server::query_context::set_cte_scope_for_correlation(
             alias.clone(),
             extract_from_alias_from_cte_name(cte_name).to_string(),

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -145,8 +145,9 @@ pub struct QueryContext {
     /// property access instead resolves forward via the render-site registry
     /// identity self-map and `plan_ctx` CTE columns — see the F0/F1
     /// forward-resolution work). Written only in
-    /// `build_chained_with_match_cte_plan`; read only by `generate_exists_sql`
-    /// — cannot affect any other resolution path.
+    /// `build_chained_with_match_cte_plan`; read by `resolve_correlation_id_sql`
+    /// (EXISTS `GraphRel` correlation and, since #613, `size()` pattern-count
+    /// correlation) — cannot affect any other resolution path.
     ///
     /// The `generation` tag (see `cte_scope_generation` /
     /// `enter_cte_scope_generation`) is what keeps this safe across

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1237,3 +1237,5 @@
 {"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN collect(b) AS ages", "name": "test_914__chained_with_rename_of_property_collect", "schema": "social_integration"}
 {"cypher": "MATCH (a:Comment)-[:REPLY_OF*1..2]->(a) RETURN count(*) AS c", "name": "test_902__fk_edge_selfref_vlp_closed_follows_fk", "schema": "ldbc_snb"}
 {"cypher": "MATCH (a:Comment)-[:REPLY_OF*1..2]->(b:Comment) RETURN count(*) AS c", "name": "test_902__fk_edge_selfref_vlp_open_follows_fk", "schema": "ldbc_snb"}
+{"cypher": "MATCH (a:User)\n            WITH a\n            RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c", "name": "test_613__size_pattern_count_after_with_single_hop", "schema": "social_integration"}
+{"cypher": "MATCH (a:User)\n            WITH a\n            RETURN a.user_id, size((a)-[:FOLLOWS]->()-[:FOLLOWS]->()) AS c", "name": "test_613__size_pattern_count_after_with_multi_hop", "schema": "social_integration"}

--- a/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_multi_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_multi_hop.clickhouse.sql
@@ -1,0 +1,8 @@
+WITH with_a_cte_0 AS (SELECT 
+      a.user_id AS "p1_a_user_id"
+FROM test_integration.users_test AS a
+)
+SELECT 
+      a.p1_a_user_id AS "a.user_id", 
+      coalesce((SELECT COUNT(*) FROM test_integration.user_follows_test AS r1 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id WHERE r1.follower_id = a.p1_a_user_id), 0) AS "c"
+FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_multi_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_multi_hop.databricks.sql
@@ -1,0 +1,8 @@
+WITH with_a_cte_0 AS (SELECT 
+      a.user_id AS `p1_a_user_id`
+FROM test_integration.users_test AS a
+)
+SELECT 
+      a.p1_a_user_id AS `a.user_id`, 
+      coalesce((SELECT COUNT(*) FROM test_integration.user_follows_test AS r1 INNER JOIN test_integration.user_follows_test AS r2 ON r1.followed_id = r2.follower_id WHERE r1.follower_id = a.p1_a_user_id), 0) AS `c`
+FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_single_hop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_single_hop.clickhouse.sql
@@ -1,0 +1,8 @@
+WITH with_a_cte_0 AS (SELECT 
+      a.user_id AS "p1_a_user_id"
+FROM test_integration.users_test AS a
+)
+SELECT 
+      a.p1_a_user_id AS "a.user_id", 
+      coalesce((SELECT COUNT(*) FROM test_integration.user_follows_test WHERE user_follows_test.follower_id = a.p1_a_user_id), 0) AS "c"
+FROM with_a_cte_0 AS a

--- a/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_single_hop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_613__size_pattern_count_after_with_single_hop.databricks.sql
@@ -1,0 +1,8 @@
+WITH with_a_cte_0 AS (SELECT 
+      a.user_id AS `p1_a_user_id`
+FROM test_integration.users_test AS a
+)
+SELECT 
+      a.p1_a_user_id AS `a.user_id`, 
+      coalesce((SELECT COUNT(*) FROM test_integration.user_follows_test WHERE user_follows_test.follower_id = a.p1_a_user_id), 0) AS `c`
+FROM with_a_cte_0 AS a

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -7948,6 +7948,76 @@ async fn size_pattern_count_coalesces_null_to_zero() {
     }
 }
 
+/// #613: `size((pattern))` in RETURN position AFTER a WITH barrier must
+/// resolve its correlation column CTE-aware. Before the fix,
+/// `generate_pattern_count_sql`/`generate_multi_hop_pattern_count_sql` baked
+/// the raw schema column (`a.user_id`) via `node_id.sql_tuple`, but after the
+/// WITH the outer anchor `a` is a CTE exposing only the renamed column
+/// (`p1_a_user_id`) → ClickHouse Code 47 UNKNOWN_IDENTIFIER (loud, not
+/// silent; violates the forward-through-scope rule, CLAUDE.md §2). The fix
+/// routes both single- and multi-hop start-id resolution through
+/// `resolve_correlation_id_sql` (the same helper `generate_exists_graph_rel_sql`
+/// uses), which returns the CTE column when the anchor is CTE-scoped and falls
+/// back to the raw `sql_tuple` for a fresh MATCH.
+///
+/// Note: WHERE-position size() after WITH already worked (the predicate folds
+/// inside the CTE where the raw column is still in scope) — covered by
+/// `size_pattern_count_coalesces_null_to_zero`; this test is the RETURN
+/// (outer-scope) position that was broken.
+#[tokio::test]
+async fn size_pattern_count_after_with_resolves_cte_column_613() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+    // Each of these emits a CTE `with_a_cte_0` that renames user_id to
+    // `p1_a_user_id`; the correlation MUST reference that CTE column.
+    let after_with = [
+        // Outgoing (the #613 headline repro).
+        "MATCH (a:User) WITH a RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c",
+        // WITH DISTINCT variant.
+        "MATCH (a:User) WITH DISTINCT a RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c",
+        // Incoming.
+        "MATCH (a:User) WITH a RETURN a.user_id, size((a)<-[:FOLLOWS]-()) AS c",
+        // Undirected.
+        "MATCH (a:User) WITH a RETURN a.user_id, size((a)-[:FOLLOWS]-()) AS c",
+        // Multi-hop chain (generate_multi_hop_pattern_count_sql path).
+        "MATCH (a:User) WITH a RETURN a.user_id, size((a)-[:FOLLOWS]->()-[:FOLLOWS]->()) AS c",
+    ];
+    for cypher in after_with {
+        let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        // The correlation predicate must reference the CTE column, never the
+        // raw schema column that isn't exported by the CTE.
+        assert!(
+            sql.contains("= a.p1_a_user_id") || sql.contains("r1.follower_id = a.p1_a_user_id"),
+            "[{cypher}] size() correlation must reference the CTE column \
+             a.p1_a_user_id, not the raw schema column:\n{sql}"
+        );
+        assert!(
+            !sql.contains("= a.user_id"),
+            "[{cypher}] size() correlation still bakes the raw schema column \
+             a.user_id (unknown identifier after the WITH barrier → Code 47):\n{sql}"
+        );
+    }
+
+    // Negative control: a FRESH MATCH (no WITH barrier) must be byte-identical
+    // to prior behavior — the anchor is a real table, so the correlation keeps
+    // the raw schema column `a.user_id` (resolve_correlation_id_sql falls back).
+    let fresh_cases = [
+        "MATCH (a:User) RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c",
+        "MATCH (a:User) RETURN size((a)-[:FOLLOWS]->()-[:FOLLOWS]->()) AS c",
+    ];
+    for cypher in fresh_cases {
+        let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        assert!(
+            sql.contains("= a.user_id") || sql.contains("r1.follower_id = a.user_id"),
+            "[{cypher}] fresh-MATCH size() must keep the raw schema column \
+             a.user_id (no CTE scope to resolve against):\n{sql}"
+        );
+        assert!(
+            !sql.contains("p1_a_user_id"),
+            "[{cypher}] fresh MATCH should not introduce a CTE column:\n{sql}"
+        );
+    }
+}
+
 /// #466 round 4 (adversarial-review blocking finding): `id(alias)` on a
 /// `pattern_union` endpoint must resolve LABEL-AGNOSTICALLY to the CTE's
 /// start_id/end_id — never to ONE label's id column.


### PR DESCRIPTION
## Summary

Fixes #613. `size((pattern))` in **RETURN position after a WITH barrier** rendered invalid SQL:

```cypher
MATCH (a:User) WITH a RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c
```
→ the correlated `COUNT(*)` subquery emitted `WHERE user_follows.follower_id = a.user_id`, but after the WITH the outer anchor `a` is a CTE exposing only `p1_a_user_id` → ClickHouse **Code 47** UNKNOWN_IDENTIFIER. Loud (ground-rule-1 safe); found during #599's adversarial review, pre-existing on main. Violates the forward-through-scope rule (CLAUDE.md §2).

## Root cause

`generate_pattern_count_sql` (single-hop) and `generate_multi_hop_pattern_count_sql` (multi-hop) baked the start-node id via `node_schema.node_id.sql_tuple(start_alias)` — the **raw** schema column — instead of the CTE-aware `resolve_correlation_id_sql` that `generate_exists_graph_rel_sql` already uses (the #596 EXISTS template).

## Fix

Route both start-id resolutions through `resolve_correlation_id_sql`, which returns the CTE column when the anchor is CTE-scoped and falls back to the raw `sql_tuple` for a fresh MATCH (byte-identical). Only the **START** node is correlated — named end nodes are internal to the pattern (`_end_id_sql` was already unused).

## Scope discipline

- **WHERE-position** size() after WITH already worked (the predicate folds inside the CTE where the raw column is still in scope) — untouched, still covered by `size_pattern_count_coalesces_null_to_zero`.
- **Fresh MATCH** (no WITH): `resolve_correlation_id_sql` falls back to `sql_tuple`, so the correlation keeps the raw `a.user_id` — **byte-identical** to prior behavior (negative control asserted).

## Verification

- SQL-shape verified (no live CH): out/in/undirected + multi-hop after WITH all resolve `a.p1_a_user_id`; fresh MATCH stays `a.user_id`.
- **corpus_sweep 0-churn** (no prior coverage of size()-after-WITH).
- 2 new dual-dialect corpus goldens (single/multi-hop × CH+Databricks) + unit test `size_pattern_count_after_with_resolves_cte_column_613`, all fail-when-reverted.
- **ratchet net-zero** (shared helper, no new axis predicates).
- Full gate green: `cargo fmt --all && cargo clippy --all-targets && cargo test`.

Closes #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)