### PR TITLE
fix: lower scalar exists(v.prop) to IS NOT NULL (both render paths)

### DIFF
--- a/src/query_planner/logical_expr/ast_conversion.rs
+++ b/src/query_planner/logical_expr/ast_conversion.rs
@@ -257,6 +257,30 @@ impl<'a> TryFrom<open_cypher_parser::ast::FunctionCall<'a>> for LogicalExpr {
             .map(LogicalExpr::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Scalar `exists(v.prop)` is the PROPERTY-existence function (distinct from
+        // the `EXISTS { pattern }` subquery, which parses as `ExistsExpression`, not
+        // `FunctionCallExp`). Cypher semantics: `exists(v.prop)` ≡ `v.prop IS NOT
+        // NULL`. No SQL backend has a scalar `exists(x)` function, so left as a
+        // `ScalarFnCall` it renders the invalid literal `exists(...)` (Code 46 on
+        // Path A) or `WHERE false` (Path C VLP/pattern-comp — silently dropping
+        // every row). Lower it here, at the single canonical AST conversion site, so
+        // BOTH render paths get the correct `IS NOT NULL`. This is dialect-agnostic
+        // by construction: it runs before the dialect is pinned and `IS NOT NULL` is
+        // standard SQL, so no per-backend handling is needed.
+        //
+        // Gated STRICTLY to a single PropertyAccess argument — the only form with an
+        // unambiguous, render-correct lowering. Any other shape (bare variable, a
+        // computed expression, ≠1 args) stays a `ScalarFnCall` and hits the existing
+        // unmapped-function path rather than guessing a semantics we can't prove.
+        if name_lower == "exists"
+            && args.len() == 1
+            && matches!(args[0], LogicalExpr::PropertyAccessExp(_))
+        {
+            return Ok(super::combinators::is_not_null(
+                args.into_iter().next().expect("len checked == 1"),
+            ));
+        }
+
         if is_standard_agg || is_passthrough_agg {
             Ok(LogicalExpr::AggregateFnCall(AggregateFnCall {
                 name: value.name,

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1258,3 +1258,6 @@
 {"cypher": "MATCH (a:User)\n            WITH a\n            RETURN a.user_id, size((a)-[:FOLLOWS]->()-[:FOLLOWS]->()) AS c", "name": "test_613__size_pattern_count_after_with_multi_hop", "schema": "social_integration"}
 {"cypher": "MATCH (a:User)-[:FOLLOWS*2]->(b:User) RETURN count(*) AS c", "name": "test_897__flat_poly_vlp_type_discriminator_count", "schema": "social_polymorphic"}
 {"cypher": "MATCH (a:Airport)-[r:FLIGHT]-(b:Airport) RETURN CASE WHEN count(r) > 5 THEN a.code ELSE 'x' END AS m", "name": "test_906__denorm_undirected_case_buried_grouping_key", "schema": "denormalized_flights"}
+{"cypher": "MATCH (u:User) RETURN exists(u.name) AS has", "name": "test_995b_scalar_exists_property_return_is_not_null", "schema": "standard"}
+{"cypher": "MATCH (u:User) WHERE exists(u.name) RETURN u.user_id", "name": "test_995b_scalar_exists_property_where_is_not_null", "schema": "standard"}
+{"cypher": "MATCH (u:User)-[:FOLLOWS*1..2]->(f:User) WHERE exists(f.name) RETURN u.user_id", "name": "test_995b_scalar_exists_property_vlp_where_is_not_null", "schema": "standard"}

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.clickhouse.sql
@@ -1,0 +1,3 @@
+SELECT 
+      u.full_name IS NOT NULL AS "has"
+FROM test_integration.users_test AS u

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.databricks.sql
@@ -1,0 +1,3 @@
+SELECT 
+      u.full_name IS NOT NULL AS `has`
+FROM test_integration.users_test AS u

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_vlp_where_is_not_null.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_vlp_where_is_not_null.clickhouse.sql
@@ -1,0 +1,33 @@
+WITH RECURSIVE vlp_u_f_inner AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        [rel.follow_id] as path_edges,
+        end_node.full_name as end_name
+    FROM test_integration.users_test AS start_node
+    JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [rel.follow_id]) as path_edges,
+        end_node.full_name as end_name
+    FROM vlp_u_f_inner vp
+    JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT has(vp.path_edges, rel.follow_id)
+),
+vlp_u_f AS (
+    SELECT * FROM vlp_u_f_inner WHERE (end_name IS NOT NULL)
+)
+SELECT 
+      t.start_id AS "u.user_id"
+FROM vlp_u_f AS t

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_vlp_where_is_not_null.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_vlp_where_is_not_null.databricks.sql
@@ -1,0 +1,33 @@
+WITH RECURSIVE vlp_u_f_inner AS (
+    SELECT 
+        start_node.user_id as start_id,
+        end_node.user_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        array(rel.follow_id) as path_edges,
+        end_node.full_name as end_name
+    FROM test_integration.users_test AS start_node
+    JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.user_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        concat(vp.path_edges, array(rel.follow_id)) as path_edges,
+        end_node.full_name as end_name
+    FROM vlp_u_f_inner vp
+    JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
+    JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
+    WHERE vp.hop_count < 2
+      AND NOT array_contains(vp.path_edges, rel.follow_id)
+),
+vlp_u_f AS (
+    SELECT * FROM vlp_u_f_inner WHERE (end_name IS NOT NULL)
+)
+SELECT 
+      t.start_id AS `u.user_id`
+FROM vlp_u_f AS t

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_where_is_not_null.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_where_is_not_null.clickhouse.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS "u.user_id"
+FROM test_integration.users_test AS u
+WHERE u.full_name IS NOT NULL

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_where_is_not_null.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_where_is_not_null.databricks.sql
@@ -1,0 +1,4 @@
+SELECT 
+      u.user_id AS `u.user_id`
+FROM test_integration.users_test AS u
+WHERE u.full_name IS NOT NULL

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -6943,6 +6943,87 @@ async fn exists_predicate_maps_property_nested_in_case_705() {
     );
 }
 
+/// Scalar `exists(v.prop)` — the property-existence FUNCTION (distinct from the
+/// `EXISTS { pattern }` subquery) — must lower to `v.prop IS NOT NULL`, on BOTH
+/// render paths and BOTH dialects. Left unmapped it renders the invalid literal
+/// `exists(...)` on Path A (no such ClickHouse/Databricks scalar fn → Code 46)
+/// and `WHERE false` on Path C (VLP/pattern-comp — silently dropping every row).
+/// The lowering is at the single canonical AST-conversion site so both paths get
+/// it; gated to a single PropertyAccess argument (other shapes stay ScalarFnCall).
+#[tokio::test]
+async fn scalar_exists_property_lowers_to_is_not_null() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    // Path A — RETURN position, ClickHouse. Property maps (name → full_name) AND
+    // renders IS NOT NULL, never the literal `exists(`.
+    let ret = normalize(
+        &render(
+            &schema,
+            "MATCH (u:User) RETURN exists(u.name) AS has",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        ret.contains("full_name IS NOT NULL") && !ret.contains("exists("),
+        "scalar exists(u.name) must render `full_name IS NOT NULL`, not a literal exists(...):\n{ret}"
+    );
+
+    // Path A — WHERE position, Databricks (confirms the lowering is dialect-agnostic
+    // — it happens before the dialect split, so no per-dialect work is needed).
+    let where_dbx = normalize(
+        &render(
+            &schema,
+            "MATCH (u:User) WHERE exists(u.name) RETURN u.user_id",
+            SqlDialect::Databricks,
+        )
+        .await,
+    );
+    assert!(
+        where_dbx.contains("full_name IS NOT NULL") && !where_dbx.contains("exists("),
+        "scalar exists(u.name) in WHERE (Databricks) must render IS NOT NULL:\n{where_dbx}"
+    );
+
+    // Path C — inside a VLP WHERE. Pre-fix this rendered `WHERE false` (dropping
+    // every row); it must now carry the endpoint's IS NOT NULL filter.
+    let vlp = normalize(
+        &render(
+            &schema,
+            "MATCH (u:User)-[:FOLLOWS*1..2]->(f) WHERE exists(f.name) RETURN u.user_id",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        vlp.contains("IS NOT NULL") && !vlp.contains("WHERE false") && !vlp.contains("exists("),
+        "scalar exists(f.name) in a VLP WHERE must render IS NOT NULL, not `WHERE false`:\n{vlp}"
+    );
+}
+
+/// Gate for `scalar_exists_property_lowers_to_is_not_null`: the lowering fires
+/// ONLY for a single PropertyAccess argument. A non-property argument (a computed
+/// expression, a bare variable, or ≠1 args) has no unambiguous IS-NOT-NULL
+/// meaning, so it must stay a `ScalarFnCall` (the existing unmapped-function
+/// path) rather than being silently rewritten.
+#[tokio::test]
+async fn scalar_exists_non_property_arg_is_not_lowered() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    // A computed-expression argument must NOT become IS NOT NULL.
+    let computed = normalize(
+        &render(
+            &schema,
+            "MATCH (u:User) RETURN exists(u.age + 1) AS x",
+            SqlDialect::ClickHouse,
+        )
+        .await,
+    );
+    assert!(
+        !computed.contains("IS NOT NULL"),
+        "exists(<computed expr>) must NOT be lowered to IS NOT NULL (stays ScalarFnCall):\n{computed}"
+    );
+}
+
 /// Regression test: `EXISTS { pattern }` whose correlated variable was bound
 /// BEFORE a `WITH` barrier — i.e. the variable lives in a CTE by the time the
 /// EXISTS subquery is rendered — must correlate against the variable's


### PR DESCRIPTION
## Summary

Scalar `exists(v.prop)` — the Cypher property-existence **function** (semantically `v.prop IS NOT NULL`), distinct from the `EXISTS { pattern }` subquery — was passing through **unmapped** to SQL:

- **Path A** (`to_sql_query.rs`): invalid literal `exists(u.full_name)` → ClickHouse **Code 46** (no such scalar function).
- **Path C** (`cte_extraction.rs`, VLP/pattern-comp): `WHERE false` → **silently dropped every row** (ground-rule-1 violation).

## Fix

One edit at the single canonical AST→LogicalExpr conversion site (`src/query_planner/logical_expr/ast_conversion.rs`, `FunctionCallExp` `TryFrom`): lower `exists(<PropertyAccess>)` to the existing `combinators::is_not_null()` → `OperatorApplication{ IsNotNull }`. Fixing it here covers **both render paths** at the source, and is dialect-agnostic (runs before the dialect is pinned; `IS NOT NULL` is standard SQL).

### Bounded gate
Fires **only** for a single `PropertyAccess` argument. Every other shape stays a `ScalarFnCall` (existing unmapped-function path), never guessing a semantics we can't prove:
- `exists()` / `exists(a, b)` (≠1 args)
- `exists(u)` (bare variable)
- `exists(u.age + 1)` (computed expression)
- Databricks HOF `exists(array, lambda)` (2-arg → passes the gate untouched)

No registry/HOF collision: Cypher list predicates are `any`/`all`/`none` (→ `arrayExists`); there is **no** scalar `exists` mapping to hijack.

Property mapping is preserved — the inner `PropertyAccess` survives lowering, so the later analyzer pass still maps `u.name → u.full_name` (no Code 47).

## Verification

- `exists(u.name)` RETURN/WHERE → `full_name IS NOT NULL` (ClickHouse + Databricks)
- VLP `WHERE exists(f.name)` → `WHERE (end_name IS NOT NULL)` (was `WHERE false`)
- `NOT exists`, `exists AND ...`, `CASE WHEN exists`, inside `EXISTS { }` — all correct
- **Fail-when-reverted confirmed**: reverting the source makes the test fail with the exact buggy `exists(u.full_name)` literal.
- **Adversarial review: APPROVE** (5 attack vectors — gate soundness, name collision incl. Databricks HOF, property mapping, NOT/nesting, GROUP BY — zero findings).
- 1689 lib + 580 int + corpus (**zero churn** beyond the 3 new entries) + ratchet **net-zero** + fmt + clippy green.

## Tests
- `scalar_exists_property_lowers_to_is_not_null` (RETURN/WHERE/VLP, both dialects)
- `scalar_exists_non_property_arg_is_not_lowered` (gate)
- corpus `test_995b_*` — 3 queries, 6 dual-dialect goldens

## Scope / relation to other issues
Surfaced adjacent to #995 (closed-single-hop filter drop, bronco's join-builder lane) but is a **distinct function-lowering bug** — separate file, separate root cause.

**Known residual (out of scope, not introduced here):** Path C renders `WHERE false` for *any* unsupported scalar predicate (e.g. `exists(f.age + 1)`) — a separate, broad Path-C-silently-drops-unsupported-predicates issue. Flagged for a follow-up track, deliberately not expanded into here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)