### PR TITLE
fix(#906): property-map a denorm node property buried in a CASE

### DIFF
--- a/src/query_planner/analyzer/filter_tagging.rs
+++ b/src/query_planner/analyzer/filter_tagging.rs
@@ -1705,6 +1705,64 @@ impl FilterTagging {
                     label: check_label,
                 })
             }
+            // #906: a CASE expression must recurse into its scrutinee, each
+            // WHEN/THEN, and the ELSE so a denorm property buried inside it (e.g.
+            // `CASE WHEN a.code = 'X' THEN ...`) is resolved to its physical column
+            // (`a.Origin`) — exactly as the OperatorApplicationExp / ScalarFnCall /
+            // List arms already do for the bare / `toUpper(a.code)` / `a.code + ...`
+            // shapes. Without this arm the CASE fell through the `other` catch-all
+            // unchanged, leaving `a.code` unmapped; on an UNDIRECTED denorm match
+            // that unresolved name then leaked as a nonexistent `r.code` column and
+            // the BidirectionalUnion per-arm origin/dest flip had no physical column
+            // to swap (#906). Standard (non-denorm) properties recurse to an
+            // identity mapping, so this is byte-identical for them.
+            LogicalExpr::Case(logical_case) => {
+                let mapped_scrutinee = match logical_case.expr {
+                    Some(e) => Some(Box::new(self.apply_property_mapping_internal(
+                        *e,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?)),
+                    None => None,
+                };
+                let mut mapped_when_then = Vec::with_capacity(logical_case.when_then.len());
+                for (when_cond, then_val) in logical_case.when_then {
+                    let mapped_when = self.apply_property_mapping_internal(
+                        when_cond,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?;
+                    let mapped_then = self.apply_property_mapping_internal(
+                        then_val,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?;
+                    mapped_when_then.push((mapped_when, mapped_then));
+                }
+                let mapped_else = match logical_case.else_expr {
+                    Some(e) => Some(Box::new(self.apply_property_mapping_internal(
+                        *e,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?)),
+                    None => None,
+                };
+                Ok(LogicalExpr::Case(
+                    crate::query_planner::logical_expr::LogicalCase {
+                        expr: mapped_scrutinee,
+                        when_then: mapped_when_then,
+                        else_expr: mapped_else,
+                    },
+                ))
+            }
             // For other expression types, return as-is
             other => Ok(other),
         }

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1240,3 +1240,4 @@
 {"cypher": "MATCH (a:User)\n            WITH a\n            RETURN a.user_id, size((a)-[:FOLLOWS]->()) AS c", "name": "test_613__size_pattern_count_after_with_single_hop", "schema": "social_integration"}
 {"cypher": "MATCH (a:User)\n            WITH a\n            RETURN a.user_id, size((a)-[:FOLLOWS]->()-[:FOLLOWS]->()) AS c", "name": "test_613__size_pattern_count_after_with_multi_hop", "schema": "social_integration"}
 {"cypher": "MATCH (a:User)-[:FOLLOWS*2]->(b:User) RETURN count(*) AS c", "name": "test_897__flat_poly_vlp_type_discriminator_count", "schema": "social_polymorphic"}
+{"cypher": "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN CASE WHEN count(r) > 5 THEN a.code ELSE 'x' END AS m", "name": "test_906__denorm_undirected_case_buried_grouping_key", "schema": "denormalized_flights"}

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_906__denorm_undirected_case_buried_grouping_key.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_906__denorm_undirected_case_buried_grouping_key.clickhouse.sql
@@ -1,0 +1,12 @@
+SELECT CASE WHEN count(`r.flight_id`) > 5 THEN `r.Origin` ELSE 'x' END AS "m" FROM (
+SELECT 
+      r.Origin AS "r.Origin",
+      r.flight_id AS "r.flight_id"
+FROM test_integration.flights AS r
+UNION ALL 
+SELECT 
+      r.Dest AS "r.Origin",
+      r.flight_id AS "r.flight_id"
+FROM test_integration.flights AS r
+) AS __union
+GROUP BY `r.Origin`

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_906__denorm_undirected_case_buried_grouping_key.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_906__denorm_undirected_case_buried_grouping_key.databricks.sql
@@ -1,0 +1,12 @@
+SELECT CASE WHEN count(`r.flight_id`) > 5 THEN `r.Origin` ELSE 'x' END AS `m` FROM (
+SELECT 
+      r.Origin AS `r.Origin`,
+      r.flight_id AS `r.flight_id`
+FROM test_integration.flights AS r
+UNION ALL 
+SELECT 
+      r.Dest AS `r.Origin`,
+      r.flight_id AS `r.flight_id`
+FROM test_integration.flights AS r
+) AS __union
+GROUP BY `r.Origin`

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_case_buried_agg_key_906__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_case_buried_agg_key_906__clickhouse.sql
@@ -1,0 +1,12 @@
+SELECT CASE WHEN count(`r.flight_id`) > 5 THEN `r.origin_code` ELSE 'x' END AS "m" FROM (
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.origin_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS "r.flight_id",
+      r.dest_code AS "r.origin_code"
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY `r.origin_code`

--- a/tests/rust/integration/golden/sql_ir/denormalized/undirected_case_buried_agg_key_906__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/denormalized/undirected_case_buried_agg_key_906__databricks.sql
@@ -1,0 +1,12 @@
+SELECT CASE WHEN count(`r.flight_id`) > 5 THEN `r.origin_code` ELSE 'x' END AS `m` FROM (
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.origin_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+UNION ALL 
+SELECT 
+      r.flight_id AS `r.flight_id`,
+      r.dest_code AS `r.origin_code`
+FROM db_denormalized.flights_denorm AS r
+) AS __union
+GROUP BY `r.origin_code`

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -1347,6 +1347,16 @@ const DENORM_CORPUS: &[(&str, &str)] = &[
         "undirected_wrapped_buried_agg_key_coalesce_876",
         "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN coalesce(a.code, 'x') + toString(count(r)) AS m",
     ),
+    // #906 (#876 sibling): a buried grouping key inside a CASE must ALSO
+    // property-map + flip per arm. FilterTagging's `apply_property_mapping_internal`
+    // had no `Case` arm, so `a.code` inside a CASE fell through unmapped → both
+    // undirected arms leaked a nonexistent `r.code` and `GROUP BY r.code` (invalid
+    // SQL). Now the CASE recurses like the scalar-fn/operator forms: arm 1 reads
+    // `r.Origin`, arm 2 flips to `r.Dest` (aliased `r.Origin`), GROUP BY `r.Origin`.
+    (
+        "undirected_case_buried_agg_key_906",
+        "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN CASE WHEN count(r) > 5 THEN a.code ELSE 'x' END AS m",
+    ),
     // #844 byte-lock guard: the bare-key form (grouping key as its own SELECT
     // item) was ALWAYS correct and must stay byte-identical — the fix is scoped
     // to the buried-key shape only.
@@ -10048,13 +10058,19 @@ mod walker_drift_family_484_490_495_476_483 {
         // used by the (already-working) plain-equality case — extract that
         // alias from the WHERE clause rather than hard-coding an
         // auto-generated counter value (t1/t2 vs t5/t6 depending on test
-        // ordering within the process).
+        // ordering within the process). #906: the `ip` property is now ALSO
+        // resolved to its physical denorm column (`id.orig_h`) inside the CASE
+        // — FilterTagging's new `Case` arm recurses like the operator/scalar-fn
+        // forms — so the predicate reads `t{n}."id.orig_h" = t{m}."id.orig_h"`
+        // (previously the property was left unresolved as `.ip`, a less-complete
+        // binding this test happened to lock).
         assert!(
             sql.contains("CASE WHEN ")
-                && sql.contains(".ip = ")
-                && !sql.contains("srcip1.ip = srcip2.ip"),
-            "#495: CASE predicate must bind to edge aliases, not the raw \
-             cypher aliases:\n{sql}"
+                && sql.contains(".orig_h\" = ")
+                && !sql.contains("srcip1.ip = srcip2.ip")
+                && !sql.contains("srcip1.\"id.orig_h\""),
+            "#495/#906: CASE predicate must bind to edge aliases AND resolve the \
+             denorm property to its physical column, not the raw cypher aliases:\n{sql}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #906. On a DENORMALIZED undirected match, a grouping key buried in a CASE (`RETURN CASE WHEN count(r) > 5 THEN a.code ELSE 'x' END`) was not property-mapped: `a.code` leaked as a nonexistent `r.code` in both BidirectionalUnion arms and `GROUP BY r.code` → ClickHouse **Code 47**.

## Root cause

`FilterTagging::apply_property_mapping_internal` (the denorm resolver that maps `a.code` → physical `Origin`/`Dest`) had no `LogicalExpr::Case` arm. It recurses into `OperatorApplicationExp`/`ScalarFnCall`/`List` — so bare, `toUpper(a.code)`, and `a.code + …` forms resolve — but a CASE-wrapped property fell through the catch-all unchanged.

**Undirected-only**: FilterTagging runs after BidirectionalUnion splits the plan into two arms. On the directed path a later `ProjectionTagging` (which HAS a Case arm) resolves it; on the undirected path that doesn't fire. And with both arms leaking identical `a.code`, the per-arm origin/dest flip (keyed by physical column) has nothing to swap.

## Fix

Add a `Case` arm that recurses into scrutinee / WHEN-THEN / ELSE. Resolving `a.code` → `a.Origin` before BidirectionalUnion lets the existing column-swap flip arm 2 to `Dest`. Standard properties recurse to an identity mapping → byte-identical.

Result: arm 1 `r.Origin`, arm 2 `r.Dest AS "r.Origin"`, `GROUP BY r.Origin`.

## Verification

- **Live** (`test_integration.flights`, undirected FLIGHT): old binary → Code 47 `r.code cannot be resolved`; fixed → JFK, LAX, x (matches the per-airport oracle).
- 1 corpus entry + `DENORM_CORPUS` snapshot + 4 goldens; **zero existing-golden churn**.
- Updated `remap_denormalized_case_expr_alias_bound_495`: its CASE predicate now also resolves the property to the physical column (`t1."id.orig_h" = t2."id.orig_h"` vs the prior less-complete `t1.ip = t2.ip`) — a strict improvement.
- `fmt`/`clippy`/`cargo test -p clickgraph` (1678 + 553) / ratchet clean.

Filed **#928** for the render-side twin (`apply_property_mapping_to_expr` also lacks a Case arm — latent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)