### PR TITLE
refactor(#887): route FK-edge tuple through shared spell_tuple_parts wrapper

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #1033, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -561,7 +561,7 @@ fixed stats fixture.
   through ONE function (6 → 5 → 4 spellings; #617 doubled-edge orientation via
   `map_col` closure, denorm passes identity). Byte-identical: zero corpus/golden
   churn, full suite + ratchet green.
-  Phase 1 slice 3 (#TBD) SHIPPED: extracted `spell_tuple_parts` — the
+  Phase 1 slice 3 (#1033) SHIPPED: extracted `spell_tuple_parts` — the
   `tuple(e1, …)` wrapper — as the shared core of the `Composite`/`None` arms of
   `spell_edge_identity` AND of `build_fk_edge_tuple` (FK-edge node pair keeps
   its per-shape `quote_identifier` qualification + comma-separated composite

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3
@@ -560,7 +560,15 @@ fixed stats fixture.
   strategy's `edge_tuple` (cte_manager) now spell the one-hop edge identity
   through ONE function (6 → 5 → 4 spellings; #617 doubled-edge orientation via
   `map_col` closure, denorm passes identity). Byte-identical: zero corpus/golden
-  churn, full suite + ratchet green. Explicitly NOT this cluster:
+  churn, full suite + ratchet green.
+  Phase 1 slice 3 (#TBD) SHIPPED: extracted `spell_tuple_parts` — the
+  `tuple(e1, …)` wrapper — as the shared core of the `Composite`/`None` arms of
+  `spell_edge_identity` AND of `build_fk_edge_tuple` (FK-edge node pair keeps
+  its per-shape `quote_identifier` qualification + comma-separated composite
+  parse). Byte-identical (the old None-arm `format!("{}({}.{}, {}.{})", …)` is
+  exactly the two-part join of the new wrapper; FK's `parts.join(", ")` is the
+  wrapper verbatim): zero golden churn, full suite + ratchet green.
+  4 spellings → 3. Explicitly NOT this cluster:
   #643/#840/#627/#683 (different subsystems). Adjacent bugs found during Phase 3/4/5
   and filed separately (NOT folded in): flat exact-bound polymorphic VLP drops the
   `interaction_type` discriminator (#897), an OPTIONAL-MATCH closed-VLP projection

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -284,7 +284,7 @@ shared helper. Once the identity spellings are consolidated, the policy type
   doubled-edge CTE). Byte-identity proven per caller arm + zero corpus/golden
   churn (full 1723-unit + 593-integration sweep green, ratchet green).
   5 spellings → 4. Review APPROVE-0.
-- **Slice 3 — DONE (#TBD)**: the FK-edge node-pair tuple now routes through the
+- **Slice 3 — DONE (#1033)**: the FK-edge node-pair tuple now routes through the
   same tuple wrapper. Extracted `spell_tuple_parts(tuple_ctor, parts)` — the
   `tuple(e1, …)` spelling — as the shared core of the `Composite`/`None` arms
   of `spell_edge_identity` AND of `build_fk_edge_tuple` (whose `quote_identifier`

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -284,10 +284,19 @@ shared helper. Once the identity spellings are consolidated, the policy type
   doubled-edge CTE). Byte-identity proven per caller arm + zero corpus/golden
   churn (full 1723-unit + 593-integration sweep green, ratchet green).
   5 spellings → 4. Review APPROVE-0.
-- **Next candidate slices** (unstarted): fold `build_fk_edge_tuple` (two aliases,
-  `quote_identifier`, comma-separated composite parse — a genuinely different
-  shape needing its own byte-identity proof) and the flat pairwise identity onto
-  the same helper family toward `EdgeIdentity::spell(...)`.
+- **Slice 3 — DONE (#TBD)**: the FK-edge node-pair tuple now routes through the
+  same tuple wrapper. Extracted `spell_tuple_parts(tuple_ctor, parts)` — the
+  `tuple(e1, …)` spelling — as the shared core of the `Composite`/`None` arms
+  of `spell_edge_identity` AND of `build_fk_edge_tuple` (whose `quote_identifier`
+  column qualification and comma-separated composite parse stay per-shape, per
+  the CORRECTION below). Byte-identity: the old `None` arm's
+  `format!("{}({}.{}, {}.{})", …)` is exactly the two-part `join(", ")` of the
+  new wrapper; the FK tuple's `format!("{}({})", tuple_ctor, parts.join(", "))`
+  is the wrapper verbatim. Zero corpus/golden churn, full suite + ratchet
+  green. 4 spellings → 3. Review APPROVE-0.
+- **Next candidate slices** (unstarted): the flat pairwise identity
+  (`generate_cycle_prevention_filters_composite`, cte_extraction.rs) onto the
+  same helper family toward `EdgeIdentity::spell(...)`.
 
   **CORRECTION (2026-08-02, post-#628):** the previously-listed slice "unify the
   two `uses_edge_uniqueness` copies" is **NOT a byte-identical refactor** and is

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -74,6 +74,16 @@ fn emit_edge_cycle_check(edge_expr: &str) -> String {
     format!("NOT {array_contains}(vp.path_edges, {edge_expr})")
 }
 
+/// Spell `tuple(e1, e2, …)` from pre-qualified `<alias>.<col>` parts. The
+/// single spelling for "an edge identity that is a tuple" — shared by the
+/// edge_id `Composite`/`None` arms of [`spell_edge_identity`] and the FK-edge
+/// node pair ([`VariableLengthCteGenerator::build_fk_edge_tuple`]) so the
+/// wrapper is spelled in exactly one place. `parts` are already-qualified
+/// column references; each caller decides its own quoting/column mapping.
+fn spell_tuple_parts(tuple_ctor: &str, parts: Vec<String>) -> String {
+    format!("{}({})", tuple_ctor, parts.join(", "))
+}
+
 /// Spell the edge-identity value for one hop, reading the edge columns off
 /// `rel_alias`. The single shared spelling for "what makes one edge the same
 /// edge" — used by the recursive generator's
@@ -105,18 +115,15 @@ pub fn spell_edge_identity(
                 .iter()
                 .map(|col| format!("{}.{}", rel_alias, map_col(col)))
                 .collect();
-            format!("{}({})", tuple_ctor, tuple_elements.join(", "))
+            spell_tuple_parts(tuple_ctor, tuple_elements)
         }
-        None => {
-            format!(
-                "{}({}.{}, {}.{})",
-                tuple_ctor,
-                rel_alias,
-                map_col(from_col),
-                rel_alias,
-                map_col(to_col)
-            )
-        }
+        None => spell_tuple_parts(
+            tuple_ctor,
+            vec![
+                format!("{}.{}", rel_alias, map_col(from_col)),
+                format!("{}.{}", rel_alias, map_col(to_col)),
+            ],
+        ),
     }
 }
 
@@ -1291,7 +1298,7 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 crate::clickhouse_query_generator::quote_identifier(c)
             ));
         }
-        format!("{}({})", tuple_ctor, parts.join(", "))
+        spell_tuple_parts(tuple_ctor, parts)
     }
 
     /// Get the ClickHouse array type for path_edges


### PR DESCRIPTION
Phase 1 slice 3 of VLP edge-identity unification (#887).

**Change**: extracts `spell_tuple_parts(tuple_ctor, parts)` — the `tuple(e1, e2, …)` spelling — as the shared core of the `Composite`/`None` arms of `spell_edge_identity` AND of `build_fk_edge_tuple`. The FK-edge node pair keeps its per-shape `quote_identifier` qualification + comma-separated composite parse (per the design-doc CORRECTION, per-shape details stay per-shape). 4 spellings → 3.

**Byte-identity proof** (per site, hand-reconstructed):
- Composite arm: old `format!("{}({})", tuple_ctor, elems.join(", "))` ≡ new `spell_tuple_parts(tuple_ctor, elems)` — identical.
- None arm: old `format!("{}({}.{}, {}.{})", …)` ≡ new two-part join — identical (verified for `tuple(r.from_id, r.to_id)`).
- FK tail: old `format!("{}({})", tuple_ctor, parts.join(", "))` ≡ wrapper verbatim — identical.

**Verification**: 1723 unit + 593 integration green, corpus sweep byte-identical (zero golden churn; FK tuple locked by ldbc #902 + filesystem #635 goldens), ratchet green, fmt/clippy clean. Adversarial review APPROVE.