### PR TITLE
refactor(#887): introduce EdgeIdentity policy value; arms spell through it (Phase 2)

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -512,7 +512,7 @@ fixed stats fixture.
 - #411 (generic `.id`) — only after P-4, per the plan.
 - Denorm foreign-edge union-dimension design (perf-staged, memory notes).
 - DeltaGraph live-workspace validation items (`GA_READINESS.md`).
-- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #1033 + 4 #1034, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
+- **VLP edge-identity & uniqueness unification — #887**  ◐ (Phase 0 #890, Phase 1 slices 1 #893 + 2 #1032 + 3 #1033 + 4 #1034, Phase 2 #TBD, **behavior cluster COMPLETE: #806 + #628 + #710 + #808/#606 fixed**; only the Phase 1–2 refactor remains)
   (`docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`). Bug-driven refactor of the
   VLP relationship-uniqueness axis: one canonical `EdgeUniquenessPolicy`
   (`PatternSchemaContext`-derived, rule-#7 clean) replaces ~14 inline sites / 3

--- a/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
+++ b/docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md
@@ -360,9 +360,31 @@ shared helper. Once the identity spellings are consolidated, the policy type
 before deleting the inline copies. Intentional divergences surface as assert
 failures, not production bugs.
 
-### Phase 2 — switch the recursive generator to the policy → refactor, byte-identical
-Replace the VLC inline switches (2805/3183/3315) and the identity helpers with
-policy calls. Goldens byte-identical (asserts from Phase 1 guarantee it).
+### Phase 2 — switch the recursive generator to the policy → **DONE (PR #TBD)** — refactor, byte-identical
+**Shipped.** Introduced the `EdgeIdentity` policy VALUE
+(`variable_length_cte.rs`, §3's `EdgeIdentity` spine, spelling-only per the
+NOTE below): `EdgeIdColumns { edge_id, from_col, to_col }` (schema `edge_id`:
+`Single` → bare `rel.col`, `Composite` → `tuple(...)`, `None` → the `(from,to)`
+pair) and `OrigOrientation` (the #617 doubled-edge wrap — every identity
+column reads its original-orientation name). Both live arms spell through it:
+- `VariableLengthCteGenerator::build_edge_tuple_recursive` →
+  `self.edge_identity().spell(ctor, rel_alias)`. The `uses_doubled_edges()`
+  gate moved from the per-column `edge_identity_column` (DELETED) into the
+  policy boundary `edge_identity()`, evaluated at the same spell time (all
+  fields final — `undirected_single_walk` is set post-construction at
+  `cte_manager`), so output is byte-identical by substitution per arm.
+- `DenormalizedCteStrategy::edge_tuple` (CM) → `self.identity.spell(...)`,
+  a plain `EdgeIdColumns` value built at both construction sites from the
+  already-resolved `resolve_edge_id` (denorm has no #617 doubled-edge CTE).
+- The FK-edge node pair (`build_fk_edge_tuple`) stays per-shape — it spells
+  across TWO aliases with per-site node-id column sets (base vs recursive
+  hop), per the Phase-1 CORRECTION. It already routes through
+  `spell_tuple_parts`, the shared tuple wrapper.
+The `EdgeUniquenessPolicy { kind, identity }` wrapper struct +
+`from_pattern(PatternSchemaContext, shape)` land with the PREDICATE fold
+(Phase 2b) — `kind` is exactly the axis the NOTE below defers. Zero
+corpus/golden churn, full 1723-unit + 593-integration suite + ratchet green.
+Review APPROVE-0.
 
 NOTE (2026-08-02): this phase can NO LONGER "retire the second
 `uses_edge_uniqueness` copy by making CM Denormalized consume the same policy" as

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use crate::clickhouse_query_generator::variable_length_cte::{
-    spell_edge_identity, NodeProperty, VariableLengthCteGenerator,
+    EdgeIdentity, NodeProperty, VariableLengthCteGenerator,
 };
 use crate::graph_catalog::{
     config::Identifier, graph_schema::GraphSchema, EdgeAccessStrategy, JoinStrategy,
@@ -342,14 +342,17 @@ pub struct DenormalizedCteStrategy {
     from_col: String,
     to_col: String,
     schema: Arc<GraphSchema>,
-    /// Schema-declared composite edge identity (`edge_id:` in YAML), if any.
-    /// When present it uniquely distinguishes parallel edges that share the
-    /// same `(from, to)` node pair (e.g. two flights on the same route keyed by
-    /// `flight_id`); when `None` the edge identity degrades to the `(from, to)`
-    /// pair. Resolved once at construction from the relationship's schema so
-    /// [`Self::edge_tuple`] can spell the correct trail-uniqueness key (#710,
-    /// the denormalized counterpart of #806/#606's flat/recursive paths).
-    edge_id: Option<Identifier>,
+    /// The policy value spelling this walk's edge identity (the #887
+    /// [`EdgeIdentity`]). A denormalized VLP is a single directional recursive
+    /// self-join over the edge table (no #617 doubled-edge CTE), so the
+    /// identity is always the plain [`EdgeIdentity::EdgeIdColumns`]: the
+    /// schema-declared `edge_id` (resolved once at construction) when present
+    /// — distinguishing parallel edges that share one `(from, to)` node pair,
+    /// e.g. two flights on one route keyed by `flight_id` (#710) — else the
+    /// `(from, to)` pair. Consumed by [`Self::edge_tuple`] to spell the
+    /// trail-uniqueness key (the denormalized counterpart of #806/#606's
+    /// flat/recursive paths).
+    identity: EdgeIdentity,
 }
 
 // ===== DenormalizedCteStrategy =====
@@ -377,14 +380,22 @@ impl DenormalizedCteStrategy {
     ) -> Result<Self, CteError> {
         // Validate that this is a denormalized schema
         match &pattern_ctx.join_strategy {
-            JoinStrategy::SingleTableScan { table } => Ok(Self {
-                pattern_ctx: pattern_ctx.clone(),
-                table: table.clone(),
-                from_col: Self::get_from_column(pattern_ctx)?,
-                to_col: Self::get_to_column(pattern_ctx)?,
-                edge_id: Self::resolve_edge_id(pattern_ctx, &schema),
-                schema,
-            }),
+            JoinStrategy::SingleTableScan { table } => {
+                let from_col = Self::get_from_column(pattern_ctx)?;
+                let to_col = Self::get_to_column(pattern_ctx)?;
+                Ok(Self {
+                    pattern_ctx: pattern_ctx.clone(),
+                    table: table.clone(),
+                    from_col: from_col.clone(),
+                    to_col: to_col.clone(),
+                    identity: EdgeIdentity::EdgeIdColumns {
+                        edge_id: Self::resolve_edge_id(pattern_ctx, &schema),
+                        from_col,
+                        to_col,
+                    },
+                    schema,
+                })
+            }
             _ => Err(CteError::InvalidStrategy(
                 "DenormalizedCteStrategy requires JoinStrategy::SingleTableScan".into(),
             )),
@@ -455,14 +466,9 @@ impl DenormalizedCteStrategy {
     /// `next` (recursive case), seeded into / matched against `path_edges` for
     /// trail-uniqueness.
     ///
-    /// When the relationship schema declares an `edge_id` (#710, the
-    /// denormalized counterpart of #806/#606), that column (or composite tuple)
-    /// IS the edge identity — this distinguishes parallel edges that share the
-    /// same `(from, to)` node pair (e.g. two flights on one route keyed by
-    /// `flight_id`), which the `(from, to)` pair alone would collapse into a
-    /// single edge and under-count. Spelled via the shared
-    /// [`spell_edge_identity`] helper — the same spelling the standard emitter
-    /// uses in [`VariableLengthCteGenerator::build_edge_tuple_recursive`]:
+    /// Spelled via the shared policy value [`Self::identity`] (the #887
+    /// [`EdgeIdentity`]) — the same spelling the standard emitter uses in
+    /// [`VariableLengthCteGenerator::build_edge_tuple_recursive`] (#710):
     ///
     /// - `Single(col)` → bare `rel_alias.col` (scalar element),
     /// - `Composite(cols)` → `tuple(rel_alias.c1, rel_alias.c2, …)`,
@@ -471,15 +477,11 @@ impl DenormalizedCteStrategy {
     ///
     /// A denormalized VLP is a single directional recursive self-join over the
     /// edge table (no #617 doubled-edge CTE), so no from/to orientation swap is
-    /// needed — the identity columns are read verbatim (identity `map_col`).
+    /// needed — the identity is the plain [`EdgeIdentity::EdgeIdColumns`].
     fn edge_tuple(&self, rel_alias: &str) -> String {
-        spell_edge_identity(
+        self.identity.spell(
             crate::sql_generator::function_mapper::current_function_mapper().tuple_constructor(),
-            &self.edge_id,
             rel_alias,
-            &self.from_col,
-            &self.to_col,
-            |col| col,
         )
     }
 
@@ -1485,12 +1487,17 @@ impl VariableLengthCteStrategy {
 
         // ✅ REFACTORING COMPLETE: Use refactored DenormalizedCteStrategy directly
         if self.is_denormalized {
+            let (rel_from_col, rel_to_col) = (self.rel_from_col.clone(), self.rel_to_col.clone());
             let strategy = DenormalizedCteStrategy {
                 pattern_ctx: self.pattern_ctx.clone(),
                 table: self.rel_table.clone(),
-                from_col: self.rel_from_col.clone(),
-                to_col: self.rel_to_col.clone(),
-                edge_id: DenormalizedCteStrategy::resolve_edge_id(&self.pattern_ctx, schema),
+                from_col: rel_from_col.clone(),
+                to_col: rel_to_col.clone(),
+                identity: EdgeIdentity::EdgeIdColumns {
+                    edge_id: DenormalizedCteStrategy::resolve_edge_id(&self.pattern_ctx, schema),
+                    from_col: rel_from_col,
+                    to_col: rel_to_col,
+                },
                 schema: Arc::new(schema.clone()),
             };
 
@@ -1823,7 +1830,11 @@ mod tests {
             table: "flights".to_string(),
             from_col: "Origin".to_string(),
             to_col: "Dest".to_string(),
-            edge_id,
+            identity: EdgeIdentity::EdgeIdColumns {
+                edge_id,
+                from_col: "Origin".to_string(),
+                to_col: "Dest".to_string(),
+            },
             schema,
         }
     }

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -85,12 +85,13 @@ fn spell_tuple_parts(tuple_ctor: &str, parts: Vec<String>) -> String {
 }
 
 /// Spell the edge-identity value for one hop, reading the edge columns off
-/// `rel_alias`. The single shared spelling for "what makes one edge the same
-/// edge" — used by the recursive generator's
-/// [`VariableLengthCteGenerator::build_edge_tuple_recursive`] and the
-/// denormalized strategy's `edge_tuple` (`cte_manager/mod.rs`) so both spell
-/// the identity identically (#710: parallel edges sharing one `(from, to)`
-/// node pair must not collapse).
+/// `rel_alias`. The single shared spelling primitive for "what makes one edge
+/// the same edge" — consumed by the policy value [`EdgeIdentity`] (which
+/// resolves the per-walk orientation) and, through it, by the recursive
+/// generator's [`VariableLengthCteGenerator::build_edge_tuple_recursive`] and
+/// the denormalized strategy's `edge_tuple` (`cte_manager/mod.rs`), so both
+/// spell the identity identically (#710: parallel edges sharing one `(from,
+/// to)` node pair must not collapse).
 ///
 /// Returns SQL like `tuple(r.from_id, r.to_id)` or `tuple(r.date, r.num, …)`.
 /// Shape depends on `edge_id`: a `Single` column emits a bare `rel.col`; a
@@ -98,8 +99,8 @@ fn spell_tuple_parts(tuple_ctor: &str, parts: Vec<String>) -> String {
 /// node pair. `map_col` is applied to EVERY referenced column, letting callers
 /// inject per-walk orientation corrections — the #617 doubled-edge walk maps
 /// the from/to id columns to their original-orientation names via
-/// [`VariableLengthCteGenerator::edge_identity_column`], while the
-/// single-directional denormalized walk passes the identity mapping.
+/// [`doubled_edge_identity_col`] (the [`EdgeIdentity::OrigOrientation`] arm),
+/// while the single-directional denormalized walk passes the identity mapping.
 pub fn spell_edge_identity(
     tuple_ctor: &str,
     edge_id: &Option<Identifier>,
@@ -141,8 +142,9 @@ pub use crate::graph_catalog::graph_schema::{DOUBLED_EDGES_ORIG_FROM, DOUBLED_ED
 /// must read `__cg_orig_from`; likewise for `to_keys` → `__cg_orig_to`. Any
 /// other column (e.g. an `edge_id` extension column like `timestamp`) is
 /// orientation-independent and passes through unchanged. The single shared
-/// spelling of this correction — used by the recursive generator's
-/// [`VariableLengthCteGenerator::edge_identity_column`] and by the flat
+/// spelling of this correction — used by the policy value's
+/// [`EdgeIdentity::OrigOrientation`] arm (recursive generator's
+/// [`VariableLengthCteGenerator::edge_identity`]) and by the flat
 /// exact-bound path (`filter_builder.rs`, #806), so both walks resolve the
 /// identity identically. `from_keys`/`to_keys` may be single- or
 /// composite-column sets; the caller decides whether this walk is doubled.
@@ -158,6 +160,66 @@ pub fn doubled_edge_identity_col<'c>(
         return DOUBLED_EDGES_ORIG_TO;
     }
     col
+}
+
+/// The edge-identity VALUE for one schema shape + walk: "what makes one edge
+/// the same edge" on this VLP — the single authority the recursive generator
+/// and the denormalized strategy spell [`path_edges`] membership from (the
+/// `EdgeIdentity` spine of the #887 unification; Phase 2 of
+/// `docs/design/VLP_EDGE_IDENTITY_UNIFICATION.md`).
+///
+/// Two axes compose:
+/// - **Shape**: [`EdgeIdentity::EdgeIdColumns`] — the schema `edge_id` (a
+///   `Single` column spells a bare `rel.col`; a `Composite` key a
+///   `tuple(...)`; `None` the `(from, to)` node pair).
+/// - **Walk**: [`EdgeIdentity::OrigOrientation`] — the #617 doubled-edge
+///   orientation correction applied to the same columns: every identity column
+///   reads its ORIGINAL-orientation name, so the reverse-orientation rows of
+///   one physical edge share one identity.
+///
+/// The FK-edge node pair (`build_fk_edge_tuple`) is deliberately NOT folded
+/// in: it spells across TWO aliases with per-site node-id column sets (base
+/// vs recursive hop) — a per-shape spelling, per the Phase-1 CORRECTION.
+#[derive(Debug, Clone)]
+pub enum EdgeIdentity {
+    /// Schema-declared `edge_id` (Single → bare column; Composite → tuple),
+    /// else the `(from, to)` node pair — read off one hop alias.
+    EdgeIdColumns {
+        edge_id: Option<Identifier>,
+        from_col: String,
+        to_col: String,
+    },
+    /// #617: the same columns read through the original-orientation names of a
+    /// doubled-edge walk (`__cg_orig_from` / `__cg_orig_to`).
+    OrigOrientation {
+        edge_id: Option<Identifier>,
+        from_col: String,
+        to_col: String,
+    },
+}
+
+impl EdgeIdentity {
+    /// Spell the identity value for ONE hop, reading the edge columns off
+    /// `rel_alias`. Byte-identical to the pre-policy spellings:
+    /// [`spell_edge_identity`] with an identity `map_col`, or — under
+    /// [`EdgeIdentity::OrigOrientation`] — with the `doubled_edge_identity_col`
+    /// mapping of the shape's from/to columns.
+    pub fn spell(&self, tuple_ctor: &str, rel_alias: &str) -> String {
+        match self {
+            EdgeIdentity::EdgeIdColumns {
+                edge_id,
+                from_col,
+                to_col,
+            } => spell_edge_identity(tuple_ctor, edge_id, rel_alias, from_col, to_col, |c| c),
+            EdgeIdentity::OrigOrientation {
+                edge_id,
+                from_col,
+                to_col,
+            } => spell_edge_identity(tuple_ctor, edge_id, rel_alias, from_col, to_col, |c| {
+                doubled_edge_identity_col(c, &[from_col.as_str()], &[to_col.as_str()])
+            }),
+        }
+    }
 }
 
 /// Name of the doubled-edge CTE for the pattern's endpoint cypher aliases +
@@ -1200,46 +1262,51 @@ impl<'a> VariableLengthCteGenerator<'a> {
         Some(format!("vp.end_id != {}", value_part))
     }
 
-    /// #617: on the doubled-edge walk, an edge-identity column reference must
-    /// resolve to the ORIGINAL-orientation value: the from/to id columns are
-    /// swapped in reverse-orientation rows, so referencing them directly would
-    /// give one physical edge two distinct identities (breaking
-    /// trail-uniqueness). Any other column is orientation-independent and
-    /// passes through unchanged.
-    fn edge_identity_column<'c>(&self, col: &'c str) -> &'c str {
+    /// The edge identity for THIS walk as a policy value (the #887
+    /// [`EdgeIdentity`]). The #617 doubled-edge orientation decision
+    /// ([`Self::uses_doubled_edges`]) is made HERE — once, at the policy
+    /// boundary — instead of per column: an undirected doubled walk wraps the
+    /// shape in [`EdgeIdentity::OrigOrientation`] so every identity column
+    /// reads its original-orientation name (from/to → `__cg_orig_from/to`,
+    /// any other column passes through unchanged); every other walk spells the
+    /// shape verbatim. Same evaluation time as the pre-policy per-column gate
+    /// (spell time, all fields final), so output is byte-identical.
+    fn edge_identity(&self) -> EdgeIdentity {
+        let (edge_id, from_col, to_col) = (
+            self.edge_id.clone(),
+            self.relationship_from_column.clone(),
+            self.relationship_to_column.clone(),
+        );
         if self.uses_doubled_edges() {
-            return doubled_edge_identity_col(
-                col,
-                &[self.relationship_from_column.as_str()],
-                &[self.relationship_to_column.as_str()],
-            );
+            EdgeIdentity::OrigOrientation {
+                edge_id,
+                from_col,
+                to_col,
+            }
+        } else {
+            EdgeIdentity::EdgeIdColumns {
+                edge_id,
+                from_col,
+                to_col,
+            }
         }
-        col
     }
 
-    /// Build the edge-identity tuple for one hop, reading the edge columns off
+    /// Build the edge-identity value for one hop, reading the edge columns off
     /// `rel_alias`. Used by both the base case (`rel_alias` =
     /// `self.relationship_alias`) and the recursive case.
     ///
     /// Returns SQL like `tuple(r.from_id, r.to_id)` or `tuple(r.date, r.num, …)`.
-    /// Shape depends on `self.edge_id`: a `Single` column emits a bare
-    /// `rel.col`; a `Composite` key builds a `tuple(...)`; `None` defaults to the
-    /// `(from, to)` node pair. #617 doubled-edge walk: from/to are SWAPPED in
-    /// reverse-orientation rows, so the `None` identity comes from the
-    /// original-orientation columns — otherwise the same physical edge traversed
-    /// the other way would look like a different relationship and
-    /// trail-uniqueness would not hold. Delegates to the shared
-    /// [`spell_edge_identity`] (the denormalized strategy spells via the same
-    /// helper, #710).
+    /// The shape is the walk's policy value ([`Self::edge_identity`],
+    /// [`EdgeIdentity`]): schema `edge_id` (Single → bare `rel.col`;
+    /// Composite → `tuple(...)`), else the `(from, to)` node pair — and, on
+    /// the #617 doubled-edge walk, every column reads its original-orientation
+    /// name, so the same physical edge traversed the other way does not look
+    /// like a different relationship and trail-uniqueness holds. The
+    /// denormalized strategy spells via the same policy value (#710).
     fn build_edge_tuple_recursive(&self, rel_alias: &str) -> String {
-        spell_edge_identity(
-            current_function_mapper().tuple_constructor(),
-            &self.edge_id,
-            rel_alias,
-            &self.relationship_from_column,
-            &self.relationship_to_column,
-            |col| self.edge_identity_column(col),
-        )
+        self.edge_identity()
+            .spell(current_function_mapper().tuple_constructor(), rel_alias)
     }
 
     /// Build the `(from_id, to_id)` edge-identity tuple for ONE FK-edge hop,


### PR DESCRIPTION
Phase 2 of #887 (spelling-only, per the design doc's 2026-08-02 NOTE — the predicate axis stays deferred).

**New `EdgeIdentity` policy value** (`variable_length_cte.rs`):
- `EdgeIdColumns { edge_id, from_col, to_col }` — schema `edge_id` (Single → bare `rel.col`, Composite → `tuple(...)`, None → `(from,to)` pair)
- `OrigOrientation` — the #617 doubled-edge wrap: every identity column reads its original-orientation name

**Live arms now consume the policy value**:
- `build_edge_tuple_recursive` → `self.edge_identity().spell(ctor, rel_alias)`; the `uses_doubled_edges()` gate moved from the per-column `edge_identity_column` (deleted) into the policy boundary, evaluated at the same spell time — byte-identical per arm
- `DenormalizedCteStrategy::edge_tuple` (CM) → `self.identity.spell(...)`, a plain `EdgeIdColumns` value built at both construction sites from the already-resolved `resolve_edge_id`

FK-edge node pair stays per-shape (two aliases + per-site node-id sets — Phase-1 CORRECTION); the `EdgeUniquenessPolicy { kind, identity }` wrapper + `from_pattern` land with the predicate fold (2b).

Zero corpus/golden churn, full 1723-unit + 593-integration + ratchet green, clippy clean. Docs updated in this PR.