### PR TITLE
fix(#987 FK-edge facet): self-ref FK-edge closed single-hop emits the self-loop constraint

### DIFF
--- a/src/query_planner/analyzer/graph_join/helpers.rs
+++ b/src/query_planner/analyzer/graph_join/helpers.rs
@@ -529,6 +529,35 @@ pub fn and_conditions(conditions: Vec<LogicalExpr>) -> LogicalExpr {
     })
 }
 
+/// Build a self-loop equality filter binding two column sets on the SAME alias:
+/// `alias.fk_c1 = alias.pk_c1 AND alias.fk_c2 = alias.pk_c2 AND ...`.
+///
+/// Used by the closed self-referencing FK-edge single-hop (#987): the edge IS the
+/// node table, so a self-loop is the row whose FK columns equal its own PK
+/// (node_id) columns. `fk_id` and `node_id` are zipped positionally (the author
+/// invariant that FK columns are declared in the same order as the node_id
+/// columns — mirroring the FK-edge JOIN condition builder). Returns `None` if
+/// either identifier is empty (defensive; callers treat `None` as "no filter").
+/// Composite-safe by construction — each column pair is a distinct
+/// `OperatorApplication`, never a comma-joined `Identifier` Display.
+pub fn self_loop_filter(
+    alias: &str,
+    fk_id: &crate::graph_catalog::config::Identifier,
+    node_id: &crate::graph_catalog::config::Identifier,
+) -> Option<LogicalExpr> {
+    let fk_cols = fk_id.columns();
+    let node_cols = node_id.columns();
+    if fk_cols.is_empty() || node_cols.is_empty() {
+        return None;
+    }
+    let eqs: Vec<LogicalExpr> = fk_cols
+        .iter()
+        .zip(node_cols.iter())
+        .map(|(fk, pk)| LogicalExpr::OperatorApplicationExp(eq_condition(alias, *fk, alias, *pk)))
+        .collect();
+    crate::query_planner::logical_expr::combinators::and(eqs)
+}
+
 // =============================================================================
 // JoinBuilder - Fluent Builder for Join Construction
 // =============================================================================

