### PR TITLE
fix(#987 facet 1): closed single-hop property form binds the node once (no Code 179)

### DIFF
--- a/src/query_planner/analyzer/graph_join/join_generation.rs
+++ b/src/query_planner/analyzer/graph_join/join_generation.rs
@@ -185,14 +185,39 @@ pub fn generate_pattern_joins(
             match (left_avail, right_avail) {
                 // Neither available: first pattern — FROM left, JOIN edge, JOIN right
                 (false, false) => {
-                    let mut v = vec![
-                        JoinBuilder::from_marker(t.left_table, t.left_alias).build(),
-                        edge_join(true, right_is_vlp),
-                    ];
-                    if !right_is_vlp {
-                        v.push(right_node_join());
+                    // #987 facet 1: a CLOSED single-hop (`(a)-[:R]->(a)`, same
+                    // variable at both endpoints, `left_alias == right_alias`)
+                    // must bind the shared node ONCE. The default layout emits a
+                    // FROM marker for the left node AND a separate right-node JOIN
+                    // with the SAME alias → duplicate table alias → ClickHouse
+                    // Code 179. Instead, keep the single FROM marker and fold BOTH
+                    // endpoint equalities onto the edge join
+                    // (`edge.from = a.id AND edge.to = a.id`), which is
+                    // self-contained (it implies the self-loop `edge.from =
+                    // edge.to`) and references `a` exactly once. Scoped to the
+                    // non-VLP, non-available case; the closed VLP routes through
+                    // the recursive CTE (#625) and never reaches here, and a closed
+                    // hop can only land in `(false, false)` or `(true, true)` (both
+                    // avail flags read the same alias), the latter already emitting
+                    // just `edge_join(true, true)`. Denorm (single edge=node scan)
+                    // and FK-edge take their own strategies, not Traditional here.
+                    let is_closed_single_hop =
+                        t.left_alias == t.right_alias && !left_is_vlp && !right_is_vlp;
+                    if is_closed_single_hop {
+                        vec![
+                            JoinBuilder::from_marker(t.left_table, t.left_alias).build(),
+                            edge_join(true, true),
+                        ]
+                    } else {
+                        let mut v = vec![
+                            JoinBuilder::from_marker(t.left_table, t.left_alias).build(),
+                            edge_join(true, right_is_vlp),
+                        ];
+                        if !right_is_vlp {
+                            v.push(right_node_join());
+                        }
+                        v
                     }
-                    v
                 }
                 // Left available: edge anchors on left, right via edge
                 (true, false) => {

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.clickhouse.sql
@@ -1,6 +1,5 @@
 SELECT 
       g.name AS "g.name"
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.member_type = 'Group'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.group_id = g.group_id AND t0.member_type = 'Group'
 WHERE t0.member_id = t0.group_id

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.databricks.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestEdgeCases_test_self_loop_membership.databricks.sql
@@ -1,6 +1,5 @@
 SELECT 
       g.name AS `g.name`
 FROM data_security.ds_groups AS g
-INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.member_type = 'Group'
-INNER JOIN data_security.ds_groups AS g ON g.group_id = t0.group_id
+INNER JOIN data_security.ds_memberships AS t0 ON t0.member_id = g.group_id AND t0.group_id = g.group_id AND t0.member_type = 'Group'
 WHERE t0.member_id = t0.group_id

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8462,6 +8462,58 @@ async fn denorm_closed_single_hop_emits_self_loop_filter_987() {
     }
 }
 
+/// #987 (facet 1): a CLOSED single-hop `(a)-[:R]->(a)` in PROPERTY-projection
+/// form used to bind the same variable `a` to BOTH the start-node scan (FROM) and
+/// the end-node scan (a second JOIN with the SAME alias) → ClickHouse Code 179
+/// (duplicate table alias). The analyzer's Traditional `(false, false)` join
+/// strategy now detects the closed pattern (`left_alias == right_alias`) and folds
+/// BOTH endpoint equalities onto the edge join (`edge.from = a.id AND edge.to =
+/// a.id`), keeping a SINGLE node scan. The OPEN single hop `(a)-[:R]->(b)`
+/// (distinct vars) keeps two scans, and the elided `count(*)` / rel-var-only forms
+/// are unchanged.
+#[tokio::test]
+async fn closed_single_hop_property_binds_node_once_987() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Every closed property-projection spelling must bind `users AS a` exactly
+        // once (no duplicate alias). Count occurrences of the node table+alias.
+        for cypher in [
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) RETURN a.name",
+            "MATCH (a:TestUser)<-[:TEST_FOLLOWS]-(a) RETURN a.name",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]-(a) RETURN a.name",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) RETURN a.name, a.user_id",
+            "MATCH (a:TestUser)-[r:TEST_FOLLOWS]->(a) RETURN a.name, r.since",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1]->(a) RETURN a.name",
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS*1..1]->(a) RETURN a.name",
+        ] {
+            let sql = render(&schema, cypher, dialect).await;
+            let node_scans = sql.matches("users AS a").count();
+            assert_eq!(
+                node_scans, 1,
+                "#987 facet 1 ({dialect:?}): closed single-hop property form must bind the node ONCE (found {node_scans} `users AS a` scans → duplicate-alias Code 179):\n{cypher}\n{sql}"
+            );
+            // Both endpoint equalities must be on the edge join (fold), so the
+            // self-loop is self-contained.
+            assert!(
+                sql.contains(".follower_id = a.user_id") && sql.contains(".followed_id = a.user_id"),
+                "#987 facet 1 ({dialect:?}): both edge endpoints must bind to the single node scan:\n{cypher}\n{sql}"
+            );
+        }
+
+        // The OPEN single hop keeps TWO distinct node scans (a and b) — unchanged.
+        let open = render(
+            &schema,
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(b:TestUser) RETURN a.name, b.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            open.contains("users AS a") && open.contains("users AS b"),
+            "#987 facet 1 ({dialect:?}): OPEN single hop must keep two distinct node scans:\n{open}"
+        );
+    }
+}
+
 /// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
 /// with ZERO pattern matches yields NULL instead of 0 — silently breaking
 /// `size(...) = 0` filters, comparisons, arithmetic, and CASE branches on


