### PR TITLE
fix(#922): closed OPTIONAL VLP keeps anchor WHERE + closed constraint

### DIFF
--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -3372,15 +3372,40 @@ impl GraphJoinInference {
                     crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string()
                 });
 
-            let vlp_join = Join {
-                table_name: cte_name.clone(),
-                table_alias: vlp_alias.clone(),
-                joining_on: vec![helpers::eq_condition(
+            // #922: a CLOSED OPTIONAL VLP (`(a)-[*..]->(a)`,
+            // `left_connection == right_connection`) must pin the CTE path back
+            // to its start — the pattern requires the walk to RETURN to the
+            // anchor. Without the extra `anchor.id = vt0.end_id` conjunct the
+            // LEFT JOIN counts EVERY path leaving the anchor (silent over-count:
+            // Alice=9 instead of the 1 null-extended row on an acyclic graph),
+            // the closed-constraint sibling of the non-optional `#625`
+            // `t.start_id = t.end_id` outer-WHERE emission in filter_builder.rs
+            // (which is unreachable for the OPTIONAL path — it lives in the
+            // non-optional `else`). It goes in the JOIN ON, NOT the outer WHERE,
+            // so anchors with no cycle are still NULL-extended (OPTIONAL
+            // semantics), not dropped. `cte_id_col` is `start_id` here (the
+            // closed shape stays on the start-side layout, `anchor_is_end ==
+            // false`), so we add the matching `end_id` equality.
+            let is_closed_vlp = graph_rel.left_connection == graph_rel.right_connection;
+            let mut vlp_joining_on = vec![helpers::eq_condition(
+                anchor_alias,
+                &anchor_id_col,
+                &vlp_alias,
+                cte_id_col,
+            )];
+            if is_closed_vlp {
+                vlp_joining_on.push(helpers::eq_condition(
                     anchor_alias,
                     &anchor_id_col,
                     &vlp_alias,
-                    cte_id_col,
-                )],
+                    crate::query_planner::join_context::VLP_END_ID_COLUMN,
+                ));
+            }
+
+            let vlp_join = Join {
+                table_name: cte_name.clone(),
+                table_alias: vlp_alias.clone(),
+                joining_on: vlp_joining_on,
                 join_type: JoinType::Left,
                 pre_filter: None,
                 from_id_column: Some(anchor_id_col),

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -788,6 +788,77 @@ impl FilterBuilder for LogicalPlan {
                 // For GraphJoins, extract filters from the input
                 let input_filter = graph_joins.input.extract_filters()?;
 
+                // #922: a CLOSED OPTIONAL VLP (`(a)-[*..]->(a)`) loses its
+                // MANDATORY anchor WHERE (`WHERE a.name = 'Alice'`) on the way
+                // here. That filter is a `LogicalPlan::Filter` wrapping the
+                // anchor GraphNode. `GraphJoinInference` runs FIRST and captures
+                // a clone of the pattern's `GraphRel` (Filter and all) into the
+                // VLP LEFT JOIN's own `join.graph_rel`. `DuplicateScansRemoving`
+                // runs AFTER and — because the anchor alias appears at BOTH VLP
+                // endpoints — elides the pattern's LEFT endpoint scan in
+                // `graph_joins.input` to `Empty`, taking the Filter with it (its
+                // `GraphJoins` arm only recurses into `.input`, never into
+                // `joins[].graph_rel`, so the captured clone is untouched). Net
+                // result: `graph_joins.input` no longer carries the anchor
+                // predicate and the recursion above returns None for it, while
+                // the filter survives intact inside the closed VLP join's
+                // `graph_rel.left`. Recover it here: for a closed optional VLP
+                // join (`left_connection == right_connection`), pull the anchor
+                // filter out of that `graph_rel.left` and AND it into the outer
+                // WHERE (where it BELONGS — restricting which base anchors
+                // appear; embedding it only in the CTE would return every anchor
+                // NULL-extended). The `left == right` gate is exclusive to the
+                // closed shape: an OPEN optional VLP keeps its anchor scan
+                // (distinct endpoints, not elided), so `input_filter` already has
+                // the predicate and its endpoints never satisfy this gate — no
+                // double-add. Directed OR undirected, `*0..`/`*1..` all covered.
+                //
+                // Dedup by equality: two closed optional VLPs on the SAME anchor
+                // (`... OPTIONAL MATCH (a)->(a) OPTIONAL MATCH (a)->(a)`) each
+                // carry the same anchor filter, and both would otherwise be AND-ed
+                // in (`a.name='X' AND a.name='X'`). Distinct anchors keep their
+                // distinct filters. Skip anything already present in
+                // `input_filter` (belt-and-suspenders — the gate already excludes
+                // the open shape whose filter lives in the input).
+                let mut input_filter = input_filter;
+                let mut recovered: Vec<RenderExpr> = Vec::new();
+                for join in &graph_joins.joins {
+                    if let Some(gr) = &join.graph_rel {
+                        // Mirror the inference-side `rel_is_optional` gate exactly
+                        // (`optional_aliases.contains(rel) || is_optional`): a VLP
+                        // that became optional purely via `optional_aliases`
+                        // (without the `is_optional` field) would otherwise get the
+                        // closed-constraint conjunct in the JOIN ON but not this
+                        // WHERE recovery → silent-wrong. In practice a
+                        // directly-written OPTIONAL MATCH sets `is_optional:
+                        // Some(true)` at lowering, so they already agree; keying on
+                        // both keeps the two gates provably consistent.
+                        let is_optional_vlp_rel = gr.is_optional.unwrap_or(false)
+                            || graph_joins.optional_aliases.contains(&gr.alias);
+                        let is_closed_optional_vlp = gr.variable_length.is_some()
+                            && is_optional_vlp_rel
+                            && gr.left_connection == gr.right_connection;
+                        if is_closed_optional_vlp {
+                            if let Some(anchor_filter) = gr.left.extract_filters()? {
+                                let already_in_input =
+                                    input_filter.as_ref().is_some_and(|f| *f == anchor_filter);
+                                if !already_in_input && !recovered.contains(&anchor_filter) {
+                                    recovered.push(anchor_filter);
+                                }
+                            }
+                        }
+                    }
+                }
+                for anchor_filter in recovered {
+                    input_filter = Some(match input_filter {
+                        Some(existing) => RenderExpr::OperatorApplicationExp(OperatorApplication {
+                            operator: Operator::And,
+                            operands: vec![existing, anchor_filter],
+                        }),
+                        None => anchor_filter,
+                    });
+                }
+
                 // #518: `correlation_predicates` carries relationship-
                 // uniqueness guards (e.g. `NOT (t1.follower_id = t2.follower_id
                 // AND t1.followed_id = t2.followed_id)`, generated by

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.clickhouse.sql
@@ -25,5 +25,6 @@ SELECT
       a.name AS "a.name", 
       count(*) AS "paths"
 FROM test_integration.users AS a
-LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id
+LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id
+WHERE a.name = 'Alice'
 GROUP BY a.name

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_optional_match__TestOptionalMatchEdgeCases_test_optional_match_self_reference.databricks.sql
@@ -25,5 +25,6 @@ SELECT
       a.name AS `a.name`, 
       count(*) AS `paths`
 FROM test_integration.users AS a
-LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id
+LEFT JOIN vlp_a_a AS vt0 ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id
+WHERE a.name = 'Alice'
 GROUP BY a.name

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -7977,6 +7977,112 @@ async fn closed_self_ref_optional_vlp_anchor_property_from_anchor_table_899() {
     }
 }
 
+/// #922: a CLOSED self-referencing OPTIONAL VLP `(a)-[:R*..]->(a)` with a
+/// MANDATORY anchor WHERE dropped BOTH the anchor filter and the closed
+/// constraint — two silent-wrong defects.
+///
+/// Defect 1 — anchor WHERE dropped: `WHERE a.name = 'Alice'` never appeared in
+/// the SQL (returned ALL users). The filter is a `LogicalPlan::Filter` wrapping
+/// the anchor; because `a` is BOTH VLP endpoints, `DuplicateScansRemoving`
+/// elides the pattern's left endpoint scan → `Empty` and the Filter goes with
+/// it, so `extract_filters` on `GraphJoins.input` no longer finds it. The
+/// `GraphJoins` arm now recovers it from the closed VLP join's own
+/// `graph_rel.left` and ANDs it into the outer WHERE.
+///
+/// Defect 2 — closed constraint missing: the LEFT JOIN was only
+/// `ON a.user_id = vt0.start_id`, counting EVERY path leaving the anchor
+/// (Alice = 9 on an acyclic graph) instead of only cycles returning to it. The
+/// non-optional path emits `WHERE t.start_id = t.end_id` (#625) but that block
+/// is unreachable for OPTIONAL. Now the closed OPTIONAL join adds
+/// `AND a.user_id = vt0.end_id` in the ON (not the WHERE — so anchors with no
+/// cycle stay NULL-extended, preserving OPTIONAL semantics). On this acyclic
+/// fixture Alice correctly returns a single null-extended row (paths = 1).
+#[tokio::test]
+async fn closed_optional_vlp_keeps_anchor_where_and_closed_constraint_922() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Directed `*1..` — the issue's canonical repro.
+        let sql = render(
+            &schema,
+            "MATCH (a:TestUser) WHERE a.name = 'Alice' \
+             OPTIONAL MATCH (a)-[:TEST_FOLLOWS*1..]->(a) \
+             RETURN a.name, COUNT(*) as paths",
+            dialect,
+        )
+        .await;
+        // Defect 1: the mandatory anchor WHERE must reach the outer query.
+        assert!(
+            sql.contains("WHERE a.name = 'Alice'"),
+            "#922 defect 1 ({dialect:?}): mandatory anchor WHERE must survive to the outer query:\n{sql}"
+        );
+        // Defect 2: the closed constraint must be in the LEFT JOIN ON (both
+        // conjuncts), NOT a WHERE (a WHERE would drop the NULL-extended anchor).
+        assert!(
+            sql.contains("ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id"),
+            "#922 defect 2 ({dialect:?}): closed constraint must be `AND a.user_id = vt0.end_id` in the JOIN ON:\n{sql}"
+        );
+
+        // `*0..` variant (the frozen corpus golden line 819) — same two fixes.
+        let sql0 = render(
+            &schema,
+            "MATCH (a:TestUser) WHERE a.name = 'Alice' \
+             OPTIONAL MATCH (a)-[:TEST_FOLLOWS*0..]->(a) \
+             RETURN a.name, COUNT(*) as paths",
+            dialect,
+        )
+        .await;
+        assert!(
+            sql0.contains("WHERE a.name = 'Alice'")
+                && sql0.contains("ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id"),
+            "#922 ({dialect:?}): `*0..` closed optional must also keep anchor WHERE + closed constraint:\n{sql0}"
+        );
+    }
+
+    // Regression guard: an OPEN optional VLP (distinct endpoints) must NOT gain
+    // the `end_id` conjunct and must NOT double-add the anchor WHERE. The
+    // `left_connection == right_connection` gate excludes it.
+    let open = render(
+        &schema,
+        "MATCH (a:TestUser) WHERE a.name = 'Alice' \
+         OPTIONAL MATCH (a)-[:TEST_FOLLOWS*1..]->(b) \
+         RETURN a.name, count(b)",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        open.contains("LEFT JOIN vlp_a_b AS vt0 ON a.user_id = vt0.start_id")
+            && !open.contains("ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id"),
+        "#922 regression: OPEN optional VLP must keep the single start_id join (no end_id conjunct in the ON):\n{open}"
+    );
+    assert!(
+        open.matches("a.name = 'Alice'").count() == 1,
+        "#922 regression: OPEN optional VLP anchor WHERE must appear exactly once (no double-add):\n{open}"
+    );
+
+    // Two closed optional VLPs on the SAME anchor: each join's captured
+    // `graph_rel.left` carries the anchor filter, so the recovery must DEDUP it
+    // (else `a.name='Alice' AND a.name='Alice'`). Both joins still get the
+    // closed constraint (vt0 + vt1).
+    let two = render(
+        &schema,
+        "MATCH (a:TestUser) WHERE a.name = 'Alice' \
+         OPTIONAL MATCH (a)-[:TEST_FOLLOWS*1..]->(a) \
+         OPTIONAL MATCH (a)-[:TEST_FOLLOWS*1..]->(a) \
+         RETURN a.name, COUNT(*)",
+        SqlDialect::ClickHouse,
+    )
+    .await;
+    assert!(
+        two.matches("a.name = 'Alice'").count() == 1,
+        "#922 regression: two closed optional VLPs on one anchor must not double-add the anchor WHERE:\n{two}"
+    );
+    assert!(
+        two.contains("vt0 ON a.user_id = vt0.start_id AND a.user_id = vt0.end_id")
+            && two.contains("vt1 ON a.user_id = vt1.start_id AND a.user_id = vt1.end_id"),
+        "#922: both closed optional VLP joins must carry the closed constraint:\n{two}"
+    );
+}
+
 /// #599: `size((pattern))` renders as a bare correlated `COUNT(*)` scalar
 /// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
 /// with ZERO pattern matches yields NULL instead of 0 — silently breaking


