### PR TITLE
fix(#899): resolve closed self-ref OPTIONAL VLP anchor property from the anchor table

### DIFF
--- a/src/render_plan/vlp_rewrite.rs
+++ b/src/render_plan/vlp_rewrite.rs
@@ -84,22 +84,27 @@ pub fn rewrite_vlp_aggregate_aliases(plan: &mut RenderPlan) -> RenderPlanBuilder
     // Extract VLP metadata from CTEs
     for cte in &plan.ctes.0 {
         if let Some(ref cypher_end_alias) = cte.vlp_cypher_end_alias {
-            // #647: skip only for a GENUINE end-anchored inversion — the FROM
-            // binds the end alias AND the pattern's two endpoints are distinct
-            // (`start_alias != end_alias`). A CLOSED VLP (`(a)<-[*]-(a)`) has
-            // start_alias == end_alias == the FROM anchor; it is a separate,
-            // loud-on-main shape (#625/#631) left on the original layout by the
-            // analyzer, so it must NOT be skipped here (skipping would silently
-            // change its projection). Guarding on distinct endpoints keeps it
-            // byte-identical.
-            let endpoints_distinct =
-                cte.vlp_cypher_start_alias.as_deref() != Some(cypher_end_alias.as_str());
-            if single_vlp_join
-                && endpoints_distinct
-                && Some(cypher_end_alias.as_str()) == optional_vlp_from_anchor
-            {
+            // #647: skip when the FROM binds the end alias — the anchor's
+            // properties then come from the base table, not the VLP CTE, so
+            // mapping `a.name → vt0.name` emits a column the CTE never exposes
+            // (Code 47). This covers TWO shapes, both with the end alias bound in
+            // FROM:
+            //   (1) end-anchored inversion `(a)<-[*]-(b)` with distinct endpoints
+            //       (#647): FROM binds the END, the far START is CTE-projected.
+            //   (2) closed self-reference `(a)-[*]->(a)` / `(a)<-[*]-(a)` (#899):
+            //       start_alias == end_alias == the FROM anchor. `a.name` is an
+            //       anchor-table property (read from FROM); only its endpoint id /
+            //       path columns live on the CTE, and those are projected via
+            //       `rewrite_vlp_union_branch_aliases`, not here. Previously this
+            //       skip was gated on DISTINCT endpoints, so the closed shape fell
+            //       through and mis-mapped `a.<prop>` to `vt0.<prop>` (#899).
+            // In both cases the FROM anchor equals this CTE's end alias, so keying
+            // the skip on that equality alone is correct and byte-identical for the
+            // common anchor-at-start layout (where the FROM alias is the start, not
+            // the end alias, so the skip never fires).
+            if single_vlp_join && Some(cypher_end_alias.as_str()) == optional_vlp_from_anchor {
                 log::debug!(
-                    "🔧 VLP aggregate rewrite: skipping FROM-bound anchor end alias '{}' (#647 end-anchored OPTIONAL VLP)",
+                    "🔧 VLP aggregate rewrite: skipping FROM-bound anchor end alias '{}' (end-anchored #647 / closed self-ref #899 OPTIONAL VLP)",
                     cypher_end_alias
                 );
                 continue;

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.clickhouse.sql
@@ -22,8 +22,8 @@ WITH RECURSIVE vlp_a_a AS (
       AND NOT has(vp.path_edges, tuple(rel.follower_id, rel.followed_id))
 )
 SELECT 
-      vt0.name AS "a.name", 
+      a.name AS "a.name", 
       count(*) AS "paths"
 FROM test_integration.users AS a
 LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id
-GROUP BY vt0.name
+GROUP BY a.name

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.databricks.sql
@@ -22,8 +22,8 @@ WITH RECURSIVE vlp_a_a AS (
       AND NOT array_contains(vp.path_edges, struct(rel.follower_id, rel.followed_id))
 )
 SELECT 
-      vt0.name AS `a.name`, 
+      a.name AS `a.name`, 
       count(*) AS `paths`
 FROM test_integration.users AS a
 LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id
-GROUP BY vt0.name
+GROUP BY a.name

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -7935,6 +7935,38 @@ async fn end_anchored_optional_vlp_drives_from_anchor_and_joins_on_end_id_647() 
     );
 }
 
+/// #899: a CLOSED self-referencing OPTIONAL VLP `(a)-[:R*..]->(a)` (start alias
+/// == end alias == the FROM anchor) previously mis-mapped the anchor's own
+/// properties onto the VLP CTE join alias (`a.name → vt0.name` in SELECT and
+/// GROUP BY), a column the CTE never exposes → ClickHouse Code 47. The anchor
+/// `a` is bound in FROM, so its non-endpoint properties must read from the
+/// anchor table. The aggregate-alias rewrite now skips the FROM-bound end anchor
+/// for the closed case (as it already did for the #647 distinct-endpoint case).
+#[tokio::test]
+async fn closed_self_ref_optional_vlp_anchor_property_from_anchor_table_899() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH (a:TestUser) OPTIONAL MATCH (a)-[:TEST_FOLLOWS*1..]->(a) \
+             RETURN a.name, COUNT(*) as paths",
+            dialect,
+        )
+        .await;
+        // The anchor property + GROUP BY must reference the anchor table `a`,
+        // never the VLP CTE join alias `vt0` (which exposes no `name` column).
+        // (Dialects quote the output alias differently — assert on the source ref.)
+        assert!(
+            sql.contains("a.name AS ") && !sql.contains("vt0.name"),
+            "#899 ({dialect:?}): anchor property must project from the anchor table `a.name`, not `vt0.name`:\n{sql}"
+        );
+        assert!(
+            sql.contains("GROUP BY a.name") && !sql.contains("GROUP BY vt0.name"),
+            "#899 ({dialect:?}): GROUP BY must reference the anchor column `a.name`:\n{sql}"
+        );
+    }
+}
+
 /// #599: `size((pattern))` renders as a bare correlated `COUNT(*)` scalar
 /// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
 /// with ZERO pattern matches yields NULL instead of 0 — silently breaking


