### PR TITLE
refactor(#887): share one #617 doubled-edge orientation mapping (slice 4)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #1033, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #1033 + 4 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -294,9 +294,37 @@ shared helper. Once the identity spellings are consolidated, the policy type
   new wrapper; the FK tuple's `format!("{}({})", tuple_ctor, parts.join(", "))`
   is the wrapper verbatim. Zero corpus/golden churn, full suite + ratchet
   green. 4 spellings → 3. Review APPROVE-0.
+- **Slice 4 — DONE (#1034)**: the #617 orientation correction is now spelled
+  ONCE. Extracted `pub fn doubled_edge_identity_col(col, from_keys, to_keys)`
+  in `variable_length_cte.rs` — the single canonical mapping from an
+  edge-identity column to its original-orientation spelling on a doubled-edge
+  walk (`from_keys` membership → `__cg_orig_from`, `to_keys` → `__cg_orig_to`,
+  anything else passes through unchanged). Both spellers delegate:
+  `VariableLengthCteGenerator::edge_identity_column` (single-column keys,
+  gated by `uses_doubled_edges()`) and the flat exact-bound path's inline
+  #806 copy in `filter_builder.rs` (composite-capable key sets, gated by
+  `undirected_doubled`) — which was the *seventh* spelling instance, added by
+  #806 as a duplicate of `edge_identity_column`. Byte-identity: single-element
+  `contains` == the old equality tests; the same membership tests on the
+  composite path. Zero corpus/golden churn, full suite + ratchet green.
+  3 spellings → 3 spellings of the *tuple value* but the #617 correction is
+  now one helper (the flat pairwise guard remains predicate-shaped — see
+  below).
 - **Next candidate slices** (unstarted): the flat pairwise identity
   (`generate_cycle_prevention_filters_composite`, cte_extraction.rs) onto the
   same helper family toward `EdgeIdentity::spell(...)`.
+
+  **CORRECTION (2026-08-07):** the flat pairwise guard is **predicate-shaped,
+  not tuple-shaped** — it emits `NOT (r_i.c1 = r_j.c1 AND r_i.c2 = r_j.c2 …)`
+  RenderExprs pairwise across TWO hop aliases, i.e. an inequality test, not an
+  edge-identity *value*. Folding it onto `spell_tuple_parts` /
+  `spell_edge_identity` would change the SQL shape (and per-issue #617
+  semantics) — NOT byte-identical, so it is **removed from the Phase-1
+  spelling-fold list**. Its shareable piece was already the #617 orientation
+  mapping (Slice 4 above). The guard itself stays in predicate form until the
+  Phase-2 `EdgeUniquenessPolicy` — at which point the *choice* of identity
+  columns is policy-driven but the predicate emission remains distinct by
+  construction.
 
   **CORRECTION (2026-08-02, post-#628):** the previously-listed slice "unify the
   two `uses_edge_uniqueness` copies" is **NOT a byte-identical refactor** and is

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -886,16 +886,15 @@ impl FilterBuilder for LogicalPlan {
                                             .iter()
                                             .map(|c| {
                                                 if undirected_doubled {
-                                                    if from_key.iter().any(|k| k == c) {
-                                                        return vlc::DOUBLED_EDGES_ORIG_FROM
-                                                            .to_string();
-                                                    }
-                                                    if to_key.iter().any(|k| k == c) {
-                                                        return vlc::DOUBLED_EDGES_ORIG_TO
-                                                            .to_string();
-                                                    }
+                                                    vlc::doubled_edge_identity_col(
+                                                        c,
+                                                        &from_key,
+                                                        &to_key,
+                                                    )
+                                                    .to_string()
+                                                } else {
+                                                    c.to_string()
                                                 }
-                                                c.to_string()
                                             })
                                             .collect::<Vec<String>>()
                                     });

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -135,6 +135,31 @@ pub fn spell_edge_identity(
 /// Canonically defined in the schema catalog (which rejects colliding tables).
 pub use crate::graph_catalog::graph_schema::{DOUBLED_EDGES_ORIG_FROM, DOUBLED_EDGES_ORIG_TO};
 
+/// #617: map ONE edge-identity column to its original-orientation spelling on
+/// a doubled-edge walk. If `col` is one of the relationship's `from_keys` (the
+/// from-side id columns), the reverse-orientation rows swap it, so the identity
+/// must read `__cg_orig_from`; likewise for `to_keys` → `__cg_orig_to`. Any
+/// other column (e.g. an `edge_id` extension column like `timestamp`) is
+/// orientation-independent and passes through unchanged. The single shared
+/// spelling of this correction — used by the recursive generator's
+/// [`VariableLengthCteGenerator::edge_identity_column`] and by the flat
+/// exact-bound path (`filter_builder.rs`, #806), so both walks resolve the
+/// identity identically. `from_keys`/`to_keys` may be single- or
+/// composite-column sets; the caller decides whether this walk is doubled.
+pub fn doubled_edge_identity_col<'c>(
+    col: &'c str,
+    from_keys: &[&str],
+    to_keys: &[&str],
+) -> &'c str {
+    if from_keys.contains(&col) {
+        return DOUBLED_EDGES_ORIG_FROM;
+    }
+    if to_keys.contains(&col) {
+        return DOUBLED_EDGES_ORIG_TO;
+    }
+    col
+}
+
 /// Name of the doubled-edge CTE for the pattern's endpoint cypher aliases +
 /// edge table (#617). Deliberately NOT `vlp_`-prefixed: several render passes
 /// special-case `vlp_`-named CTEs (column pruning, outer-alias mapping) and
@@ -1183,12 +1208,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
     /// passes through unchanged.
     fn edge_identity_column<'c>(&self, col: &'c str) -> &'c str {
         if self.uses_doubled_edges() {
-            if col == self.relationship_from_column {
-                return DOUBLED_EDGES_ORIG_FROM;
-            }
-            if col == self.relationship_to_column {
-                return DOUBLED_EDGES_ORIG_TO;
-            }
+            return doubled_edge_identity_col(
+                col,
+                &[self.relationship_from_column.as_str()],
+                &[self.relationship_to_column.as_str()],
+            );
         }
         col
     }


### PR DESCRIPTION
Phase 1 slice 4 of #887: collapse the #617 doubled-edge orientation mapping to ONE helper.

- `doubled_edge_identity_col(col, from_keys, to_keys)` in `variable_length_cte.rs` — from-key membership → `__cg_orig_from`, to-key → `__cg_orig_to`, else pass-through.
- `edge_identity_column` (recursive VLP) delegates (single-column keys, `uses_doubled_edges()` gate).
- filter_builder's inline #806 copy (the seventh spelling instance) delegates (composite key sets, `undirected_doubled` gate).

Byte-identical per arm (single-element contains == old equality; same membership semantics composite). Zero corpus/golden churn, 1723 unit + 593 integration + ratchet green, clippy clean.

Docs updated in this PR (design doc slice 4 entry + out-of-shape verdict on the flat pairwise guard; PRIORITIES.md).