### PR TITLE
fix(#928): defer NOT (composite-FK pattern) LOUD instead of malformed SQL

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -524,6 +524,29 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-02: **Fix — `NOT (composite-FK pattern)` now fails LOUD instead of
+  emitting malformed SQL** (branch `fix/928-not-composite-fk-guard`, closes #928;
+  sibling of #921, flagged in its review). `MATCH (a:Account) WHERE NOT
+  (a)-[:TRANSFERRED]->()` emitted `NOT EXISTS (... WHERE transfers.from_bank_id,
+  from_account_number = (...))` — the correlation WHERE **LHS** is a bare
+  comma-list (composite `rel_schema.from_id`/`to_id` stringified), invalid SQL
+  (ground-rule-1). **Root cause:** `generate_not_exists_from_path_pattern`
+  (`render_expr.rs`) interpolates the facing edge FK column verbatim into the
+  correlated `NOT EXISTS` WHERE and had no composite guard — the same gap #921
+  closed for the pattern-count paths and `generate_exists_graph_rel_sql` already
+  guards. **Fix:** add a **direction-aware** composite guard — defer LOUD
+  (`UnsupportedFeature`, suggesting `OPTIONAL MATCH ... WHERE <rel> IS NULL`) when
+  a column actually used as a correlation predicate is composite. Shape-aware
+  `from_used`/`to_used`: an anonymous-end DIRECTED pattern uses only the facing
+  column (so `(c:Customer)-[:OWNS]->()` on single `from_id` still renders even
+  though `to_id` is composite); named-end and undirected shapes use both. Standard
+  single-column schemas byte-identical (corpus_sweep 0-churn); new regression test
+  (composite out/in/undirected/named-end + single-column anon-end negative
+  control), fail-when-reverted; ratchet net-zero. (NOTE: this #928 is the
+  `size()`/NOT render-path composite comma-list — distinct from the
+  denorm-CASE render-side twin that #906's log entry cross-references under the
+  same number; the render-path leak was the one that reproduced and is fixed here.)
+
 - 2026-08-02: **Fix — denorm property buried in a CASE is now property-mapped**
   (branch `fix/906-denorm-case-buried-grouping-key-v2`, PR #930, closes #906).
   On a denormalized UNDIRECTED match, `RETURN CASE WHEN count(r) > 5 THEN a.code

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -1330,7 +1330,34 @@ fn generate_not_exists_from_path_pattern(
                     let from_col = &rel_schema.from_id;
                     let to_col = &rel_schema.to_id;
 
-                    // Get the node ID columns from their labels or infer from relationship schema
+                    // #928: the NOT EXISTS correlation predicates below interpolate the
+                    // edge FK column(s) verbatim (`{table}.{from_col}`/`{to_col}`). A
+                    // COMPOSITE FK column stringifies to a bare comma-list
+                    // (`from_bank_id, from_account_number`) → malformed SQL. Defer LOUD
+                    // (ground-rule-1), mirroring the #921 pattern-count guard and the
+                    // composite deferral `generate_exists_graph_rel_sql` already applies.
+                    // Which columns are actually used depends on the shape: an
+                    // anonymous-end DIRECTED pattern references only the facing column
+                    // (from for Outgoing, to for Incoming); every other shape (named end,
+                    // or undirected) references BOTH. Guard exactly the used column(s) so
+                    // a single-column facing side still renders when the other is
+                    // composite (direction-aware, like #921).
+                    let from_used = !(end_alias.is_none()
+                        && conn.relationship.direction == Direction::Incoming);
+                    let to_used = !(end_alias.is_none()
+                        && conn.relationship.direction == Direction::Outgoing);
+                    if (from_used && from_col.columns().len() != 1)
+                        || (to_used && to_col.columns().len() != 1)
+                    {
+                        return Err(RenderBuildError::UnsupportedFeature(format!(
+                            "NOT pattern over relationship '{}' with a COMPOSITE \
+                             foreign-key column is not supported (the correlation predicate \
+                             needs composite-key tuple equality). Express it as a top-level \
+                             OPTIONAL MATCH ... WHERE <rel> IS NULL instead.",
+                            rel_type
+                        )));
+                    }
+
                     let start_id_sql = if let Some(label) = &conn.start_node.label {
                         let node_schema = schema
                             .node_schema_opt(label)

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8145,6 +8145,63 @@ async fn size_pattern_count_composite_fk_errors_cleanly_921() {
     );
 }
 
+/// #928 (sibling of #921): `NOT (pattern)` over a relationship whose FACING
+/// correlation FK column is COMPOSITE must fail LOUD, not emit malformed SQL.
+/// `generate_not_exists_from_path_pattern` interpolates `rel_schema.from_id`/
+/// `to_id` verbatim into the correlated `NOT EXISTS` WHERE; a composite id
+/// stringifies to a bare comma-list (`from_bank_id, from_account_number`) →
+/// invalid SQL (ground-rule-1). Direction-aware guard: an anonymous-end DIRECTED
+/// pattern uses only the facing column, so a single-column facing side still
+/// renders even when the opposite side is composite.
+#[tokio::test]
+async fn not_pattern_composite_fk_errors_cleanly_928() {
+    let schema = load_schema(SchemaId::CompositeId.yaml_path());
+    let composite_cases = [
+        // Outgoing, composite from_id.
+        "MATCH (a:Account) WHERE NOT (a)-[:TRANSFERRED]->() RETURN a.bank_id",
+        // Incoming, composite to_id.
+        "MATCH (a:Account) WHERE NOT (a)<-[:OWNS]-() RETURN a.bank_id",
+        // Undirected (references both facing columns).
+        "MATCH (a:Account) WHERE NOT (a)-[:TRANSFERRED]-() RETURN a.bank_id",
+        // Named end binds BOTH from and to → the composite to_id is used even
+        // though the single from_id side would pass alone.
+        "MATCH (c:Customer) WHERE NOT (c)-[:OWNS]->(a:Account) RETURN c.customer_id",
+    ];
+    for cypher in composite_cases {
+        let result = try_render(&schema, cypher, SqlDialect::ClickHouse).await;
+        let err = result
+            .as_ref()
+            .err()
+            .unwrap_or_else(|| {
+                panic!("[{cypher}] composite-FK NOT pattern must error, not render: {result:?}")
+            })
+            .clone();
+        assert!(
+            err.contains("UnsupportedFeature") && err.contains("COMPOSITE"),
+            "[{cypher}] expected a composite-FK UnsupportedFeature error, got:\n{err}"
+        );
+        assert!(
+            !err.contains("from_bank_id, from_account_number")
+                && !err.contains("bank_id, account_number"),
+            "[{cypher}] error must not contain the malformed comma-list SQL:\n{err}"
+        );
+    }
+
+    // Negative control: a SINGLE-column facing side with an anonymous end still
+    // renders (direction-aware guard). OWNS outgoing correlates on `from_id =
+    // customer_id`; the composite `to_id` is not referenced with an anon end.
+    let sql = render(
+        &schema,
+        "MATCH (c:Customer) WHERE NOT (c)-[:OWNS]->() RETURN c.customer_id",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        sql.contains("account_ownership.customer_id = c.customer_id"),
+        "single-column OWNS outgoing (anon end) must still render its NOT EXISTS:\n{sql}"
+    );
+}
+
 /// #466 round 4 (adversarial-review blocking finding): `id(alias)` on a
 /// `pattern_union` endpoint must resolve LABEL-AGNOSTICALLY to the CTE's
 /// start_id/end_id — never to ONE label's id column.


### PR DESCRIPTION
## Summary

Fixes #928. Sibling of #921 (flagged in its adversarial review as LOW-1). `NOT (pattern)` over a relationship whose facing FK column is **composite** emitted malformed SQL:

```cypher
MATCH (a:Account) WHERE NOT (a)-[:TRANSFERRED]->() RETURN a.bank_id
```
→ `NOT EXISTS (... WHERE transfers.from_bank_id, from_account_number = (...))` — the WHERE **LHS** is a bare, unparenthesized comma-list (composite `rel_schema.from_id`/`to_id` stringified), invalid SQL (ground-rule-1).

## Root cause

`generate_not_exists_from_path_pattern` (`src/render_plan/render_expr.rs`) interpolates the facing edge FK column **verbatim** into the correlated `NOT EXISTS` WHERE, with **no composite guard** — the same gap #921 closed for the `size()`/pattern-count paths, and that `generate_exists_graph_rel_sql` already guards (so `exists(...)` / `size(...)` are safe).

## Fix

Add a **direction-aware** composite guard mirroring #921: defer LOUD (`UnsupportedFeature`, suggesting `OPTIONAL MATCH ... WHERE <rel> IS NULL`) when a column **actually used** as a correlation predicate is composite.

Shape-aware `from_used`/`to_used` — an anonymous-end **directed** pattern references only the facing column, so a single-column facing side still renders even when the opposite is composite:

| Pattern | columns used | behavior |
|---|---|---|
| `(c:Customer)-[:OWNS]->()` (anon end) | `from_id` (single) | **still renders** ✓ |
| `(a:Account)-[:TRANSFERRED]->()` | `from_id` composite | clean error ✓ |
| `(a:Account)<-[:OWNS]-()` | `to_id` composite | clean error ✓ |
| `(a)-[:TRANSFERRED]-()` undirected | both | clean error ✓ |
| `(c)-[:OWNS]->(a:Account)` named end | both (to_id composite) | clean error ✓ |

## Verification

- SQL-shape verified (no live CH): composite out/in/undirected/named-end error cleanly; single-column anon-end `OWNS` outgoing still renders; standard schema byte-identical.
- **corpus_sweep 0-churn**; new regression test `not_pattern_composite_fk_errors_cleanly_928`, fail-when-reverted.
- **ratchet net-zero**; full gate green.

Closes #928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)