### PR TITLE
fix(#955): reduce() over an empty list literal returns the init accumulator

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -2039,6 +2039,15 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
                 init_sql
             };
 
+            // #955: a fold over an EMPTY list literal does zero iterations, so
+            // the result is exactly the initial accumulator. The fold would fail
+            // on ClickHouse with Code 53 (the bare `[]` is `Array(Nothing)`, so
+            // the lambda return type can't unify with the accumulator). Mirrors
+            // the Path A (`RenderExpr::to_sql`) short-circuit exactly.
+            if matches!(reduce.list.as_ref(), RenderExpr::List(items) if items.is_empty()) {
+                return init_cast;
+            }
+
             crate::clickhouse_query_generator::reduce_fold_sql(
                 &reduce.variable,
                 &reduce.accumulator,

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7988,6 +7988,19 @@ impl RenderExpr {
                     init_sql
                 };
 
+                // #955: a fold over an EMPTY list literal does zero iterations,
+                // so the result is exactly the initial accumulator. Emitting the
+                // fold anyway (`arrayFold(…, [], init)`) fails on ClickHouse with
+                // Code 53 — the bare `[]` literal is `Array(Nothing)`, so the
+                // lambda's inferred return type can't unify with the accumulator
+                // (and Spark's untyped `array()` is the same hazard). We can't
+                // synthesize a correctly-typed empty array here (the element type
+                // is unknowable from an empty literal), and it isn't needed:
+                // short-circuit to the init expression.
+                if matches!(reduce.list.as_ref(), RenderExpr::List(items) if items.is_empty()) {
+                    return init_cast;
+                }
+
                 super::common::reduce_fold_sql(
                     &reduce.variable,
                     &reduce.accumulator,

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10728,6 +10728,23 @@ mod walker_drift_family_484_490_495_476_483 {
             "#955: an empty-list reduce with a string init returns the init \
              verbatim:\n{str_sql}"
         );
+
+        // Path C coverage: a reduce inside a VLP WHERE filter is rendered by
+        // `cte_extraction::render_expr_to_sql_string` (not `RenderExpr::to_sql`),
+        // so it needs its OWN short-circuit. Without it this emits
+        // `arrayFold(…, [], toInt64(0))` inside the VLP CTE → Code 53.
+        let vlp_sql = render(
+            &schema,
+            "MATCH (u:User)-[r:FOLLOWS*1..2]->(v:User) \
+             WHERE reduce(acc = 0, y IN [] | acc + y) = 0 RETURN u.user_id",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !vlp_sql.contains("arrayFold") && vlp_sql.contains("toInt64(0)"),
+            "#955: an empty-list reduce in a VLP WHERE (Path C) must also \
+             short-circuit to the init:\n{vlp_sql}"
+        );
     }
 
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10670,6 +10670,66 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #955: a `reduce()` over an EMPTY list literal does zero iterations, so the
+    /// result is the initial accumulator. Emitting the fold anyway
+    /// (`arrayFold(…, [], init)`) fails on ClickHouse with Code 53 — the bare
+    /// `[]` is `Array(Nothing)`, so the lambda return type can't unify with the
+    /// accumulator (Spark's untyped `array()` is the same hazard). Both render
+    /// paths short-circuit to the init expression.
+    #[tokio::test]
+    async fn reduce_over_empty_list_returns_init_955() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        // ClickHouse: numeric init → `toInt64(7)`, no `arrayFold`.
+        let ch_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = 7, y IN [] | acc + y) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !ch_sql.contains("arrayFold"),
+            "#955: an empty-list reduce must NOT emit arrayFold (Code 53 on the \
+             untyped `[]`):\n{ch_sql}"
+        );
+        assert!(
+            ch_sql.contains("toInt64(7)"),
+            "#955: an empty-list reduce must short-circuit to the (cast) init \
+             expression:\n{ch_sql}"
+        );
+
+        // Databricks: same short-circuit → `bigint(7)`, no `aggregate`.
+        let dbx_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = 7, y IN [] | acc + y) AS r",
+            SqlDialect::Databricks,
+        )
+        .await;
+        assert!(
+            !dbx_sql.contains("aggregate("),
+            "#955: an empty-list reduce must NOT emit aggregate() on Databricks \
+             either:\n{dbx_sql}"
+        );
+        assert!(
+            dbx_sql.contains("bigint(7)"),
+            "#955: Databricks empty-list reduce must short-circuit to the (cast) \
+             init:\n{dbx_sql}"
+        );
+
+        // A non-numeric init keeps its own rendering (no numeric cast).
+        let str_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(acc = 'seed', y IN [] | acc + y) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !str_sql.contains("arrayFold") && str_sql.contains("'seed'"),
+            "#955: an empty-list reduce with a string init returns the init \
+             verbatim:\n{str_sql}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// build its cross-label DISTINCT discriminator tuple from the #467
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`


### PR DESCRIPTION
## Summary

A Cypher `reduce(acc = init, x IN [] | body)` over an EMPTY list does zero iterations, so its result is exactly `init`. The renderer emitted the fold anyway — `arrayFold(…, [], init)` (ClickHouse) / `aggregate(array(), init, …)` (Spark) — which fails with **Code 53 TYPE_MISMATCH**: the bare `[]` literal is typed `Array(Nothing)`, so the lambda's inferred return type can't unify with the accumulator.

Closes #955. Follow-up to #950 (same reduce/arrayFold render sites).

## Fix

We can't synthesize a correctly-typed empty array (the element type is unknowable from an empty literal, and can differ from the accumulator type — e.g. `reduce(acc = 0, y IN [] | acc + length(y))`), and it isn't needed. At BOTH `RenderExpr::ReduceExpr` render sites — `to_sql_query.rs` (Path A) and `cte_extraction.rs` (Path C) — when `reduce.list` is a `RenderExpr::List` with no elements, short-circuit to the init expression (preserving the existing numeric `toInt64` cast). Dialect-agnostic — fixes both ClickHouse and Spark's untyped `array()`.

The check is deliberately the INLINE `[]` literal only; a non-literal list (a WITH variable / `collect()`) may be runtime-typed and folds fine, so it is correctly left alone.

## Verification

- **Live-verified**: `reduce(acc = 7, y IN [] | acc + y)` → `toInt64(7)` → returns **7** (was Code 53); string init → `'seed'`; Databricks renders `bigint(7)`; nested `reduce(...) + 1` → 8. Non-empty reduces unchanged (`acc*10 + y` over [1,2,3] still 123).
- No corpus churn (no reduce in the corpus); 1687 lib + integration + ratchet + snapshots green.
- New golden test `reduce_over_empty_list_returns_init_955` covers **both** render paths (CH projection = Path A; VLP-WHERE = Path C) + Databricks + string-init, proven load-bearing (neutering either short-circuit fails it).
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER** — live-confirmed the Code 53, both-path parity, and that runtime-typed empty arrays are correctly untouched. Its Path-C-coverage finding is addressed by the added VLP-WHERE assertion.

## Follow-up filed

**#957**: a `[]` bound through WITH (`WITH [] AS xs … reduce(…, y IN xs …)`) still fails Code 53 — the untyped `[]` flows through WITH-literal-array rendering, a distinct upstream site this fix correctly does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)