### PR TITLE
fix(#944): resolve denorm props inside computed RETURN projection wrappers

### DIFF
--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -1773,8 +1773,21 @@ impl SelectBuilder for LogicalPlan {
                                 "🔍 SelectBuilder Case 6 (Other): Expression type = {:?}",
                                 item.expression
                             );
+                            // #944: a COMPUTED, non-aggregate projection expression
+                            // (`[s.ip][1]`, `{a: s.ip}`, `reduce(...)`, a scalar-fn
+                            // wrapper, etc.) must still resolve denormalized node
+                            // references, exactly as Case 6a does for the
+                            // aggregate-bearing form and Case 4 does for a bare
+                            // property. Without it a denorm property buried in the
+                            // wrapper leaked its raw cypher alias → `s.ip` instead of
+                            // `t1."id.orig_h"` → live Code 47.
+                            // `resolve_denorm_refs_in_expr` now recurses into every
+                            // wrapper (with reduce-binder shielding) and is a no-op
+                            // for standard nodes → byte-identical goldens there.
+                            let mut expr: RenderExpr = item.expression.clone().try_into()?;
+                            self.resolve_denorm_refs_in_expr(&mut expr, plan_ctx);
                             select_items.push(SelectItem {
-                                expression: item.expression.clone().try_into()?,
+                                expression: expr,
                                 col_alias: item
                                     .col_alias
                                     .as_ref()
@@ -2213,9 +2226,28 @@ impl LogicalPlan {
         expr: &mut RenderExpr,
         plan_ctx: Option<&crate::query_planner::plan_ctx::PlanCtx>,
     ) {
+        self.resolve_denorm_refs_in_expr_shielded(expr, plan_ctx, &mut Vec::new());
+    }
+
+    /// As [`resolve_denorm_refs_in_expr`], but carries `shielded` — names bound
+    /// by an enclosing `reduce()` lambda (`accumulator`/`variable`). The leaf
+    /// arms below rewrite a bare `TableAlias`/`PropertyAccessExp` keyed on its
+    /// NAME, so a lambda binder that shadows a node/rel alias must be left alone
+    /// (the #929/#940 reduce-binder-shadow hazard). A shielded name
+    /// short-circuits before any remap.
+    fn resolve_denorm_refs_in_expr_shielded(
+        &self,
+        expr: &mut RenderExpr,
+        plan_ctx: Option<&crate::query_planner::plan_ctx::PlanCtx>,
+        shielded: &mut Vec<String>,
+    ) {
         match expr {
             RenderExpr::PropertyAccessExp(pa) => {
                 let alias = pa.table_alias.0.clone();
+                // Shadowed by an enclosing reduce binder — not a node/rel alias.
+                if shielded.iter().any(|n| n == &alias) {
+                    return;
+                }
                 // CTE-sourced variables resolve forward through their CTE
                 // columns (CLAUDE.md rule 2) — never remap them here.
                 if let Some(ctx) = plan_ctx {
@@ -2340,6 +2372,10 @@ impl LogicalPlan {
                 // planner error instead of a numeric id-column result),
                 // that's a deliberate, separate decision — not a bug fix.
                 let alias = t.0.clone();
+                // Shadowed by an enclosing reduce binder — not a node alias.
+                if shielded.iter().any(|n| n == &alias) {
+                    return;
+                }
                 // CTE-sourced / pattern_union node variables resolve forward
                 // through their own columns — never remap them here (same
                 // gate as the PropertyAccessExp case above). Node-ness itself
@@ -2362,43 +2398,55 @@ impl LogicalPlan {
                 }
                 if let Some(id_expr) = node_alias_id_expr(&alias, plan_ctx) {
                     let mut resolved = id_expr;
-                    self.resolve_denorm_refs_in_expr(&mut resolved, plan_ctx);
+                    self.resolve_denorm_refs_in_expr_shielded(&mut resolved, plan_ctx, shielded);
                     *expr = resolved;
                 }
             }
-            RenderExpr::AggregateFnCall(agg) => {
-                for arg in &mut agg.args {
-                    self.resolve_denorm_refs_in_expr(arg, plan_ctx);
-                }
+            RenderExpr::ReduceExpr(reduce) => {
+                // #944: `initial_value` and `list` evaluate in the OUTER scope —
+                // resolve normally (an outer denorm prop there is legitimate).
+                // The `expression` (body) BINDS `accumulator`/`variable`, which
+                // shadow any same-named node/rel alias; the leaf arms above are
+                // NAME-keyed, so a lambda binder colliding with an alias must be
+                // shielded or it is rewritten into that node's column (the
+                // #929/#940 reduce-binder-shadow hazard). Push the binders for
+                // the body only.
+                self.resolve_denorm_refs_in_expr_shielded(
+                    &mut reduce.initial_value,
+                    plan_ctx,
+                    shielded,
+                );
+                self.resolve_denorm_refs_in_expr_shielded(&mut reduce.list, plan_ctx, shielded);
+                shielded.push(reduce.accumulator.clone());
+                shielded.push(reduce.variable.clone());
+                self.resolve_denorm_refs_in_expr_shielded(
+                    &mut reduce.expression,
+                    plan_ctx,
+                    shielded,
+                );
+                shielded.pop();
+                shielded.pop();
             }
-            RenderExpr::ScalarFnCall(sf) => {
-                for arg in &mut sf.args {
-                    self.resolve_denorm_refs_in_expr(arg, plan_ctx);
-                }
+            // Every OTHER wrapper recurses structurally through the EXHAUSTIVE
+            // `descend_render_expr_mut` (no `_` catch-all — a new `RenderExpr`
+            // variant is a compile error here, not a silently-dropped denorm
+            // resolution). Previously a `_ => {}` catch-all dropped
+            // `ArraySubscript`/`ArraySlicing`/`MapLiteral`/`ReduceExpr`, leaking a
+            // denorm property buried in a computed RETURN projection wrapper
+            // (`RETURN [s.ip][1]` → `s.ip` not `t1."id.orig_h"` → live Code 47,
+            // #944). `ReduceExpr` is handled above (binder shielding); leaves and
+            // deliberately-not-descended nodes (`InSubquery`/`ExistsSubquery`/
+            // `PatternCount`/`CteEntityRef`) are no-ops in
+            // `descend_render_expr_mut`, matching the prior catch-all. Mirrors the
+            // #929/#940 folds of the sibling property-mapping walks.
+            other => {
+                let mut recur =
+                    |child: &mut RenderExpr| -> crate::render_plan::render_expr::MutVisit {
+                        self.resolve_denorm_refs_in_expr_shielded(child, plan_ctx, shielded);
+                        crate::render_plan::render_expr::MutVisit::Stop
+                    };
+                crate::render_plan::render_expr::descend_render_expr_mut(other, &mut recur);
             }
-            RenderExpr::OperatorApplicationExp(op) => {
-                for operand in &mut op.operands {
-                    self.resolve_denorm_refs_in_expr(operand, plan_ctx);
-                }
-            }
-            RenderExpr::Case(case) => {
-                if let Some(ref mut e) = case.expr {
-                    self.resolve_denorm_refs_in_expr(e, plan_ctx);
-                }
-                for (cond, result) in &mut case.when_then {
-                    self.resolve_denorm_refs_in_expr(cond, plan_ctx);
-                    self.resolve_denorm_refs_in_expr(result, plan_ctx);
-                }
-                if let Some(ref mut e) = case.else_expr {
-                    self.resolve_denorm_refs_in_expr(e, plan_ctx);
-                }
-            }
-            RenderExpr::List(items) => {
-                for item in items {
-                    self.resolve_denorm_refs_in_expr(item, plan_ctx);
-                }
-            }
-            _ => {}
         }
     }
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10404,6 +10404,84 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #944: a denormalized node's property buried inside a COMPUTED RETURN
+    /// projection wrapper (`ArraySubscript`/`ArraySlicing`/`MapLiteral`/
+    /// `ReduceExpr`/`List`) must resolve to its physical edge-table column, just
+    /// like a bare `s.ip` projection and the same wrappers in WHERE/ORDER BY. The
+    /// projection path's computed-expression arm (`select_builder.rs` Case 6)
+    /// previously did a raw `try_into()` with no denorm resolution, and
+    /// `resolve_denorm_refs_in_expr` itself dropped those wrappers via a `_ => {}`
+    /// catch-all → the raw cypher alias `s` leaked into
+    /// `arrayElementOrNull([toString(s.ip)], …)` → live Code 47. The fold routes
+    /// the resolver's wrapper recursion through the exhaustive
+    /// `descend_render_expr_mut` (with `reduce()` binder shielding, #929/#940).
+    #[tokio::test]
+    async fn computed_projection_denorm_prop_resolves_944() {
+        let schema = load_schema("schemas/dev/zeek_merged_test.yaml");
+
+        // Each computed wrapper over a denorm prop must remap `s.ip` → the edge
+        // table's `id.orig_h` (auto-counter alias `t{n}`), and must NOT leak the
+        // raw cypher alias `s`.
+        for cypher in [
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN [s.ip][1] AS x",
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN [s.ip][0..1] AS x",
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN {a: s.ip} AS x",
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN [s.ip] AS x",
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN reduce(acc = '', y IN [s.ip] | acc) AS x",
+        ] {
+            let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+            assert!(
+                sql.contains("\"id.orig_h\""),
+                "#944: denorm prop in a computed projection must remap to the \
+                 physical column:\n{cypher}\n{sql}"
+            );
+            assert!(
+                !sql.contains("toString(s.ip)")
+                    && !sql.contains("[s.ip]")
+                    && !sql.contains("s.\"id.orig_h\""),
+                "#944: raw cypher alias `s` leaked unremapped in a computed \
+                 projection (would be Code 47 on live CH):\n{cypher}\n{sql}"
+            );
+        }
+    }
+
+    /// #944 (shielding guard): the projection-path denorm resolver descends into
+    /// `reduce()` bodies, so a lambda binder that shadows a bound denorm node
+    /// alias must be shielded — same hazard #929/#940 fixed on the WHERE/inline
+    /// paths, here on the SELECT path.
+    #[tokio::test]
+    async fn computed_projection_reduce_binder_shielded_944() {
+        let schema = load_schema("schemas/dev/zeek_merged_test.yaml");
+
+        // Iteration var `s` shadows the bound denorm node alias `s` — the body
+        // `s` must stay, NOT become the node column.
+        let var_sql = render(
+            &schema,
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN reduce(acc = 0, s IN [1, 2] | acc + s) AS y",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            var_sql.contains("acc + s") && !var_sql.contains("acc + t"),
+            "#944: reduce iteration var `s` shadowing a denorm node alias must \
+             NOT be remapped in a projection:\n{var_sql}"
+        );
+
+        // But an OUTER denorm prop in the reduce `list` (not shadowed) STILL
+        // remaps — the legitimate win is preserved.
+        let outer_sql = render(
+            &schema,
+            "MATCH (s:IP)-[:ACCESSED]->(d:IP) RETURN reduce(acc = '', x IN [s.ip] | acc) AS y",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            outer_sql.contains("\"id.orig_h\"") && !outer_sql.contains("toString(s.ip)"),
+            "#944: an OUTER denorm prop in the reduce list must STILL remap in a \
+             projection (only binder-shadowed names are shielded):\n{outer_sql}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// build its cross-label DISTINCT discriminator tuple from the #467
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`


### PR DESCRIPTION
## Summary

A denormalized node's property buried inside a **computed RETURN projection** wrapper (`[s.ip][1]`, `{a: s.ip}`, `reduce(...)`, `[s.ip]`, `[s.ip][0..1]`) leaked its raw cypher alias → `arrayElementOrNull([toString(s.ip)], …)` with `s` bound to no table → live **Code 47 UNKNOWN_IDENTIFIER**. The identical expressions in WHERE / ORDER BY resolve correctly, and a bare `s.ip` projection resolves via Case 4 — only the computed-projection arm was uncovered.

Closes #944. Fourth sibling of the #906/#929/#940 denorm property-mapping walk cluster, now on the SELECT path.

## Fix (two coordinated edits in `select_builder.rs`)

1. **Case 6** (the computed-expression projection arm) did a raw `try_into()` with **no** denorm resolution — unlike Case 6a (aggregate-bearing) which already calls `resolve_denorm_refs_in_expr`, and Case 4 (bare property) which remaps via `get_properties_with_table_alias`. Wire Case 6 to call the resolver too.
2. **`resolve_denorm_refs_in_expr`** itself hand-rolled its wrapper recursion with a `_ => {}` catch-all that dropped `ArraySubscript`/`ArraySlicing`/`MapLiteral`/`ReduceExpr` — so even when called it stopped at the wrapper. Fold its recursion onto the exhaustive `descend_render_expr_mut` (no `_` catch-all → a new `RenderExpr` variant is a compile error, not a silent drop).

Because the resolver rewrites bare `TableAlias`/`PropertyAccessExp` keyed on the NAME, descending into `reduce()` bodies reintroduces the #929/#940 reduce-binder-shadow hazard; fixed with the identical binder shielding (`initial_value`/`list` resolve in the outer scope, `accumulator`/`variable` shielded for the body).

## Verification

- **Live-verified** on the zeek denorm schema: all five wrappers previously Code 47 now execute and return correct denorm-resolved values (`[s.ip][0]` = `head([s.ip])` = bare `s.ip` = `192.168.1.10`; `[s.ip][1]` = NULL, correct out-of-bounds). Reduce binder shadowing `s` stays unremapped; an outer denorm prop in the list still remaps.
- **Non-denorm = no-op** → `corpus_sweep` byte-identical (563/565 goldens); ratchet net-neutral; 1682 lib tests green.
- Two golden tests (wrapper resolution + projection-path binder shielding), **proven load-bearing** (neutering either the Case 6 call or the fold descent makes them fail).
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER** — every claim backed by live SQL diff + neuter-and-fail experiments; verified behavioral equivalence on covered arms, shielding push/pop balance, CTE-source/pattern_union gates still fire, and standard-schema negatives unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)