### PR TITLE
fix(#983): closed single-hop relationship emits the self-loop constraint

### DIFF
--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -146,6 +146,76 @@ impl FilterBuilder for LogicalPlan {
                 // Example: MATCH (a)-[*2]->(b) WHERE b.name = 'Diana'
                 //   - Uses chained JOINs: a → r1 → r2 → b
                 //   - WHERE b.name = 'Diana' must be in outer query
+
+                // #983: a CLOSED single-hop relationship — `(a)-[:R]->(a)` (and
+                // its `*1`/`*1..1` spelling, which is stripped to
+                // `variable_length: None` for a single-type edge in
+                // `match_clause/helpers.rs`) — matches only SELF-LOOP edges
+                // (`from_id == to_id`). The self-loop constraint used to survive
+                // only IMPLICITLY, through the two node-join ON clauses
+                // (`t1.from = a.id AND a.id = t1.to` ⇒ `from = to` transitively).
+                // But a bare `RETURN count(*)` elides both (unreferenced) node
+                // joins (plan_optimizer.rs), leaving `FROM <edge> AS t1` with the
+                // constraint GONE → it silently counts ALL edges, not just
+                // self-loops (returned 6 where 0 is correct). Compute the explicit
+                // self-loop equality on the edge alias here and inject it into
+                // `all_predicates` below (NOT an early return — the normal path's
+                // schema-filter / OPTIONAL null-safe collection must still run).
+                // The `left == right` gate is exact and rename-safe (the planner
+                // never renames one endpoint of a same-variable pattern — see
+                // from_builder.rs #605/#625), so the OPEN single hop
+                // `(a)-[:R]->(b)` (distinct connections) is untouched. Scoped to
+                // the STANDARD (separate edge table) schema: a denormalized or
+                // FK-edge "edge" shares a table with a node, so `alias.from =
+                // alias.to` would be a different (or wrong) constraint there —
+                // those stay on their current path (the duplicate-alias / Code 179
+                // property-projection facet is a separate join-builder defect,
+                // tracked in #983's follow-ups). Longer closed VLPs (`*2..2` etc.)
+                // keep their spec and route through the recursive CTE's own
+                // `start_id = end_id` (#625), so the `variable_length.is_none()`
+                // guard excludes them. OPTIONAL is excluded too: an OPTIONAL closed
+                // single-hop is already broken on main (Code 179 duplicate anchor
+                // alias with a property, anchor dropped for bare count), and a
+                // self-loop equality in the outer WHERE would filter out the
+                // NULL-extended anchor rows — leave it on its current (unchanged)
+                // path rather than risk a new OPTIONAL-semantics violation.
+                let closed_single_hop_self_loop: Option<RenderExpr> = if graph_rel
+                    .variable_length
+                    .is_none()
+                    && graph_rel.shortest_path_mode.is_none()
+                    && graph_rel.left_connection == graph_rel.right_connection
+                    && !graph_rel.is_optional.unwrap_or(false)
+                    && !is_node_denormalized(&graph_rel.left)
+                    && !is_node_denormalized(&graph_rel.right)
+                    && !crate::render_plan::cte_extraction::vlp_relationship_is_foreign_key_edge(
+                        graph_rel,
+                    ) {
+                    crate::render_plan::cte_extraction::extract_relationship_columns(
+                        &graph_rel.center,
+                    )
+                    .map(|rel_cols| {
+                        // Use `Identifier::to_sql_equality` so a COMPOSITE key
+                        // expands to a per-column AND chain
+                        // (`t1.from_a = t1.to_a AND t1.from_b = t1.to_b`) with
+                        // proper identifier quoting — a bare `format!` would emit
+                        // the invalid `t1.from_a, from_b = t1.to_a, to_b` (the
+                        // `Identifier` Display comma-joins). Same alias on both
+                        // sides (the single edge scan).
+                        let self_loop = rel_cols.from_id.to_sql_equality(
+                            &graph_rel.alias,
+                            &rel_cols.to_id,
+                            &graph_rel.alias,
+                        );
+                        log::info!(
+                            "🔧 #983: closed single-hop self-loop constraint — emitting {}",
+                            self_loop
+                        );
+                        RenderExpr::Raw(self_loop)
+                    })
+                } else {
+                    None
+                };
+
                 if graph_rel.variable_length.is_some() || graph_rel.shortest_path_mode.is_some() {
                     // Check if this uses chained JOINs (fixed-length, no CTE)
                     let uses_cte = if let Some(ref spec) = graph_rel.variable_length {
@@ -436,6 +506,14 @@ impl FilterBuilder for LogicalPlan {
                     .into_iter()
                     .filter(|p| !is_labels_predicate(p))
                     .collect();
+
+                // #983: inject the closed single-hop self-loop equality (computed
+                // above) into the normal predicate flow, so it is AND-ed with the
+                // anchor WHERE, schema filters, and OPTIONAL null-safe filters
+                // collected below (rather than short-circuiting past them).
+                if let Some(self_loop) = closed_single_hop_self_loop {
+                    all_predicates.push(self_loop);
+                }
 
                 // 🔒 Add schema-level filters from ViewScans
                 // For OPTIONAL MATCH (LEFT JOIN), wrap filters with NULL-safety

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.clickhouse.sql
@@ -3,3 +3,4 @@ SELECT
 FROM data_security.ds_groups AS g
 INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
+WHERE t0.member_id = t0.group_id

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.databricks.sql
@@ -3,3 +3,4 @@ SELECT
 FROM data_security.ds_groups AS g
 INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.member_type = 'Group'
 INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
+WHERE t0.member_id = t0.group_id

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8233,6 +8233,124 @@ async fn denorm_closed_non_optional_vlp_zero_hop_fails_loud_980() {
     }
 }
 
+/// #983: a CLOSED single-hop relationship `(a)-[:R]->(a)` (and its `*1`/`*1..1`
+/// spelling, stripped to a plain relationship for single-type edges) matches
+/// only SELF-LOOP edges (`from_id == to_id`). The constraint used to survive
+/// only implicitly through the two node-join ON clauses, so a bare `count(*)`
+/// that elides those joins silently counted ALL edges. The `extract_filters`
+/// GraphRel arm now emits an explicit `<edge_alias>.<from> = <edge_alias>.<to>`
+/// self-loop filter for the closed single-hop (standard edge schema only). The
+/// OPEN single hop `(a)-[:R]->(b)` (distinct connections) is untouched.
+#[tokio::test]
+async fn closed_single_hop_emits_self_loop_filter_983() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // All spellings of the closed single hop must emit the self-loop filter.
+        for cypher in [
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1]->(a) RETURN count(*)",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1..1]->(a) RETURN count(*)",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) RETURN count(*)",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1]-(a) RETURN count(*)",
+        ] {
+            let sql = render(&schema, cypher, dialect).await;
+            // The edge alias varies (t1/t2/…); assert on the self-loop column
+            // equality shape, which is what matters.
+            assert!(
+                sql.contains(".follower_id = ") && sql.contains(".followed_id"),
+                "#983 ({dialect:?}): closed single-hop must emit the self-loop filter \
+                 `<edge>.follower_id = <edge>.followed_id`:\n{cypher}\n{sql}"
+            );
+        }
+
+        // The OPEN single hop must NOT get a self-loop filter (distinct
+        // endpoints), and must not be otherwise disturbed.
+        let open = render(
+            &schema,
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1]->(b:TestUser) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            !(open.contains(".follower_id = ") && open.contains(".followed_id")),
+            "#983 ({dialect:?}): OPEN single hop must NOT get a self-loop filter:\n{open}"
+        );
+
+        // A longer closed VLP keeps its recursive-CTE closed constraint
+        // (`start_id = end_id`), NOT the flat self-loop filter.
+        let vlp = render(
+            &schema,
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*2..2]->(a) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            vlp.contains("start_id = t.end_id") || vlp.contains("t.start_id = t.end_id"),
+            "#983 ({dialect:?}): closed `*2..2` VLP must keep the CTE closed constraint:\n{vlp}"
+        );
+
+        // A user WHERE on the anchor must be preserved AND-combined with the
+        // self-loop filter (the fix injects into the normal predicate flow, not
+        // an early return that would drop schema/anchor filters).
+        let with_where = render(
+            &schema,
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) WHERE a.name = 'Bob' RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            with_where.contains("a.name = 'Bob'")
+                && with_where.contains(".follower_id = ")
+                && with_where.contains(".followed_id"),
+            "#983 ({dialect:?}): anchor WHERE must be preserved alongside the self-loop filter:\n{with_where}"
+        );
+
+        // OPTIONAL closed single-hop is EXCLUDED (a self-loop equality in the
+        // outer WHERE would drop the NULL-extended anchor rows) — it must NOT get
+        // the self-loop filter, staying byte-identical to its current behavior.
+        let optional = render(
+            &schema,
+            "MATCH (a:TestUser) OPTIONAL MATCH (a)-[:TEST_FOLLOWS]->(a) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            !(optional.contains(".follower_id = ") && optional.contains(".followed_id")),
+            "#983 ({dialect:?}): OPTIONAL closed single-hop must be excluded from the self-loop fix:\n{optional}"
+        );
+    }
+}
+
+/// #983: a COMPOSITE-key self-referencing standard edge closed single-hop must
+/// expand the self-loop equality into a per-column AND chain — a bare `format!`
+/// on the `Identifier` would emit the syntactically-invalid
+/// `t1.from_a, from_b = t1.to_a, to_b` (Display comma-joins composites).
+#[tokio::test]
+async fn closed_single_hop_composite_key_self_loop_983() {
+    let schema = load_schema("schemas/test/composite_node_ids.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH (a:Account)-[:TRANSFERRED]->(a) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        // Per-column AND, each side qualified — never the comma-joined Display.
+        // (The edge alias varies t1/t2/…; assert on the column-equality shape.)
+        assert!(
+            sql.contains(".from_bank_id = ")
+                && sql.contains(".to_bank_id")
+                && sql.contains(".from_account_number = ")
+                && sql.contains(".to_account_number")
+                && sql.contains(" AND "),
+            "#983 ({dialect:?}): composite self-loop must be a per-column AND chain:\n{sql}"
+        );
+        assert!(
+            !sql.contains("from_bank_id, from_account_number ="),
+            "#983 ({dialect:?}): composite self-loop must NOT emit the invalid comma-joined form:\n{sql}"
+        );
+    }
+}
+
 /// #599: `size((pattern))` renders as a bare correlated `COUNT(*)` scalar
 /// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
 /// with ZERO pattern matches yields NULL instead of 0 — silently breaking


