### PR TITLE
fix(#1018): resolve reduce()/map/list outer-column refs across a WITH barrier

### DIFF
--- a/src/render_plan/variable_scope.rs
+++ b/src/render_plan/variable_scope.rs
@@ -1220,15 +1220,166 @@ pub fn rewrite_render_expr(expr: &RenderExpr, scope: &VariableScope) -> RenderEx
                 expr.clone()
             }
         }
+        // #1018: a `reduce()`'s outer-scope sub-expressions (init, list) and its
+        // body can reference an outer node column across a WITH barrier; scope
+        // resolution must descend into them to rewrite `u.user_id` →
+        // `u_xs.p1_u_user_id` (previously `ReduceExpr` sat in the leaf/no-op
+        // group, so the ref kept its pre-barrier alias → Code 47). The lambda
+        // binders (`accumulator` / `variable`) are query-local and could shadow a
+        // WITH-exported alias of the same name (#949 concern); shield them so the
+        // body's binder references are never resolved as CTE columns. `init` and
+        // `list` evaluate in the OUTER scope (no binders in scope there), so they
+        // resolve normally.
+        RenderExpr::ReduceExpr(reduce) => {
+            let shield = [reduce.accumulator.clone(), reduce.variable.clone()];
+            RenderExpr::ReduceExpr(super::render_expr::ReduceExpr {
+                accumulator: reduce.accumulator.clone(),
+                initial_value: Box::new(rewrite_render_expr(&reduce.initial_value, scope)),
+                variable: reduce.variable.clone(),
+                list: Box::new(rewrite_render_expr(&reduce.list, scope)),
+                expression: Box::new(rewrite_render_expr_shielded(
+                    &reduce.expression,
+                    scope,
+                    &shield,
+                )),
+            })
+        }
         // Leaf nodes — no rewriting needed
         RenderExpr::Literal(_)
         | RenderExpr::Star
         | RenderExpr::Parameter(_)
         | RenderExpr::InSubquery(_)
         | RenderExpr::ExistsSubquery(_)
-        | RenderExpr::ReduceExpr(_)
         | RenderExpr::PatternCount(_)
         | RenderExpr::CteEntityRef(_) => expr.clone(),
