### PR TITLE
fix(#1021): carry role-independent non-node WITH projections into denorm-union branches

### DIFF
--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -7794,6 +7794,67 @@ fn apply_with_items_projection(
                         union.input.insert(0, first_branch);
                     }
 
+                    // #1021: the denorm node's role-expansion built each UNION
+                    // branch with ONLY the node's denorm columns (Origin*/Dest*).
+                    // Any SIBLING non-node WITH projection (`['x'] AS xs`, `5 AS n`,
+                    // a computed scalar) lives in `select_items` but is otherwise
+                    // dropped here (this branch discards `select_items` in favour of
+                    // the per-branch node SELECTs) → the outer `<cte>.xs` reference
+                    // is unresolved (Code 47). A ROLE-INDEPENDENT non-node item (a
+                    // literal/scalar that does NOT reference the denorm node) is
+                    // identical in every branch, so append each such item to EVERY
+                    // branch. Two guards make this safe:
+                    //   (a) col_alias is NOT one of the node's branch columns
+                    //       (the `rename_alias`-prefixed `<alias>_<prop>` set) —
+                    //       i.e. it is a sibling projection, not a node column; and
+                    //   (b) the expression does NOT reference the node alias — a
+                    //       ROLE-DEPENDENT computed scalar (`toUpper(a.code)`) must
+                    //       NOT be blindly copied, because a single rendered form
+                    //       binds ONE role's column (e.g. `origin_code`) and would
+                    //       be WRONG in the other branch (silent-wrong). Leaving it
+                    //       dropped keeps that case LOUD (Code 47), which is correct
+                    //       until per-branch remapping (like the WHERE propagation
+                    //       above) is added — ground rule 1.
+                    if let UnionItems(Some(ref mut union)) = rendered.union {
+                        let branch_cols: std::collections::HashSet<String> = union
+                            .input
+                            .iter()
+                            .flat_map(|b| {
+                                b.select
+                                    .items
+                                    .iter()
+                                    .filter_map(|it| it.col_alias.as_ref().map(|a| a.0.clone()))
+                            })
+                            .collect();
+                        let sibling_items: Vec<crate::render_plan::SelectItem> = select_items
+                            .iter()
+                            .filter(|it| {
+                                let alias_ok = it
+                                    .col_alias
+                                    .as_ref()
+                                    .map(|a| !branch_cols.contains(&a.0))
+                                    .unwrap_or(false);
+                                // Role-independent only: must not reference the node.
+                                alias_ok
+                                    && !super::expression_utils::references_alias(
+                                        &it.expression,
+                                        &rename_alias,
+                                    )
+                            })
+                            .cloned()
+                            .collect();
+                        if !sibling_items.is_empty() {
+                            log::info!(
+                                "🔧 #1021: carrying {} role-independent non-node WITH projection(s) into {} denorm-union branch(es)",
+                                sibling_items.len(),
+                                union.input.len()
+                            );
+                            for branch in &mut union.input {
+                                branch.select.items.extend(sibling_items.iter().cloned());
+                            }
+                        }
+                    }
+
                     // Clear plan-level fields so CTE renders union directly
                     rendered.select = SelectItems {
                         items: vec![],

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -7591,6 +7591,71 @@ fn build_with_projection_select_items(
 /// `WITH a` (TableAlias) items — expanding, rewriting (scope-aware, with
 /// denormalized-property resolution), filtering out pattern-comprehension result
 /// aliases, and setting `rendered.select` / `rendered.group_by` (plus the
+/// #1021: is this sibling WITH projection safe to replicate VERBATIM into every
+/// denorm-union role branch? Only ROLE-INDEPENDENT expressions are — those built
+/// purely from literals/parameters and pure combinators over them, with NO
+/// column/alias reference (a node column would bind ONE role and be wrong in the
+/// other branch), NO aggregate (must not be replicated across DISTINCT branches),
+/// and NO correlated subquery / pattern-count (references the outer node,
+/// unresolvable per-branch). Positive allowlist (safe-by-construction),
+/// EXHAUSTIVE over `RenderExpr` — no `_` catch-all, so a new variant is a compile
+/// error here until classified. Replaces an earlier `!references_alias(...)`
+/// blacklist whose `false` arms for `PatternCount`/`ExistsSubquery`/`CteEntityRef`
+/// let a role-dependent correlated ref slip through.
+fn is_role_independent_carryable(expr: &RenderExpr) -> bool {
+    match expr {
+        // Pure constants / free-standing values.
+        RenderExpr::Literal(_) | RenderExpr::Parameter(_) | RenderExpr::Star => true,
+        // Pure combinators — safe iff every child is.
+        RenderExpr::List(items) => items.iter().all(is_role_independent_carryable),
+        RenderExpr::MapLiteral(entries) => entries
+            .iter()
+            .all(|(_, v)| is_role_independent_carryable(v)),
+        RenderExpr::ScalarFnCall(f) => f.args.iter().all(is_role_independent_carryable),
+        RenderExpr::OperatorApplicationExp(op) => {
+            op.operands.iter().all(is_role_independent_carryable)
+        }
+        RenderExpr::Case(c) => {
+            c.expr
+                .as_ref()
+                .is_none_or(|e| is_role_independent_carryable(e))
+                && c.when_then.iter().all(|(w, t)| {
+                    is_role_independent_carryable(w) && is_role_independent_carryable(t)
+                })
+                && c.else_expr
+                    .as_ref()
+                    .is_none_or(|e| is_role_independent_carryable(e))
+        }
+        RenderExpr::ArraySubscript { array, index } => {
+            is_role_independent_carryable(array) && is_role_independent_carryable(index)
+        }
+        RenderExpr::ArraySlicing { array, from, to } => {
+            is_role_independent_carryable(array)
+                && from
+                    .as_ref()
+                    .is_none_or(|f| is_role_independent_carryable(f))
+                && to.as_ref().is_none_or(|t| is_role_independent_carryable(t))
+        }
+        RenderExpr::ReduceExpr(r) => {
+            is_role_independent_carryable(&r.initial_value)
+                && is_role_independent_carryable(&r.list)
+                && is_role_independent_carryable(&r.expression)
+        }
+        // Anything that binds a column/alias, aggregates, or correlates to the
+        // outer node is NOT role-independent — do not carry (stays dropped/loud).
+        RenderExpr::PropertyAccessExp(_)
+        | RenderExpr::TableAlias(_)
+        | RenderExpr::ColumnAlias(_)
+        | RenderExpr::Column(_)
+        | RenderExpr::Raw(_)
+        | RenderExpr::AggregateFnCall(_)
+        | RenderExpr::InSubquery(_)
+        | RenderExpr::ExistsSubquery(_)
+        | RenderExpr::PatternCount(_)
+        | RenderExpr::CteEntityRef(_) => false,
+    }
+}
+
 /// denormalized-UNION restructuring path). No-op when the segment carries no WITH
 /// items. Returns `Err` only on the unsupported-feature path. Mutates `rendered`;
 /// all other params are read-only inputs.
@@ -7800,21 +7865,26 @@ fn apply_with_items_projection(
                     // a computed scalar) lives in `select_items` but is otherwise
                     // dropped here (this branch discards `select_items` in favour of
                     // the per-branch node SELECTs) → the outer `<cte>.xs` reference
-                    // is unresolved (Code 47). A ROLE-INDEPENDENT non-node item (a
-                    // literal/scalar that does NOT reference the denorm node) is
+                    // is unresolved (Code 47). A ROLE-INDEPENDENT non-node item is
                     // identical in every branch, so append each such item to EVERY
                     // branch. Two guards make this safe:
                     //   (a) col_alias is NOT one of the node's branch columns
                     //       (the `rename_alias`-prefixed `<alias>_<prop>` set) —
                     //       i.e. it is a sibling projection, not a node column; and
-                    //   (b) the expression does NOT reference the node alias — a
-                    //       ROLE-DEPENDENT computed scalar (`toUpper(a.code)`) must
-                    //       NOT be blindly copied, because a single rendered form
-                    //       binds ONE role's column (e.g. `origin_code`) and would
-                    //       be WRONG in the other branch (silent-wrong). Leaving it
-                    //       dropped keeps that case LOUD (Code 47), which is correct
-                    //       until per-branch remapping (like the WHERE propagation
-                    //       above) is added — ground rule 1.
+                    //   (b) `is_role_independent_carryable` — a POSITIVE allowlist:
+                    //       the item must be built purely from literals/params/pure
+                    //       combinators, with NO column/alias reference, NO aggregate,
+                    //       and NO correlated subquery / pattern-count. A
+                    //       ROLE-DEPENDENT form (`toUpper(a.code)`, `size((a)-...)`)
+                    //       binds ONE role's column / correlates to the outer node
+                    //       and would be wrong (or a dangling correlation) in the
+                    //       other branch, so it is NOT carried — it stays dropped →
+                    //       LOUD (Code 47), correct until per-branch remapping is
+                    //       added (ground rule 1). The allowlist is exhaustive over
+                    //       `RenderExpr`, so it cannot silently admit a new variant
+                    //       (unlike the earlier `!references_alias(...)` blacklist,
+                    //       which missed `PatternCount`/`ExistsSubquery`/
+                    //       `CteEntityRef`).
                     if let UnionItems(Some(ref mut union)) = rendered.union {
                         let branch_cols: std::collections::HashSet<String> = union
                             .input
@@ -7834,12 +7904,7 @@ fn apply_with_items_projection(
                                     .as_ref()
                                     .map(|a| !branch_cols.contains(&a.0))
                                     .unwrap_or(false);
-                                // Role-independent only: must not reference the node.
-                                alias_ok
-                                    && !super::expression_utils::references_alias(
-                                        &it.expression,
-                                        &rename_alias,
-                                    )
+                                alias_ok && is_role_independent_carryable(&it.expression)
                             })
                             .cloned()
                             .collect();

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -4276,6 +4276,38 @@ async fn denorm_with_carries_role_independent_sibling_projection_1021() {
              blindly carried into the branches (would be silent-wrong); it stays \
              dropped/loud:\n{role_dep}"
         );
+
+        // Review-caught (positive-allowlist): a PatternCount sibling
+        // (`size((a)-[:FLIGHT]->())`) correlates to the outer node, so it must NOT
+        // be carried into the DISTINCT branches (the earlier `!references_alias`
+        // blacklist missed PatternCount and carried it with one role's column).
+        let pattern_count = render(
+            &schema,
+            "MATCH (a:Airport) WITH a, size((a)-[:FLIGHT]->()) AS deg RETURN deg",
+            dialect,
+        )
+        .await;
+        assert!(
+            !pattern_count.contains("= a.code"),
+            "#1021 ({dialect:?}): a PatternCount sibling must NOT be carried into \
+             the branches (correlated to the node):\n{pattern_count}"
+        );
+
+        // An aggregate sibling (`count(*)`) must not be replicated into the
+        // DISTINCT role branches either.
+        let agg = render(
+            &schema,
+            "MATCH (a:Airport) WITH a, count(*) AS c RETURN a.code, c",
+            dialect,
+        )
+        .await;
+        let count_in_branches =
+            agg.matches("count(*) AS \"c\"").count() + agg.matches("count(*) AS `c`").count();
+        assert_eq!(
+            count_in_branches, 0,
+            "#1021 ({dialect:?}): an aggregate sibling must NOT be replicated into \
+             the DISTINCT role branches:\n{agg}"
+        );
     }
 }
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -4225,6 +4225,60 @@ async fn denorm_with_match_chain_filters_per_branch_column_456() {
     }
 }
 
+/// #1021: a WITH clause on a denormalized node expands into a UNION of role
+/// branches (origin/dest), each projecting only the node's own denorm columns.
+/// A SIBLING non-node projection (`['x'] AS xs`, `5 AS n`) was dropped from
+/// every branch → the outer `<cte>.xs` reference was unresolved (Code 47). A
+/// role-INDEPENDENT sibling item (does not reference the node) is now appended
+/// to every branch. A ROLE-DEPENDENT computed item (`toUpper(a.code)`) is NOT
+/// carried — a single rendered form binds one role's column and would be
+/// silently wrong in the other branch, so it stays LOUD (ground rule 1) until
+/// per-branch remapping is added.
+#[tokio::test]
+async fn denorm_with_carries_role_independent_sibling_projection_1021() {
+    let schema = load_schema(SchemaId::Denormalized.yaml_path());
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Role-independent literal list → carried into EVERY branch.
+        let sql = render(
+            &schema,
+            "MATCH (a:Airport) WITH a, ['x'] AS xs RETURN xs",
+            dialect,
+        )
+        .await;
+        // The CTE is a UNION of >= 2 role branches; each must project `xs`.
+        let xs_count = sql.matches("AS \"xs\"").count() + sql.matches("AS `xs`").count();
+        assert!(
+            xs_count >= 2,
+            "#1021 ({dialect:?}): the sibling `xs` projection must be carried into \
+             every denorm-union branch (found {xs_count}):\n{sql}"
+        );
+
+        // Role-DEPENDENT computed sibling (references the node) is NOT carried —
+        // it must stay dropped (loud), never silently copied with one role's
+        // column into both branches. Check that the computed expression itself
+        // (`upper...(a.…code)`) never appears in the CTE body — the outer SELECT
+        // still aliases `label`, but the CTE never projects it, so the query is
+        // loud (Code 47), not silently wrong.
+        let role_dep = render(
+            &schema,
+            "MATCH (a:Airport) WITH a, toUpper(a.code) AS label RETURN a.code, label",
+            dialect,
+        )
+        .await;
+        let upper_fn = if dialect == SqlDialect::ClickHouse {
+            "upperUTF8("
+        } else {
+            "upper("
+        };
+        assert!(
+            !role_dep.contains(upper_fn),
+            "#1021 ({dialect:?}): a role-dependent computed sibling must NOT be \
+             blindly carried into the branches (would be silent-wrong); it stays \
+             dropped/loud:\n{role_dep}"
+        );
+    }
+}
+
 /// #456 regression (OPTIONAL, production path): `MATCH (a:Airport) OPTIONAL MATCH
 /// (a)-[:FLIGHT]->(b:Airport) RETURN a.code, b.code` on the coupled-denormalized
 /// schema. The production render path (`to_render_plan_with_ctx`) restructures the


