### PR TITLE
refactor(#887): fold build_edge_tuple_recursive + CM edge_tuple onto one spell_edge_identity helper

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -554,7 +554,7 @@ fixed stats fixture.
   #710, #806, #808 all fixed.
   Remaining #887:
   Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical
-  design-cycle refactor). Phase 1 slice 2 (#TBD) SHIPPED: shared
+  design-cycle refactor). Phase 1 slice 2 (#1032) SHIPPED: shared
   `spell_edge_identity` tuple helper (in `variable_length_cte.rs`) — the
   recursive generator's `build_edge_tuple_recursive` and the denormalized
   strategy's `edge_tuple` (cte_manager) now spell the one-hop edge identity

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slice 1 #893, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -554,7 +554,13 @@ fixed stats fixture.
   #710, #806, #808 all fixed.
   Remaining #887:
   Phase 1–2 (`EdgeUniquenessPolicy` + transition-assert + switch, byte-identical
-  design-cycle refactor). Explicitly NOT this cluster:
+  design-cycle refactor). Phase 1 slice 2 (#TBD) SHIPPED: shared
+  `spell_edge_identity` tuple helper (in `variable_length_cte.rs`) — the
+  recursive generator's `build_edge_tuple_recursive` and the denormalized
+  strategy's `edge_tuple` (cte_manager) now spell the one-hop edge identity
+  through ONE function (6 → 5 → 4 spellings; #617 doubled-edge orientation via
+  `map_col` closure, denorm passes identity). Byte-identical: zero corpus/golden
+  churn, full suite + ratchet green. Explicitly NOT this cluster:
   #643/#840/#627/#683 (different subsystems). Adjacent bugs found during Phase 3/4/5
   and filed separately (NOT folded in): flat exact-bound polymorphic VLP drops the
   `interaction_type` discriminator (#897), an OPTIONAL-MATCH closed-VLP projection

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -273,7 +273,7 @@ shared helper. Once the identity spellings are consolidated, the policy type
   callers already pass exactly that), so the merge is byte-identical by
   substitution — verified arm-by-arm and against 374 `path_edges` goldens incl.
   the #617 doubled-edge branch. 6 spellings → 5. Review APPROVE-0.
-- **Slice 2 — DONE (PR #TBD)**: the two single-alias tuple spellings now share
+- **Slice 2 — DONE (#1032)**: the two single-alias tuple spellings now share
   ONE helper. Introduced `pub fn spell_edge_identity(tuple_ctor, edge_id,
   rel_alias, from_col, to_col, map_col)` in `variable_length_cte.rs`; both
   `build_edge_tuple_recursive` and `DenormalizedCteStrategy::edge_tuple`

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -273,8 +273,21 @@ shared helper. Once the identity spellings are consolidated, the policy type
   callers already pass exactly that), so the merge is byte-identical by
   substitution — verified arm-by-arm and against 374 `path_edges` goldens incl.
   the #617 doubled-edge branch. 6 spellings → 5. Review APPROVE-0.
-- **Next candidate slices** (unstarted): fold `build_fk_edge_tuple` and the flat
-  pairwise identity onto one `EdgeIdentity::spell(...)`.
+- **Slice 2 — DONE (PR #TBD)**: the two single-alias tuple spellings now share
+  ONE helper. Introduced `pub fn spell_edge_identity(tuple_ctor, edge_id,
+  rel_alias, from_col, to_col, map_col)` in `variable_length_cte.rs`; both
+  `build_edge_tuple_recursive` and `DenormalizedCteStrategy::edge_tuple`
+  delegate to it. The only difference between the two callers is the per-column
+  mapping: VLC passes `edge_identity_column` (the #617 doubled-edge
+  orientation correction — provably identical to the old `None` arm's inline
+  `DOUBLED_EDGES_ORIG_FROM/TO` selection), CM passes identity (denorm has no
+  doubled-edge CTE). Byte-identity proven per caller arm + zero corpus/golden
+  churn (full 1723-unit + 593-integration sweep green, ratchet green).
+  5 spellings → 4. Review APPROVE-0.
+- **Next candidate slices** (unstarted): fold `build_fk_edge_tuple` (two aliases,
+  `quote_identifier`, comma-separated composite parse — a genuinely different
+  shape needing its own byte-identity proof) and the flat pairwise identity onto
+  the same helper family toward `EdgeIdentity::spell(...)`.
 
   **CORRECTION (2026-08-02, post-#628):** the previously-listed slice "unify the
   two `uses_edge_uniqueness` copies" is **NOT a byte-identical refactor** and is

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use crate::clickhouse_query_generator::variable_length_cte::{
-    NodeProperty, VariableLengthCteGenerator,
+    spell_edge_identity, NodeProperty, VariableLengthCteGenerator,
 };
 use crate::graph_catalog::{
     config::Identifier, graph_schema::GraphSchema, EdgeAccessStrategy, JoinStrategy,
@@ -460,8 +460,9 @@ impl DenormalizedCteStrategy {
     /// IS the edge identity — this distinguishes parallel edges that share the
     /// same `(from, to)` node pair (e.g. two flights on one route keyed by
     /// `flight_id`), which the `(from, to)` pair alone would collapse into a
-    /// single edge and under-count. Spelled identically to the standard
-    /// emitter's [`VariableLengthCteGenerator::build_edge_tuple_recursive`]:
+    /// single edge and under-count. Spelled via the shared
+    /// [`spell_edge_identity`] helper — the same spelling the standard emitter
+    /// uses in [`VariableLengthCteGenerator::build_edge_tuple_recursive`]:
     ///
     /// - `Single(col)` → bare `rel_alias.col` (scalar element),
     /// - `Composite(cols)` → `tuple(rel_alias.c1, rel_alias.c2, …)`,
@@ -470,24 +471,16 @@ impl DenormalizedCteStrategy {
     ///
     /// A denormalized VLP is a single directional recursive self-join over the
     /// edge table (no #617 doubled-edge CTE), so no from/to orientation swap is
-    /// needed — the identity columns are read verbatim.
+    /// needed — the identity columns are read verbatim (identity `map_col`).
     fn edge_tuple(&self, rel_alias: &str) -> String {
-        let tuple_ctor =
-            crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor();
-        match &self.edge_id {
-            Some(Identifier::Single(col)) => format!("{}.{}", rel_alias, col),
-            Some(Identifier::Composite(cols)) => {
-                let elems: Vec<String> = cols
-                    .iter()
-                    .map(|col| format!("{}.{}", rel_alias, col))
-                    .collect();
-                format!("{}({})", tuple_ctor, elems.join(", "))
-            }
-            None => format!(
-                "{}({}.{}, {}.{})",
-                tuple_ctor, rel_alias, self.from_col, rel_alias, self.to_col
-            ),
-        }
+        spell_edge_identity(
+            crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor(),
+            &self.edge_id,
+            rel_alias,
+            &self.from_col,
+            &self.to_col,
+            |col| col,
+        )
     }
 
     pub fn generate_sql(

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -68,10 +68,56 @@ fn emit_cycle_check(id_expr: &str) -> String {
 /// Enforces Cypher's default relationship-uniqueness (a path MAY revisit a node
 /// but must not reuse the same edge), unlike [`emit_cycle_check`] which enforces
 /// the stronger node-uniqueness. `edge_expr` is the edge-identity expression for
-/// the hop being added this step (typically from [`VariableLengthCteGenerator::build_edge_tuple_recursive`]).
+/// the hop being added this step (typically from [`spell_edge_identity`]).
 fn emit_edge_cycle_check(edge_expr: &str) -> String {
     let array_contains = current_function_mapper().array_contains();
     format!("NOT {array_contains}(vp.path_edges, {edge_expr})")
+}
+
+/// Spell the edge-identity value for one hop, reading the edge columns off
+/// `rel_alias`. The single shared spelling for "what makes one edge the same
+/// edge" — used by the recursive generator's
+/// [`VariableLengthCteGenerator::build_edge_tuple_recursive`] and the
+/// denormalized strategy's `edge_tuple` (`cte_manager/mod.rs`) so both spell
+/// the identity identically (#710: parallel edges sharing one `(from, to)`
+/// node pair must not collapse).
+///
+/// Returns SQL like `tuple(r.from_id, r.to_id)` or `tuple(r.date, r.num, …)`.
+/// Shape depends on `edge_id`: a `Single` column emits a bare `rel.col`; a
+/// `Composite` key builds a `tuple(...)`; `None` defaults to the `(from, to)`
+/// node pair. `map_col` is applied to EVERY referenced column, letting callers
+/// inject per-walk orientation corrections — the #617 doubled-edge walk maps
+/// the from/to id columns to their original-orientation names via
+/// [`VariableLengthCteGenerator::edge_identity_column`], while the
+/// single-directional denormalized walk passes the identity mapping.
+pub fn spell_edge_identity(
+    tuple_ctor: &str,
+    edge_id: &Option<Identifier>,
+    rel_alias: &str,
+    from_col: &str,
+    to_col: &str,
+    map_col: impl Fn(&str) -> &str,
+) -> String {
+    match edge_id {
+        Some(Identifier::Single(col)) => format!("{}.{}", rel_alias, map_col(col)),
+        Some(Identifier::Composite(cols)) => {
+            let tuple_elements: Vec<String> = cols
+                .iter()
+                .map(|col| format!("{}.{}", rel_alias, map_col(col)))
+                .collect();
+            format!("{}({})", tuple_ctor, tuple_elements.join(", "))
+        }
+        None => {
+            format!(
+                "{}({}.{}, {}.{})",
+                tuple_ctor,
+                rel_alias,
+                map_col(from_col),
+                rel_alias,
+                map_col(to_col)
+            )
+        }
+    }
 }
 
 /// Original-orientation edge-identity column names projected by the
@@ -1151,46 +1197,18 @@ impl<'a> VariableLengthCteGenerator<'a> {
     /// reverse-orientation rows, so the `None` identity comes from the
     /// original-orientation columns — otherwise the same physical edge traversed
     /// the other way would look like a different relationship and
-    /// trail-uniqueness would not hold.
+    /// trail-uniqueness would not hold. Delegates to the shared
+    /// [`spell_edge_identity`] (the denormalized strategy spells via the same
+    /// helper, #710).
     fn build_edge_tuple_recursive(&self, rel_alias: &str) -> String {
-        match &self.edge_id {
-            Some(Identifier::Single(col)) => {
-                format!("{}.{}", rel_alias, self.edge_identity_column(col))
-            }
-            Some(Identifier::Composite(cols)) => {
-                let tuple_elements: Vec<String> = cols
-                    .iter()
-                    .map(|col| format!("{}.{}", rel_alias, self.edge_identity_column(col)))
-                    .collect();
-                format!(
-                    "{}({})",
-                    crate::sql_generator::function_mapper::current_function_mapper()
-                        .tuple_constructor(),
-                    tuple_elements.join(", ")
-                )
-            }
-            None => {
-                // #617: original-orientation identity on the doubled-edge walk
-                // (see this fn's doc comment).
-                let (from_c, to_c) = if self.uses_doubled_edges() {
-                    (DOUBLED_EDGES_ORIG_FROM, DOUBLED_EDGES_ORIG_TO)
-                } else {
-                    (
-                        self.relationship_from_column.as_str(),
-                        self.relationship_to_column.as_str(),
-                    )
-                };
-                format!(
-                    "{}({}.{}, {}.{})",
-                    crate::sql_generator::function_mapper::current_function_mapper()
-                        .tuple_constructor(),
-                    rel_alias,
-                    from_c,
-                    rel_alias,
-                    to_c
-                )
-            }
-        }
+        spell_edge_identity(
+            current_function_mapper().tuple_constructor(),
+            &self.edge_id,
+            rel_alias,
+            &self.relationship_from_column,
+            &self.relationship_to_column,
+            |col| self.edge_identity_column(col),
+        )
     }
 
     /// Build the `(from_id, to_id)` edge-identity tuple for ONE FK-edge hop,


### PR DESCRIPTION
Phase 1 slice 2 of VLP edge-identity unification (#887).

**Change**: introduces `pub fn spell_edge_identity(tuple_ctor, edge_id, rel_alias, from_col, to_col, map_col)` in `variable_length_cte.rs` as the single one-hop edge-identity spelling. Both `VariableLengthCteGenerator::build_edge_tuple_recursive` and `DenormalizedCteStrategy::edge_tuple` (cte_manager) now delegate to it. 5 spellings → 4.

**Byte-identity proof** (per caller arm):
- VLC passes `edge_identity_column` as the `map_col` closure; its None arm previously inlined the `uses_doubled_edges()` → `DOUBLED_EDGES_ORIG_FROM/TO` selection, and `edge_identity_column(relationship_from_column)` returns exactly that (or the column itself) — so all three arms reproduce byte-for-byte.
- CM passes identity `|col| col` — denorm walk has no #617 doubled-edge CTE.

**Verification**: 1723 unit + 593 integration green, corpus sweep byte-identical (zero golden churn), ratchet green, fmt/clippy clean. Adversarial review APPROVE (hand-reconstructed all arms incl. the doubled-edge None case).