### PR TITLE
fix(#987 facet 2, denorm): denorm closed single-hop emits the self-loop constraint

### DIFF
--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -164,29 +164,32 @@ impl FilterBuilder for LogicalPlan {
                 // The `left == right` gate is exact and rename-safe (the planner
                 // never renames one endpoint of a same-variable pattern — see
                 // from_builder.rs #605/#625), so the OPEN single hop
-                // `(a)-[:R]->(b)` (distinct connections) is untouched. Scoped to
-                // the STANDARD (separate edge table) schema: a denormalized or
-                // FK-edge "edge" shares a table with a node, so `alias.from =
-                // alias.to` would be a different (or wrong) constraint there —
-                // those stay on their current path (the duplicate-alias / Code 179
-                // property-projection facet is a separate join-builder defect,
-                // tracked in #983's follow-ups). Longer closed VLPs (`*2..2` etc.)
-                // keep their spec and route through the recursive CTE's own
-                // `start_id = end_id` (#625), so the `variable_length.is_none()`
-                // guard excludes them. OPTIONAL is excluded too: an OPTIONAL closed
-                // single-hop is already broken on main (Code 179 duplicate anchor
-                // alias with a property, anchor dropped for bare count), and a
-                // self-loop equality in the outer WHERE would filter out the
-                // NULL-extended anchor rows — leave it on its current (unchanged)
-                // path rather than risk a new OPTIONAL-semantics violation.
+                // `(a)-[:R]->(b)` (distinct connections) is untouched. Applies to
+                // the STANDARD separate-edge-table schema AND the DENORMALIZED
+                // schema (#987 facet 2): for a denorm edge the endpoint columns
+                // (`from_id`/`to_id`, e.g. `Origin`/`Dest`) live on the single
+                // edge=node scan, so `alias.from_id = alias.to_id` is exactly the
+                // self-loop constraint there too (`t1.Origin = t1.Dest`) — the
+                // denorm closed single-hop otherwise bare-counts ALL edges (silent
+                // over-count: 10 flights returned where only 1 is a self-loop).
+                // FK-EDGE is still EXCLUDED: its "edge" is a node table whose
+                // endpoint is a FK column, so the self-loop test is `node_id ==
+                // fk_col`, not `from_id == to_id` — a different constraint tracked
+                // as a separate #987 facet. Longer closed VLPs (`*2..2` etc.) keep
+                // their spec and route through the recursive CTE's own `start_id =
+                // end_id` (#625), so the `variable_length.is_none()` guard excludes
+                // them. OPTIONAL is excluded too: an OPTIONAL closed single-hop is
+                // already broken on main (Code 179 duplicate anchor alias with a
+                // property, anchor dropped for bare count), and a self-loop
+                // equality in the outer WHERE would filter out the NULL-extended
+                // anchor rows — leave it on its current (unchanged) path rather
+                // than risk a new OPTIONAL-semantics violation.
                 let closed_single_hop_self_loop: Option<RenderExpr> = if graph_rel
                     .variable_length
                     .is_none()
                     && graph_rel.shortest_path_mode.is_none()
                     && graph_rel.left_connection == graph_rel.right_connection
                     && !graph_rel.is_optional.unwrap_or(false)
-                    && !is_node_denormalized(&graph_rel.left)
-                    && !is_node_denormalized(&graph_rel.right)
                     && !crate::render_plan::cte_extraction::vlp_relationship_is_foreign_key_edge(
                         graph_rel,
                     ) {

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1146,6 +1146,8 @@
 {"cypher": "MATCH (a:Airport)-[:FLIGHT*2..3]->(a) RETURN count(*)", "name": "test_980_denorm_closed_range_vlp_renders_edge_unique", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport)-[:FLIGHT*0..]->(a) RETURN count(*)", "name": "test_980_denorm_closed_zero_hop_vlp_fails_loud", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*0..]->(a) RETURN a.code, count(*)", "name": "test_978_denorm_closed_optional_vlp_zero_hop_fails_loud", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN count(*)", "name": "test_987_denorm_closed_single_hop_self_loop", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN a.city", "name": "test_987_denorm_closed_single_hop_self_loop_property", "schema": "denormalized_flights"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WITH o, count(r) AS rc RETURN o.order_id, rc ORDER BY o.order_id", "name": "test_584_fk_edge_coupled_rel_var_count_r_in_with", "schema": "fk_edge"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) RETURN count(r)", "name": "test_584_fk_edge_standalone_count_r_still_works", "schema": "fk_edge"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WITH count(r) AS rc RETURN rc", "name": "test_584_fk_edge_count_r_only_no_node_carried", "schema": "fk_edge"}

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop.clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      count(*) AS "count(*)"
+FROM test_integration.flights AS t0
+WHERE t0.Origin = t0.Dest

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop.databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      count(*) AS `count(*)`
+FROM test_integration.flights AS t0
+WHERE t0.Origin = t0.Dest

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop_property.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop_property.clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      t0.OriginCityName AS "a.city"
+FROM test_integration.flights AS t0
+WHERE t0.Origin = t0.Dest

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop_property.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_987_denorm_closed_single_hop_self_loop_property.databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      t0.OriginCityName AS `a.city`
+FROM test_integration.flights AS t0
+WHERE t0.Origin = t0.Dest

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8405,7 +8405,63 @@ async fn composite_optional_vlp_fails_loud_979() {
     }
 }
 
-/// #599: `size((pattern))` renders as a bare correlated `COUNT(*)` scalar
+/// #987 (facet 2, denorm): a DENORMALIZED closed single-hop `(a)-[:FLIGHT]->(a)`
+/// matches only self-loop edges (`from_id == to_id`, e.g. `Origin == Dest`), but
+/// #983 excluded denorm from its self-loop injection so it bare-counted ALL edges
+/// (silent over-count: 10 flights where only 1 is a self-loop). For a denorm edge
+/// the endpoint columns live on the single edge=node scan, so the same
+/// `<alias>.<from_id> = <alias>.<to_id>` constraint the standard path uses is
+/// correct here too. The OPEN denorm single hop `(a)->(b)` (distinct connections)
+/// stays untouched. FK-edge remains excluded (a different `node_id == fk_col`
+/// test).
+#[tokio::test]
+async fn denorm_closed_single_hop_emits_self_loop_filter_987() {
+    let denorm = load_schema("schemas/test/denormalized_flights.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // count(*) and property forms both get the denorm self-loop filter.
+        for cypher in [
+            "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN count(*)",
+            "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN a.city",
+        ] {
+            let sql = render(&denorm, cypher, dialect).await;
+            // Denorm endpoint columns are Origin (from_id) / Dest (to_id); the
+            // edge alias varies (t1/t2/…), so assert on the column-equality shape.
+            assert!(
+                sql.contains(".Origin = ") && sql.contains(".Dest"),
+                "#987 ({dialect:?}): denorm closed single-hop must emit the self-loop \
+                 filter `<edge>.Origin = <edge>.Dest`:\n{cypher}\n{sql}"
+            );
+        }
+
+        // The OPEN denorm single hop must NOT get a self-loop filter.
+        let open = render(
+            &denorm,
+            "MATCH (a:Airport)-[:FLIGHT]->(b:Airport) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            !(open.contains(".Origin = ") && open.contains(".Dest")),
+            "#987 ({dialect:?}): OPEN denorm single hop must NOT get a self-loop filter:\n{open}"
+        );
+
+        // A user WHERE on the anchor must be AND-combined with the self-loop
+        // filter (injected into the normal predicate flow, not an early return).
+        let with_where = render(
+            &denorm,
+            "MATCH (a:Airport)-[:FLIGHT]->(a) WHERE a.state = 'GA' RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            with_where.contains("OriginState = 'GA'")
+                && with_where.contains(".Origin = ")
+                && with_where.contains(".Dest"),
+            "#987 ({dialect:?}): denorm anchor WHERE must be preserved alongside the self-loop filter:\n{with_where}"
+        );
+    }
+}
+
 /// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
 /// with ZERO pattern matches yields NULL instead of 0 — silently breaking
 /// `size(...) = 0` filters, comparisons, arithmetic, and CASE branches on


### PR DESCRIPTION
## Problem

#983 fixed the STANDARD closed single-hop `(a)-[:R]->(a)` self-loop-constraint drop (a bare `count(*)` elides the node joins that implicitly enforced `from == to`, so it counted ALL edges) but explicitly **excluded denormalized schemas** out of caution. A denorm closed single-hop `(a:Airport)-[:FLIGHT]->(a)` therefore still bare-counted every edge instead of just self-loops (`Origin == Dest`) — a **silent over-count**.

**Live-proven** on the flights fixture (10 flights, 1 self-loop ATL→ATL): the query returned **10** where the correct answer is **1**.

## Fix

For a denorm edge the endpoint columns (`from_id`/`to_id`, e.g. `Origin`/`Dest`) live on the single edge=node scan, so `<alias>.from_id = <alias>.to_id` is exactly the self-loop constraint there too — structurally identical to the standard case the #983 code already handles (`extract_relationship_columns` + `Identifier::to_sql_equality` on `graph_rel.alias`). The fix removes the two `!is_node_denormalized(&graph_rel.left/right)` conjuncts from #983's gate.

Renders `WHERE t1.Origin = t1.Dest` → live returns 1. Property form (`RETURN a.city`) and anchor-WHERE (`WHERE a.state = 'GA'` → `(t1.OriginState = 'GA' AND t1.Origin = t1.Dest)`, live-verified GA=1/CA=0) both AND-combine the self-loop filter via the normal predicate flow.

**Scope unchanged otherwise:** OPEN denorm single hop `(a)->(b)` untouched; FK-edge still EXCLUDED (its "edge" is a node table whose endpoint is a FK column → self-loop test is `node_id == fk_col`, a different constraint, separate #987 facet); OPTIONAL still excluded; longer closed VLPs keep the CTE's `start_id = end_id` (#625). Standard/composite #983 behavior byte-identical.

## Tests

- Corpus: `test_987_denorm_closed_single_hop_self_loop{,_property}` (both dialects, 4 new `.sql` goldens).
- Golden test `denorm_closed_single_hop_emits_self_loop_filter_987`: count(*)/property forms get the filter, OPEN form does not, anchor WHERE is AND-combined.
- 1689 lib / 578 integration / corpus / ratchet / clippy / fmt green.

## Review

Adversarial worktree-isolated review (built fix + main into separate `CARGO_TARGET_DIR`s to avoid stale-binary conclusions): **APPROVE, zero findings**. Confirmed the over-count on main (10) vs fix (1, = hand oracle); verified `from_id`/`to_id` are the identity columns across every denorm fixture; all controls (OPEN denorm, FK-edge, standard #983, `*2..2` VLP, OPTIONAL) byte-identical to main; ratchet clean (removes predicate calls, no baseline bump); zero `UPDATE_GOLDEN` churn.

Refs #987 (facet 2, denorm sub-case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)