### PR DESCRIPTION
## Summary

Fixes #899. A CLOSED self-referencing VLP in OPTIONAL MATCH — `(a)-[:R*..]->(a)`, start alias == end alias == the FROM-bound anchor — mapped the anchor's own properties onto the VLP CTE join alias (`a.name → vt0.name` in SELECT and GROUP BY). `vt0` (`vlp_a_a`) projects only `start_id`/`end_id`/`hop_count`/`path_*`, never `name` → ClickHouse **Code 47** `Identifier 'vt0.name' cannot be resolved`.

## Root cause

`rewrite_vlp_aggregate_aliases` maps a VLP end alias → its CTE join alias (`b.<prop>` → `vt0.<prop>`). #647 already skips this when the FROM binds the end alias (anchor properties come from the base table) — but that skip was gated on the two endpoints being **distinct**, so the closed self-ref shape (start == end) fell through and mis-mapped `a.<prop>`.

## Fix

Drop the `endpoints_distinct` guard — the skip now fires whenever the CTE's end alias equals the FROM-bound anchor, covering both the #647 distinct-endpoint inversion and the #899 closed self-reference. **Byte-identical** for the common anchor-at-start layout (FROM alias is the start, so the skip never fires). Endpoint id/path columns still bind to the CTE via `rewrite_vlp_union_branch_aliases`.

## Verification

- **Live** (`test_integration`, DAG follows graph): old binary → Code 47 `vt0.name cannot be resolved`; fixed → executes, `a.name` grouped from the anchor table.
- The `test_optional_match_self_reference` golden (both dialects) changes exactly `vt0.name → a.name` in SELECT + GROUP BY.
- Golden test over both dialects; `cargo test -p clickgraph` (1678 + 551) / ratchet / clippy clean.

## Scope

Filed **#922** for two adjacent PRE-EXISTING defects in the same query (the anchor `WHERE a.name` is dropped; the closed constraint `end_id = start_id` is missing) — both reproduce on the old binary, independent of this projection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)