### PR DESCRIPTION
## Summary

A closed self-referencing OPTIONAL variable-length path with a mandatory anchor `WHERE` — `MATCH (a) WHERE a.name='X' OPTIONAL MATCH (a)-[:R*..]->(a) RETURN a.name, COUNT(*)` — silently dropped **two** things, returning every anchor with an inflated path count instead of the filtered anchor null-extended. Two independent silent-wrong defects (ground rule 1). Closes #922.

**Defect 1 — anchor `WHERE` dropped.** The mandatory `WHERE a.name='X'` is a `LogicalPlan::Filter` wrapping the anchor. `GraphJoinInference` runs first and captures a `GraphRel` clone (Filter included) into the VLP LEFT JOIN's `graph_rel`; `DuplicateScansRemoving` runs after and — because `a` is *both* VLP endpoints — elides the pattern's left endpoint scan in `GraphJoins.input` to `Empty`, taking the Filter with it (its `GraphJoins` arm only recurses into `.input`, never `joins[].graph_rel`). So `extract_filters` on the input no longer finds the anchor predicate. **Fix:** in the `GraphJoins` arm of `extract_filters`, for a closed optional VLP join recover the anchor filter from the join's own `graph_rel.left` and AND it into the outer WHERE (deduped by equality; gate mirrors the inference-side optional gate).

