### PR TITLE
fix(#969): render reduce() string-concat body as concat()

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -2045,7 +2045,19 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             // ReduceExpr arm exactly).
             let init_sql = render_expr_to_sql_string(&reduce.initial_value, alias_mapping);
             let list_sql = render_expr_to_sql_string(&reduce.list, alias_mapping);
+            // #969: install the lambda binder types around the BODY render only,
+            // so the string-`+`→`concat` detector sees `s + x` as a string
+            // concatenation (mirrors Path A). initial_value/list are outer-scope
+            // (rendered above). Save/restore for nested reduces.
+            let binder_types = crate::clickhouse_query_generator::reduce_binder_type_map(
+                &reduce.accumulator,
+                &reduce.initial_value,
+                &reduce.variable,
+                &reduce.list,
+            );
+            let prev_binders = crate::server::query_context::push_reduce_binder_types(binder_types);
             let expr_sql = render_expr_to_sql_string(&reduce.expression, alias_mapping);
+            crate::server::query_context::restore_reduce_binder_types(prev_binders);
 
             // Wrap numeric init values in a 64-bit integer cast to prevent
             // type mismatch.

--- a/src/render_plan/expression_utils.rs
+++ b/src/render_plan/expression_utils.rs
@@ -391,6 +391,21 @@ pub fn contains_string_literal(expr: &RenderExpr) -> bool {
         RenderExpr::OperatorApplicationExp(op) if op.operator == Operator::Addition => {
             op.operands.iter().any(contains_string_literal)
         }
+        // #969: a bare reduce lambda binder typed String task-locally — consulted
+        // ONLY by the string-concat detectors (mirrors `is_string_operand` in the
+        // clickhouse emitter), never via the shared `infer_render_type`.
+        RenderExpr::TableAlias(ta) => {
+            crate::server::query_context::get_reduce_binder_type(&ta.0)
+                == Some(
+                    crate::sql_generator::emitters::clickhouse::type_inference::RenderType::String,
+                )
+        }
+        RenderExpr::Column(col) => {
+            crate::server::query_context::get_reduce_binder_type(col.raw())
+                == Some(
+                    crate::sql_generator::emitters::clickhouse::type_inference::RenderType::String,
+                )
+        }
         _ => {
             crate::sql_generator::emitters::clickhouse::type_inference::infer_render_type(expr)
                 == Some(

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -67,6 +67,19 @@ pub struct QueryContext {
     /// Used for IS NULL checks on relationship aliases
     pub relationship_columns: HashMap<String, (String, String)>,
 
+    /// #969: types of `reduce()` lambda binders in scope while the CURRENT
+    /// reduce body is being rendered — `accumulator → type of initial_value`,
+    /// `variable → element type of list`. `infer_render_type` consults this so a
+    /// bare binder reference (`s`/`x`, which otherwise types as unknown) resolves
+    /// to its real type. That lets the string-`+`→`concat` detector (#871) fire
+    /// for `reduce(s = '', x IN ['a','b','c'] | s + x)` — otherwise the body
+    /// renders a numeric `+` on two strings → ClickHouse Code 43. Pushed (saving
+    /// the prior map) around the body render at each `ReduceExpr` site and
+    /// restored after, so nested reduces scope correctly. Empty outside any
+    /// reduce → unknown binder stays `None` (conservative, unchanged behavior).
+    pub reduce_binder_types:
+        HashMap<String, crate::sql_generator::emitters::clickhouse::type_inference::RenderType>,
+
     /// Multi-type VLP aliases: alias → cte_name
     /// For aliases that are multi-type VLP endpoints requiring JSON extraction
     pub multi_type_vlp_aliases: HashMap<String, String>,
@@ -487,6 +500,37 @@ pub fn set_relationship_columns(columns: HashMap<String, (String, String)>) {
 pub fn get_relationship_columns(alias: &str) -> Option<(String, String)> {
     QUERY_CONTEXT
         .try_with(|ctx| ctx.borrow().relationship_columns.get(alias).cloned())
+        .ok()
+        .flatten()
+}
+
+/// #969: install the reduce-lambda binder-type map for the CURRENT reduce body
+/// render, returning the PRIOR map so the caller can restore it after (so nested
+/// reduces scope correctly). See [`QueryContext::reduce_binder_types`].
+pub fn push_reduce_binder_types(
+    types: HashMap<String, crate::sql_generator::emitters::clickhouse::type_inference::RenderType>,
+) -> HashMap<String, crate::sql_generator::emitters::clickhouse::type_inference::RenderType> {
+    QUERY_CONTEXT
+        .try_with(|ctx| std::mem::replace(&mut ctx.borrow_mut().reduce_binder_types, types))
+        .unwrap_or_default()
+}
+
+/// #969: restore a reduce binder-type map saved by [`push_reduce_binder_types`].
+pub fn restore_reduce_binder_types(
+    prev: HashMap<String, crate::sql_generator::emitters::clickhouse::type_inference::RenderType>,
+) {
+    let _ = QUERY_CONTEXT.try_with(|ctx| {
+        ctx.borrow_mut().reduce_binder_types = prev;
+    });
+}
+
+/// #969: the declared type of a `reduce()` lambda binder currently in scope, if
+/// any. `None` outside a reduce body (map empty) → conservative, unchanged.
+pub fn get_reduce_binder_type(
+    name: &str,
+) -> Option<crate::sql_generator::emitters::clickhouse::type_inference::RenderType> {
+    QUERY_CONTEXT
+        .try_with(|ctx| ctx.borrow().reduce_binder_types.get(name).copied())
         .ok()
         .flatten()
 }

--- a/src/sql_generator/emitters/clickhouse/common.rs
+++ b/src/sql_generator/emitters/clickhouse/common.rs
@@ -168,6 +168,37 @@ pub fn reduce_fold_sql(
     }
 }
 
+/// #969: build the `{binder_name → RenderType}` map for a `reduce()`'s lambda
+/// body from its structural components — `accumulator` takes the type of
+/// `initial_value`, `variable` the ELEMENT type of `list`. Only binders whose
+/// type resolves are inserted (an unresolved binder stays untyped → unchanged).
+///
+/// Install it around the body render with
+/// `push_reduce_binder_types` / `restore_reduce_binder_types` so
+/// `infer_render_type` can type a bare binder reference — letting the string-`+`
+/// → `concat` detector fire for `reduce(s = '', x IN ['a','b'] | s + x)`.
+pub fn reduce_binder_type_map(
+    accumulator: &str,
+    initial_value: &crate::render_plan::render_expr::RenderExpr,
+    variable: &str,
+    list: &crate::render_plan::render_expr::RenderExpr,
+) -> std::collections::HashMap<
+    String,
+    crate::sql_generator::emitters::clickhouse::type_inference::RenderType,
+> {
+    use crate::sql_generator::emitters::clickhouse::type_inference::{
+        infer_list_element_type, infer_render_type,
+    };
+    let mut map = std::collections::HashMap::new();
+    if let Some(t) = infer_render_type(initial_value) {
+        map.insert(accumulator.to_string(), t);
+    }
+    if let Some(t) = infer_list_element_type(list) {
+        map.insert(variable.to_string(), t);
+    }
+    map
+}
+
 /// Render a Cypher *simple* CASE (`CASE expr WHEN v1 THEN r1 ... ELSE d END`)
 /// for the active dialect, from its already-rendered component strings.
 ///

--- a/src/sql_generator/emitters/clickhouse/mod.rs
+++ b/src/sql_generator/emitters/clickhouse/mod.rs
@@ -22,8 +22,8 @@ mod where_clause_tests;
 
 pub use common::{
     contains_predicate, dialect_function_name, ends_with_predicate, list_higher_order_fn_sql,
-    qualified_column, quote_identifier, reduce_fold_sql, regex_match_predicate, round_half_up_sql,
-    starts_with_predicate,
+    qualified_column, quote_identifier, reduce_binder_type_map, reduce_fold_sql,
+    regex_match_predicate, round_half_up_sql, starts_with_predicate,
 };
 pub use errors::ClickhouseQueryGeneratorError;
 pub use function_translator::{

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -55,6 +55,18 @@ fn is_string_operand(expr: &RenderExpr) -> bool {
         RenderExpr::OperatorApplicationExp(op) if op.operator == Operator::Addition => {
             op.operands.iter().any(is_string_operand)
         }
+        // #969: a bare reduce lambda binder (`s`/`x`) whose task-local type is
+        // String — consulted ONLY here (the string-concat detector), never via
+        // the shared `infer_render_type` classifier, so #880/#854/#962 keep
+        // seeing binders as untyped (preserving the conservative-None invariant).
+        RenderExpr::TableAlias(ta) => {
+            crate::server::query_context::get_reduce_binder_type(&ta.0)
+                == Some(super::type_inference::RenderType::String)
+        }
+        RenderExpr::Column(col) => {
+            crate::server::query_context::get_reduce_binder_type(col.raw())
+                == Some(super::type_inference::RenderType::String)
+        }
         _ => {
             super::type_inference::infer_render_type(expr)
                 == Some(super::type_inference::RenderType::String)

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -8015,7 +8015,21 @@ impl RenderExpr {
                 // Cast numeric init to Int64 to prevent type mismatch issues
                 let init_sql = reduce.initial_value.to_sql();
                 let list_sql = reduce.list.to_sql();
+                // #969: install the lambda binder types (acc = type of
+                // initial_value, x = element type of list) around the BODY render
+                // only, so the string-`+`→`concat` detector can see `s + x` as a
+                // string concatenation. initial_value/list are outer-scope and
+                // rendered above, unaffected. Save/restore for nested reduces.
+                let binder_types = super::common::reduce_binder_type_map(
+                    &reduce.accumulator,
+                    &reduce.initial_value,
+                    &reduce.variable,
+                    &reduce.list,
+                );
+                let prev_binders =
+                    crate::server::query_context::push_reduce_binder_types(binder_types);
                 let expr_sql = reduce.expression.to_sql();
+                crate::server::query_context::restore_reduce_binder_types(prev_binders);
 
                 // Wrap numeric init values in a 64-bit-int cast to prevent
                 // type mismatch when the lambda returns a wider type.

--- a/src/sql_generator/emitters/clickhouse/type_inference.rs
+++ b/src/sql_generator/emitters/clickhouse/type_inference.rs
@@ -107,12 +107,48 @@ pub fn infer_render_type(expr: &RenderExpr) -> Option<RenderType> {
         RenderExpr::InSubquery(_) | RenderExpr::ExistsSubquery(_) => Some(RenderType::Boolean),
         RenderExpr::PatternCount(_) => Some(RenderType::Integer),
 
+        // ---- #969: a `reduce()` lambda binder in scope ----
+        // A bare `TableAlias`/`Column` is normally untyped (unknown), but while a
+        // reduce BODY is being rendered its `accumulator`/`variable` binders have
+        // a known type (seeded from `initial_value` / the list element type),
+        // installed task-locally by the ReduceExpr render sites. Consulting it
+        // lets the string-`+`→`concat` detector see that `s + x` is a string
+        // concatenation. Empty outside a reduce → `None` (unchanged).
+        RenderExpr::TableAlias(ta) => crate::server::query_context::get_reduce_binder_type(&ta.0),
+        RenderExpr::Column(col) => crate::server::query_context::get_reduce_binder_type(col.raw()),
+
         // ---- Everything else: unknown (conservative) ----
-        // Column (bare, no alias→label), TableAlias, ColumnAlias, Parameter,
-        // Raw, Star, MapLiteral, Case, ReduceExpr, ArraySubscript (element type
-        // unknown), CteEntityRef.
+        // ColumnAlias, Parameter, Raw, Star, MapLiteral, Case, ReduceExpr,
+        // ArraySubscript (element type unknown), CteEntityRef.
         _ => None,
     }
+}
+
+/// #969: infer the ELEMENT type of a list-valued expression, if uniform.
+///
+/// Used to type a `reduce()` iteration variable from its `list`. A `List` of
+/// literals/expressions returns the common element type when every non-null
+/// element agrees (e.g. `['a','b','c']` → `String`); an empty, mixed-type, or
+/// non-`List` expression returns `None` (conservative — the binder then stays
+/// untyped and behavior is unchanged).
+pub fn infer_list_element_type(expr: &RenderExpr) -> Option<RenderType> {
+    let RenderExpr::List(items) = expr else {
+        return None;
+    };
+    let mut elem: Option<RenderType> = None;
+    for item in items {
+        match infer_render_type(item) {
+            // A typeless element (e.g. Cypher null) doesn't constrain the type.
+            None => {}
+            Some(t) => match elem {
+                None => elem = Some(t),
+                Some(prev) if prev == t => {}
+                // Mixed element types → not uniform.
+                Some(_) => return None,
+            },
+        }
+    }
+    elem
 }
 
 /// Classify a function call by its registry [`FnReturnKind`], recursing for the
@@ -440,5 +476,40 @@ mod tests {
             column: PropertyValue::Column("name".into()),
         });
         assert_eq!(infer_render_type(&pa), None);
+    }
+
+    #[test]
+    fn infer_list_element_type_uniform_and_mixed() {
+        use crate::render_plan::render_expr::Literal;
+        let s = |v: &str| RenderExpr::Literal(Literal::String(v.to_string()));
+        let i = |v: i64| RenderExpr::Literal(Literal::Integer(v));
+
+        // Uniform string list → String.
+        assert_eq!(
+            infer_list_element_type(&RenderExpr::List(vec![s("a"), s("b"), s("c")])),
+            Some(RenderType::String)
+        );
+        // Uniform integer list → Integer.
+        assert_eq!(
+            infer_list_element_type(&RenderExpr::List(vec![i(1), i(2)])),
+            Some(RenderType::Integer)
+        );
+        // Mixed → None.
+        assert_eq!(
+            infer_list_element_type(&RenderExpr::List(vec![s("a"), i(1)])),
+            None
+        );
+        // Empty → None.
+        assert_eq!(infer_list_element_type(&RenderExpr::List(vec![])), None);
+        // A null element doesn't constrain: [null, 'a'] → String.
+        assert_eq!(
+            infer_list_element_type(&RenderExpr::List(vec![
+                RenderExpr::Literal(Literal::Null),
+                s("a")
+            ])),
+            Some(RenderType::String)
+        );
+        // Non-list → None.
+        assert_eq!(infer_list_element_type(&s("a")), None);
     }
 }

--- a/src/sql_generator/emitters/clickhouse/type_inference.rs
+++ b/src/sql_generator/emitters/clickhouse/type_inference.rs
@@ -107,19 +107,21 @@ pub fn infer_render_type(expr: &RenderExpr) -> Option<RenderType> {
         RenderExpr::InSubquery(_) | RenderExpr::ExistsSubquery(_) => Some(RenderType::Boolean),
         RenderExpr::PatternCount(_) => Some(RenderType::Integer),
 
-        // ---- #969: a `reduce()` lambda binder in scope ----
-        // A bare `TableAlias`/`Column` is normally untyped (unknown), but while a
-        // reduce BODY is being rendered its `accumulator`/`variable` binders have
-        // a known type (seeded from `initial_value` / the list element type),
-        // installed task-locally by the ReduceExpr render sites. Consulting it
-        // lets the string-`+`→`concat` detector see that `s + x` is a string
-        // concatenation. Empty outside a reduce → `None` (unchanged).
-        RenderExpr::TableAlias(ta) => crate::server::query_context::get_reduce_binder_type(&ta.0),
-        RenderExpr::Column(col) => crate::server::query_context::get_reduce_binder_type(col.raw()),
-
         // ---- Everything else: unknown (conservative) ----
-        // ColumnAlias, Parameter, Raw, Star, MapLiteral, Case, ReduceExpr,
-        // ArraySubscript (element type unknown), CteEntityRef.
+        // Column (bare, no alias→label), TableAlias, ColumnAlias, Parameter,
+        // Raw, Star, MapLiteral, Case, ReduceExpr, ArraySubscript (element type
+        // unknown), CteEntityRef.
+        //
+        // NOTE (#969): a `reduce()` lambda binder DOES have a known type inside
+        // its body, but it is deliberately NOT surfaced here. This shared
+        // classifier feeds #880 (toInteger/toFloat-OrNull), #854 (temporal), and
+        // #962 (size/reverse UTF8) as well as #871 (string-`+`→concat); typing a
+        // binder here made #880 rewrite `toInteger(x)` on a string-element binder
+        // to `toInt64OrNull` → `Nullable` → Code 53 (a regression). The binder
+        // type is instead consulted ONLY by the string-concat detectors
+        // (`is_string_operand` / `expression_utils::contains_string_literal`) via
+        // `query_context::get_reduce_binder_type`, keeping the conservative-None
+        // invariant intact for every other consumer.
         _ => None,
     }
 }

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10879,6 +10879,54 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #969: a `reduce()` whose body concatenates strings via `+` must render
+    /// `concat(...)`, not numeric `+` (ClickHouse `+` on strings → Code 43). The
+    /// operands are lambda binders (`s` = accumulator, `x` = variable), so the
+    /// string-`+`→`concat` detector needs their types — installed task-locally
+    /// from `initial_value` (String seed) and the list element type. A numeric
+    /// reduce (Integer seed + integer list) must stay `+`.
+    #[tokio::test]
+    async fn reduce_string_concat_body_renders_concat_969() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        // String fold: `+` → concat, both dialects.
+        let ch = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(s = '', x IN ['a', 'b', 'c'] | s + x) AS v",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            ch.contains("concat(s, x)") && !ch.contains("s + x"),
+            "#969: a string reduce body must render concat(s, x), not numeric \
+             `s + x`:\n{ch}"
+        );
+        let dbx = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(s = '', x IN ['a', 'b', 'c'] | s + x) AS v",
+            SqlDialect::Databricks,
+        )
+        .await;
+        assert!(
+            dbx.contains("concat(s, x)"),
+            "#969: string reduce body must concat on Databricks too:\n{dbx}"
+        );
+
+        // Numeric fold: must stay `+` (no over-fire to concat) — guards the
+        // conservative binder-type gate.
+        let num = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(s = 0, x IN [1, 2, 3] | s + x) AS v",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            num.contains("s + x") && !num.contains("concat"),
+            "#969: a numeric reduce body must stay `s + x` (binder types are \
+             Integer, not String):\n{num}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`
     /// ViewScan UNION, which has genuinely separate `post_id`/`user_id`

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10925,6 +10925,24 @@ mod walker_drift_family_484_490_495_476_483 {
             "#969: a numeric reduce body must stay `s + x` (binder types are \
              Integer, not String):\n{num}"
         );
+
+        // #969 (review): the binder-type signal must NOT leak into the shared
+        // `infer_render_type` classifier — only the string-concat detectors read
+        // it. Otherwise #880's `toInteger(x)`→`toInt64OrNull` dispatch would fire
+        // on a string-element binder, producing `Nullable(Int64)` that can't
+        // unify with the Int accumulator → Code 53 (a regression). The binder
+        // stays untyped for #880, so `toInteger(x)` keeps the plain `toInt64`.
+        let coerce = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(n = 0, x IN ['1', '2'] | n + toInteger(x)) AS v",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            coerce.contains("toInt64(") && !coerce.contains("toInt64OrNull"),
+            "#969: a reduce binder must NOT bleed into the #880 toInteger/toFloat \
+             string-arg dispatch (would be Code 53):\n{coerce}"
+        );
     }
 
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to


### PR DESCRIPTION
## Summary

A `reduce()` whose body concatenates strings via `+` failed with **Code 43**: `reduce(s = '', x IN ['a','b','c'] | s + x)` rendered `arrayFold(s, x -> s + x, ['a','b','c'], '')` — the #871 string-`+`→`concat` detector inspects the `+` operands for a string literal/column, but here both operands are lambda **binders** (`s` accumulator, `x` variable) rendering as bare vars with no detectable type, so the `+` stayed numeric and ClickHouse rejects String `+` String.

Closes #969.

## Fix

The binders' types are inferable from the reduce — accumulator = type of `initial_value`, variable = element type of `list` — so install a task-local `{binder → RenderType}` map (`QueryContext::reduce_binder_types`) around the body render at both render paths (Path A `to_sql_query.rs`, Path C `cte_extraction.rs`), saved/restored for nested reduces. Added `infer_list_element_type` (uniform element type of a list literal; mixed/empty/non-list → None). Type-carrying analog of the `shielded` binder stack from #929/#944/#949.

**Crucially** (round-1 review finding), the binder type is consulted **only** by the two string-concat detectors (`is_string_operand` + `expression_utils::contains_string_literal`), NOT the shared `infer_render_type` classifier — surfacing it there violated the conservative-None invariant and regressed #880 (`toInteger(x)` on a string binder → `toInt64OrNull` → Code 53). The shared classifier stays conservative-None, so #880/#854/#962 see binders as untyped (main-vs-branch byte-identical for those paths).

Dialect-neutral: the codebase already renders string `+` as `concat` on both CH and Spark.

## Verification

- **Live-verified**: string reduce → `concat(s, x)` → 'abc'; numeric reduce stays `s + x` → 6; `reduce(n=0, x IN ['1','2'] | n + toInteger(x))` → `toInt64(x)` → 3 (the #880 regression is fixed); nested/shadowing correct; both dialects.
- Zero golden churn (numeric fn_reduce byte-identical); 1689 lib + 570 integration + ratchet (net-neutral) green.
- Golden test (CH + Databricks + numeric-regression + toInteger-invariant-guard) + `infer_list_element_type` unit test, both mutation-verified load-bearing.
- **Adversarial review, 2 rounds** — round 1 caught the shared-classifier invariant violation (MAJOR); round 2 APPROVE-0 after the narrowing, confirmed via main-vs-branch byte-diff that #880/#854/#962 are untouched.

## Follow-up

Reviewer noted a pre-existing, orthogonal, byte-identical-on-main issue: `reduce(n=0.0, x IN ['1.5'] | n + toFloat(x))` errors Code 53 because `init_cast` only wraps Integer (not Float) seeds. Will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)