### PR TITLE
fix(#950): render reduce()'s arrayFold accumulator as the FIRST lambda param

### DIFF
--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -133,10 +133,20 @@ pub fn regex_match_predicate(haystack: &str, pattern: &str) -> String {
 /// Render a Cypher `reduce(acc = init, x IN list | expr)` fold for the active
 /// dialect, from its already-rendered component strings.
 ///
-/// ClickHouse has `arrayFold((x, acc) -> expr, list, init)`; Spark/Databricks
-/// has no `arrayFold` and uses `aggregate(list, init, (acc, x) -> expr)` (same
-/// semantics, different arg order + spelling). Emitted from every `ReduceExpr`
+/// ClickHouse's `arrayFold` binds the lambda's FIRST parameter to the
+/// **accumulator** and the second to the element:
+/// `arrayFold((accumulator, element) -> expr, list, init)` (CH also accepts the
+/// unparenthesized `arrayFold(acc, x -> expr, list, init)`). Spark/Databricks
+/// has no `arrayFold` and uses `aggregate(list, init, (acc, x) -> expr)` — same
+/// accumulator-first order, different spelling. Emitted from every `ReduceExpr`
 /// render site so the two dialects stay in sync.
+///
+/// #950: the ClickHouse branch previously emitted `arrayFold(x, acc -> expr,
+/// …)` — the ELEMENT first — so ClickHouse bound `x` to the accumulator and
+/// `acc` to the element, SWAPPING the two inside `expr`. That is silently wrong
+/// for any non-commutative/non-associative body (`reduce(acc = 0, y IN [1,2,3] |
+/// acc*10 + y)` gave 60 instead of 123) and a `Code 43` when the element and
+/// accumulator types differ. The Databricks branch was already correct.
 pub fn reduce_fold_sql(
     variable: &str,
     accumulator: &str,
@@ -150,9 +160,10 @@ pub fn reduce_fold_sql(
             "aggregate({}, {}, ({}, {}) -> {})",
             list_sql, init_sql, accumulator, variable, expr_sql
         ),
+        // ClickHouse: accumulator is the FIRST lambda parameter.
         _ => format!(
             "arrayFold({}, {} -> {}, {}, {})",
-            variable, accumulator, expr_sql, list_sql, init_sql
+            accumulator, variable, expr_sql, list_sql, init_sql
         ),
     }
 }
@@ -514,11 +525,12 @@ mod reduce_fold_sql_tests {
 
     #[test]
     fn clickhouse_default_uses_array_fold() {
-        // Default (no scope) = ClickHouse: the historical `arrayFold` spelling,
-        // byte-identical to what both render paths emitted before this helper.
+        // Default (no scope) = ClickHouse. #950: the accumulator is the FIRST
+        // lambda parameter (`arrayFold(acc, x -> …)`), matching ClickHouse's
+        // fold semantics — the element-first form was silently wrong.
         assert_eq!(
             reduce_fold_sql("x", "acc", "acc + x", "[1, 2, 3]", "0"),
-            "arrayFold(x, acc -> acc + x, [1, 2, 3], 0)"
+            "arrayFold(acc, x -> acc + x, [1, 2, 3], 0)"
         );
     }
 

--- a/tests/rust/integration/golden/sql_ir/standard/fn_reduce__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/fn_reduce__clickhouse.sql
@@ -1,3 +1,3 @@
 SELECT 
-      arrayFold(x, s -> s + x, [1, 2, 3], toInt64(0)) AS "r"
+      arrayFold(s, x -> s + x, [1, 2, 3], toInt64(0)) AS "r"
 FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10641,6 +10641,35 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #950: ClickHouse `arrayFold` binds the lambda's FIRST parameter to the
+    /// accumulator. The renderer previously emitted the ELEMENT first
+    /// (`arrayFold(x, acc -> …)`), so ClickHouse swapped accumulator/element
+    /// inside the body — silently wrong for a non-commutative body
+    /// (`reduce(acc = 0, y IN [1,2,3] | acc*10 + y)` folded to 60 not 123) and a
+    /// `Code 43` when their types differ. The accumulator must be rendered first.
+    #[tokio::test]
+    async fn reduce_renders_accumulator_first_950() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        let sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = 0, y IN [1, 2, 3] | acc * 10 + y) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        // Accumulator `acc` is the first lambda parameter, element `y` second.
+        assert!(
+            sql.contains("arrayFold(acc, y ->"),
+            "#950: ClickHouse arrayFold must render the accumulator first \
+             (`arrayFold(acc, y -> …)`):\n{sql}"
+        );
+        assert!(
+            !sql.contains("arrayFold(y, acc ->"),
+            "#950: element-first `arrayFold(y, acc -> …)` swaps accumulator and \
+             element inside the body → silently wrong fold:\n{sql}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// build its cross-label DISTINCT discriminator tuple from the #467
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -500,7 +500,7 @@ const CORPUS: &[(&str, &str)] = &[
         "fn_regex_match",
         "MATCH (u:User) WHERE u.name =~ '.*a.*' RETURN u.user_id",
     ),
-    // reduce -> CH arrayFold((x, acc) -> expr, list, init) / Spark
+    // reduce -> CH arrayFold((acc, x) -> expr, list, init) / Spark
     // aggregate(list, init, (acc, x) -> expr). Spark has no arrayFold; it
     // previously emitted the CH name on Databricks (UNRESOLVED_ROUTINE).
     (


### PR DESCRIPTION
## Summary

Cypher `reduce(acc = init, x IN list | body)` lowers to ClickHouse `arrayFold`. ClickHouse binds the lambda's **first** parameter to the **accumulator**; the renderer emitted the **element** first (`arrayFold(x, acc -> body, list, init)`), so ClickHouse swapped accumulator/element everywhere they appear in the body.

**Silent-wrong** for any non-commutative/non-associative body: `reduce(acc = 0, y IN [1,2,3] | acc*10 + y)` should fold to **123** (Neo4j left-fold) but produced **60**. Bodies whose element/accumulator types differ additionally failed with **Code 43** (`reduce(acc = 0, y IN ['ab','cde'] | acc + length(y))` — the originally-reported symptom). A symmetric body (`acc + y`) masks the swap, which is why it went unnoticed.

Closes #950.

## Fix

Swap `variable`/`accumulator` in the ClickHouse branch of `reduce_fold_sql` — the single render helper both `to_sql_query.rs` and `cte_extraction.rs` route through — so the accumulator is rendered first, and correct the inverted doc comment. **The Databricks branch was already correct** (`aggregate(list, init, (acc, x) -> expr)`, accumulator-first) and is unchanged.

## Verification

- **Live-verified on ClickHouse 26.7** (independently confirmed by review, not from docs): `arrayFold(acc, y -> acc*10+y, [1,2,3], 0)` = 123 (correct left-fold), the old `arrayFold(y, acc -> …)` = 60; a subtraction body `acc - y` over [1,2,3] from 10 = 4 (old form: -8).
- **End-to-end** on `schemas/dev/social_standard.yaml`: `acc*10+y` → 123 (was 60); string body → 5 (was Code 43); `acc - y` → 4.
- **Zero corpus churn** (no `arrayFold` in the corpus); one golden snapshot regenerated (`fn_reduce__clickhouse.sql`: `arrayFold(x, s -> …)` → `arrayFold(s, x -> …)`; Databricks snapshot untouched); `common.rs` unit test updated; new golden test `reduce_renders_accumulator_first_950`.
- 1687 lib + 565 integration + ratchet green; the #944/#946/#949 reduce shielding tests still pass (they assert body content, not header arg order).
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER** — live-confirmed arg order; noted one orthogonal pre-existing empty-list `reduce` Code 53 (untyped `[]` literal, order-independent) worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)