### PR TITLE
fix(#934): resolve denorm-start non-id WHERE against own-table on mixed VLP

### DIFF
--- a/schemas/test/foreign_selfloop_end.yaml
+++ b/schemas/test/foreign_selfloop_end.yaml
@@ -1,0 +1,37 @@
+# End-denorm mirror of foreign_selfloop.yaml (#934). Same foreign-embedded
+# self-loop shape that reaches the MIXED-access VLP arm, but the embedded role
+# is the TO-role (end), not the from-role — so on a directed
+# `(a)-[:REPORTS_TO]->(b)` VLP the END node is `EmbeddedInEdge` and
+# `end_is_denormalized` holds. This exercises the recursive-arm end-filter
+# rewrite (#934 Defect 1): a non-id WHERE on the denorm END node
+# (`WHERE b.name = 'Bob'`) must resolve against the `end_own` own-table join on
+# BOTH the base and recursive arms, not the nonexistent `rel.name`.
+#
+# Nodes live on `people` (pid, name); the edge `reports` embeds only the
+# to-role id (`pid` -> `emp_id`). Mirrors foreign_selfloop.yaml (which embeds
+# the from-role) exactly, with from/to_node_properties swapped.
+name: foreign_selfloop_end_test
+version: "1.0"
+description: "End-denorm foreign-embedded self-loop: to-role embedded -> mixed-access VLP arm with end_is_denormalized (#934)"
+
+graph_schema:
+  nodes:
+    - label: Person
+      database: testdb
+      table: people
+      node_id: pid
+      is_denormalized: true
+      property_mappings:
+        pid: pid
+        name: name
+      to_node_properties:
+        pid: emp_id
+  edges:
+    - type: REPORTS_TO
+      database: testdb
+      table: reports
+      from_node: Person
+      to_node: Person
+      from_id: mgr_id
+      to_id: emp_id
+      property_mappings: {}

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -3653,6 +3653,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
     /// id column `mgr_id` does not corrupt a non-id column `mgr_id_extra` whose
     /// name has the id column as a prefix (`start_node.mgr_id_extra` must stay a
     /// non-id column, routed to `*_own` in step 2, not become `rel.mgr_id_extra`).
+    /// Both steps run only OUTSIDE single-quoted string literals
+    /// (`rewrite_outside_string_literals`) so a value literal containing the
+    /// prefix text (e.g. `= 'end_node.x'`) is left intact.
     ///
     /// `own_join_present` guards the non-id fallback: the `*_own` join is only
     /// emitted when a denorm-endpoint non-id property is in `self.properties`
@@ -3671,25 +3674,72 @@ impl<'a> VariableLengthCteGenerator<'a> {
         if !own_join_present {
             // No own-table join in scope — nothing to resolve non-id columns
             // against. Keep the historical behavior (id-only filters still map
-            // correctly onto the edge alias).
-            return filters.replace(node_prefix, &format!("{}.", self.relationship_alias));
+            // correctly onto the edge alias). Still literal-safe.
+            let rel_prefix = format!("{}.", self.relationship_alias);
+            return Self::rewrite_outside_string_literals(filters, |seg| {
+                seg.replace(node_prefix, &rel_prefix)
+            });
         }
-        // Step 1: pin each id column to the relationship alias. `id_col` may be a
-        // comma-separated composite (mirroring `relationship_from/to_column`).
-        let mut out = filters.to_string();
-        for col in id_col.split(',') {
-            let col = col.trim();
-            if col.is_empty() {
-                continue;
+        // Both rewrite steps run only on the NON-string-literal spans of the
+        // predicate (#934 Defect 3): a value literal like `'end_node.x'` must not
+        // be mangled by the column-prefix rewrites.
+        let rel_alias = self.relationship_alias.clone();
+        Self::rewrite_outside_string_literals(filters, |seg| {
+            // Step 1: pin each id column to the relationship alias. `id_col` may
+            // be a comma-separated composite (mirroring
+            // `relationship_from/to_column`). Word-boundary aware so an id column
+            // does not over-match a longer non-id column that has it as a prefix.
+            let mut out = seg.to_string();
+            for col in id_col.split(',') {
+                let col = col.trim();
+                if col.is_empty() {
+                    continue;
+                }
+                out = Self::replace_column_token(
+                    &out,
+                    &format!("{}{}", node_prefix, col),
+                    &format!("{}.{}", rel_alias, col),
+                );
             }
-            out = Self::replace_column_token(
-                &out,
-                &format!("{}{}", node_prefix, col),
-                &format!("{}.{}", self.relationship_alias, col),
-            );
+            // Step 2: every remaining non-id column resolves via the own-table join.
+            out.replace(node_prefix, own_prefix)
+        })
+    }
+
+    /// Apply `rewrite` to every span of `s` that is OUTSIDE a single-quoted
+    /// string literal, leaving literal contents untouched (#934 Defect 3). SQL
+    /// string literals escape an embedded quote by doubling it (`''`); this
+    /// scanner treats `''` inside a literal as an escaped quote, not a close.
+    /// Column-prefix rewrites must not corrupt a value literal that happens to
+    /// contain the prefix text (e.g. `WHERE b.name = 'end_node.x'`).
+    fn rewrite_outside_string_literals(s: &str, rewrite: impl Fn(&str) -> String) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut buf = String::new();
+        let mut in_literal = false;
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if in_literal {
+                out.push(c);
+                if c == '\'' {
+                    if chars.peek() == Some(&'\'') {
+                        // Escaped quote ('') — consume the pair, stay in literal.
+                        out.push(chars.next().unwrap());
+                    } else {
+                        in_literal = false;
+                    }
+                }
+            } else if c == '\'' {
+                // Flush the accumulated non-literal span through the rewrite.
+                out.push_str(&rewrite(&buf));
+                buf.clear();
+                out.push(c);
+                in_literal = true;
+            } else {
+                buf.push(c);
+            }
         }
-        // Step 2: every remaining non-id column resolves via the own-table join.
-        out.replace(node_prefix, own_prefix)
+        out.push_str(&rewrite(&buf));
+        out
     }
 
     /// Replace occurrences of `needle` (a `prefix.column` token) with
@@ -4019,8 +4069,21 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         if self.shortest_path_mode.is_none() {
             if let Some(ref filters) = self.end_node_filters {
+                // #934: mirror the base-case rewrite on the recursive arm. A
+                // non-id property of a denormalized END node must resolve via the
+                // `end_own` join (`denorm_end_recursive_join`, emitted just below
+                // in the FROM clause) — the old blanket `end_node.` -> `rel.`
+                // rewrite pointed a non-id column at the edge table (which lacks
+                // it) → Code 47 on the recursive UNION arm for any `*n..m`, m >= 2.
+                // The end id property still maps to the edge's `to` column.
                 let rewritten = if self.end_is_denormalized {
-                    filters.replace("end_node.", &format!("{}.", self.relationship_alias))
+                    self.rewrite_denorm_endpoint_filter(
+                        filters,
+                        "end_node.",
+                        "end_own.",
+                        &self.relationship_to_column,
+                        denorm_end_recursive_join.is_some(),
+                    )
                 } else {
                     filters.clone()
                 };
@@ -4115,6 +4178,41 @@ mod tests {
         assert_eq!(
             rep("start_node.mgr_id>5", "start_node.mgr_id", "rel.mgr_id"),
             "rel.mgr_id>5"
+        );
+    }
+
+    /// #934 Defect 3: `rewrite_outside_string_literals` must skip single-quoted
+    /// literals so a value containing the column-prefix text is not corrupted.
+    #[test]
+    fn rewrite_outside_string_literals_skips_literals_934() {
+        use VariableLengthCteGenerator as G;
+        // Each call takes a distinct closure type, so call the method directly
+        // rather than binding it to a single monomorphized `let`.
+        // The prefix inside a literal is untouched; outside it is rewritten.
+        assert_eq!(
+            G::rewrite_outside_string_literals("start_node.name = 'start_node.x'", |s| s
+                .replace("start_node.", "start_own.")),
+            "start_own.name = 'start_node.x'"
+        );
+        // Escaped quote ('') inside a literal keeps the literal open.
+        assert_eq!(
+            G::rewrite_outside_string_literals(
+                "a = 'it''s start_node.here' AND start_node.b = 1",
+                |s| s.replace("start_node.", "X.")
+            ),
+            "a = 'it''s start_node.here' AND X.b = 1"
+        );
+        // No literals → whole string rewritten.
+        assert_eq!(
+            G::rewrite_outside_string_literals("start_node.a = start_node.b", |s| s
+                .replace("start_node.", "X.")),
+            "X.a = X.b"
+        );
+        // Only a literal → untouched.
+        assert_eq!(
+            G::rewrite_outside_string_literals("'start_node.only'", |s| s
+                .replace("start_node.", "X.")),
+            "'start_node.only'"
         );
     }
 

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -3635,6 +3635,57 @@ impl<'a> VariableLengthCteGenerator<'a> {
         }
     }
 
+    /// Rewrite a denormalized-endpoint filter string (#934). The incoming
+    /// `filters` string is already property-mapped to CH columns and prefixed
+    /// with `node_prefix` (`start_node.` / `end_node.`). The endpoint's id
+    /// property maps to the edge's own FK column (`id_col`, e.g. `mgr_id`), so
+    /// it stays on the relationship alias (`rel.`); every OTHER (non-id) column
+    /// lives on the node's own table and must resolve via the `*_own` LEFT JOIN
+    /// (`own_prefix`, `start_own.` / `end_own.`) that #908 already emits.
+    ///
+    /// Order matters: the specific id-column replace runs first, then the
+    /// general fallback maps any remaining `node_prefix.` to `own_prefix.`, so a
+    /// combined predicate like `(start_node.mgr_id = 1 AND start_node.name =
+    /// 'Alice')` splits correctly to `(rel.mgr_id = 1 AND start_own.name =
+    /// 'Alice')`. Composite ids are handled by replacing each id column in turn.
+    ///
+    /// `own_join_present` guards the non-id fallback: the `*_own` join is only
+    /// emitted when a denorm-endpoint non-id property is in `self.properties`
+    /// (which the planner populates from WHERE predicates too). If it is somehow
+    /// absent, fall back to the old whole-string `rel.` rewrite rather than
+    /// emitting a dangling `*_own.` reference — preserves prior behavior for any
+    /// path that only carried the id filter.
+    fn rewrite_denorm_endpoint_filter(
+        &self,
+        filters: &str,
+        node_prefix: &str,
+        own_prefix: &str,
+        id_col: &str,
+        own_join_present: bool,
+    ) -> String {
+        if !own_join_present {
+            // No own-table join in scope — nothing to resolve non-id columns
+            // against. Keep the historical behavior (id-only filters still map
+            // correctly onto the edge alias).
+            return filters.replace(node_prefix, &format!("{}.", self.relationship_alias));
+        }
+        // Step 1: pin each id column to the relationship alias. `id_col` may be a
+        // comma-separated composite (mirroring `relationship_from/to_column`).
+        let mut out = filters.to_string();
+        for col in id_col.split(',') {
+            let col = col.trim();
+            if col.is_empty() {
+                continue;
+            }
+            out = out.replace(
+                &format!("{}{}", node_prefix, col),
+                &format!("{}.{}", self.relationship_alias, col),
+            );
+        }
+        // Step 2: every remaining non-id column resolves via the own-table join.
+        out.replace(node_prefix, own_prefix)
+    }
+
     /// Generate base case for mixed patterns
     fn generate_mixed_base_case(&self, hop_count: u32) -> String {
         if hop_count != 1 {
@@ -3751,6 +3802,10 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // #908: append the denorm endpoint's own-table join (foreign-embedded
         // shape) so its non-id properties resolve. Only one of the two can be set
         // in a mixed pattern (exactly one endpoint is denormalized).
+        // #934: capture presence BEFORE the `.or()` move — the WHERE rewrite below
+        // routes non-id endpoint props to `*_own` only when its join is emitted.
+        let start_own_join_present = denorm_start_join.is_some();
+        let end_own_join_present = denorm_end_join.is_some();
         if let Some(join) = denorm_start_join.or(denorm_end_join) {
             query.push_str(&format!("\n    {}", join));
         }
@@ -3758,9 +3813,27 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // Add WHERE conditions
         let mut where_conditions = Vec::new();
         if let Some(ref filters) = self.start_node_filters {
-            // Rewrite for denorm start if needed
+            // Rewrite for denorm start if needed.
+            //
+            // #934: the start filter string arrives already property-mapped to
+            // CH columns and prefixed `start_node.<col>`. The old blanket
+            // `start_node.` -> `rel.` rewrite was correct ONLY for the start
+            // node's id property (which maps to the edge's own FK column,
+            // `relationship_from_column`, e.g. `mgr_id`) — a NON-id property
+            // (e.g. `name`) lives on the node's OWN table, not the edge, so
+            // `rel.name` is an unknown identifier (Code 47). The `start_own`
+            // LEFT JOIN (#908, `denorm_start_join`) already resolves those own
+            // columns; route non-id start props to `start_own.` and keep the id
+            // prop on `rel.`, mirroring the id-vs-non-id branch in
+            // `mixed_denorm_endpoint_property_items`.
             let rewritten = if self.start_is_denormalized {
-                filters.replace("start_node.", &format!("{}.", self.relationship_alias))
+                self.rewrite_denorm_endpoint_filter(
+                    filters,
+                    "start_node.",
+                    "start_own.",
+                    &self.relationship_from_column,
+                    start_own_join_present,
+                )
             } else {
                 filters.clone()
             };
@@ -3769,9 +3842,18 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
         if self.shortest_path_mode.is_none() {
             if let Some(ref filters) = self.end_node_filters {
-                // Rewrite for denorm end if needed
+                // Rewrite for denorm end if needed. #934: symmetric to the start
+                // side — a non-id property of a denormalized END node resolves
+                // via the `end_own` join (`denorm_end_join`), while the end id
+                // maps to the edge's `relationship_to_column`.
                 let rewritten = if self.end_is_denormalized {
-                    filters.replace("end_node.", &format!("{}.", self.relationship_alias))
+                    self.rewrite_denorm_endpoint_filter(
+                        filters,
+                        "end_node.",
+                        "end_own.",
+                        &self.relationship_to_column,
+                        end_own_join_present,
+                    )
                 } else {
                     filters.clone()
                 };

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -3649,6 +3649,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
     /// 'Alice')` splits correctly to `(rel.mgr_id = 1 AND start_own.name =
     /// 'Alice')`. Composite ids are handled by replacing each id column in turn.
     ///
+    /// Step 1 uses a WORD-BOUNDARY-aware replace (`replace_column_token`) so an
+    /// id column `mgr_id` does not corrupt a non-id column `mgr_id_extra` whose
+    /// name has the id column as a prefix (`start_node.mgr_id_extra` must stay a
+    /// non-id column, routed to `*_own` in step 2, not become `rel.mgr_id_extra`).
+    ///
     /// `own_join_present` guards the non-id fallback: the `*_own` join is only
     /// emitted when a denorm-endpoint non-id property is in `self.properties`
     /// (which the planner populates from WHERE predicates too). If it is somehow
@@ -3677,13 +3682,45 @@ impl<'a> VariableLengthCteGenerator<'a> {
             if col.is_empty() {
                 continue;
             }
-            out = out.replace(
+            out = Self::replace_column_token(
+                &out,
                 &format!("{}{}", node_prefix, col),
                 &format!("{}.{}", self.relationship_alias, col),
             );
         }
         // Step 2: every remaining non-id column resolves via the own-table join.
         out.replace(node_prefix, own_prefix)
+    }
+
+    /// Replace occurrences of `needle` (a `prefix.column` token) with
+    /// `replacement`, but ONLY when the character immediately following `needle`
+    /// is not an identifier character (`[A-Za-z0-9_]`) — i.e. `needle` is a whole
+    /// column token, not a prefix of a longer column name. This prevents the id
+    /// column `start_node.mgr_id` from matching inside `start_node.mgr_id_extra`
+    /// (which is a distinct non-id column). A plain `str::replace` would over-match.
+    fn replace_column_token(haystack: &str, needle: &str, replacement: &str) -> String {
+        if needle.is_empty() {
+            return haystack.to_string();
+        }
+        let mut out = String::with_capacity(haystack.len());
+        let mut rest = haystack;
+        while let Some(pos) = rest.find(needle) {
+            out.push_str(&rest[..pos]);
+            let after = &rest[pos + needle.len()..];
+            let boundary_ok = after
+                .chars()
+                .next()
+                .map(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(true); // end-of-string is a boundary
+            if boundary_ok {
+                out.push_str(replacement);
+            } else {
+                out.push_str(needle);
+            }
+            rest = after;
+        }
+        out.push_str(rest);
+        out
     }
 
     /// Generate base case for mixed patterns
@@ -4026,6 +4063,59 @@ mod tests {
     /// Helper to create a minimal test schema for VLC tests
     fn create_test_schema() -> GraphSchema {
         GraphSchema::build(1, "test_db".to_string(), HashMap::new(), HashMap::new())
+    }
+
+    /// #934: `replace_column_token` must be word-boundary aware so an id column
+    /// does not corrupt a longer non-id column that has it as a prefix.
+    #[test]
+    fn replace_column_token_respects_word_boundary_934() {
+        let rep = VariableLengthCteGenerator::replace_column_token;
+        // Whole-token match at end-of-string and before an operator/space.
+        assert_eq!(
+            rep("start_node.mgr_id = 1", "start_node.mgr_id", "rel.mgr_id"),
+            "rel.mgr_id = 1"
+        );
+        assert_eq!(
+            rep("x = start_node.mgr_id", "start_node.mgr_id", "rel.mgr_id"),
+            "x = rel.mgr_id"
+        );
+        // PREFIX COLLISION: `mgr_id` must NOT match inside `mgr_id_extra`.
+        assert_eq!(
+            rep(
+                "start_node.mgr_id_extra = 1",
+                "start_node.mgr_id",
+                "rel.mgr_id"
+            ),
+            "start_node.mgr_id_extra = 1",
+            "id column must not over-match a longer non-id column with the same prefix"
+        );
+        // Mixed: the real id token is rewritten, the colliding prefix is left alone.
+        assert_eq!(
+            rep(
+                "(start_node.mgr_id = 1 AND start_node.mgr_id_extra = 2)",
+                "start_node.mgr_id",
+                "rel.mgr_id"
+            ),
+            "(rel.mgr_id = 1 AND start_node.mgr_id_extra = 2)"
+        );
+        // Trailing underscore/alnum are identifier chars → no match.
+        assert_eq!(
+            rep("start_node.mgr_id9", "start_node.mgr_id", "rel.mgr_id"),
+            "start_node.mgr_id9"
+        );
+        assert_eq!(
+            rep("start_node.mgr_id_", "start_node.mgr_id", "rel.mgr_id"),
+            "start_node.mgr_id_"
+        );
+        // Closing paren / comparison operators are boundaries.
+        assert_eq!(
+            rep("(start_node.mgr_id)", "start_node.mgr_id", "rel.mgr_id"),
+            "(rel.mgr_id)"
+        );
+        assert_eq!(
+            rep("start_node.mgr_id>5", "start_node.mgr_id", "rel.mgr_id"),
+            "rel.mgr_id>5"
+        );
     }
 
     #[test]

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1257,6 +1257,8 @@
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) RETURN a.name, b.name", "name": "test_908__mixed_arm_vlp_denorm_start_property", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.name = 'Alice' RETURN b.name", "name": "test_934_mixed_vlp_denorm_start_non_id_where", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.pid = 1 AND a.name = 'Alice' RETURN b.name", "name": "test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where", "schema": "foreign_selfloop"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE b.name = 'Bob' RETURN a.name", "name": "test_934_mixed_vlp_denorm_end_non_id_where_both_arms", "schema": "foreign_selfloop_end"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE b.pid = 2 AND b.name = 'Bob' RETURN a.name", "name": "test_934_mixed_vlp_denorm_end_combined_id_and_non_id_where", "schema": "foreign_selfloop_end"}
 {"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN sum(b) AS total", "name": "test_914__chained_with_rename_of_property_sum", "schema": "social_integration"}
 {"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN collect(b) AS ages", "name": "test_914__chained_with_rename_of_property_collect", "schema": "social_integration"}
 {"cypher": "MATCH (a:Comment)-[:REPLY_OF*1..2]->(a) RETURN count(*) AS c", "name": "test_902__fk_edge_selfref_vlp_closed_follows_fk", "schema": "ldbc_snb"}

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1255,6 +1255,8 @@
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) RETURN b.name", "name": "test_808__mixed_arm_vlp_uses_edge_uniqueness", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*1..2]->(b:Person) RETURN count(*) AS trails", "name": "test_808__mixed_arm_vlp_range_count", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) RETURN a.name, b.name", "name": "test_908__mixed_arm_vlp_denorm_start_property", "schema": "foreign_selfloop"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.name = 'Alice' RETURN b.name", "name": "test_934_mixed_vlp_denorm_start_non_id_where", "schema": "foreign_selfloop"}
+{"cypher": "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.pid = 1 AND a.name = 'Alice' RETURN b.name", "name": "test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where", "schema": "foreign_selfloop"}
 {"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN sum(b) AS total", "name": "test_914__chained_with_rename_of_property_sum", "schema": "social_integration"}
 {"cypher": "MATCH (u:User)\n            WITH u.age AS a\n            WITH a AS b\n            RETURN collect(b) AS ages", "name": "test_914__chained_with_rename_of_property_collect", "schema": "social_integration"}
 {"cypher": "MATCH (a:Comment)-[:REPLY_OF*1..2]->(a) RETURN count(*) AS c", "name": "test_902__fk_edge_selfref_vlp_closed_follows_fk", "schema": "ldbc_snb"}

--- a/tests/corpus/schema_map.json
+++ b/tests/corpus/schema_map.json
@@ -39,6 +39,10 @@
     "subschema": null,
     "yaml": "schemas/test/foreign_selfloop.yaml"
   },
+  "foreign_selfloop_end": {
+    "subschema": null,
+    "yaml": "schemas/test/foreign_selfloop_end.yaml"
+  },
   "ldbc_snb": {
     "subschema": "ldbc_snb",
     "yaml": "schemas/test/unified_test_multi_schema.yaml"

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where.clickhouse.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [rel.mgr_id, end_node.pid] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) start_own ON start_own.pid = rel.mgr_id
+    WHERE (rel.mgr_id = 1 AND start_own.name = 'Alice')
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.pid]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_combined_id_and_non_id_where.databricks.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(rel.mgr_id, end_node.pid) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) start_own ON start_own.pid = rel.mgr_id
+    WHERE (rel.mgr_id = 1 AND start_own.name = 'Alice')
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.pid)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_non_id_where.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_non_id_where.clickhouse.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [rel.mgr_id, end_node.pid] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) start_own ON start_own.pid = rel.mgr_id
+    WHERE start_own.name = 'Alice'
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [end_node.pid]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_non_id_where.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop/test_934_mixed_vlp_denorm_start_non_id_where.databricks.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        rel.mgr_id as start_id,
+        end_node.pid as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(rel.mgr_id, end_node.pid) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges,
+        end_node.name as end_name
+    FROM testdb.reports rel
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) start_own ON start_own.pid = rel.mgr_id
+    WHERE start_own.name = 'Alice'
+    UNION ALL
+    SELECT
+        vp.start_id,
+        end_node.pid as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(end_node.pid)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges,
+        end_node.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    JOIN testdb.people end_node ON rel.emp_id = end_node.pid
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE hop_count >= 2
+)
+SELECT 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_combined_id_and_non_id_where.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_combined_id_and_non_id_where.clickhouse.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        start_node.pid as start_id,
+        rel.emp_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.pid, rel.emp_id] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges,
+        start_node.name as start_name,
+        end_own.name as end_name
+    FROM testdb.people start_node
+    JOIN testdb.reports rel ON start_node.pid = rel.mgr_id
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE (rel.emp_id = 2 AND end_own.name = 'Bob')
+    UNION ALL
+    SELECT
+        vp.start_id,
+        rel.emp_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [rel.emp_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges,
+        vp.start_name as start_name,
+        end_own.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+      AND (rel.emp_id = 2 AND end_own.name = 'Bob')
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE ((end_id = 2 AND end_name = 'Bob')) AND hop_count >= 2
+)
+SELECT 
+      t.start_name AS "a.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_combined_id_and_non_id_where.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_combined_id_and_non_id_where.databricks.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        start_node.pid as start_id,
+        rel.emp_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.pid, rel.emp_id) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges,
+        start_node.name as start_name,
+        end_own.name as end_name
+    FROM testdb.people start_node
+    JOIN testdb.reports rel ON start_node.pid = rel.mgr_id
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE (rel.emp_id = 2 AND end_own.name = 'Bob')
+    UNION ALL
+    SELECT
+        vp.start_id,
+        rel.emp_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(rel.emp_id)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges,
+        vp.start_name as start_name,
+        end_own.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+      AND (rel.emp_id = 2 AND end_own.name = 'Bob')
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE ((end_id = 2 AND end_name = 'Bob')) AND hop_count >= 2
+)
+SELECT 
+      t.start_name AS `a.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_non_id_where_both_arms.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_non_id_where_both_arms.clickhouse.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        start_node.pid as start_id,
+        rel.emp_id as end_id,
+        1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.pid, rel.emp_id] as path_nodes,
+        [tuple(rel.mgr_id, rel.emp_id)] as path_edges,
+        start_node.name as start_name,
+        end_own.name as end_name
+    FROM testdb.people start_node
+    JOIN testdb.reports rel ON start_node.pid = rel.mgr_id
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE end_own.name = 'Bob'
+    UNION ALL
+    SELECT
+        vp.start_id,
+        rel.emp_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        arrayConcat(vp.path_nodes, [rel.emp_id]) as path_nodes,
+        arrayConcat(vp.path_edges, [tuple(rel.mgr_id, rel.emp_id)]) as path_edges,
+        vp.start_name as start_name,
+        end_own.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    LEFT JOIN (SELECT pid, any(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE vp.hop_count < 3
+      AND NOT has(vp.path_edges, tuple(rel.mgr_id, rel.emp_id))
+      AND end_own.name = 'Bob'
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (end_name = 'Bob') AND hop_count >= 2
+)
+SELECT 
+      t.start_name AS "a.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_non_id_where_both_arms.databricks.sql
+++ b/tests/rust/integration/golden/corpus/foreign_selfloop_end/test_934_mixed_vlp_denorm_end_non_id_where_both_arms.databricks.sql
@@ -1,0 +1,37 @@
+WITH RECURSIVE vlp_a_b_inner AS (
+    SELECT 
+        start_node.pid as start_id,
+        rel.emp_id as end_id,
+        1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.pid, rel.emp_id) as path_nodes,
+        array(struct(rel.mgr_id, rel.emp_id)) as path_edges,
+        start_node.name as start_name,
+        end_own.name as end_name
+    FROM testdb.people start_node
+    JOIN testdb.reports rel ON start_node.pid = rel.mgr_id
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE end_own.name = 'Bob'
+    UNION ALL
+    SELECT
+        vp.start_id,
+        rel.emp_id as end_id,
+        vp.hop_count + 1 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        concat(vp.path_nodes, array(rel.emp_id)) as path_nodes,
+        concat(vp.path_edges, array(struct(rel.mgr_id, rel.emp_id))) as path_edges,
+        vp.start_name as start_name,
+        end_own.name as end_name
+    FROM vlp_a_b_inner vp
+    JOIN testdb.reports rel ON vp.end_id = rel.mgr_id
+    LEFT JOIN (SELECT pid, any_value(name) as name FROM testdb.people GROUP BY pid) end_own ON end_own.pid = rel.emp_id
+    WHERE vp.hop_count < 3
+      AND NOT array_contains(vp.path_edges, struct(rel.mgr_id, rel.emp_id))
+      AND end_own.name = 'Bob'
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (end_name = 'Bob') AND hop_count >= 2
+)
+SELECT 
+      t.start_name AS `a.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -17957,3 +17957,57 @@ async fn mixed_vlp_denorm_endpoint_property_column_order_matches_across_arms_908
         );
     }
 }