+    }
+}
+
+/// #1018: scope-resolve an expression while SHIELDING a set of binder names
+/// (a `reduce()` lambda's `accumulator` / `variable`). A bare reference whose
+/// alias/name is a shielded binder is left untouched (it is a query-local lambda
+/// variable, not a WITH-exported column); everything else resolves as in
+/// `rewrite_render_expr`. Only the shape that can hold a shielded bare reference
+/// needs special handling — a `PropertyAccessExp` / `TableAlias` / `ColumnAlias`
+/// / `Column` whose name is shielded is returned verbatim; all other variants
+/// (and nested reduces, which re-shield their own binders) delegate through a
+/// small recursive descent that re-applies the shield.
+fn rewrite_render_expr_shielded(
+    expr: &RenderExpr,
+    scope: &VariableScope,
+    shield: &[String],
+) -> RenderExpr {
+    let is_shielded = |name: &str| shield.iter().any(|b| b == name);
+    match expr {
+        // A shielded bare reference is a lambda binder — never resolve it.
+        RenderExpr::PropertyAccessExp(pa) if is_shielded(&pa.table_alias.0) => expr.clone(),
+        RenderExpr::TableAlias(TableAlias(n)) if is_shielded(n) => expr.clone(),
+        RenderExpr::ColumnAlias(ColumnAlias(n)) if is_shielded(n) => expr.clone(),
+        RenderExpr::Column(col) if matches!(&col.0, PropertyValue::Column(n) if is_shielded(n)) => {
+            expr.clone()
+        }
+        // Recurse through the value-wrapper variants, re-applying the shield.
+        RenderExpr::OperatorApplicationExp(oa) => {
+            RenderExpr::OperatorApplicationExp(OperatorApplication {
+                operator: oa.operator,
+                operands: oa
+                    .operands
+                    .iter()
+                    .map(|o| rewrite_render_expr_shielded(o, scope, shield))
+                    .collect(),
+            })
+        }
+        RenderExpr::ScalarFnCall(sf) => {
+            RenderExpr::ScalarFnCall(super::render_expr::ScalarFnCall {
+                name: sf.name.clone(),
+                args: sf
+                    .args
+                    .iter()
+                    .map(|a| rewrite_render_expr_shielded(a, scope, shield))
+                    .collect(),
+            })
+        }
+        RenderExpr::AggregateFnCall(agg) => {
+            RenderExpr::AggregateFnCall(super::render_expr::AggregateFnCall {
+                name: agg.name.clone(),
+                args: agg
+                    .args
+                    .iter()
+                    .map(|a| rewrite_render_expr_shielded(a, scope, shield))
+                    .collect(),
+            })
+        }
+        RenderExpr::List(items) => RenderExpr::List(
+            items
+                .iter()
+                .map(|i| rewrite_render_expr_shielded(i, scope, shield))
+                .collect(),
+        ),
+        RenderExpr::Case(case) => RenderExpr::Case(super::render_expr::RenderCase {
+            expr: case
+                .expr
+                .as_ref()
+                .map(|e| Box::new(rewrite_render_expr_shielded(e, scope, shield))),
+            when_then: case
+                .when_then
+                .iter()
+                .map(|(c, v)| {
+                    (
+                        rewrite_render_expr_shielded(c, scope, shield),
+                        rewrite_render_expr_shielded(v, scope, shield),
+                    )
+                })
+                .collect(),
+            else_expr: case
+                .else_expr
+                .as_ref()
+                .map(|e| Box::new(rewrite_render_expr_shielded(e, scope, shield))),
+        }),
+        RenderExpr::ArraySubscript { array, index } => RenderExpr::ArraySubscript {
+            array: Box::new(rewrite_render_expr_shielded(array, scope, shield)),
+            index: Box::new(rewrite_render_expr_shielded(index, scope, shield)),
+        },
+        RenderExpr::ArraySlicing { array, from, to } => RenderExpr::ArraySlicing {
+            array: Box::new(rewrite_render_expr_shielded(array, scope, shield)),
+            from: from
+                .as_ref()
+                .map(|f| Box::new(rewrite_render_expr_shielded(f, scope, shield))),
+            to: to
+                .as_ref()
+                .map(|t| Box::new(rewrite_render_expr_shielded(t, scope, shield))),
+        },
+        RenderExpr::MapLiteral(entries) => RenderExpr::MapLiteral(
+            entries
+                .iter()
+                .map(|(k, v)| (k.clone(), rewrite_render_expr_shielded(v, scope, shield)))
+                .collect(),
+        ),
+        RenderExpr::ReduceExpr(inner) => {
+            // A nested reduce re-shields its OWN binders on top of the inherited
+            // shield (both sets are query-local lambda vars).
+            let mut nested: Vec<String> = shield.to_vec();
+            nested.push(inner.accumulator.clone());
+            nested.push(inner.variable.clone());
+            RenderExpr::ReduceExpr(super::render_expr::ReduceExpr {
+                accumulator: inner.accumulator.clone(),
+                initial_value: Box::new(rewrite_render_expr_shielded(
+                    &inner.initial_value,
+                    scope,
+                    shield,
+                )),
+                variable: inner.variable.clone(),
+                list: Box::new(rewrite_render_expr_shielded(&inner.list, scope, shield)),
+                expression: Box::new(rewrite_render_expr_shielded(
+                    &inner.expression,
+                    scope,
+                    &nested,
+                )),
+            })
+        }
+        // Non-shielded leaves and everything else: resolve exactly as the
+        // unshielded walker would (a non-binder PropertyAccess/TableAlias/Column
+        // resolves normally; literals/subqueries/etc. are unchanged).
+        _ => rewrite_render_expr(expr, scope),
     }
 }
 

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -565,7 +565,102 @@ fn remap_property_access_for_cte(
             }
             LogicalExpr::Case(case_expr)
         }
