### PR TITLE
fix(#921): defer size() composite-FK pattern count LOUD instead of malformed SQL

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -524,6 +524,29 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — `size((composite-FK pattern))` now fails LOUD instead of
+  emitting malformed SQL** (branch `fix/921-composite-fk-size-guard`, closes #921;
+  follow-up to #613, surfaced during its review). On a composite-id schema,
+  `size((a:Account)-[:TRANSFERRED]->())` (composite `from_id`) emitted
+  `WHERE transfers.from_bank_id, from_account_number = (...)` — the correlation
+  WHERE **LHS** is a bare comma-list (`rel_schema.from_id`/`to_id` stringified),
+  invalid SQL (ground-rule-1). **Root cause:** `generate_pattern_count_sql` and
+  `generate_multi_hop_pattern_count_sql` (`render_expr.rs`) interpolate the facing
+  edge FK column verbatim into the WHERE/JOIN and had no composite guard — unlike
+  `generate_exists_graph_rel_sql`, which already defers composite FK columns.
+  **Fix:** add a **direction-aware** composite guard to both pattern-count paths —
+  defer LOUD (`UnsupportedFeature`, suggesting a top-level `MATCH ... WITH
+  count(*)`) when the column actually used as the correlation/JOIN predicate is
+  composite. Direction-aware so a SINGLE-column facing side still renders even when
+  the opposite side is composite: `(c:Customer)-[:OWNS]->()` (single `from_id`)
+  keeps working; `(a:Account)<-[:OWNS]-()` (composite `to_id`) and
+  `(a)-[:TRANSFERRED]->()` (composite `from_id`) now error cleanly. Standard/FK
+  single-column schemas byte-identical (corpus_sweep 0-churn, #613 goldens
+  unchanged); new regression test over composite out/in/after-WITH/multi-hop +
+  single-column negative control, fail-when-reverted; ratchet net-zero. Option 1
+  (loud guard) of #921; option 2 (real composite tuple-equality) remains open if
+  composite `size()` support is wanted.
+
 - 2026-08-02: **Fix — closed self-ref OPTIONAL VLP resolves the anchor property
   from the anchor table** (branch `fix/899-optional-closed-vlp-anchor-prop`, PR
   #923, closes #899). `MATCH (a) OPTIONAL MATCH (a)-[:R*..]->(a) RETURN a.name,

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -908,6 +908,19 @@ fn generate_multi_hop_pattern_count_sql(
         Direction::Incoming => &first_rel_schema.to_id,
         _ => &first_rel_schema.from_id, // default
     };
+    // #921: the correlation predicate `r1.{first_col} = ...` references the edge
+    // column verbatim; a COMPOSITE FK column stringifies to a bare comma-list =
+    // malformed SQL. Defer LOUD rather than emit garbage (mirrors the single-hop
+    // guard and `generate_exists_graph_rel_sql`).
+    if first_col.columns().len() != 1 {
+        return Err(RenderBuildError::UnsupportedFeature(format!(
+            "size() multi-hop pattern count over relationship '{}' with a COMPOSITE \
+             foreign-key column is not supported (the correlation predicate needs \
+             composite-key tuple equality). Express it as a top-level MATCH ... \
+             WITH count(*) instead.",
+            first_rel_type
+        )));
+    }
     where_conditions.push(format!("r1.{} = {}", first_col, start_id_sql));
 
     // Add subsequent relationships as JOINs
@@ -997,6 +1010,19 @@ fn generate_multi_hop_pattern_count_sql(
             Direction::Incoming => &rel_schema.to_id,
             _ => &rel_schema.from_id,
         };
+
+        // #921: the JOIN ON references both columns verbatim; a COMPOSITE column
+        // on either side stringifies to a bare comma-list = malformed SQL. Defer
+        // LOUD (consistent with the correlation guard above).
+        if prev_end_col.columns().len() != 1 || curr_start_col.columns().len() != 1 {
+            return Err(RenderBuildError::UnsupportedFeature(format!(
+                "size() multi-hop pattern count over relationship '{}' with a COMPOSITE \
+                 foreign-key column is not supported (the JOIN predicate needs \
+                 composite-key tuple equality). Express it as a top-level MATCH ... \
+                 WITH count(*) instead.",
+                rel_type
+            )));
+        }
 
         from_clause.push_str(&format!(
             " INNER JOIN {} AS {} ON {}.{} = {}.{}",
@@ -1096,6 +1122,34 @@ fn generate_pattern_count_sql(pattern: &PathPattern) -> Result<String, RenderBui
                     };
                     let from_col = &rel_schema.from_id;
                     let to_col = &rel_schema.to_id;
+
+                    // #921: the correlation WHERE below references the facing edge
+                    // column verbatim (`{table}.{from_col}`/`{to_col}`). A COMPOSITE
+                    // FK column stringifies to a bare comma-list (`from_bank_id,
+                    // from_account_number`), which is malformed SQL there. Defer LOUD
+                    // (ground-rule-1) rather than emit garbage — mirrors the composite
+                    // deferral `generate_exists_graph_rel_sql` already applies. The
+                    // guard is DIRECTION-AWARE: only the column(s) actually used as the
+                    // correlation predicate matter, so a single-column facing side
+                    // (e.g. `(c:Customer)-[:OWNS]->()` on a single `from_id`) keeps
+                    // working even when the OPPOSITE side is composite.
+                    let correlation_is_composite = match conn.relationship.direction {
+                        Direction::Outgoing => from_col.columns().len() != 1,
+                        Direction::Incoming => to_col.columns().len() != 1,
+                        // Undirected references BOTH facing columns in the OR.
+                        Direction::Either => {
+                            from_col.columns().len() != 1 || to_col.columns().len() != 1
+                        }
+                    };
+                    if correlation_is_composite {
+                        return Err(RenderBuildError::UnsupportedFeature(format!(
+                            "size() pattern count over relationship '{}' with a COMPOSITE \
+                             foreign-key column is not supported (the correlation predicate \
+                             needs composite-key tuple equality). Express it as a top-level \
+                             MATCH ... WITH count(*) instead.",
+                            rel_type
+                        )));
+                    }
 
                     // Get the start node's ID column.
                     // First try the explicit label from the pattern, then fall back to relationship schema.

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8077,6 +8077,64 @@ async fn size_pattern_count_after_with_resolves_cte_column_613() {
     }
 }
 
+/// #921 (follow-up to #613): `size((pattern))` over a relationship whose FACING
+/// correlation FK column is COMPOSITE must fail LOUD, not emit malformed SQL.
+/// Before the guard, `generate_pattern_count_sql`/`generate_multi_hop_...`
+/// interpolated `rel_schema.from_id`/`to_id` verbatim into the WHERE/JOIN, and a
+/// composite id stringifies to a bare comma-list (`from_bank_id,
+/// from_account_number`) → invalid SQL (ground-rule-1 violation). The guard is
+/// DIRECTION-AWARE: only the column(s) actually used as the correlation/JOIN
+/// predicate matter, so a single-column FACING side still renders even when the
+/// opposite side is composite.
+#[tokio::test]
+async fn size_pattern_count_composite_fk_errors_cleanly_921() {
+    let schema = load_schema(SchemaId::CompositeId.yaml_path());
+    // Composite FACING column → clean UnsupportedFeature error.
+    let composite_cases = [
+        // TRANSFERRED outgoing: from_id = [from_bank_id, from_account_number].
+        "MATCH (a:Account) RETURN size((a)-[:TRANSFERRED]->()) AS n",
+        // OWNS incoming: to_id = [bank_id, account_number].
+        "MATCH (a:Account) RETURN size((a)<-[:OWNS]-()) AS n",
+        // After a WITH barrier (the #613 position) — still errors, not malformed.
+        "MATCH (a:Account) WITH a RETURN size((a)-[:TRANSFERRED]->()) AS n",
+        // Multi-hop over a composite edge.
+        "MATCH (a:Account) RETURN size((a)-[:TRANSFERRED]->()-[:TRANSFERRED]->()) AS n",
+    ];
+    for cypher in composite_cases {
+        let result = try_render(&schema, cypher, SqlDialect::ClickHouse).await;
+        let err = result
+            .as_ref()
+            .err()
+            .unwrap_or_else(|| {
+                panic!("[{cypher}] composite-FK size() must error, not render: {result:?}")
+            })
+            .clone();
+        assert!(
+            err.contains("UnsupportedFeature") && err.contains("COMPOSITE"),
+            "[{cypher}] expected a composite-FK UnsupportedFeature error, got:\n{err}"
+        );
+        // Never leak the malformed bare comma-list into any emitted string.
+        assert!(
+            !err.contains("from_bank_id, from_account_number")
+                && !err.contains("bank_id, account_number"),
+            "[{cypher}] error must not contain the malformed comma-list SQL:\n{err}"
+        );
+    }
+
+    // Negative control: a SINGLE-column facing side still renders (direction-aware
+    // guard). OWNS outgoing correlates on the single `from_id = customer_id`.
+    let sql = render(
+        &schema,
+        "MATCH (c:Customer) RETURN size((c)-[:OWNS]->()) AS n",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        sql.contains("account_ownership.customer_id = c.customer_id"),
+        "single-column OWNS outgoing must still render its correlation:\n{sql}"
+    );
+}
+
 /// #466 round 4 (adversarial-review blocking finding): `id(alias)` on a
 /// `pattern_union` endpoint must resolve LABEL-AGNOSTICALLY to the CTE's
 /// start_id/end_id — never to ONE label's id column.


### PR DESCRIPTION
## Summary

Fixes #921 (option 1). Follow-up to #613, surfaced during its adversarial review. On a composite-id schema, `size()` over a relationship whose facing FK column is **composite** emitted malformed SQL:

```cypher
MATCH (a:Account) RETURN size((a)-[:TRANSFERRED]->()) AS n
```
→ `WHERE transfers.from_bank_id, from_account_number = (...)` — the WHERE **LHS** is a bare, unparenthesized comma-list (`rel_schema.from_id`/`to_id` stringified), invalid SQL (ground-rule-1: never silently/loudly wrong output).

## Root cause

`generate_pattern_count_sql` (single-hop) and `generate_multi_hop_pattern_count_sql` (multi-hop) in `src/render_plan/render_expr.rs` interpolate the facing edge FK column **verbatim** into the correlation WHERE / JOIN ON, and had **no composite guard** — unlike `generate_exists_graph_rel_sql`, which already defers composite FK columns (`from_id.columns().len() != 1 → return None`).

## Fix

Add a **direction-aware** composite guard to both pattern-count paths: defer LOUD (`UnsupportedFeature`, suggesting a top-level `MATCH ... WITH count(*)`) when the column **actually used** as the correlation/JOIN predicate is composite.

Direction-awareness is load-bearing — a blanket guard (like EXISTS's) would over-reject:

| Pattern | facing column | behavior |
|---|---|---|
| `(c:Customer)-[:OWNS]->()` | `from_id = customer_id` (single) | **still renders** ✓ |
| `(a:Account)<-[:OWNS]-()` | `to_id = [bank_id, account_number]` | clean error ✓ |
| `(a:Account)-[:TRANSFERRED]->()` | `from_id` composite | clean error ✓ |
| after-WITH + multi-hop composite | — | clean error ✓ |

## Verification

- SQL-shape verified (no live CH): composite out/in/after-WITH/multi-hop all error cleanly; `OWNS` outgoing (single `from_id`) still renders; standard schema (incl. all #613 cases) **byte-identical**.
- **corpus_sweep 0-churn** (no existing corpus entry uses composite size()); #613 goldens unchanged.
- New regression test `size_pattern_count_composite_fk_errors_cleanly_921` (composite out/in/after-WITH/multi-hop + single-column negative control), fail-when-reverted.
- **ratchet net-zero**; full gate green (`cargo fmt --all && cargo clippy --all-targets && cargo test`).

Option 1 (loud guard) of #921. Option 2 (real composite-key tuple equality for actual support) remains open if wanted.

Closes #921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)