### PR TITLE
fix(#583): denorm single-hop undirected OPTIONAL spurious NULL row

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -526,6 +526,50 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-08-04: **Correctness — denorm/coupled single-hop undirected OPTIONAL
+  spurious NULL row** (branch `fix/583-denorm-undirected-optional-null`,
+  PR #1029, denorm stage of #583; standard/poly/composite stay OPEN). An
+  undirected single-hop `MATCH (a) OPTIONAL MATCH (a)-[:R]-(b)` over a
+  fully-denormalized (or coupled, e.g. zeek) edge table was split by
+  `BidirectionalUnion` into two per-direction branches, each independently
+  `LEFT JOIN`ing the `__denorm_scan_a` anchor CTE and NULL-extending blind to
+  the other. An anchor matching in only ONE physical role got a spurious
+  `(anchor, NULL)` row from the non-matching branch — silent wrong results
+  (ground-rule-1). Live: denorm 18 rows → 16; zeek 12 → 10; `count(b)` was
+  Code 53 (arms projected different column counts). Fix mirrors the #617
+  doubled-edge VLP strategy for the single hop: a new analyzer pre-pass
+  (`normalize_undirected_denorm_single_hop_optional_rels`) keeps the hop as ONE
+  `was_undirected` GraphRel instead of splitting, and the render targets a
+  doubled-edge subquery (every physical edge in both orientations, role columns
+  swapped) under the existing single anchor LEFT JOIN — so NULL-extension
+  happens once, only for genuinely zero-neighbor anchors. Passthrough columns
+  are sourced from the relationship schema's `all_valid_physical_columns()` so
+  the edge-identity column (`edge_id`, which `count(r)` lowers to and which is
+  NOT necessarily in `property_mappings`) is always projected — otherwise
+  `count(r)` referenced an unprojected column (Code 47). **Scoped denorm/coupled
+  only**: standard/polymorphic still two-arm split (unchanged) — a loud guard
+  there would regress standard `count(b)`, which SQL's NULL-skipping
+  `count(col)` renders accidentally correct today; composite excluded
+  (single-column-id requirement keeps gate and render helper in lockstep);
+  fk-edge (distinct from/to labels) prunes to a single branch and never had the
+  bug; #583 stays OPEN for the excluded layouts. Chained-optional patterns
+  defer to the #589 loud guard (the pre-pass skips when
+  `has_chained_optional_nested_undirected_edge` holds, so it can't silently
+  disarm #589 by normalizing the inner hop's direction away). **Two adversarial
+  review rounds (worktree-isolated)**: round 1 caught the `count(r)` Code-47
+  regression (doubled-edge dropped the unmapped edge-id column — masked because
+  corpus goldens render without executing); round 2 confirmed the fix live
+  (built a full-column table, executed `count(r)` and `RETURN r.flight_id`,
+  both correct) and confirmed all chained shapes back to #589-loud. If the
+  doubled-edge subquery cannot be built for a rel the analyzer marked
+  `was_undirected`, the render fails LOUD rather than silently reverting to a
+  single-direction join. 3 coupled-schema goldens rewritten to lock the new
+  single-doubled-edge shape (node-grain wrap + determinism preserved); a render
+  test asserts the unmapped edge-id column is projected in both arms; 4 corpus
+  regression entries added. fmt/clippy/1700 lib + 592 integration/ratchet/
+  corpus_sweep all green; differential sweep shows control queries
+  byte-identical to main.
+
 - 2026-08-04: **Correctness (ground-rule-1) — pattern_union node-property JSON key mismatch returned empty strings** (branch `fix/1024-pattern-union-json-key`, closes #1024 facet 1). On the fully-unlabeled `pattern_union` path (`MATCH (a)-[r]->(b) RETURN a.name`), node props are packed into `start_properties`/`end_properties` JSON blobs. The blobs used bare column expressions, so ClickHouse re-qualified the SECOND blob's keys on a User→User self-join (`to_node.full_name`), and the single-property extractor's bare-DB-column lookup missed → empty strings (silent-wrong). A bare `AS <col>` collides (Code 179 MULTIPLE_EXPRESSIONS_FOR_ALIAS on the self-join). Fix (3 sites): (1) `cte_extraction.rs` keys each blob column `AS _s_<db_col>`/`_e_<db_col>` — a role-unique SLOT prefix applied by the OUTPUT slot (swap-aware: the undirected reverse branch routes to-role cols into `start_properties` and keeps `_s_`); (2) `select_builder.rs` extractor asks the `_s_`/`_e_` prefixed key, gated on `has_pattern_combinations` (VLP-multitype path unchanged — separate producer, bare keys); (3) `result_transformer.rs` whole-node cleaner strips `_s_`/`_e_` BEFORE the `.`-qualifier split (byte-identical to prior behavior for unprefixed keys). Live-verified on ClickHouse 25.8: directed `a.name`=3×Alice, undirected adds reversed FOLLOWS b→a=Bob with Post-reverse branches correctly empty (no `name`), `a.user_id`/`id(a)`/`WHERE a.name=…`/dotted-col `a.ip` all correct, standalone `(a:User)` scan unaffected. 28 goldens regenerated + eyeballed (pattern_union + denorm_selfloop_multitype). Regression test `pattern_union_node_property_uses_slot_prefixed_json_keys_1024` fail-when-reverted on BOTH the extractor prefix and the swap slot-prefix. Adversarial review: fix correct + strict improvement, no HIGH holes; surfaced two PRE-EXISTING (baseline-identical) residuals — #1027 (undirected denorm self-loop cross-side prop → empty on reverse branches, filed) and a dotted-denorm whole-node strip quirk (addressed by the prefix-first ordering). Facets 2 (ORDER BY→Code 47) and 3 (polymorphic count no-FROM), plus a 4th sibling (end-side `b.name` on mixed-type unlabeled → `WHERE false`), remain separate follow-ups logged on #1024.
 
 - 2026-08-04: **Correctness — self-loop constraint for closed unlabeled

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -46,6 +46,17 @@ impl AnalyzerPass for BidirectionalUnion {
         // under-counts 40-60% at >=2 hops). Normalize those hops FIRST so the
         // split below only fires for the remaining plain undirected hops.
         let normalized = normalize_undirected_vlp_rels(&logical_plan, graph_schema);
+        // #583: denormalized single-hop undirected OPTIONAL hops are likewise
+        // rewritten to a single directed `was_undirected` GraphRel (rendered as a
+        // doubled-edge set under ONE anchor LEFT JOIN) instead of the two-arm
+        // split, whose independent per-arm NULL-extension manufactures a spurious
+        // `(anchor, NULL)` row for one-role-only anchors. Compose with the #617
+        // pre-pass: run on whichever plan the VLP pass produced.
+        let normalized = {
+            let base = normalized.unwrap_or_else(|| logical_plan.clone());
+            normalize_undirected_denorm_single_hop_optional_rels(&base, graph_schema)
+                .or_else(|| (!Arc::ptr_eq(&base, &logical_plan)).then_some(base))
+        };
         match normalized {
             Some(plan) => {
                 let inner = transform_bidirectional(&plan, plan_ctx, graph_schema)?;
@@ -151,6 +162,170 @@ fn normalize_undirected_vlp_rels(
             if undirected_vlp_single_walk_scope(graph_rel, graph_schema) {
                 crate::debug_print!(
                     "🔄 BidirectionalUnion(#617): undirected VLP '{}' → single doubled-edge walk (no Union split)",
+                    graph_rel.alias
+                );
+                *changed = true;
+                return LogicalPlan::GraphRel(GraphRel {
+                    direction: Direction::Outgoing,
+                    was_undirected: Some(true),
+                    ..graph_rel.clone()
+                });
+            }
+        }
+        mapped
+    }
+    let mut changed = false;
+    let new_plan = walk(plan, graph_schema, &mut changed);
+    changed.then(|| Arc::new(new_plan))
+}
+
+/// #583: scope predicate for the DENORMALIZED single-hop undirected OPTIONAL
+/// strategy. Mirrors [`undirected_vlp_single_walk_scope`] but for a plain
+/// (non-VLP) single hop over a fully-denormalized edge table.
+///
+/// The two-monotone-arm Union split renders each orientation as an independent
+/// `__denorm_scan_a LEFT JOIN <edge>` chain; each arm NULL-extends blind to the
+/// other, so an anchor that matches in only one physical role (e.g. an airport
+/// that only ever appears as a flight ORIGIN) gets a spurious `(anchor, NULL)`
+/// row from the non-matching arm (#583, silent wrong result — ground-rule-1).
+///
+/// When this predicate is true the hop is NOT split: it stays a single directed
+/// GraphRel marked `was_undirected`, and the render layer targets a doubled-edge
+/// set (each physical edge in both orientations) under the SINGLE existing
+/// anchor LEFT JOIN, so NULL-extension happens once — only for genuinely
+/// zero-neighbor anchors.
+///
+/// In scope: `Direction::Either`, `is_optional`, exactly one plain (non-VLP,
+/// non-shortestPath, non-deferred-union) hop, a single known relationship type
+/// whose schema has BOTH endpoints denormalized onto the edge table
+/// (`rel_has_both_nodes_denormalized`) with same-label endpoints. Out-of-scope
+/// shapes (standard / polymorphic / FK-edge / composite / non-optional / VLP /
+/// multi-hop) keep the legacy two-arm behavior unchanged — #583 stays open for
+/// them (a loud guard would regress standard `count(b)`, which SQL's NULL-
+/// skipping `count(col)` renders accidentally correct today).
+pub(crate) fn undirected_denorm_single_hop_optional_scope(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    graph_rel.direction == Direction::Either
+        && graph_rel.is_optional.unwrap_or(false)
+        && undirected_denorm_single_hop_optional_core(graph_rel, graph_schema)
+}
+
+/// #583: direction-agnostic core of
+/// [`undirected_denorm_single_hop_optional_scope`]. Shared with the RENDER
+/// layer, which re-derives the decision from `was_undirected == Some(true)` +
+/// this core (the analyzer has already normalized direction to Outgoing by
+/// then). The legacy two-arm split ALSO stamps `was_undirected` on its
+/// branches, so the flag alone cannot tell "one normalized single hop" from
+/// "one monotone arm of a split" — but the core predicate can: whenever it is
+/// true the analyzer normalized instead of splitting.
+pub(crate) fn undirected_denorm_single_hop_optional_core(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    // Plain single hop only: no VLP, no shortestPath, no deferred multi-type
+    // (pattern_combinations) union.
+    if graph_rel.variable_length.is_some()
+        || graph_rel.shortest_path_mode.is_some()
+        || graph_rel.pattern_combinations.is_some()
+    {
+        return false;
+    }
+    // Endpoints must be plain single-node scans — either a bare `GraphNode` or
+    // the denormalized standalone-scan `Union` (from/to role branches) that the
+    // anchor side already carries at this stage (built before this pass). This
+    // is the "exactly 2 branches, one anchor" single-hop shape; a nested
+    // `GraphRel` / `CartesianProduct` on either side is a chained or
+    // disconnected pattern handled (or loud-guarded) by the #589 / #590 gates,
+    // not here.
+    fn is_single_node_endpoint(plan: &LogicalPlan) -> bool {
+        match plan {
+            LogicalPlan::GraphNode(_) => true,
+            // A denormalized standalone-scan Union of from/to role branches — the
+            // anchor shape `optional_denorm_union_anchor_is_left` keys on. Bare
+            // node scans only (no nested GraphRel), each a GraphNode.
+            LogicalPlan::Union(u) => {
+                !u.inputs.is_empty()
+                    && u.inputs
+                        .iter()
+                        .all(|i| matches!(i.as_ref(), LogicalPlan::GraphNode(_)))
+            }
+            _ => false,
+        }
+    }
+    if !is_single_node_endpoint(graph_rel.left.as_ref())
+        || !is_single_node_endpoint(graph_rel.right.as_ref())
+    {
+        return false;
+    }
+    // Exactly one known relationship type. Labels at this stage may be composite
+    // schema keys ("FLIGHT::Airport::Airport"); resolve those directly, falling
+    // back to the plain-type index (mirrors `undirected_vlp_single_walk_core`).
+    let Some(labels) = graph_rel.labels.as_ref() else {
+        return false;
+    };
+    let [rel_type] = labels.as_slice() else {
+        return false;
+    };
+    let rel_schema = if let Some(rs) = graph_schema.get_relationships_schema_opt(rel_type) {
+        rs
+    } else {
+        let plain_type = rel_type.split("::").next().unwrap_or(rel_type);
+        let rel_schemas = graph_schema.rel_schemas_for_type(plain_type);
+        if rel_schemas.len() != 1 {
+            return false;
+        }
+        rel_schemas[0]
+    };
+    // Fully-denormalized edge table (both endpoints embedded) with same-label
+    // endpoints and SINGLE-column from/to ids. `rel_has_both_nodes_denormalized`
+    // consumes the schema-catalog denorm classification (both role-property maps
+    // present), never a raw plan-level flag (CLAUDE.md rule 7). Same-label
+    // endpoints ensure the doubled-edge role swap is type-consistent. The
+    // single-column-id requirement keeps the gate in lockstep with the render
+    // helper (`build_denorm_doubled_edge_subquery`), which builds the join key
+    // from `from_id.first_column()` only — a composite-id denorm edge would
+    // otherwise pass the gate but silently drop its second key column. Composite
+    // denorm same-label edges therefore keep the legacy two-arm behavior (no
+    // such schema exists in-tree today; this is a forward guard).
+    crate::graph_catalog::node_classification::rel_has_both_nodes_denormalized(rel_schema)
+        && rel_schema.from_node == rel_schema.to_node
+        && matches!(rel_schema.from_id, Identifier::Single(_))
+        && matches!(rel_schema.to_id, Identifier::Single(_))
+}
+
+/// #583: rewrite every in-scope denormalized single-hop undirected OPTIONAL
+/// GraphRel (see [`undirected_denorm_single_hop_optional_scope`]) to
+/// `direction: Outgoing` + `was_undirected: Some(true)`. Returns `None` when
+/// nothing changed. The render layer recognizes the marker and targets a
+/// doubled-edge set under the single anchor LEFT JOIN. Mirrors
+/// [`normalize_undirected_vlp_rels`] (#617), as a whole-tree pre-pass so
+/// patterns mixing this hop with others still split the others.
+///
+/// #583 scope discipline: this pass must NOT fire inside a chained-optional
+/// structure. `OPTIONAL (a)-[:R]-(b) OPTIONAL (b)-[:R]->(c)` is #589 territory
+/// (an undirected optional hop chained onto another optional hop), and #589's
+/// loud guard keys on the inner hop still being `Direction::Either` when the
+/// Projection arm inspects it. If this pre-pass ran first and normalized that
+/// inner hop to `Outgoing`, it would silently neutralize the #589 guard and
+/// render a shape #583 was never scoped or validated for. So when the tree
+/// contains a chained-optional-undirected structure, skip normalization
+/// entirely and let #589 fire.
+fn normalize_undirected_denorm_single_hop_optional_rels(
+    plan: &Arc<LogicalPlan>,
+    graph_schema: &GraphSchema,
+) -> Option<Arc<LogicalPlan>> {
+    // Defer to #589 for chained-optional-undirected patterns (see doc above).
+    if has_chained_optional_nested_undirected_edge(plan) {
+        return None;
+    }
+    fn walk(plan: &LogicalPlan, graph_schema: &GraphSchema, changed: &mut bool) -> LogicalPlan {
+        let mapped = plan.map_children(|child| walk(child, graph_schema, changed));
+        if let LogicalPlan::GraphRel(graph_rel) = &mapped {
+            if undirected_denorm_single_hop_optional_scope(graph_rel, graph_schema) {
+                crate::debug_print!(
+                    "🔄 BidirectionalUnion(#583): denorm single-hop undirected OPTIONAL '{}' → doubled-edge single anchor LEFT JOIN (no Union split)",
                     graph_rel.alias
                 );
                 *changed = true;

--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -2052,8 +2052,68 @@ impl RenderPlanBuilder for LogicalPlan {
                                     anchor_edge_id, mapped_props, cte_name, cte_exposed_columns
                                 )));
                             };
+                            // #583: a denormalized single-hop undirected OPTIONAL
+                            // hop is kept as ONE directed `was_undirected` GraphRel
+                            // by the BidirectionalUnion analyzer (instead of the
+                            // spurious-NULL two-arm split). Target a doubled-edge
+                            // subquery (every physical edge in BOTH orientations) so
+                            // this single anchor LEFT JOIN NULL-extends only for
+                            // genuinely zero-neighbor anchors. The join key and the
+                            // neighbor projection are unchanged — only the join
+                            // target table becomes the doubled subquery.
+                            //
+                            // The analyzer only marks `was_undirected` for a
+                            // denorm edge whose schema has BOTH role-property maps
+                            // (`rel_has_both_nodes_denormalized`), so the builder
+                            // must succeed here. If it does NOT (the edge ViewScan
+                            // unexpectedly lacks the role maps the rel schema
+                            // promised), fall through to the raw edge table would
+                            // SILENTLY reintroduce #583 (single-direction join, no
+                            // split, no doubled edge) — a ground-rule-1 violation.
+                            // Fail LOUD instead.
+                            let edge_table_or_doubled = if gr.was_undirected == Some(true) {
+                                // Resolve the relationship schema so the builder can
+                                // project EVERY physical edge column (incl. the
+                                // edge-id column `count(r)` needs), not just the ones
+                                // on the ViewScan. Mirrors the analyzer gate's
+                                // label-resolution (composite key → plain type).
+                                let rel_schema = gr
+                                    .labels
+                                    .as_ref()
+                                    .and_then(|labels| labels.first())
+                                    .and_then(|rel_type| {
+                                        schema.get_relationships_schema_opt(rel_type).or_else(
+                                            || {
+                                                let plain =
+                                                    rel_type.split("::").next().unwrap_or(rel_type);
+                                                schema
+                                                    .rel_schemas_for_type(plain)
+                                                    .into_iter()
+                                                    .next()
+                                            },
+                                        )
+                                    });
+                                let doubled = rel_schema.and_then(|rs| {
+                                    super::plan_builder_helpers::build_denorm_doubled_edge_subquery(
+                                        edge_vs, rs,
+                                    )
+                                });
+                                doubled.ok_or_else(|| {
+                                    RenderBuildError::MissingTableInfo(format!(
+                                        "#583: denorm undirected OPTIONAL rel '{}' was marked \
+                                         was_undirected by the analyzer, but its edge ViewScan \
+                                         (table '{}') / relationship schema lacks the from/to \
+                                         role-property maps needed to build the doubled-edge \
+                                         subquery — refusing to emit a silently-single-direction \
+                                         join",
+                                        gr.alias, edge_vs.source_table,
+                                    ))
+                                })?
+                            } else {
+                                edge_vs.source_table.clone()
+                            };
                             (
-                                edge_vs.source_table.clone(),
+                                edge_table_or_doubled,
                                 gr.alias.clone(),
                                 anchor_edge_id,
                                 node_id,

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -254,6 +254,125 @@ pub(super) fn is_denormalized_union(plan: &LogicalPlan) -> bool {
     }
 }
 
+/// #583: build a doubled-edge subquery for a denormalized single-hop undirected
+/// OPTIONAL pattern, so the existing single anchor LEFT JOIN sees every physical
+/// edge in BOTH orientations.
+///
+/// The undirected split renders each direction as an independent
+/// `__denorm_scan_a LEFT JOIN <edge> ON a.code = <edge>.origin_code` (and the
+/// reverse arm on `dest_code`) under UNION ALL; each arm NULL-extends blind to
+/// the other, so a one-role-only anchor gets a spurious `(anchor, NULL)` (#583).
+/// Instead, the analyzer keeps ONE directed `was_undirected` GraphRel and this
+/// helper replaces the raw edge table with:
+///
+/// ```sql
+/// (SELECT e.<all cols> FROM <edge_table> AS e
+///  UNION ALL
+///  SELECT e.<to-role cols AS from-role names>, e.<from-role cols AS to-role names>,
+///         e.<edge-own cols> FROM <edge_table> AS e)
+/// ```
+///
+/// so the outer join (`a.code = t1.origin_code`) and the neighbor projection
+/// (`t1.dest_*`) are BYTE-IDENTICAL to the directed shape — only the join target
+/// changes. NULL-extension then happens once, for genuinely zero-neighbor
+/// anchors only (proven: 16 rows vs the buggy 18).
+///
+/// Column set is derived entirely from the edge `ViewScan` via the
+/// schema-catalog `edge_side_node_properties` dispatch point (the from/to
+/// role-property maps give the role-swap pairs by Cypher key; from_id/to_id
+/// are the id swap pair; `property_mapping` values are edge-own pass-throughs).
+/// Every reference is table-qualified (`e.<col>`) so the reverse arm's
+/// `e.dest_code AS origin_code` binds the RAW column, never the just-created
+/// alias (ClickHouse would otherwise silently flip the value — mirrors #617's
+/// doubled-edge qualification discipline).
+pub(super) fn build_denorm_doubled_edge_subquery(
+    edge_vs: &crate::query_planner::logical_plan::ViewScan,
+    rel_schema: &crate::graph_catalog::graph_schema::RelationshipSchema,
+) -> Option<String> {
+    let q = crate::clickhouse_query_generator::quote_identifier;
+
+    // Role id columns (single-column only — composite denorm ids are out of
+    // scope for #583's denorm stage; the analyzer gate resolves same-label
+    // endpoints but composite ids ride a different family).
+    let from_id = edge_vs.from_id.as_ref()?.first_column().to_string();
+    let to_id = edge_vs.to_id.as_ref()?.first_column().to_string();
+
+    // Role-property swap pairs, matched by Cypher property key present on BOTH
+    // sides (e.g. `code` → (origin_code, dest_code), `city` → (origin_city,
+    // dest_city)). Deterministic order. Routed through the schema-catalog
+    // dispatch point (CLAUDE.md rule 7) rather than reading the raw ViewScan
+    // role-property fields directly.
+    let from_props =
+        crate::graph_catalog::pattern_schema::edge_side_node_properties(edge_vs, true)?;
+    let to_props = crate::graph_catalog::pattern_schema::edge_side_node_properties(edge_vs, false)?;
+    let mut swap_pairs: Vec<(String, String)> = Vec::new(); // (from_col, to_col)
+    let mut keys: Vec<&String> = from_props.keys().collect();
+    keys.sort();
+    for key in keys {
+        let (Some(PropertyValue::Column(from_col)), Some(PropertyValue::Column(to_col))) =
+            (from_props.get(key), to_props.get(key))
+        else {
+            continue;
+        };
+        swap_pairs.push((from_col.clone(), to_col.clone()));
+    }
+    // The id columns are role-swap columns too (they may or may not also appear
+    // as a mapped property). Ensure they are present exactly once.
+    if !swap_pairs.iter().any(|(f, _)| f == &from_id) {
+        swap_pairs.push((from_id.clone(), to_id.clone()));
+    }
+
+    // Edge-own pass-through columns: EVERY physical column the relationship's
+    // own row can carry (property_mappings, the edge identity column(s) —
+    // `edge_id`, which `count(r)` lowers to and which is NOT necessarily in
+    // `property_mappings` — and any denormalized role-property columns), MINUS
+    // the role-swap columns handled above. Sourced from the schema-catalog
+    // `all_valid_physical_columns()` so an edge-id-only column (e.g. a FLIGHT
+    // edge's `flight_id` listed under `edge_id:` but not `property_mappings:`)
+    // is never dropped — dropping it would make `count(r)` reference a column
+    // the subquery doesn't project (ClickHouse Code 47). Deterministic order.
+    let role_cols: HashSet<String> = swap_pairs
+        .iter()
+        .flat_map(|(f, t)| [f.clone(), t.clone()])
+        .collect();
+    let mut passthrough: Vec<String> = rel_schema
+        .all_valid_physical_columns()
+        .into_iter()
+        .filter(|c| !role_cols.contains(c))
+        .collect();
+    passthrough.sort();
+    passthrough.dedup();
+
+    // Forward arm: every column verbatim.
+    let mut forward_cols: Vec<String> = Vec::new();
+    for (f, t) in &swap_pairs {
+        forward_cols.push(format!("e.{}", q(f)));
+        forward_cols.push(format!("e.{}", q(t)));
+    }
+    for c in &passthrough {
+        forward_cols.push(format!("e.{}", q(c)));
+    }
+
+    // Reverse arm: swap each role pair (to-col AS from-name, from-col AS
+    // to-name); edge-own columns unchanged. Table-qualified so the AS target
+    // never shadows the raw source column.
+    let mut reverse_cols: Vec<String> = Vec::new();
+    for (f, t) in &swap_pairs {
+        reverse_cols.push(format!("e.{} AS {}", q(t), q(f)));
+        reverse_cols.push(format!("e.{} AS {}", q(f), q(t)));
+    }
+    for c in &passthrough {
+        reverse_cols.push(format!("e.{}", q(c)));
+    }
+
+    let table = &edge_vs.source_table;
+    Some(format!(
+        "(SELECT {fwd} FROM {table} AS e UNION ALL SELECT {rev} FROM {table} AS e)",
+        fwd = forward_cols.join(", "),
+        rev = reverse_cols.join(", "),
+    ))
+}
+
 /// #611: true when a denormalized standalone-scan Union appears ANYWHERE in
 /// the subtree — not just as a direct child. A CHAINED optional clause over
 /// a denormalized schema (`MATCH (a) OPTIONAL MATCH (a)-[f]->(b) OPTIONAL

--- a/tests/corpus/queries.jsonl
+++ b/tests/corpus/queries.jsonl
@@ -1283,3 +1283,7 @@
 {"cypher": "MATCH (a)-[r]->(b) RETURN count(*)", "name": "test_987_open_unlabeled_single_hop_no_self_loop_control", "schema": "standard"}
 {"cypher": "MATCH (a)-[r]-(a) RETURN count(*)", "name": "test_987_closed_unlabeled_self_loop_fk_edge_cross_type", "schema": "fk_edge"}
 {"cypher": "MATCH (a)-[r*1..2]->(a) RETURN count(*)", "name": "test_987_closed_unlabeled_vlp_fails_loud", "schema": "standard"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT]-(b:Airport) RETURN a.code, b.code", "name": "test_583_denorm_undirected_optional_no_spurious_null", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT]-(b:Airport) RETURN count(*) AS n", "name": "test_583_denorm_undirected_optional_count_star", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[r:FLIGHT]-(b:Airport) RETURN a.code, count(r) AS c ORDER BY a.code", "name": "test_583_denorm_undirected_optional_count_rel", "schema": "denormalized_flights"}
+{"cypher": "MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT]->(b:Airport) RETURN a.code, b.code", "name": "test_583_denorm_directed_optional_control", "schema": "denormalized_flights"}

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_directed_optional_control.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_directed_optional_control.clickhouse.sql
@@ -1,0 +1,27 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS "city", 
+      a.Origin AS "code", 
+      a.OriginState AS "state"
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS "city", 
+      a.Dest AS "code", 
+      a.DestState AS "state"
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS "a.code", 
+      t0.Dest AS "b.code"
+FROM __denorm_scan_a AS a
+LEFT JOIN test_integration.flights AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_directed_optional_control.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_directed_optional_control.databricks.sql
@@ -1,0 +1,27 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS `city`, 
+      a.Origin AS `code`, 
+      a.OriginState AS `state`
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS `city`, 
+      a.Dest AS `code`, 
+      a.DestState AS `state`
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS `a.code`, 
+      t0.Dest AS `b.code`
+FROM __denorm_scan_a AS a
+LEFT JOIN test_integration.flights AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_rel.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_rel.clickhouse.sql
@@ -1,0 +1,29 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS "city", 
+      a.Origin AS "code", 
+      a.OriginState AS "state"
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS "city", 
+      a.Dest AS "code", 
+      a.DestState AS "state"
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS "a.code", 
+      count(r.flight_id) AS "c"
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS r ON a.code = r.Origin
+GROUP BY a.code
+ORDER BY a.code ASC

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_rel.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_rel.databricks.sql
@@ -1,0 +1,29 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS `city`, 
+      a.Origin AS `code`, 
+      a.OriginState AS `state`
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS `city`, 
+      a.Dest AS `code`, 
+      a.DestState AS `state`
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS `a.code`, 
+      count(r.flight_id) AS `c`
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS r ON a.code = r.Origin
+GROUP BY a.code
+ORDER BY a.code ASC

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_star.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_star.clickhouse.sql
@@ -1,0 +1,26 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS "city", 
+      a.Origin AS "code", 
+      a.OriginState AS "state"
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS "city", 
+      a.Dest AS "code", 
+      a.DestState AS "state"
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      count(*) AS "n"
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_star.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_count_star.databricks.sql
@@ -1,0 +1,26 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS `city`, 
+      a.Origin AS `code`, 
+      a.OriginState AS `state`
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS `city`, 
+      a.Dest AS `code`, 
+      a.DestState AS `state`
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      count(*) AS `n`
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_no_spurious_null.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_no_spurious_null.clickhouse.sql
@@ -1,0 +1,27 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS "city", 
+      a.Origin AS "code", 
+      a.OriginState AS "state"
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS "city", 
+      a.Dest AS "code", 
+      a.DestState AS "state"
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS "a.code", 
+      t0.Dest AS "b.code"
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_no_spurious_null.databricks.sql
+++ b/tests/rust/integration/golden/corpus/denormalized_flights/test_583_denorm_undirected_optional_no_spurious_null.databricks.sql
@@ -1,0 +1,27 @@
+WITH __denorm_scan_a AS (
+SELECT 
+      "code" AS "code",
+      min("city") AS "city",
+      min("state") AS "state"
+FROM (
+SELECT 
+      a.OriginCityName AS `city`, 
+      a.Origin AS `code`, 
+      a.OriginState AS `state`
+FROM test_integration.flights AS a
+UNION DISTINCT 
+SELECT 
+      a.DestCityName AS `city`, 
+      a.Dest AS `code`, 
+      a.DestState AS `state`
+FROM test_integration.flights AS a
+
+)
+GROUP BY "code"
+
+)
+SELECT 
+      a.code AS `a.code`, 
+      t0.Dest AS `b.code`
+FROM __denorm_scan_a AS a
+LEFT JOIN (SELECT e.OriginCityName, e.DestCityName, e.Origin, e.Dest, e.OriginState, e.DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e UNION ALL SELECT e.DestCityName AS OriginCityName, e.OriginCityName AS DestCityName, e.Dest AS Origin, e.Origin AS Dest, e.DestState AS OriginState, e.OriginState AS DestState, e.airline, e.arr_time, e.dep_time, e.distance_miles, e.flight_id, e.flight_number FROM test_integration.flights AS e) AS t0 ON a.code = t0.Origin

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -12879,9 +12879,12 @@ mod vlp_fixed_path_family_496_497_498_499_501 {
             .await,
         );
         assert!(
-            optional.contains("ORDER BY `a.code`"),
-            "#503 (OPTIONAL variant): ORDER BY must reference the \
-             backtick-quoted outer alias:\n{optional}"
+            optional.contains("ORDER BY `a.code`") || optional.contains("ORDER BY a.code"),
+            "#503 (OPTIONAL variant): ORDER BY must reference a resolvable \
+             outer alias/column. #583: the denormalized single-hop undirected \
+             OPTIONAL no longer renders through the two-arm `__union` wrapper \
+             (it is a single doubled-edge anchor LEFT JOIN), so the ORDER BY \
+             binds the anchor column directly rather than a union-outer alias:\n{optional}"
         );
 
         // Determinism.
@@ -13390,21 +13393,28 @@ mod vlp_fixed_path_family_496_497_498_499_501 {
         );
 
         // Exactly ONE denorm-scan CTE for the anchor — no "_2" duplicate
-        // (which would indicate the two UnionDistribution branches produced
-        // inconsistent CTE bodies again).
+        // (which would indicate inconsistent CTE bodies again).
         assert!(
             sql.contains("__denorm_scan_a") && !sql.contains("__denorm_scan_a_2"),
-            "B1: exactly one __denorm_scan_a CTE must be shared by both \
-             direction branches — a `__denorm_scan_a_2` duplicate indicates \
-             the branches disagreed on node-grain wrapping again:\n{sql}"
+            "B1: exactly one __denorm_scan_a CTE:\n{sql}"
         );
-        // Both branches must reference the SAME (wrapped, node-grain) CTE.
+        // #583: the undirected OPTIONAL hop is no longer split into two
+        // direction branches — it renders as ONE anchor LEFT JOIN against a
+        // doubled-edge subquery (a single inner UNION ALL). The node-grain wrap
+        // (#507) that keeps `count(r)` at node grain is preserved. Live-verified
+        // (unchanged): 192.168.1.10 -> exactly one row with c = 4, matching the
+        // raw ground truth `count() WHERE id.orig_h='192.168.1.10' OR
+        // id.resp_h='192.168.1.10'`.
         assert_eq!(
-            sql.matches("LEFT JOIN zeek.conn_log AS r ON a.ip =")
-                .count(),
-            2,
-            "B1: expected both direction branches to LEFT JOIN against the \
-             anchor CTE:\n{sql}"
+            sql.matches("LEFT JOIN (SELECT").count(),
+            1,
+            "B1/#583: the anchor must LEFT JOIN a single doubled-edge subquery, \
+             not two per-direction branches:\n{sql}"
+        );
+        assert!(
+            sql.matches("UNION ALL").count() == 1 && !sql.contains(") AS __union"),
+            "B1/#583: one doubled-edge inner UNION ALL, no two-arm outer \
+             `__union` split:\n{sql}"
         );
         // The CTE itself must carry the node-grain wrap (GROUP BY the id
         // property, `min()` for the non-identity `port` column) — this is
@@ -14217,35 +14227,44 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
                      WITH a, count(r) AS c RETURN a.ip, c";
         let sql = normalize(&render(&schema, repro, SqlDialect::ClickHouse).await);
 
+        // #583: this coupled/denormalized single-hop undirected OPTIONAL is no
+        // longer split into a two-arm `__union` — the BidirectionalUnion
+        // analyzer keeps ONE `was_undirected` GraphRel and the render targets a
+        // doubled-edge subquery under the single anchor LEFT JOIN. So there is
+        // no outer `__union` wrapper and no `p1_a_ip` inner-union column here;
+        // the GROUP BY binds the anchor CTE column directly. (Live-verified: the
+        // undirected `count(r)` grain is unchanged — 4/2/2/1/1 on the zeek
+        // fixture — and the non-aggregate form drops the two spurious
+        // `(ip, NULL)` rows main produced, 12 -> 10.)
         assert!(
             !sql.contains(r#"GROUP BY a."id.orig_h""#),
-            "#529 shape 2: GROUP BY must not reference the raw physical \
-             column — the __union derived table only exposes the CTE \
-             column:\n{sql}"
+            "#529/#583: GROUP BY must not reference the raw physical column:\n{sql}"
         );
         assert!(
-            sql.contains("GROUP BY `p1_a_ip`") || sql.contains("GROUP BY \"p1_a_ip\""),
-            "#529 shape 2: GROUP BY must reference the properly-quoted CTE \
-             column exposed by the inner UNION:\n{sql}"
+            sql.matches("UNION ALL").count() == 1 && !sql.contains(") AS __union"),
+            "#583: the coupled undirected OPTIONAL renders as ONE doubled-edge \
+             subquery (a single inner UNION ALL), not a two-arm outer \
+             `__union` split:\n{sql}"
         );
 
-        // Sibling B1 path (top-level OPTIONAL-denorm-Union detection) must be
-        // unaffected: still renders its own full two-branch union, not a
-        // single-branch delegation (the risk the narrow fix scoping avoids).
+        // The anchor scan must still collapse to NODE grain (#507): one row per
+        // distinct id, `min()` over the non-identity `port` column. This is what
+        // keeps the LEFT-JOIN count at node grain rather than table grain.
         let b1_repro = "MATCH (a:IP) OPTIONAL MATCH (a)-[r:ACCESSED]-(b:IP) \
                          RETURN a.ip, a.port, count(r) AS c";
         let b1_sql = normalize(&render(&schema, b1_repro, SqlDialect::ClickHouse).await);
         assert!(
             b1_sql.contains("__denorm_scan_a") && !b1_sql.contains("__denorm_scan_a_2"),
-            "#529 shape 2 fix must not regress B1 (single shared anchor CTE):\n{b1_sql}"
+            "#529/#583: exactly one shared node-grain anchor CTE:\n{b1_sql}"
         );
-        assert_eq!(
-            b1_sql
-                .matches("LEFT JOIN zeek.conn_log AS r ON a.ip =")
-                .count(),
-            2,
-            "#529 shape 2 fix must not regress B1 (both direction branches \
-             LEFT JOIN against the anchor CTE):\n{b1_sql}"
+        assert!(
+            b1_sql.contains("GROUP BY \"ip\"") && b1_sql.contains("min(\"port\")"),
+            "#507: the anchor CTE must still carry the node-grain wrap:\n{b1_sql}"
+        );
+        assert!(
+            b1_sql.matches("UNION ALL").count() == 1 && !b1_sql.contains(") AS __union"),
+            "#583: the B1 aggregate form also renders as ONE doubled-edge \
+             subquery, not a two-arm split:\n{b1_sql}"
         );
 
         // Determinism.
@@ -14253,6 +14272,52 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
             let again = normalize(&render(&schema, repro, SqlDialect::ClickHouse).await);
             assert_eq!(sql, again, "#529 shape 2: nondeterministic render");
         }
+    }
+
+    /// #583 (adversarial-review regression): the doubled-edge subquery for a
+    /// denorm undirected OPTIONAL must project the edge's IDENTITY column even
+    /// when it is declared only under `edge_id:` and NOT in `property_mappings:`.
+    /// `count(r)` lowers to `count(r.<edge_id>)`, so if the subquery omits that
+    /// column the outer query references a column the subquery never exposes →
+    /// ClickHouse Code 47 (`Identifier 'r.flight_id' cannot be resolved`). This
+    /// exact shape shipped broken in a render-only golden (corpus goldens render
+    /// without executing) and regressed a query that works on `main`; the fix
+    /// sources the passthrough columns from the schema-catalog
+    /// `all_valid_physical_columns()` (which includes `edge_id`) rather than
+    /// from `property_mappings` alone. `schemas/test/denormalized_flights.yaml`'s
+    /// FLIGHT edge has `edge_id: [flight_id, flight_number]` with `flight_id`
+    /// unmapped — the precise trigger.
+    #[tokio::test]
+    async fn denorm_undirected_optional_count_rel_projects_unmapped_edge_id_583() {
+        let schema = load_schema("schemas/test/denormalized_flights.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (a:Airport) OPTIONAL MATCH (a)-[r:FLIGHT]-(b:Airport) \
+                 RETURN a.code, count(r) AS c",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+
+        // The outer aggregate references the edge-id column…
+        assert!(
+            sql.contains("count(r.flight_id)"),
+            "#583: count(r) should lower to count(r.flight_id):\n{sql}"
+        );
+        // …so BOTH doubled-edge arms must project it (once per arm). Total 3
+        // occurrences: the outer count + one per UNION ALL arm.
+        assert_eq!(
+            sql.matches("flight_id").count(),
+            3,
+            "#583: the unmapped edge-id column must be projected in both \
+             doubled-edge arms so `count(r.flight_id)` resolves (else Code 47):\n{sql}"
+        );
+        // Single doubled-edge subquery (one inner UNION ALL), no two-arm split.
+        assert!(
+            sql.matches("UNION ALL").count() == 1 && !sql.contains(") AS __union"),
+            "#583: one doubled-edge subquery, not a two-arm outer split:\n{sql}"
+        );
     }
 
     /// #529 shape 1 — R4/R5: bugs 1+2 of the 3-bug package FIXED; bug 3


### PR DESCRIPTION
## Problem (#583, silent wrong results — ground-rule-1)

An undirected single-hop `MATCH (a:Airport) OPTIONAL MATCH (a)-[:FLIGHT]-(b:Airport)` over a denormalized (or coupled) edge table returns a spurious extra `(anchor, NULL)` row for any anchor that matches in only ONE physical role. `BidirectionalUnion` splits the hop into two per-direction branches, each of which independently `LEFT JOIN`s the `__denorm_scan_a` anchor CTE and NULL-extends blind to the other.

**Live-confirmed:** denorm returns 18 rows (should be 16 — spurious `(PHX,NULL)` + `(SFO,NULL)`); zeek/coupled returns 12 (should be 10). Also breaks `count(*)` (18) and `count(b)` (Code 53 on denorm). The directed `->` control is unaffected.

## Fix — reuse the #617 doubled-edge strategy for the single hop

The undirected **VLP** OPTIONAL path (#617) already renders the correct architecture: a direction-unioned edge set under a **single** anchor LEFT JOIN. Only the single-hop non-VLP denorm path still used the buggy independent-branch split. This PR brings the single hop onto the same shape:

1. **Analyzer** (`bidirectional_union.rs`): a new pre-pass `normalize_undirected_denorm_single_hop_optional_rels` (sibling of #617's `normalize_undirected_vlp_rels`) keeps the hop as ONE directed `was_undirected` GraphRel instead of splitting. Gated denorm-only via the schema-catalog `rel_has_both_nodes_denormalized` dispatch API (CLAUDE.md rule 7), same-label endpoints, single rel type, plain single hop.
2. **Render** (`plan_builder_helpers.rs` + `plan_builder.rs`): when `was_undirected`, the existing single anchor LEFT JOIN targets a **doubled-edge subquery** (every physical edge in both orientations; role columns swapped via `edge_side_node_properties`; table-qualified refs so the reverse arm binds raw columns) instead of the raw edge table. The join key and neighbor projection are byte-identical to the directed shape — only the join target changes — so NULL-extension happens once, for genuinely zero-neighbor anchors only.

## Scope (intentionally staged)

- **Fixed:** denormalized + coupled layouts (flights-denorm, zeek). Verified `count(*)`/`count(r)`/plain all correct; grain preserved (#507 node-grain wrap intact).
- **Unchanged (#583 stays open):** standard/polymorphic (branch-2 swaps the FROM alias) and composite (multi-col key + NULL-anchor artifact). A loud guard there is deliberately **not** added — it would regress standard `count(b)`, which SQL's NULL-skipping `count(col)` renders accidentally correct today.
- **No bug:** fk_edge (distinct from/to labels prune the reverse branch to a single branch).

## Validation

- Full suite green (1700 lib + 591 integration + ratchet + all crates); fmt + clippy clean.
- Differential SQL sweep: all control queries (directed, non-optional, standard-schema) byte-identical to `main`.
- Ratchet: routed the render read through the `edge_side_node_properties` dispatch API — **no baseline bump**.
- Dialect-safe: `quote_identifier` is dialect-aware (CH double-quote / Databricks backtick); verified on zeek `id.orig_h`.
- WHERE-fold and self-loop behavior verified consistent with the directed case (not regressions).
- Three coupled-schema goldens rewritten to lock the new single-doubled-edge shape (node-grain + determinism asserts preserved); 4 corpus regression entries added (both dialects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)