### PR DESCRIPTION
## Summary

On a **denormalized** schema, a `WITH` clause projecting a node expands into a UNION of role branches (origin/dest), each projecting only the node's own denorm columns. A **sibling non-node projection** (`['x'] AS xs`, `5 AS n`) was dropped from every branch → the outer `<cte>.xs` reference was unresolved (**Code 47**). Standard schema works (single-SELECT CTE carries it).

## Root cause & fix

In `apply_with_items_projection`'s `is_denorm_union` branch (`with_to_cte/mod.rs`), the rendered `select_items` (which DO contain the sibling) are discarded in favour of the per-branch node-column SELECTs, so the sibling never reaches any branch.

Fix: after the branches are assembled, append each **role-independent** sibling item to every branch, with two guards:
1. col_alias is not one of the node's branch columns (it's a sibling, not a node column); **and**
2. the expression does not reference the node alias — a **role-dependent** computed scalar (`toUpper(a.code)`) is NOT copied, because a single rendered form binds one role's column (`origin_code`) and would be **silently wrong** in the other branch. It stays dropped → LOUD (Code 47), correct until per-branch remapping is added (**ground rule 1** — a loud→silent-wrong regression avoided).

## Verification (live, `db_denormalized`)
- `WITH a, ['x'] AS xs RETURN xs` → `[x]` in each branch ✓
- `WITH a, 5 AS n RETURN a.code, n` → node col + sibling together ✓
- role-dependent `WITH a, toUpper(a.code) AS label` → stays **loud** (not silently copied) ✓

Golden `denorm_with_carries_role_independent_sibling_projection_1021` (both dialects). Full suite green (1700 lib + 591 integration); fmt/clippy/ratchet clean.

## Note
The issue's original `schemas/test/denormalized_flights.yaml` repro has a **separate** broken column mapping (`OriginCityName` — no such column), so it errors regardless of this fix; `schemas/dev/flights_denormalized.yaml` is the working denorm schema and proves the fix. Worth cleaning up that fixture separately.

Closes #1021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)