--- a/src/query_planner/analyzer/graph_join/join_generation.rs
+++ b/src/query_planner/analyzer/graph_join/join_generation.rs
@@ -245,8 +245,38 @@ pub fn generate_pattern_joins(
             if already_available.contains(t.rel_alias) {
                 vec![] // Edge already available, nothing to add
             } else {
+                // #987 (FK-edge facet, count/aggregate path): a CLOSED
+                // self-referencing FK-edge single-hop (`(a)-[:PARENT]->(a)`) whose
+                // node properties are unreferenced (e.g. bare `count(*)`) takes the
+                // SingleTableScan strategy — the edge table (== the node table) is
+                // scanned once as `t.rel_alias`. Without the self-loop constraint
+                // it silently counts ALL rows instead of only self-loops (the row
+                // whose FK equals its own PK). The property form takes the
+                // FkEdgeJoin strategy and is fixed separately (see the
+                // `closed_self_ref` branch there). AND the self-loop
+                // (`rel_alias.from_id = rel_alias.to_id`, per-column, composite-safe
+                // via `self_loop_filter`) into the FROM-marker `pre_filter` — it
+                // lives on the single scanned table so it survives even when the
+                // count(*) form prunes everything else. Denorm closed self-hops
+                // are not foreign-key edges and are handled by the render-side #983
+                // filter, so there is no double-add. Gated to the closed
+                // (`left_alias == right_alias`) self-referencing FK-edge.
+                let self_loop_pre_filter = if rel_schema.is_self_referencing_fk_edge()
+                    && t.left_alias == t.right_alias
+                {
+                    helpers::self_loop_filter(t.rel_alias, &rel_schema.from_id, &rel_schema.to_id)
+                } else {
+                    None
+                };
+                let merged_pre_filter = match (pre_filter, self_loop_pre_filter) {
+                    (Some(p), Some(s)) => {
+                        crate::query_planner::logical_expr::combinators::and(vec![p, s])
+                    }
+                    (Some(p), None) => Some(p),
+                    (None, s) => s,
+                };
                 let mut builder = JoinBuilder::new(t.rel_table, t.rel_alias)
-                    .pre_filter(pre_filter)
+                    .pre_filter(merged_pre_filter)
                     .from_id(rel_schema.from_id.first_column().to_string())
                     .to_id(rel_schema.to_id.first_column().to_string());
 
@@ -433,6 +463,41 @@ pub fn generate_pattern_joins(
                     };
                     let right_avail = already_available.contains(t.right_alias);
                     let left_avail = already_available.contains(t.left_alias);
+
+                    // #987 (FK-edge facet): a CLOSED self-referencing FK-edge
+                    // single-hop (`(a)-[:PARENT]->(a)`, `left_alias ==
+                    // right_alias`) must bind the shared node ONCE. The default
+                    // `(false, false)` layout emits a FROM marker for the right
+                    // node plus a separate JOIN for the left node, both with the
+                    // SAME alias (the edge IS the node table, self-referencing) →
+                    // duplicate table alias → ClickHouse Code 179 for the property
+                    // form, and — because the self-loop equality lives ONLY in
+                    // that JOIN's ON — the bare `count(*)` form silently drops the
+                    // constraint when `remove_unreferenced_joins` elides the
+                    // unreferenced node join, counting ALL rows instead of only
+                    // self-loops. Emit a SINGLE FROM-marker scan and attach the
+                    // self-loop equality (`fk == node_id` on the one alias, e.g.
+                    // `a.parent_region = a.region AND a.parent_id = a.object_id`)
+                    // as its `pre_filter` — `from_marker_pre_filter` promotes it to
+                    // the outer WHERE, which lives on the FROM anchor (never
+                    // pruned) so it survives `count(*)` elision. Composite-safe:
+                    // built from the same `cond_left_id`/`cond_right_id` Identifier
+                    // column sets the JOIN would have used, zipped per-column and
+                    // AND-combined (never a bare `format!`, which would comma-join
+                    // a composite Identifier into invalid SQL). Gated to
+                    // `is_self_referencing && left_alias == right_alias`, so
+                    // non-self-ref FK-edges (distinct tables) and OPEN self-ref
+                    // FK-edges (distinct aliases) are untouched.
+                    let closed_self_ref = *is_self_referencing && t.left_alias == t.right_alias;
+                    if closed_self_ref && !right_avail && !left_avail {
+                        let self_loop =
+                            helpers::self_loop_filter(t.right_alias, cond_left_id, cond_right_id);
+                        return Ok(vec![JoinBuilder::from_marker(t.right_table, t.right_alias)
+                            .from_id(from_id.clone())
+                            .to_id(to_id.clone())
+                            .pre_filter(self_loop)
+                            .build()]);
+                    }
 
                     match (right_avail, left_avail) {
                         (false, false) => vec![

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1237,6 +1237,8 @@
 {"cypher": "MATCH (c:Comment)-[:IN_FORUM]->(f:Forum) RETURN c.comment_id, f.forum_id LIMIT 5", "name": "test_672_composite_non_self_ref_fk_single_hop", "schema": "composite_fk_edge_nonselfref"}
 {"cypher": "MATCH (c:Comment)<-[:IN_FORUM]-(f:Forum) RETURN c.comment_id, f.forum_id LIMIT 5", "name": "test_672_composite_non_self_ref_fk_reverse_single_hop", "schema": "composite_fk_edge_nonselfref"}
 {"cypher": "MATCH (a:Object)-[:PARENT*1..3]->(b:Object) WHERE a.name = 'doc' RETURN b.name", "name": "test_713_composite_self_ref_fk_vlp_ancestors_append", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)-[:PARENT]->(a) RETURN count(*)", "name": "test_987_composite_self_ref_fk_closed_single_hop_count", "schema": "composite_self_ref_fk"}
+{"cypher": "MATCH (a:Object)-[:PARENT]->(a) RETURN a.name", "name": "test_987_composite_self_ref_fk_closed_single_hop_property", "schema": "composite_self_ref_fk"}
 {"cypher": "MATCH (a:Object) OPTIONAL MATCH (a)-[:PARENT*1..]->(b:Object) RETURN a.name, count(*)", "name": "test_979_composite_optional_vlp_open_fails_loud", "schema": "composite_self_ref_fk"}
 {"cypher": "MATCH (a:Object) OPTIONAL MATCH (a)-[:PARENT*1..]->(a) RETURN a.name, count(*)", "name": "test_979_composite_optional_vlp_closed_fails_loud", "schema": "composite_self_ref_fk"}
 {"cypher": "MATCH (a:Account)-[:TRANSFERRED*2..2]->(b:Account) RETURN a.bank_id, b.bank_id", "name": "test_604_composite_normal_exact_two_hop", "schema": "composite_id"}

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_count.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_count.clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      count(*) AS "count(*)"
+FROM test_integration.fs_objects_composite AS t0
+WHERE (t0.parent_region = t0.region AND t0.parent_id = t0.object_id)

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_count.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_count.databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      count(*) AS `count(*)`
+FROM test_integration.fs_objects_composite AS t0
+WHERE (t0.parent_region = t0.region AND t0.parent_id = t0.object_id)

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_property.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_property.clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      a.name AS "a.name"
+FROM test_integration.fs_objects_composite AS a
+WHERE (a.parent_region = a.region AND a.parent_id = a.object_id)

--- a/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_property.databricks.sql
+++ b/tests/rust/integration/golden/corpus/composite_self_ref_fk/test_987_composite_self_ref_fk_closed_single_hop_property.databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      a.name AS `a.name`
+FROM test_integration.fs_objects_composite AS a
+WHERE (a.parent_region = a.region AND a.parent_id = a.object_id)

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8514,8 +8514,75 @@ async fn closed_single_hop_property_binds_node_once_987() {
     }
 }
 
-/// subquery; ClickHouse decorrelates that into a LEFT JOIN, so an outer row
-/// with ZERO pattern matches yields NULL instead of 0 — silently breaking
+/// #987 (FK-edge facet): a self-referencing FK-edge closed single-hop
+/// `(a)-[:PARENT]->(a)` (the "edge" IS the node table — FK columns live on the
+/// node row) was broken two ways: the `count(*)` form (SingleTableScan strategy)
+/// silently counted ALL rows with no self-loop constraint, and the property form
+/// (FkEdgeJoin strategy) bound the node twice with the same alias → Code 179. Both
+/// forms now emit a single scan with the self-loop `fk == node_id` filter
+/// (`a.parent_id = a.object_id` single-id, or a per-column AND for composite keys).
+/// The OPEN self-ref `(a)->(b)` and non-self-ref FK-edges are untouched.
+#[tokio::test]
+async fn fk_edge_self_ref_closed_single_hop_emits_self_loop_987() {
+    // Single-id self-ref FK-edge: fs_objects_single, fk parent_id → pk object_id.
+    let single = load_schema("schemas/examples/filesystem_single.yaml");
+    // Composite self-ref FK-edge: [parent_region, parent_id] → [region, object_id].
+    let composite = load_schema("schemas/test/composite_self_ref_fk.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Single-id: both count(*) and property forms get `.parent_id = .object_id`
+        // on a single scan (no duplicate alias).
+        for cypher in [
+            "MATCH (a:Object)-[:PARENT]->(a) RETURN count(*)",
+            "MATCH (a:Object)-[:PARENT]->(a) RETURN a.name",
+        ] {
+            let sql = render(&single, cypher, dialect).await;
+            assert!(
+                sql.contains(".parent_id = ") && sql.contains(".object_id"),
+                "#987 FK-edge ({dialect:?}): single-id self-ref closed hop must emit the self-loop filter:\n{cypher}\n{sql}"
+            );
+            // Single scan: `fs_objects_single` appears exactly once.
+            assert_eq!(
+                sql.matches("fs_objects_single").count(),
+                1,
+                "#987 FK-edge ({dialect:?}): must be a single scan (no duplicate alias):\n{cypher}\n{sql}"
+            );
+        }
+
+        // Composite: per-column AND self-loop, single scan.
+        for cypher in [
+            "MATCH (a:Object)-[:PARENT]->(a) RETURN count(*)",
+            "MATCH (a:Object)-[:PARENT]->(a) RETURN a.name",
+        ] {
+            let sql = render(&composite, cypher, dialect).await;
+            assert!(
+                sql.contains(".parent_region = ")
+                    && sql.contains(".region")
+                    && sql.contains(".parent_id = ")
+                    && sql.contains(".object_id"),
+                "#987 FK-edge ({dialect:?}): composite self-ref closed hop must emit a per-column self-loop:\n{cypher}\n{sql}"
+            );
+            assert_eq!(
+                sql.matches("fs_objects_composite").count(),
+                1,
+                "#987 FK-edge ({dialect:?}): composite must be a single scan:\n{cypher}\n{sql}"
+            );
+        }
+
+        // OPEN self-ref (distinct vars) must NOT get a self-loop filter and keeps
+        // the two-table join.
+        let open = render(
+            &single,
+            "MATCH (a:Object)-[:PARENT]->(b:Object) RETURN count(*)",
+            dialect,
+        )
+        .await;
+        assert!(
+            !(open.contains(".parent_id = a.object_id") && open.contains("WHERE")),
+            "#987 FK-edge ({dialect:?}): OPEN self-ref must NOT get a self-loop WHERE:\n{open}"
+        );
+    }
+}
+
 /// `size(...) = 0` filters, comparisons, arithmetic, and CASE branches on
 /// zero-degree nodes. Every PatternCount rendering (all three direction
 /// variants and the multi-hop chain, in RETURN and WHERE positions alike)


### PR DESCRIPTION
## Problem

A SELF-REFERENCING FK-edge closed single-hop `(a)-[:PARENT]->(a)` (the "edge" IS the node table — FK columns live on the node row) was broken two ways, both stemming from the same missing self-loop constraint (node is its own parent: `fk_cols == node_id_cols`):

1. **count(*) form** (SingleTableScan strategy) rendered `FROM <table> AS t1` with NO constraint → silently counted ALL rows. Live: 5 rows / 1 self-loop → returned **5** instead of **1**.
2. **property form** (FkEdgeJoin strategy) bound the node to both a FROM marker and a separate JOIN with the SAME alias → ClickHouse **Code 179** (duplicate alias).

The two forms take *different* analyzer strategies, so each needs its own fix.

## Fix

Both analyzer-side, both composite-safe via a new `helpers::self_loop_filter(alias, fk_id, node_id)` that zips the FK and node_id column sets into a per-column AND (never a bare `format!` that would comma-join a composite `Identifier` into invalid SQL):

- **FkEdgeJoin `NodePosition::Left` `(false, false)` arm** (property form): when `is_self_referencing && left_alias == right_alias`, emit a SINGLE FROM-marker scan with the self-loop as its `pre_filter` (promoted to WHERE by `from_marker_pre_filter`) instead of the duplicate node JOIN.
- **SingleTableScan arm** (count(*) form): when `rel_schema.is_self_referencing_fk_edge() && left_alias == right_alias`, AND the self-loop (`rel_alias.from_id = rel_alias.to_id`) into the edge scan's pre_filter — it lives on the single scanned table, so it survives count(*) join elision.

Live-verified on both single-id (`filesystem_single`, `a.parent_id = a.object_id`) and composite (`composite_self_ref_fk`, `a.parent_region = a.region AND a.parent_id = a.object_id`) fixtures: count(*) → 1, property → the self-parent's name, both = oracle.

**No double-add with denorm:** denorm closed self-hops use the render-side #983 filter and are structurally not FK-edges (`is_self_referencing_fk_edge()` requires no node_properties) — byte-identical, verified. OPEN self-ref `(a)->(b)` and non-self-ref FK-edges untouched. **Rule #7:** routes through the `is_self_referencing_fk_edge()` schema-catalog API (ratchet clean, no baseline bump).

## Tests

- Corpus: `test_987_composite_self_ref_fk_closed_single_hop_{count,property}` (both dialects, 4 new goldens).
- Golden test `fk_edge_self_ref_closed_single_hop_emits_self_loop_987`: both forms on both fixtures + OPEN/non-self-ref controls.
- 1689 lib / 580 integration / corpus / ratchet / clippy / fmt green; no existing-golden churn.

## Review

Adversarial worktree-isolated review (isolated `CARGO_TARGET_DIR` builds): **APPROVE, zero defects**. Both bugs confirmed on main (count→5, property→Code 179) and fixed (→1, →`root`) vs hand oracle; composite pairing positionally correct (`parent_region=region`, not swapped); denorm #983 path structurally isolated (no double-add — a denorm can't be an fk-edge self-ref); 32-query differential sweep byte-identical except the intended closed self-ref family; WHERE-anchor AND-combined; ratchet clean.

Refs #987 (FK-edge facet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)