### PR TITLE
fix(#946): map property names inside computed RETURN projection wrappers

### DIFF
--- a/src/query_planner/analyzer/filter_tagging.rs
+++ b/src/query_planner/analyzer/filter_tagging.rs
@@ -1640,6 +1640,110 @@ impl FilterTagging {
                     to: mapped_to,
                 })
             }
+            // #946: an `ArraySubscript` (`[u.name][0]`, `labels(n)[1]`) must
+            // recurse into its array and index so a property buried in it is
+            // mapped from its Cypher name to its physical column — exactly as the
+            // sibling `ArraySlicing`/`List`/`Case` arms already do. Without this
+            // it fell through the `other => Ok(other)` catch-all unmapped
+            // (`u.name` instead of `u.full_name`) → Code 47 at execution. Standard
+            // properties recurse to an identity mapping, so this is byte-identical
+            // for un-renamed schemas.
+            LogicalExpr::ArraySubscript { array, index } => {
+                let mapped_array = self.apply_property_mapping_internal(
+                    *array,
+                    plan_ctx,
+                    graph_schema,
+                    plan,
+                    preserve_id_function,
+                )?;
+                let mapped_index = self.apply_property_mapping_internal(
+                    *index,
+                    plan_ctx,
+                    graph_schema,
+                    plan,
+                    preserve_id_function,
+                )?;
+                Ok(LogicalExpr::ArraySubscript {
+                    array: Box::new(mapped_array),
+                    index: Box::new(mapped_index),
+                })
+            }
+            // #946: a `MapLiteral` (`{a: u.name}`) must map each value; keys are
+            // literal identifiers, never property references. Sibling of the
+            // `List` arm.
+            LogicalExpr::MapLiteral(entries) => {
+                let mut mapped_entries = Vec::with_capacity(entries.len());
+                for (key, value) in entries {
+                    let mapped_value = self.apply_property_mapping_internal(
+                        value,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?;
+                    mapped_entries.push((key, mapped_value));
+                }
+                Ok(LogicalExpr::MapLiteral(mapped_entries))
+            }
+            // #946: a `ReduceExpr` (`reduce(acc = init, x IN list | body)`) must
+            // map `initial_value` and `list` (they evaluate in the OUTER scope) so
+            // a property buried there resolves to its physical column. The body
+            // BINDS `accumulator`/`variable`, which shadow any same-named node
+            // alias — and property mapping is keyed on an alias found in
+            // `plan_ctx`, so a body reference like `x.name` (where `x` is the
+            // binder over a list of maps) would be WRONGLY rewritten to the
+            // shadowed node's column. This is the analyzer-side of the #929/#940/
+            // #944 reduce-binder-shadow hazard: recursing into the body to close a
+            // silent-DROP opens a silent-MIS-REWRITE. There is no binder-scoped
+            // property-mapping context here, so conservatively skip mapping the
+            // body whenever a binder name resolves to a real table alias (exactly
+            // the pre-#946 behavior for that case — the body stayed unmapped
+            // because `ReduceExpr` fell through the `other` catch-all). The common
+            // case — binders that do NOT shadow a node/CTE alias — still maps the
+            // body normally, so `initial_value`/`list` and unshadowed bodies get
+            // the fix.
+            LogicalExpr::ReduceExpr(reduce) => {
+                let mapped_initial = self.apply_property_mapping_internal(
+                    *reduce.initial_value,
+                    plan_ctx,
+                    graph_schema,
+                    plan,
+                    preserve_id_function,
+                )?;
+                let mapped_list = self.apply_property_mapping_internal(
+                    *reduce.list,
+                    plan_ctx,
+                    graph_schema,
+                    plan,
+                    preserve_id_function,
+                )?;
+                // A binder shadows a real alias iff `plan_ctx` resolves its name
+                // to a table context; if either binder does, leave the body
+                // unmapped (safe, matches pre-#946) rather than risk mis-mapping a
+                // `binder.prop` reference onto the shadowed node's column.
+                let binder_shadows_alias = plan_ctx.get_table_ctx(&reduce.accumulator).is_ok()
+                    || plan_ctx.get_table_ctx(&reduce.variable).is_ok();
+                let mapped_body = if binder_shadows_alias {
+                    *reduce.expression
+                } else {
+                    self.apply_property_mapping_internal(
+                        *reduce.expression,
+                        plan_ctx,
+                        graph_schema,
+                        plan,
+                        preserve_id_function,
+                    )?
+                };
+                Ok(LogicalExpr::ReduceExpr(
+                    crate::query_planner::logical_expr::ReduceExpr {
+                        accumulator: reduce.accumulator,
+                        initial_value: Box::new(mapped_initial),
+                        variable: reduce.variable,
+                        list: Box::new(mapped_list),
+                        expression: Box::new(mapped_body),
+                    },
+                ))
+            }
             LogicalExpr::LabelExpression {
                 variable,
                 label: check_label,

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10522,6 +10522,78 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #946: on a STANDARD schema, a property inside a computed RETURN wrapper
+    /// (`ArraySubscript`/`MapLiteral`/`ReduceExpr`) must map its Cypher property
+    /// name to the physical column (`u.name` → `u.full_name`), exactly as the
+    /// bare `u.name` and the sibling `List`/`ArraySlicing`/`Case` wrappers do.
+    /// The analyzer's `apply_property_mapping_internal` dropped these three
+    /// wrappers via `other => Ok(other)` → the raw property name leaked → Code 47
+    /// (`users` has `full_name`, not `name`).
+    #[tokio::test]
+    async fn computed_projection_property_name_mapped_946() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        for cypher in [
+            "MATCH (u:User) RETURN [u.name][0] AS x",
+            "MATCH (u:User) RETURN [u.name][0..1] AS x",
+            "MATCH (u:User) RETURN {a: u.name} AS x",
+            "MATCH (u:User) RETURN reduce(acc = '', y IN [u.name] | acc) AS x",
+        ] {
+            let sql = render(&schema, cypher, SqlDialect::ClickHouse).await;
+            assert!(
+                sql.contains("full_name"),
+                "#946: property in a computed projection must map to its physical \
+                 column:\n{cypher}\n{sql}"
+            );
+            // The raw Cypher property name must NOT leak as `u.name` (would be
+            // Code 47 — `users` has no `name` column). Guard against the
+            // qualified form specifically so a substring in an output alias
+            // (`AS \"x\"`) does not false-positive.
+            assert!(
+                !sql.contains("u.name") && !sql.contains("u.\"name\""),
+                "#946: raw Cypher property `u.name` leaked unmapped in a computed \
+                 projection:\n{cypher}\n{sql}"
+            );
+        }
+    }
+
+    /// #946 (shielding guard): the analyzer-side fold recurses into `reduce()`
+    /// bodies, so a lambda binder that shadows a node alias must NOT have a
+    /// `binder.prop` reference mapped onto the shadowed node's column — the
+    /// analyzer-side #929/#940/#944 reduce-binder-shadow hazard. Conservatively
+    /// the body is left unmapped whenever a binder name resolves to a real alias.
+    #[tokio::test]
+    async fn computed_projection_reduce_binder_shadow_not_mapped_946() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        // Binder `u` shadows node `u`; `u.name` in the body is the binder (a map
+        // element), NOT the node — it must stay `u.name`, not become `full_name`.
+        let shadow_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = '', u IN [{name: 'a'}] | acc + u.name) AS y",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !shadow_sql.contains("full_name"),
+            "#946: a reduce body `binder.prop` where the binder shadows a node \
+             alias must NOT be mapped onto the node column:\n{shadow_sql}"
+        );
+
+        // Non-shadowing binder: an OUTER prop in the `list` still maps (the fix).
+        let win_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = '', y IN [u.name] | acc + y) AS z",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            win_sql.contains("full_name"),
+            "#946: an OUTER prop in the reduce list (binder does not shadow) must \
+             still map:\n{win_sql}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// build its cross-label DISTINCT discriminator tuple from the #467
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`


### PR DESCRIPTION
## Summary

On a standard (non-denormalized) schema, a property inside a **computed RETURN projection** wrapper (`[u.name][0]`, `{a: u.name}`, `reduce(...)`) was not mapped from its Cypher property name to its physical column — the raw name leaked (`u.name` instead of `u.full_name`) → live **Code 47 UNKNOWN_IDENTIFIER** (`users` has `full_name`, not `name`). Bare `[u.name]` worked (the analyzer's `List` arm recurses); the subscript/map/reduce wrappers did not.

Closes #946. Analyzer-side sibling of #944 (which fixed the render-side denorm ALIAS remap for the same wrappers); this fixes the analyzer-side property-NAME mapping. Both compose: analyzer maps the name, render side remaps the denorm alias.

## Fix

`FilterTagging::apply_property_mapping_internal` handles `List`/`ArraySlicing`/`Case` (Case = #906) but its terminal `other => Ok(other)` dropped `ArraySubscript`/`MapLiteral`/`ReduceExpr`. Add the three missing arms, recursing into children exactly as the sibling arms do. There is no exhaustive `LogicalExpr` walker to fold onto (unlike the render side's `descend_render_expr_mut`; `LogicalExpr` has no `children()` API), so these are explicit arms.

**Reduce-binder-shadow guard** (the #929/#940/#944 hazard, analyzer-side): recursing into the reduce body to close a silent-DROP would open a silent-MIS-REWRITE — a body `binder.prop` where the binder shadows a node alias would be wrongly mapped onto the shadowed node's column, because mapping is keyed on an alias in `plan_ctx`. There is no binder-scoped mapping context in the analyzer, so conservatively skip mapping the body whenever a binder name resolves to a real table alias (exactly the pre-fix behavior for that case). `initial_value`/`list` always map; unshadowed bodies still map.

## Verification

- **Live-verified** on `db_standard` (`schemas/dev/social_standard.yaml`): all wrappers previously Code 47 now execute and return correct values (`[u.name][0]` = `head([u.name])` = bare `u.name` = "Alice Smith"). The reduce binder-shadow case stays unmapped; an outer prop in the list still maps.
- **Standard = identity mapping for un-renamed schemas** → `corpus_sweep` byte-identical (565); ratchet net-neutral; 1687 lib tests green.
- **#944 composition intact**: denorm `[s.ip][1]` still resolves to `s."id.orig_h"` per union arm (no double-mapping).
- Two golden tests, **proven load-bearing** (neutering the arm or the shadow guard makes them fail).
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER** — live diffs + neuter experiments.

## Known limitation (not a regression, follow-up filed)

The shadow guard is coarse: it skips the *entire* reduce body when *either* binder shadows an alias, so a legitimate `otherNode.prop` in the same body is also left unmapped. On main the whole `ReduceExpr` body was unmapped anyway, so this is strictly an improvement; a fully-scoped fix needs a binder-scoped mapping context the analyzer lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)