### PR TITLE
fix(#995): preserve inline node-property map on closed single-hop start node

### DIFF
--- a/src/query_planner/logical_plan/match_clause/traversal.rs
+++ b/src/query_planner/logical_plan/match_clause/traversal.rs
@@ -1568,13 +1568,37 @@ fn traverse_connected_pattern_with_mode<'a>(
                 projected_columns: None,
                 node_types: None,
             };
-            register_node_in_context(
-                plan_ctx,
-                &end_node_alias,
-                &end_node_label,
-                end_node_props,
-                end_node_ref.name.is_some(),
-            );
+            // #995: a CLOSED single hop `(a)-[:R]->(a)` names the SAME alias at
+            // both endpoints, so the `start_node_alias` registration above
+            // already created `a`'s `TableCtx` — carrying any inline node-property
+            // map (`{name:'Alice'}`). A blind `register_node_in_context` here
+            // would `insert` a fresh (empty-prop) `TableCtx` over it, silently
+            // discarding the start node's inline filter — `MATCH (a {name:'Alice'})
+            // -[:R]->(a)` then returned ALL self-loops, not just Alice's (the WHERE
+            // form `WHERE a.name='Alice'` and the OPEN hop `(a)->(b)` both kept it,
+            // because WHERE predicates aren't keyed to node registration and the
+            // open hop's endpoints have distinct aliases). APPEND-when-present
+            // instead, mirroring the sibling "start already in ctx" branch above
+            // (its identical end-node guard preserves multi-pattern filters like
+            // `(p1 {id:$a}), (p2 {id:$b}), path=shortestPath(...)`). For the open
+            // case `end_node_alias` is not yet in the ctx, so this stays a plain
+            // register (byte-identical to before).
+            if let Some(existing_ctx) = plan_ctx.get_mut_table_ctx_opt(&end_node_alias) {
+                if end_node_label.is_some() {
+                    existing_ctx.set_labels(end_node_label.clone().map(|l| vec![l]));
+                }
+                if !end_node_props.is_empty() {
+                    existing_ctx.append_properties(end_node_props);
+                }
+            } else {
+                register_node_in_context(
+                    plan_ctx,
+                    &end_node_alias,
+                    &end_node_label,
+                    end_node_props,
+                    end_node_ref.name.is_some(),
+                );
+            }
 
             let (left_conn, right_conn) =
                 compute_connection_aliases(&rel.direction, &start_node_alias, &end_node_alias);

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1148,6 +1148,9 @@
 {"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT*0..]->(a) RETURN a.code, count(*)", "name": "test_978_denorm_closed_optional_vlp_zero_hop_fails_loud", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN count(*)", "name": "test_987_denorm_closed_single_hop_self_loop", "schema": "denormalized_flights"}
 {"cypher": "MATCH (a:Airport)-[:FLIGHT]->(a) RETURN a.city", "name": "test_987_denorm_closed_single_hop_self_loop_property", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(a) RETURN a.user_id", "name": "test_995_closed_single_hop_inline_map_start_node", "schema": "test_fixtures"}
+{"cypher": "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a:TestUser {name:'Alice'}) RETURN a.user_id", "name": "test_995_closed_single_hop_inline_map_end_node", "schema": "test_fixtures"}
+{"cypher": "MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(a:TestUser {user_id:1}) RETURN a.user_id", "name": "test_995_closed_single_hop_inline_map_both_endpoints", "schema": "test_fixtures"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WITH o, count(r) AS rc RETURN o.order_id, rc ORDER BY o.order_id", "name": "test_584_fk_edge_coupled_rel_var_count_r_in_with", "schema": "fk_edge"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) RETURN count(r)", "name": "test_584_fk_edge_standalone_count_r_still_works", "schema": "fk_edge"}
 {"cypher": "MATCH (o:Order)-[r:PLACED_BY]->(c:Customer) WITH count(r) AS rc RETURN rc", "name": "test_584_fk_edge_count_r_only_no_node_carried", "schema": "fk_edge"}

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_both_endpoints.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_both_endpoints.clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS "a.user_id"
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE ((a.name = 'Alice' AND a.user_id = 1) AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_both_endpoints.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_both_endpoints.databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS `a.user_id`
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE ((a.name = 'Alice' AND a.user_id = 1) AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_end_node.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_end_node.clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS "a.user_id"
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE (a.name = 'Alice' AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_end_node.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_end_node.databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS `a.user_id`
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE (a.name = 'Alice' AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_start_node.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_start_node.clickhouse.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS "a.user_id"
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE (a.name = 'Alice' AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_start_node.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_995_closed_single_hop_inline_map_start_node.databricks.sql
@@ -1,0 +1,5 @@
+SELECT 
+      a.user_id AS `a.user_id`
+FROM test_integration.users AS a
+INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id AND t0.followed_id = a.user_id
+WHERE (a.name = 'Alice' AND t0.follower_id = t0.followed_id)

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -8514,6 +8514,76 @@ async fn closed_single_hop_property_binds_node_once_987() {
     }
 }
 
+/// #995: a CLOSED single hop with an INLINE node-property map on the START node
+/// (`(a:TestUser {name:'Alice'})-[:R]->(a)`) silently DROPPED that filter. The
+/// closed hop names the same alias `a` at both endpoints, and the planner's
+/// "not-connected" traversal branch registered `a`'s `TableCtx` twice — the second
+/// (end-node) `register_node_in_context` blindly `insert`ed a fresh empty-prop ctx
+/// OVER the first, discarding the start node's inline `{name:'Alice'}` before it
+/// could be lowered to a predicate. The end-node registration now APPENDS to the
+/// existing ctx (mirroring the sibling "start already in ctx" branch), so the
+/// inline map survives regardless of which endpoint carries it. The WHERE-clause
+/// form and the OPEN hop were always correct (WHERE predicates aren't keyed to node
+/// registration; the open hop's endpoints have distinct aliases).
+#[tokio::test]
+async fn closed_single_hop_inline_node_property_preserved_995() {
+    let schema = load_schema("schemas/test/test_fixtures.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Inline map on the START node (the exact bug) — must survive.
+        let start_map = render(
+            &schema,
+            "MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(a) RETURN a.user_id",
+            dialect,
+        )
+        .await;
+        assert!(
+            start_map.contains("a.name = 'Alice'"),
+            "#995 ({dialect:?}): inline node-property map on the START node of a closed hop must be preserved:\n{start_map}"
+        );
+        // The self-loop constraint must ALSO still be present (both, AND'd).
+        assert!(
+            start_map.contains("follower_id = ") && start_map.contains("followed_id = "),
+            "#995 ({dialect:?}): the closed-hop self-loop constraint must coexist with the inline filter:\n{start_map}"
+        );
+
+        // Inline map on the END node — was already correct, must stay correct.
+        let end_map = render(
+            &schema,
+            "MATCH (a:TestUser)-[:TEST_FOLLOWS]->(a:TestUser {name:'Alice'}) RETURN a.user_id",
+            dialect,
+        )
+        .await;
+        assert!(
+            end_map.contains("a.name = 'Alice'"),
+            "#995 ({dialect:?}): inline node-property map on the END node of a closed hop must be preserved:\n{end_map}"
+        );
+
+        // Inline maps on BOTH endpoints — both conjuncts must appear (no clobber).
+        let both_maps = render(
+            &schema,
+            "MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(a:TestUser {user_id:1}) RETURN a.user_id",
+            dialect,
+        )
+        .await;
+        assert!(
+            both_maps.contains("a.name = 'Alice'") && both_maps.contains("a.user_id = 1"),
+            "#995 ({dialect:?}): inline maps on both endpoints of a closed hop must both survive:\n{both_maps}"
+        );
+
+        // OPEN hop with an inline map — untouched (single node filter, no self-loop).
+        let open = render(
+            &schema,
+            "MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(b:TestUser) RETURN a.user_id",
+            dialect,
+        )
+        .await;
+        assert!(
+            open.contains("a.name = 'Alice'"),
+            "#995 ({dialect:?}): OPEN hop inline map must be preserved (control):\n{open}"
+        );
+    }
+}
+
 /// #987 (FK-edge facet): a self-referencing FK-edge closed single-hop
 /// `(a)-[:PARENT]->(a)` (the "edge" IS the node table — FK columns live on the
 /// node row) was broken two ways: the `count(*)` form (SingleTableScan strategy)


### PR DESCRIPTION
## Summary

A **closed** single hop with an **inline node-property map on the START node** silently dropped the filter:

```cypher
MATCH (a:TestUser {name:'Alice'})-[:TEST_FOLLOWS]->(a) RETURN a.user_id
```

rendered `WHERE t1.follower_id = t1.followed_id` with **`a.name = 'Alice'` gone** → returned ALL self-followers, not just Alice (silent-wrong, ground rule 1). Filed from the #987 facet-1 adversarial review.

## Root cause

Upstream in the **planner traversal**, not the recent closed-hop JOIN collapse. A closed hop names the same alias `a` at both endpoints, so the "not-connected" branch registers `a`'s `TableCtx` twice. The second (end-node) `register_node_in_context` did a blind `HashMap::insert` of a fresh **empty-prop** `TableCtx` over the first, discarding the start node's inline `{name:'Alice'}` **before** `convert_properties_to_operator_application` could lower it to an `a.name = 'Alice'` equality.

Empirically confirmed last-write-wins: the map on the **start** node was dropped; the same map on the **end** node survived. The WHERE-clause form and the OPEN hop `(a)->(b)` were always correct — WHERE predicates aren't keyed to node registration, and open endpoints have distinct aliases.

## Fix

The end-node registration now **appends** to the existing ctx when the alias is already present, exactly mirroring the sibling "start already in ctx" branch (whose identical end-node guard already preserves multi-pattern filters like `(p1 {id:$a}), (p2 {id:$b}), path=shortestPath(...)`). For the open case the end alias isn't yet in the ctx, so it stays a plain register — **byte-identical to before**. This converges the inline-map and WHERE paths for the closed hop, removing a latent "one placement works, the other silently drops" trap.

## Verification

- **Live oracle** (Alice `1→1` + Bob `2→2` self-loops inserted into `follows`, then restored): fixed query returns **only `1`** (Alice); the unfiltered closed hop still returns **`1` and `2`** — the fix is *selective*, not over-filtering.
- All placements now correct: start-map / end-map / both-endpoints (AND'd, no clobber) / open control / `count(*)` form / labeled-either-endpoint / unlabeled-both.
- New golden test `closed_single_hop_inline_node_property_preserved_995` (4 placements × 2 dialects) + 3 corpus entries.
- Full suite green: lib 1689, integration 581 (+1), corpus, clippy clean, ratchet clean (routes through existing `PlanCtx` APIs — no axis-branch, no baseline bump).

Closes #995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)