+
+/// #934: on the mixed-access VLP arm, a `WHERE` on a DENORMALIZED start node's
+/// NON-id property was blindly rewritten to the edge alias (`rel.<col>`) for a
+/// column that lives on the node's OWN table, not the edge → ClickHouse Code 47.
+/// The id-property WHERE correctly maps to the edge's FK column and must be
+/// unaffected. The `start_own` own-table LEFT JOIN (#908) already resolves the
+/// non-id columns, so the fix routes non-id start props there while keeping the
+/// id prop on `rel.`.
+#[tokio::test]
+async fn mixed_vlp_denorm_start_non_id_where_resolves_own_table_934() {
+    let schema = load_schema("schemas/test/foreign_selfloop.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // (a) NON-id start property in WHERE → must resolve against `start_own`,
+        // NOT `rel.name` (which does not exist on the `reports` edge → Code 47).
+        let non_id = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.name = 'Alice' RETURN b.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            non_id.contains("start_own.name = 'Alice'"),
+            "#934 ({dialect:?}): non-id start WHERE must resolve against the own-table join:\n{non_id}"
+        );
+        assert!(
+            !non_id.contains("rel.name"),
+            "#934 ({dialect:?}): non-id start WHERE must NOT target the edge alias (Code 47):\n{non_id}"
+        );
+
+        // (b) id-property start WHERE → stays on the edge FK column `rel.mgr_id`.
+        let id = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.pid = 1 RETURN b.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            id.contains("rel.mgr_id = 1") && !id.contains("start_own.mgr_id"),
+            "#934 ({dialect:?}): id-property start WHERE must map to the edge FK column:\n{id}"
+        );
+
+        // (c) COMBINED id + non-id in one predicate → must split correctly.
+        let combined = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.pid = 1 AND a.name = 'Alice' RETURN b.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            combined.contains("rel.mgr_id = 1") && combined.contains("start_own.name = 'Alice'"),
+            "#934 ({dialect:?}): combined id + non-id start WHERE must split (id→rel, non-id→start_own):\n{combined}"
+        );
+    }
+}

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -18009,5 +18009,66 @@ async fn mixed_vlp_denorm_start_non_id_where_resolves_own_table_934() {
             combined.contains("rel.mgr_id = 1") && combined.contains("start_own.name = 'Alice'"),
             "#934 ({dialect:?}): combined id + non-id start WHERE must split (id→rel, non-id→start_own):\n{combined}"
         );
