### PR TITLE
fix(#971): cast a Float reduce() accumulator seed to Float64

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -2059,15 +2059,16 @@ pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, St
             let expr_sql = render_expr_to_sql_string(&reduce.expression, alias_mapping);
             crate::server::query_context::restore_reduce_binder_types(prev_binders);
 
-            // Wrap numeric init values in a 64-bit integer cast to prevent
-            // type mismatch.
-            let init_cast = if matches!(
-                *reduce.initial_value,
-                RenderExpr::Literal(Literal::Integer(_))
-            ) {
-                format!("{}({})", current_function_mapper().cast_int64(), init_sql)
-            } else {
-                init_sql
+            // Wrap a numeric init literal in the matching 64-bit cast to prevent
+            // a Code 53 type mismatch (mirrors Path A: #955 Integer, #971 Float).
+            let init_cast = match *reduce.initial_value {
+                RenderExpr::Literal(Literal::Integer(_)) => {
+                    format!("{}({})", current_function_mapper().cast_int64(), init_sql)
+                }
+                RenderExpr::Literal(Literal::Float(_)) => {
+                    format!("{}({})", current_function_mapper().cast_float64(), init_sql)
+                }
+                _ => init_sql,
             };
 
             // #955: a fold over an EMPTY list literal does zero iterations, so

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -8043,16 +8043,22 @@ impl RenderExpr {
                 let expr_sql = reduce.expression.to_sql();
                 crate::server::query_context::restore_reduce_binder_types(prev_binders);
 
-                // Wrap numeric init values in a 64-bit-int cast to prevent
-                // type mismatch when the lambda returns a wider type.
-                let init_cast = if matches!(
-                    *reduce.initial_value,
-                    RenderExpr::Literal(Literal::Integer(_))
-                ) {
-                    let fmap = crate::sql_generator::function_mapper::current_function_mapper();
-                    format!("{}({})", fmap.cast_int64(), init_sql)
-                } else {
-                    init_sql
+                // Wrap a numeric init literal in the matching 64-bit cast to
+                // prevent a Code 53 type mismatch when the lambda returns a wider
+                // type than the bare literal's inferred type. An Integer `0`
+                // infers as UInt8 and a Float `0.0` as Float64-vs-the-bare-`0`
+                // rendering; the cast pins the accumulator type. #955 (Integer),
+                // #971 (Float — `reduce(n = 0.0, x IN [1.5] | n + x)` seeded a
+                // bare `0` (UInt8) against a Float64 body → Code 53).
+                let fmap = crate::sql_generator::function_mapper::current_function_mapper();
+                let init_cast = match *reduce.initial_value {
+                    RenderExpr::Literal(Literal::Integer(_)) => {
+                        format!("{}({})", fmap.cast_int64(), init_sql)
+                    }
+                    RenderExpr::Literal(Literal::Float(_)) => {
+                        format!("{}({})", fmap.cast_float64(), init_sql)
+                    }
+                    _ => init_sql,
                 };
 
                 // #955: a fold over an EMPTY list literal does zero iterations,

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10987,6 +10987,22 @@ mod walker_drift_family_484_490_495_476_483 {
             int_seed.contains("toInt64(0)") && !int_seed.contains("toFloat64"),
             "#971: an Integer reduce seed must keep the Int64 cast:\n{int_seed}"
         );
+
+        // Path C coverage: a reduce with a Float seed inside a VLP WHERE filter
+        // is rendered by `cte_extraction::render_expr_to_sql_string` (not
+        // `RenderExpr::to_sql`), so it needs its OWN Float arm.
+        let vlp = render(
+            &schema,
+            "MATCH (u:User)-[r:FOLLOWS*1..2]->(v:User) \
+             WHERE reduce(n = 0.0, x IN [1.5, 2.5] | n + x) > 3 RETURN u.user_id",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            vlp.contains("toFloat64(0"),
+            "#971: a Float reduce seed in a VLP WHERE (Path C) must also cast to \
+             Float64:\n{vlp}"
+        );
     }
 
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -10945,6 +10945,50 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #971: a `reduce()` with a FLOAT accumulator seed (`n = 0.0`) must cast the
+    /// init to Float64 — a bare `0.0` renders as `0` (UInt8), which can't unify
+    /// with a Float64-returning lambda → Code 53. Mirrors the #955 Integer→Int64
+    /// cast for the Float case, at both render paths.
+    #[tokio::test]
+    async fn reduce_float_seed_casts_to_float64_971() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        let ch = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(n = 0.0, x IN [1.5, 2.5] | n + x) AS v",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            ch.contains("toFloat64(0"),
+            "#971: a Float reduce seed must be cast to Float64:\n{ch}"
+        );
+
+        // Databricks: the seed is cast via `double(...)`.
+        let dbx = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(n = 0.0, x IN [1.5, 2.5] | n + x) AS v",
+            SqlDialect::Databricks,
+        )
+        .await;
+        assert!(
+            dbx.contains("double(0"),
+            "#971: a Float reduce seed must be cast to Spark double:\n{dbx}"
+        );
+
+        // Integer seed unaffected — still Int64 (guards the match arm).
+        let int_seed = render(
+            &schema,
+            "MATCH (u:User) RETURN reduce(n = 0, x IN [1, 2, 3] | n + x) AS v",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            int_seed.contains("toInt64(0)") && !int_seed.contains("toFloat64"),
+            "#971: an Integer reduce seed must keep the Int64 cast:\n{int_seed}"
+        );
+    }
+
     /// `bidirectional_union` CTE, e.g. `MATCH (a:User)-[r]-(o)`) used to
     /// per-label-raw-column logic (designed for a bare `MATCH (n)`
     /// ViewScan UNION, which has genuinely separate `post_id`/`user_id`


### PR DESCRIPTION
## Summary

A `reduce()` with a Float accumulator seed failed with **Code 53**: `reduce(n = 0.0, x IN [1.5, 2.5] | n + x)` rendered `arrayFold(n, x -> n + x, [1.5,2.5], 0)` — the bare `0.0` seed renders as `0` (UInt8), which can't unify with the Float64-returning lambda.

Closes #971. Completes the reduce-init-cast family (#955 Integer/empty-list, #971 Float).

## Fix

The `init_cast` at both `ReduceExpr` render sites (`to_sql_query.rs` Path A, `cte_extraction.rs` Path C) only wrapped an Integer literal seed in `cast_int64` (#955). Extend the match to wrap a Float literal seed in the dialect's `cast_float64` (CH `toFloat64`, Spark `double`) — symmetric to the Integer arm, via the existing `FunctionMapper` method (Rule #7).

## Verification

- **Live-verified**: `reduce(n=0.0, x IN [1.5,2.5] | n + x)` → `toFloat64(0)` seed → **4** (was Code 53); product/single/negative-float folds correct; Integer seed still `toInt64` → 6; string seed still concat → 'abc'; empty-list float reduce short-circuits to `toFloat64(0)` (#955 preserved). Non-literal/Boolean seeds fall to no-cast, unchanged from main.
- No golden churn (no Float-seed reduce in corpus/goldens); 1689 lib + 571 integration + ratchet (net-neutral) green.
- Golden `reduce_float_seed_casts_to_float64_971` (CH `toFloat64` + Databricks `double` + Integer-unaffected + **Path C VLP-WHERE**), all arms load-bearing.
- **Adversarial review: APPROVE, 0 MAJOR/BLOCKER** — all points live-verified on CH + Databricks; its Path-C-coverage NIT addressed by the added VLP-WHERE assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)