### PR DESCRIPTION
## Problem

A CLOSED single-hop relationship `(a)-[:R]->(a)` (same variable at both endpoints) in **property-projection** form bound `a` to BOTH the start-node scan (FROM marker) AND a separate end-node JOIN with the SAME alias → ClickHouse **Code 179** (MULTIPLE_EXPRESSIONS_FOR_ALIAS). Live-proven: `MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a) RETURN a.name` errored Code 179 on main.

## Root cause

In the **analyzer**, not the render builders: `generate_pattern_joins`'s `JoinStrategy::Traditional` `(false, false)` arm (`src/query_planner/analyzer/graph_join/join_generation.rs`) unconditionally emits a FROM marker for the left node plus a `right_node_join()` for the right node — both using the same alias when `left_connection == right_connection`.

## Fix

Detect the closed single-hop (`t.left_alias == t.right_alias`, non-VLP) in that arm and fold BOTH endpoint equalities onto the edge join (`edge.from = a.id AND edge.to = a.id`) instead of the duplicate node scan. This binds `a` exactly once and is self-contained — the two edge binds imply the self-loop `edge.from = edge.to` on their own. Live-verified: with a self-loop follow, the query returns exactly `Alice` (= direct oracle).

A closed hop can only land in `(false, false)` or `(true, true)` (both avail flags read the same alias); the latter already emits just `edge_join(true, true)`, so only `(false, false)` needed the guard.

**Scope:** all directions (directed/reversed/undirected), multi-property, named-rel + node-property, `*1`/`*1..1` spellings. **Unchanged:** OPEN single hop `(a)->(b)` (two scans); elided `count(*)`/rel-var-only; denorm (single edge=node scan); FK-edge (its own JoinStrategy — its self-ref dup-alias is a separate #987 facet, byte-identical to main); closed VLP `*2..2` (recursive CTE, #625). **Bonus:** the OPTIONAL closed hop `MATCH (a) OPTIONAL MATCH (a)-[:R]->(a)` was ALSO Code-179 on main and is repaired here (fold into the LEFT JOIN ON, no WHERE → optional semantics intact).

## Tests

- Golden test `closed_single_hop_property_binds_node_once_987`: single node scan across all closed spellings, two scans for the OPEN control.
- Corpus golden `test_self_loop_membership` (both dialects) was locking the Code-179-broken SQL (`ds_groups AS g` twice) → regenerated to the correct single-scan form; now executes live.
- 1689 lib / 579 integration / corpus / ratchet / clippy / fmt green.

## Review

Adversarial worktree-isolated review (isolated `CARGO_TARGET_DIR` builds): **APPROVE, zero defects**. Confirmed Code 179 on main → clean on fix (live oracle with inserted self-loops); the fold is semantically self-contained (verified WHERE-stripped); **byte-identical across 4 schemas × ~50 non-closed queries** (only intended closed-hop diffs); closed-VLP/FK-edge/denorm/polymorphic paths untouched; ratchet clean; zero unintended golden churn. Flagged one pre-existing out-of-scope latent issue (inline node-property filter on a closed hop dropped, identical main/fix) for a follow-up.

Refs #987 (facet 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)