-        // Other expressions don't contain PropertyAccess
+        // #1018: descend into the value-wrapper variants that can carry a
+        // PropertyAccess — the sibling collector `collect_property_accesses`
+        // already recurses into exactly these, but this rewriter historically
+        // dropped them via the `other => other` catch-all (the #929/#946
+        // hand-rolled-walker bug class). Without this, a `reduce()` whose init /
+        // list / body references an outer node column across a WITH barrier keeps
+        // the pre-barrier column name (`u.user_id` instead of the CTE column
+        // `u.p1_u_user_id`) → part of the #1018 Code 47. The lambda binders
+        // (`accumulator` / `variable`) are bare scalar identifiers, never a
+        // `PropertyAccessExp{table_alias: cte_alias}`, so remapping every
+        // sub-expression is binder-safe (mirrors the collector's unconditional
+        // descent).
+        LogicalExpr::ReduceExpr(mut reduce) => {
+            reduce.initial_value = Box::new(remap_property_access_for_cte(
+                *reduce.initial_value,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            ));
+            reduce.list = Box::new(remap_property_access_for_cte(
+                *reduce.list,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            ));
+            reduce.expression = Box::new(remap_property_access_for_cte(
+                *reduce.expression,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            ));
+            LogicalExpr::ReduceExpr(reduce)
+        }
+        LogicalExpr::MapLiteral(entries) => LogicalExpr::MapLiteral(
+            entries
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k,
+                        remap_property_access_for_cte(v, cte_alias, property_mapping, db_to_cypher),
+                    )
+                })
+                .collect(),
+        ),
+        LogicalExpr::ArraySubscript { array, index } => LogicalExpr::ArraySubscript {
+            array: Box::new(remap_property_access_for_cte(
+                *array,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            )),
+            index: Box::new(remap_property_access_for_cte(
+                *index,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            )),
+        },
+        LogicalExpr::ArraySlicing { array, from, to } => LogicalExpr::ArraySlicing {
+            array: Box::new(remap_property_access_for_cte(
+                *array,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            )),
+            from: from.map(|f| {
+                Box::new(remap_property_access_for_cte(
+                    *f,
+                    cte_alias,
+                    property_mapping,
+                    db_to_cypher,
+                ))
+            }),
+            to: to.map(|t| {
+                Box::new(remap_property_access_for_cte(
+                    *t,
+                    cte_alias,
+                    property_mapping,
+                    db_to_cypher,
+                ))
+            }),
+        },
+        LogicalExpr::InSubquery(mut in_sq) => {
+            // Only the outer-scope `expr` is remapped (the correlated `subplan`
+            // is a separate scope), mirroring `collect_property_accesses`.
+            in_sq.expr = Box::new(remap_property_access_for_cte(
+                *in_sq.expr,
+                cte_alias,
+                property_mapping,
+                db_to_cypher,
+            ));
+            LogicalExpr::InSubquery(in_sq)
+        }
+        // Remaining variants (literals, bare aliases, subqueries with their own
+        // scope, PatternCount, CteEntityRef, …) carry no outer PropertyAccess to
+        // remap.
         other => other,
     }
 }

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -11751,6 +11751,80 @@ mod walker_drift_family_484_490_495_476_483 {
         );
     }
 