**Defect 2 — closed constraint missing.** The LEFT JOIN was only `ON anchor.id = vt0.start_id`, counting every path leaving the anchor rather than only cycles returning to it. The non-optional path emits `WHERE t.start_id = t.end_id` (#625), but that block is unreachable for OPTIONAL. **Fix:** append `AND anchor.id = vt0.end_id` to the JOIN ON (not a WHERE — a WHERE would drop the NULL-extended anchor row, violating OPTIONAL semantics).

## Verification

Live oracle (acyclic DAG fixture): directed `*1..`/`*0..`/`*2..2` Alice 9→1; different-anchor Bob→1; open-optional `->(b)` byte-unchanged (Alice 9, no end_id conjunct, single anchor WHERE); closed non-optional unchanged; no-WHERE closed (#899 shape) all anchors null-extended to 1; renamed-property schema (`name`→`full_name`) maps correctly. Regenerated the frozen corpus golden (line 819, both dialects) that locked the buggy SQL.

**Adversarial review: APPROVE.** An isolated-worktree reviewer independently reproduced both defects on a *cyclic* graph (Alice 6→2, and `WHERE a.name='Bob'` dropped on main / honored on fix), confirmed the closed constraint is in the ON (null-extension preserved), and verified every adjacent shape is either handled or a pre-existing loud failure (denorm closed optional fails loud; composite-id closed optional has a pre-existing key mismatch, out of scope). Two non-blocking findings — a two-closed-VLP double-add and a gate-asymmetry NIT — were both addressed (dedup + gate broadened to match inference).

1689 lib + 572 integration + corpus + ratchet + clippy + fmt green; both fixes proven load-bearing by neutering each independently. Ratchet net-neutral (topology check, not a schema-flag/dialect branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)