### PR DESCRIPTION
## Summary

A CLOSED single-hop relationship — `MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) RETURN count(*)` (and its `*1`/`*1..1` spelling, stripped to a plain relationship for single-type edges) — matches only SELF-LOOP edges (`from_id == to_id`) but silently counted ALL edges. Live: returned 6 where the correct answer is 0 (no self-loops); with a self-loop present it now returns 1. Silent-wrong (ground rule 1). Closes #983.

Root cause: the self-loop equality survived only *implicitly*, transitively through the two node-join ON clauses — and a bare `count(*)` elides those (unreferenced) node joins, leaving `FROM <edge> AS t1` with the constraint gone. The `extract_filters` GraphRel arm now computes the self-loop equality via `Identifier::to_sql_equality` and INJECTS it into the normal `all_predicates` flow (not an early return), so anchor WHERE, schema filters, and OPTIONAL null-safe filters are all preserved and AND-combined. `to_sql_equality` expands a COMPOSITE key into a per-column AND chain (`t1.from_a = t1.to_a AND t1.from_b = t1.to_b`) with proper quoting.

Scoped tightly: STANDARD separate-edge-table schema only (denorm/FK-edge gated out — their "edge" shares a table with a node); NON-optional only (an OPTIONAL closed single-hop is already broken on main, and a self-loop WHERE would drop null-extended rows). The OPEN single hop `(a)-[:R]->(b)` is untouched; longer closed VLPs (`*2..2`) keep their recursive-CTE `start_id = end_id` (#625).

## Verification

Live-verified single AND composite keys (single-col 6→0, self-loop→1; composite `TRANSFERRED` Account→Account renders valid per-column SQL, executes, counts the one self-transfer — main returns 8). Directed + undirected + all three spellings + anchor-WHERE preservation + OPTIONAL exclusion + composite expansion covered. 1689 lib + 576 integration + corpus + ratchet + clippy green; curated tests load-bearing. Only golden churn: one additive `WHERE t0.member_id = t0.group_id` line on the existing `test_self_loop_membership` data_security golden (both dialects).

**Adversarial review (2 rounds): APPROVE.** Round 1 found a schema-filter drop, an OPTIONAL-semantics violation, and a composite-key invalid-SQL CRITICAL; the restructure (inject-not-early-return + OPTIONAL exclusion) resolved the first two, and this commit fixes the composite one via `to_sql_equality`. Round 2 independently verified the composite fix executes correctly, all gates hold, and a 17-query×2-dialect main-vs-branch diff is exactly the intended self-loop lines and nothing else.

Follow-ups filed: the property-projection form emits a duplicate node alias (Code 179), a separate join-builder defect; and denorm/FK-edge/OPTIONAL closed single-hop still drop the constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)