+    /// #1018: a `reduce()` whose init / list / body references an outer node
+    /// column across a WITH barrier kept the pre-barrier alias (`u.user_id`
+    /// instead of the CTE column `u_xs.p1_u_user_id`) → Code 47. Two hand-rolled
+    /// walkers dropped `ReduceExpr`: `remap_property_access_for_cte` (the column
+    /// remap, `#929`-class `other => other` catch-all) and
+    /// `variable_scope::rewrite_render_expr` (the alias/scope resolution, which
+    /// lumped `ReduceExpr` into its leaf/no-op group). Both now descend into the
+    /// reduce (the alias-resolution descent SHIELDS the lambda binders so a
+    /// binder shadowing a WITH var is not corrupted, #949). Also covers a reduce
+    /// NESTED in a map/list (needs the value-wrapper descent to reach it).
+    #[tokio::test]
+    async fn reduce_referencing_outer_column_across_with_barrier_1018() {
+        let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+
+        // Init references the outer column: must resolve to the CTE column, not
+        // the pre-barrier `u.user_id`, and NOT keep a bare `u.` alias.
+        let init_ref = render(
+            &schema,
+            "MATCH (u:User) WITH u, [1, 2, 3] AS xs \
+             RETURN reduce(acc = u.user_id, y IN xs | acc + y) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            init_ref.contains("arrayFold") && !init_ref.contains(", u.user_id)"),
+            "#1018: reduce init's outer-column ref must resolve to the CTE column, \
+             not keep the pre-barrier `u.user_id`:\n{init_ref}"
+        );
+
+        // Body references the outer column (not just the init).
+        let body_ref = render(
+            &schema,
+            "MATCH (u:User) WITH u, [1, 2, 3] AS xs \
+             RETURN reduce(acc = 0, y IN xs | acc + y + u.user_id) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !body_ref.contains("+ u.user_id"),
+            "#1018: reduce body's outer-column ref must be resolved across the \
+             barrier:\n{body_ref}"
+        );
+
+        // Binder-shadow safety: a lambda binder named like the WITH var must NOT
+        // be rewritten to a CTE column (only the outer-scope init ref is).
+        let shadow = render(
+            &schema,
+            "MATCH (u:User) WITH u, [1, 2, 3] AS xs \
+             RETURN reduce(u = u.user_id, y IN xs | u + y) AS r",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            shadow.contains("arrayFold(u, y -> u + y,"),
+            "#1018: a reduce binder shadowing the WITH var must stay the lambda \
+             binder (not resolved to a CTE column):\n{shadow}"
+        );
+
+        // Reduce nested in a map literal: the value-wrapper descent must reach
+        // the reduce to resolve its outer ref.
+        let nested = render(
+            &schema,
+            "MATCH (u:User) WITH u, [1, 2, 3] AS xs \
+             RETURN {r: reduce(acc = u.user_id, y IN xs | acc + y)} AS m",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            !nested.contains(", u.user_id)"),
+            "#1018: a reduce nested in a map literal must still resolve its \
+             outer-column ref:\n{nested}"
+        );
+    }
+
     /// The ClickHouse dialect must route the string-only functions to their
     /// `…UTF8` variants; Spark's are already Unicode-aware, so Databricks keeps
     /// the plain names.


### PR DESCRIPTION
## Summary

A `reduce()` (or map/array literal) whose init / list / body references an outer node column **across a WITH barrier** kept the pre-barrier alias (`u.user_id` instead of the CTE column `u_xs.p1_u_user_id`) → ClickHouse **Code 47**. Two hand-rolled walkers both dropped `ReduceExpr` — the #929/#946 non-exhaustive-walker bug class.

## Root cause & fix

**Walker 1 — `remap_property_access_for_cte`** (`with_to_cte/mod.rs`, the WITH→CTE column remap): had an `other => other` catch-all silently skipping `ReduceExpr`/`MapLiteral`/`ArraySubscript`/`ArraySlicing`/`InSubquery`. Its sibling collector `collect_property_accesses` was already made exhaustive over exactly these (#529/#640); the rewriter never was. Added the descent arms. **Load-bearing, not just defensive:** a reduce nested in a map/array literal (`{r: reduce(… u.user_id …)}`) needs the wrapper descent to reach the reduce (verified broken on main).

**Walker 2 — `variable_scope::rewrite_render_expr`** (the alias/scope resolution `u.user_id`→`u_xs.p1_u_user_id`): lumped `ReduceExpr` into its leaf/no-op group. Moved it out and added a **binder-shielded** descent (`rewrite_render_expr_shielded`): the outer-scope init/list resolve normally, but the body shields the lambda `accumulator`/`variable` so a binder shadowing a WITH var of the same name is not corrupted into a CTE column (#949 concern; nested reduces re-shield their own binders).

Once the reduce's column ref is correct, the CTE projection-carry exports the column automatically — so this also fixes the whole-node-carry form (`WITH u … reduce(… u.user_id …)`) with **no separate change** (prior recon had wrongly predicted a third independent gap there).

## Verification (live, ClickHouse)
- init ref `reduce(acc = u.user_id, y IN [1,2,3] | acc+y)` → `user_id + 6` ✓
- body ref `acc + y + u.user_id` ✓
- whole-node carry (no sibling ref) → correct (was Code 47) ✓
- reduce nested in map literal `{r: reduce(…)}` → correct (was Code 47) ✓
- binder-shadow `reduce(u = u.user_id, y IN xs | u + y)` → keeps lambda `u`, only the init resolves ✓

Golden `reduce_referencing_outer_column_across_with_barrier_1018`. Full suite green (1700 lib + 590 integration); fmt/clippy/ratchet clean.

Closes #1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)