### PR TITLE
fix(#962): dispatch size()/reverse() to UTF8 variants for proven-string args

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1955,6 +1955,25 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             {
                 return sql;
             }
+            // #962: on ClickHouse, `size`/`reverse` over a PROVEN string arg
+            // upgrade to the codepoint-based `lengthUTF8`/`reverseUTF8` (the
+            // byte-based `length`/`reverse` mangle multi-byte UTF-8). Array /
+            // unknown args keep the plain name (correct for arrays, byte-
+            // identical for unknowns). Mirrors the Path A renderer
+            // (to_sql_query.rs); this Path-C renderer backs VLP bound-node /
+            // pattern-comprehension WHERE filters.
+            if fn_lower == "size" || fn_lower == "reverse" {
+                let dialect = crate::server::query_context::get_current_dialect();
+                if let Some(utf8) =
+                    crate::sql_generator::emitters::clickhouse::to_sql_query::clickhouse_utf8_string_fn(
+                        &fn_lower,
+                        func.args.first(),
+                        dialect,
+                    )
+                {
+                    return format!("{}({})", utf8, args.join(", "));
+                }
+            }
             // Map dialect-divergent names (e.g. tuple -> Spark struct) via the registry.
             let name = crate::clickhouse_query_generator::dialect_function_name(&func.name);
             format!("{}({})", name, args.join(", "))

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -1005,6 +1005,40 @@ fn databricks_size_name(
     arg.filter(|a| render_arg_is_collection(a)).map(|_| "size")
 }
 
+/// #962: ClickHouse UTF8 upgrade for the OVERLOADED string/array functions
+/// `size`→`length` and `reverse`. ClickHouse's `length`/`reverse` are
+/// byte-based on strings (silently wrong on multi-byte UTF-8 — `size('héllo')`
+/// counts 6 bytes, not 5 codepoints; `reverse('héllo')` byte-reverses into
+/// garbage), but `lengthUTF8`/`reverseUTF8` are STRING-ONLY (reject arrays).
+/// So — unlike the string-only functions fixed at the registry level in #960 —
+/// we can only upgrade when the argument is PROVEN to be a string. An array or
+/// an unknown-typed argument keeps the plain `length`/`reverse` (correct for
+/// arrays; byte-identical to pre-#962 for unknowns, so no regression and never
+/// breaks an array). ClickHouse only — Spark's `length`/`reverse` are already
+/// codepoint-based (and `size` there is separately dispatched to Spark `size`
+/// for collections via [`databricks_size_name`]).
+pub(crate) fn clickhouse_utf8_string_fn(
+    fn_name_lower: &str,
+    arg: Option<&RenderExpr>,
+    dialect: crate::sql_generator::SqlDialect,
+) -> Option<&'static str> {
+    use crate::sql_generator::SqlDialect;
+    if dialect == SqlDialect::Databricks {
+        return None;
+    }
+    let arg = arg?;
+    let is_string = super::type_inference::infer_render_type(arg)
+        == Some(super::type_inference::RenderType::String);
+    if !is_string {
+        return None;
+    }
+    match fn_name_lower {
+        "size" => Some("lengthUTF8"),
+        "reverse" => Some("reverseUTF8"),
+        _ => None,
+    }
+}
+
 /// True when a `size()` argument is recognizably a collection (vs a string).
 fn render_arg_is_collection(arg: &RenderExpr) -> bool {
     fn name_is_collection(name: &str) -> bool {
@@ -7259,8 +7293,15 @@ impl RenderExpr {
                         // Cypher `size()` is dialect-/type-sensitive on Spark: emit
                         // `size` for a collection argument, else the string-safe
                         // `length` default. ClickHouse keeps overloaded `length`.
+                        // #962: on ClickHouse, `size`/`reverse` over a PROVEN
+                        // string upgrade to the codepoint-based `lengthUTF8`/
+                        // `reverseUTF8` (array/unknown args keep the plain name).
                         let fn_name = if fn_name_lower == "size" {
-                            databricks_size_name(fn_call.args.first(), dialect)
+                            clickhouse_utf8_string_fn(&fn_name_lower, fn_call.args.first(), dialect)
+                                .or_else(|| databricks_size_name(fn_call.args.first(), dialect))
+                                .unwrap_or_else(|| mapping.name_for(dialect))
+                        } else if fn_name_lower == "reverse" {
+                            clickhouse_utf8_string_fn(&fn_name_lower, fn_call.args.first(), dialect)
                                 .unwrap_or_else(|| mapping.name_for(dialect))
                         } else {
                             mapping.name_for(dialect)
@@ -9734,6 +9775,44 @@ mod tests {
         let lit = RenderExpr::Literal(Literal::String("abc".to_string()));
         assert_eq!(
             databricks_size_name(Some(&lit), SqlDialect::Databricks),
+            None
+        );
+    }
+
+    /// #962: `clickhouse_utf8_string_fn` upgrades `size`/`reverse` to the
+    /// codepoint-based UTF8 variants ONLY for a proven-string arg on ClickHouse.
+    #[test]
+    fn clickhouse_utf8_string_fn_dispatches_by_arg_type() {
+        use crate::sql_generator::SqlDialect;
+        let str_lit = RenderExpr::Literal(Literal::String("héllo".to_string()));
+        let arr = RenderExpr::List(vec![RenderExpr::Literal(Literal::Integer(1))]);
+
+        // Proven string on ClickHouse → UTF8 variant.
+        assert_eq!(
+            clickhouse_utf8_string_fn("size", Some(&str_lit), SqlDialect::ClickHouse),
+            Some("lengthUTF8")
+        );
+        assert_eq!(
+            clickhouse_utf8_string_fn("reverse", Some(&str_lit), SqlDialect::ClickHouse),
+            Some("reverseUTF8")
+        );
+        // Array arg → None (keep the plain, array-safe name).
+        assert_eq!(
+            clickhouse_utf8_string_fn("size", Some(&arr), SqlDialect::ClickHouse),
+            None
+        );
+        assert_eq!(
+            clickhouse_utf8_string_fn("reverse", Some(&arr), SqlDialect::ClickHouse),
+            None
+        );
+        // Databricks → None (Spark is already codepoint-based).
+        assert_eq!(
+            clickhouse_utf8_string_fn("size", Some(&str_lit), SqlDialect::Databricks),
+            None
+        );
+        // A non-size/reverse function name → None even for a string.
+        assert_eq!(
+            clickhouse_utf8_string_fn("upper", Some(&str_lit), SqlDialect::ClickHouse),
             None
         );
     }

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10790,6 +10790,57 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #962: `size`/`reverse` are overloaded across strings AND arrays, so —
+    /// unlike the string-only functions in #960 — the UTF8 upgrade must be
+    /// argument-type-dispatched: `lengthUTF8`/`reverseUTF8` (string-only on
+    /// ClickHouse) fire only when the argument is a PROVEN string; an array or
+    /// unknown-typed argument keeps the plain `length`/`reverse`.
+    #[tokio::test]
+    async fn size_reverse_utf8_dispatch_by_arg_type_962() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        // PROVEN string (literal, and a string-returning-fn arg) → UTF8 variant.
+        let str_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN size('héllo') AS a, reverse('héllo') AS b, \
+             size(toUpper('x')) AS c",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            str_sql.contains("lengthUTF8(") && str_sql.contains("reverseUTF8("),
+            "#962: size/reverse over a proven string must use the UTF8 variant:\n{str_sql}"
+        );
+
+        // ARRAY argument → plain `length`/`reverse` (UTF8 variants reject arrays).
+        let arr_sql = render(
+            &schema,
+            "MATCH (u:User) RETURN size([1, 2, 3]) AS a, reverse([1, 2, 3]) AS b",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            arr_sql.contains("length(")
+                && arr_sql.contains("reverse(")
+                && !arr_sql.contains("lengthUTF8(")
+                && !arr_sql.contains("reverseUTF8("),
+            "#962: size/reverse over an ARRAY must keep the plain (non-UTF8) name:\n{arr_sql}"
+        );
+
+        // Databricks keeps plain names for both (Spark is already codepoint-based;
+        // `size` over a collection is separately dispatched to Spark `size`).
+        let dbx = render(
+            &schema,
+            "MATCH (u:User) RETURN size('héllo') AS a, reverse('héllo') AS b",
+            SqlDialect::Databricks,
+        )
+        .await;
+        assert!(
+            !dbx.contains("UTF8"),
+            "#962: Databricks must not emit any UTF8 variant:\n{dbx}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`
     /// ViewScan UNION, which has genuinely separate `post_id`/`user_id`


### PR DESCRIPTION
## Summary

Follow-up to #960 (which fixed the string-only functions at the registry level). `size`/`length` and `reverse` are **overloaded across strings AND arrays**, so they can't be swapped in the registry: ClickHouse's `lengthUTF8`/`reverseUTF8` are **string-only** (reject arrays), while the plain `length`/`reverse` are byte-based on strings (silently wrong on multi-byte UTF-8 — `size('héllo')` counts 6 bytes not 5 codepoints; `reverse('héllo')` byte-reverses into garbage) but correct on arrays.

Closes #962. Completes the #960 string-UTF8-fidelity family.

## Fix

Add `clickhouse_utf8_string_fn`, an argument-type-dispatched upgrade parallel to the existing `databricks_size_name`: on ClickHouse (not Databricks), for `size`/`reverse`, emit `lengthUTF8`/`reverseUTF8` **only when `infer_render_type(arg)` proves the argument is a `String`** (literal, string-returning function, or a `string`-declared property). An array or unknown-typed argument keeps the plain name — correct for arrays, byte-identical to pre-#962 for unknowns (no regression, never breaks an array). Wired into **both** render paths: the ScalarFnCall arm in `to_sql_query.rs` (Path A) and `render_expr_to_sql_string` in `cte_extraction.rs` (Path C, VLP/pattern-comp WHERE).

## Verification

- **Live-verified**: `size('héllo')`=5 (was 6), `reverse('héllo')`='olléh' (was garbage), `size(toUpper('héllo'))`=5; `size([1,2,3])`=3 and `reverse([1,2,3])`=[3,2,1] unchanged.
- Zero golden churn (no existing golden had a proven-string size/reverse); 1688 lib + 568 integration + ratchet (net-neutral) green. New golden `size_reverse_utf8_dispatch_by_arg_type_962` + unit test, both load-bearing.
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER.** The crux array-safety audit PASSED — reviewer exhaustively verified `infer_render_type` never returns `String` for any array-producing expression (list literals, `collect`/`range`/`split`, list comprehensions → `arrayFilter`, `SameAsArg0` recursion, and decisively that `SchemaType` has no array variant), confirmed live that `size(collect(...))`/`size(range(...))` keep the plain name. Both paths parity-verified; Databricks untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)