+
+        // (d) #934 Defect 3: a value literal containing the `start_node.` prefix
+        // text must NOT be corrupted by the column-prefix rewrite.
+        let literal = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.name = 'start_node.x' RETURN b.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            literal.contains("start_own.name = 'start_node.x'"),
+            "#934 ({dialect:?}): a string literal containing the prefix text must be left intact:\n{literal}"
+        );
+    }
+}
+
+/// #934 Defect 1: the mixed-VLP fix must patch the RECURSIVE arm too. For an
+/// END-denormalized mixed VLP (the `to`-role is embedded), a non-id WHERE on the
+/// end node produced a correct base arm (`end_own.name`) but the recursive UNION
+/// arm still emitted `rel.name` → Code 47 for any `*n..m`, m ≥ 2. Both arms must
+/// now resolve the non-id end property against the `end_own` join, while the end
+/// id property maps to the edge's `to` column.
+#[tokio::test]
+async fn mixed_vlp_denorm_end_non_id_where_resolves_own_table_both_arms_934() {
+    let schema = load_schema("schemas/test/foreign_selfloop_end.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE b.name = 'Bob' RETURN a.name",
+            dialect,
+        )
+        .await;
+        // The non-id end property must resolve to `end_own.name` and NEVER to the
+        // nonexistent `rel.name` — in BOTH the base and recursive UNION arms.
+        assert!(
+            sql.contains("end_own.name = 'Bob'"),
+            "#934 ({dialect:?}): non-id end WHERE must resolve against the own-table join:\n{sql}"
+        );
+        assert!(
+            !sql.contains("rel.name"),
+            "#934 ({dialect:?}): non-id end WHERE must NOT target the edge alias in EITHER arm (Code 47):\n{sql}"
+        );
+        // The base and recursive arms are the two halves of the UNION ALL; the
+        // filter must appear at least twice (once per arm) — proving the recursive
+        // arm was patched, not just the base.
+        assert!(
+            sql.matches("end_own.name = 'Bob'").count() >= 2,
+            "#934 ({dialect:?}): the end filter must be resolved in BOTH the base and recursive arms:\n{sql}"
+        );
+
+        // id-property end WHERE → stays on the edge FK column `rel.emp_id`.
+        let id = render(
+            &schema,
+            "MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE b.pid = 2 RETURN a.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            id.contains("rel.emp_id = 2") && !id.contains("end_own.emp_id"),
+            "#934 ({dialect:?}): id-property end WHERE must map to the edge FK column:\n{id}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

On the mixed-access VLP strategy, a `WHERE` on a **denormalized start node's non-id property** was blindly rewritten to the edge alias (`rel.<col>`) for a column that lives on the node's OWN table → ClickHouse **Code 47** (UNKNOWN_IDENTIFIER).

```cypher
MATCH (a:Person)-[:REPORTS_TO*2..3]->(b:Person) WHERE a.name = 'Alice' RETURN b.name
```
(schema `schemas/test/foreign_selfloop.yaml`) generated `WHERE rel.name = 'Alice'` — but `reports` (the edge) has no `name` column. Pre-existing; reproduces identically on main. The id-property WHERE `a.pid` correctly mapped to `rel.mgr_id` and was unaffected.

## Root cause & fix

#908 added a `start_own` own-table LEFT JOIN (deduplicated `SELECT pid, any(name) ... GROUP BY pid`) so a denorm endpoint's non-id **projections** (`RETURN a.name`) resolve — but the **WHERE-filter** path still did the blanket `start_node.` → `rel.` string rewrite.

`rewrite_denorm_endpoint_filter` now does an ordered two-step rewrite:
1. Pin each id column (`relationship_from_column`, composite-aware) → `rel.`
2. Map every remaining non-id `start_node.` → `start_own.`

mirroring the id-vs-non-id branch in `mixed_denorm_endpoint_property_items`. A combined predicate `(start_node.mgr_id = 1 AND start_node.name = 'Alice')` splits to `(rel.mgr_id = 1 AND start_own.name = 'Alice')`. Gated on the `*_own` join actually being emitted (`denorm_start_join.is_some()`) — falls back to the historical `rel.` rewrite if absent rather than dangling. Applied symmetrically to the end side (`end_own` / `relationship_to_column`).

## Verification

- **Live oracle**: the query now executes (was Code 47) and returns `{Alice, Carol}` — byte-matching a hand oracle over the 3-cycle `1→2→3→1` for length-2 (`1→2→3`, b=Carol) and length-3 (`1→2→3→1`, b=Alice) edge-unique paths from Alice.
- id-property WHERE stays `rel.mgr_id = 1`; combined splits correctly; no `rel.rel`/prefix artifacts.
- New golden `mixed_vlp_denorm_start_non_id_where_resolves_own_table_934` (non-id / id / combined × 2 dialects) + 2 corpus entries.
- #908 test still passes; lib 1689 + integration 582 + corpus + ratchet + clippy + fmt green.

Closes #934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)