### PR TITLE
fix(#583): standard single-hop undirected OPTIONAL spurious NULL row (standard stage)

### DIFF
--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -528,6 +528,17 @@ impl RelationshipSchema {
         !self.is_fk_edge && self.from_node_properties.is_none() && self.to_node_properties.is_none()
     }
 
+    /// True when the relationship is a **polymorphic** edge: all edge types
+    /// share one physical table, discriminated by a type column. Schema-pattern
+    /// classification belongs here (axis-dispatch rule); callers outside
+    /// `graph_catalog` should use this instead of testing the raw discriminator
+    /// field. Note `is_plain_edge_table()` is ALSO true for a polymorphic edge
+    /// (it has no denormalized node properties), so a caller that needs "plain
+    /// AND monomorphic" must combine `is_plain_edge_table() && !is_polymorphic()`.
+    pub fn is_polymorphic(&self) -> bool {
+        self.type_column.is_some()
+    }
+
     /// True for a **self-referencing FK-edge** — an FK-edge whose from- and
     /// to-node are the same table with no denormalized node properties (e.g.
     /// `(child:Object)-[:PARENT]->(parent:Object)` on one `fs_objects` table, or

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -57,6 +57,18 @@ impl AnalyzerPass for BidirectionalUnion {
             normalize_undirected_denorm_single_hop_optional_rels(&base, graph_schema)
                 .or_else(|| (!Arc::ptr_eq(&base, &logical_plan)).then_some(base))
         };
+        // #583 (standard stage): standard plain-edge single-hop undirected
+        // OPTIONAL hops get the SAME single-anchor-LEFT-JOIN-over-match-union
+        // treatment as the denorm stage — the two-arm split's independent
+        // per-arm NULL-extension manufactures a spurious `(anchor, NULL)` row
+        // (and, worse than denorm, a phantom `(NULL, neighbor)` row from the
+        // neighbor-driven second arm) for one-role-only anchors. Compose after
+        // the denorm pass: run on whichever plan the prior passes produced.
+        let normalized = {
+            let base = normalized.unwrap_or_else(|| logical_plan.clone());
+            normalize_undirected_standard_single_hop_optional_rels(&base, graph_schema)
+                .or_else(|| (!Arc::ptr_eq(&base, &logical_plan)).then_some(base))
+        };
         match normalized {
             Some(plan) => {
                 let inner = transform_bidirectional(&plan, plan_ctx, graph_schema)?;
@@ -295,6 +307,112 @@ pub(crate) fn undirected_denorm_single_hop_optional_core(
         && matches!(rel_schema.to_id, Identifier::Single(_))
 }
 
+/// #583 (standard stage): scope predicate for the STANDARD single-hop undirected
+/// OPTIONAL rewrite — the direct analog of
+/// [`undirected_denorm_single_hop_optional_scope`] for a *separate* edge table
+/// (plain edge table + separate node table) rather than a denormalized
+/// embedded-node edge. In scope → the GraphRel is NOT split into a two-arm
+/// Union; instead the render layer targets a single anchor
+/// `LEFT JOIN (match-union subquery) AS <neighbor>` keyed on a synthetic anchor
+/// key, so NULL-extension happens ONCE (only for genuinely neighborless
+/// anchors) instead of independently per direction arm.
+pub(crate) fn undirected_standard_single_hop_optional_scope(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    graph_rel.direction == Direction::Either
+        && graph_rel.is_optional.unwrap_or(false)
+        && undirected_standard_single_hop_optional_core(graph_rel, graph_schema)
+}
+
+/// #583 (standard stage): direction-agnostic core of
+/// [`undirected_standard_single_hop_optional_scope`]. Shared with the RENDER
+/// layer, which re-derives the decision from `was_undirected == Some(true)` +
+/// this core (the analyzer has normalized direction to Outgoing by then). Like
+/// the denorm core, the `was_undirected` flag alone cannot distinguish "one
+/// normalized single hop" from "one monotone arm of a legacy split" — but this
+/// core predicate can: whenever it is true the analyzer normalized instead of
+/// splitting.
+///
+/// Differs from the denorm core in exactly two places: the endpoint-shape check
+/// (standard anchors are bare `GraphNode`s, never the denorm role-Union) and
+/// the final gate (`is_plain_edge_table()` instead of
+/// `rel_has_both_nodes_denormalized`). Everything else — single hop, one known
+/// rel type, same-label endpoints, scalar from/to ids — is identical.
+pub(crate) fn undirected_standard_single_hop_optional_core(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    // Plain single hop only: no VLP, no shortestPath, no deferred multi-type
+    // (pattern_combinations) union.
+    if graph_rel.variable_length.is_some()
+        || graph_rel.shortest_path_mode.is_some()
+        || graph_rel.pattern_combinations.is_some()
+    {
+        return false;
+    }
+    // Endpoints must be plain single-node scans. Unlike denorm, standard anchors
+    // are always bare `GraphNode`s (there is no denormalized standalone-scan
+    // Union), so a `GraphNode` on both sides is the whole shape; a nested
+    // `GraphRel` / `CartesianProduct` is chained / disconnected and handled by
+    // the #589 / #590 gates, not here.
+    if !matches!(graph_rel.left.as_ref(), LogicalPlan::GraphNode(_))
+        || !matches!(graph_rel.right.as_ref(), LogicalPlan::GraphNode(_))
+    {
+        return false;
+    }
+    // Exactly one known relationship type. Labels at this stage may be composite
+    // schema keys ("FOLLOWS::User::User"); resolve those directly, falling back
+    // to the plain-type index (mirrors `undirected_vlp_single_walk_core`).
+    let Some(labels) = graph_rel.labels.as_ref() else {
+        return false;
+    };
+    let [rel_type] = labels.as_slice() else {
+        return false;
+    };
+    let rel_schema = if let Some(rs) = graph_schema.get_relationships_schema_opt(rel_type) {
+        rs
+    } else {
+        let plain_type = rel_type.split("::").next().unwrap_or(rel_type);
+        let rel_schemas = graph_schema.rel_schemas_for_type(plain_type);
+        if rel_schemas.len() != 1 {
+            return false;
+        }
+        rel_schemas[0]
+    };
+    // Plain (separate) edge table with same-label endpoints and SINGLE-column
+    // from/to ids. `is_plain_edge_table()` consumes the schema-catalog
+    // classification (not FK-edge, neither role-property map present), never a
+    // raw plan-level flag (CLAUDE.md rule 7) — the exact gate
+    // `undirected_vlp_single_walk_core` (#617) uses for the standard VLP walk.
+    // Same-label endpoints keep the match-union role swap type-consistent; the
+    // single-column-id requirement keeps the gate in lockstep with the render
+    // helper, which builds the anchor key from `from_id.first_column()` only.
+    // Composite-id standard edges keep the legacy two-arm behavior (#583 stays
+    // open for them). `doubled_edge_walk_compatible()` rejects property mappings
+    // that target the from/to columns (a reverse-arm row would read the swapped
+    // value) — the same hazard the #617 doubled-edge walk guards against, and
+    // this match-union performs the identical orientation swap.
+    //
+    // POLYMORPHIC exclusion (`!is_polymorphic()`): a polymorphic edge stores
+    // ALL edge types in one shared table discriminated by a type column (e.g.
+    // `interactions` with a discriminator IN {FOLLOWS, AUTHORED, …}).
+    // `is_plain_edge_table()` is TRUE for it (it has no denormalized role-
+    // property maps), but the match-union subquery this stage builds does NOT
+    // carry the per-type discriminator predicate — so a polymorphic edge would
+    // silently match EVERY type, not just the requested one. Polymorphic
+    // undirected single hops therefore keep the legacy two-arm path (which does
+    // inject the discriminator per branch); #583 stays open for them. Routed
+    // through the schema-catalog `is_polymorphic()` dispatch API (CLAUDE.md
+    // rule 7), never the raw discriminator field.
+    rel_schema.is_plain_edge_table()
+        && !rel_schema.is_polymorphic()
+        && rel_schema.from_node == rel_schema.to_node
+        && matches!(rel_schema.from_id, Identifier::Single(_))
+        && matches!(rel_schema.to_id, Identifier::Single(_))
+        && rel_schema.doubled_edge_walk_compatible()
+}
+
 /// #583: rewrite every in-scope denormalized single-hop undirected OPTIONAL
 /// GraphRel (see [`undirected_denorm_single_hop_optional_scope`]) to
 /// `direction: Outgoing` + `was_undirected: Some(true)`. Returns `None` when
@@ -326,6 +444,55 @@ fn normalize_undirected_denorm_single_hop_optional_rels(
             if undirected_denorm_single_hop_optional_scope(graph_rel, graph_schema) {
                 crate::debug_print!(
                     "🔄 BidirectionalUnion(#583): denorm single-hop undirected OPTIONAL '{}' → doubled-edge single anchor LEFT JOIN (no Union split)",
+                    graph_rel.alias
+                );
+                *changed = true;
+                return LogicalPlan::GraphRel(GraphRel {
+                    direction: Direction::Outgoing,
+                    was_undirected: Some(true),
+                    ..graph_rel.clone()
+                });
+            }
+        }
+        mapped
+    }
+    let mut changed = false;
+    let new_plan = walk(plan, graph_schema, &mut changed);
+    changed.then(|| Arc::new(new_plan))
+}
+
+/// #583 (standard stage): rewrite every in-scope STANDARD single-hop undirected
+/// OPTIONAL GraphRel (see [`undirected_standard_single_hop_optional_scope`]) to
+/// `direction: Outgoing` + `was_undirected: Some(true)`. Returns `None` when
+/// nothing changed. The render layer recognizes the marker on a standard
+/// plain-edge single hop and targets a single anchor
+/// `LEFT JOIN (match-union subquery) AS <neighbor>` instead of the two-arm
+/// split. Mirrors [`normalize_undirected_denorm_single_hop_optional_rels`]; the
+/// only differences are in the shared scope core (endpoint shape + the
+/// `is_plain_edge_table()` gate).
+///
+/// #583 scope discipline (identical to the denorm stage): this pass must NOT
+/// fire inside a chained-optional structure. `OPTIONAL (a)-[:R]-(b) OPTIONAL
+/// (b)-[:R]->(c)` is #589 territory, and #589's loud guard keys on the inner
+/// hop still being `Direction::Either` when the Projection arm inspects it. If
+/// this pre-pass normalized that inner hop to `Outgoing` first it would
+/// silently neutralize the #589 guard and render a shape #583 was never scoped
+/// for. So when the tree contains a chained-optional-undirected structure, skip
+/// normalization entirely and let #589 fire.
+fn normalize_undirected_standard_single_hop_optional_rels(
+    plan: &Arc<LogicalPlan>,
+    graph_schema: &GraphSchema,
+) -> Option<Arc<LogicalPlan>> {
+    // Defer to #589 for chained-optional-undirected patterns (see doc above).
+    if has_chained_optional_nested_undirected_edge(plan) {
+        return None;
+    }
+    fn walk(plan: &LogicalPlan, graph_schema: &GraphSchema, changed: &mut bool) -> LogicalPlan {
+        let mapped = plan.map_children(|child| walk(child, graph_schema, changed));
+        if let LogicalPlan::GraphRel(graph_rel) = &mapped {
+            if undirected_standard_single_hop_optional_scope(graph_rel, graph_schema) {
+                crate::debug_print!(
+                    "🔄 BidirectionalUnion(#583 standard): standard single-hop undirected OPTIONAL '{}' → match-union single anchor LEFT JOIN (no Union split)",
                     graph_rel.alias
                 );
                 *changed = true;

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -727,96 +727,6 @@ fn consensus_endpoint_label(
     }
 }
 
-/// #583 (standard stage): build the single `LEFT JOIN (two-arm match-union
-/// subquery) AS <neighbor>` that replaces the spurious-NULL two-arm split for a
-/// STANDARD plain-edge single-hop undirected OPTIONAL hop.
-///
-/// The caller has already verified (via `was_undirected == Some(true)` + the
-/// shared analyzer core `undirected_standard_single_hop_optional_core`) that
-/// `graph_rel` is exactly this shape. This helper resolves the anchor id, the
-/// edge ViewScan (`center`) and the neighbor ViewScan (`right`), builds the
-/// doubled-neighbor subquery, and returns the outer join keyed on the synthetic
-/// `__cg_combined_anchor_key`. Fails LOUD if any required column info is missing
-/// — the caller must NOT fall through to the single-direction chain.
-fn build_standard_undirected_optional_join(
-    graph_rel: &crate::query_planner::logical_plan::GraphRel,
-    _schema: &GraphSchema,
-) -> RenderPlanBuilderResult<Join> {
-    let anchor_alias = graph_rel.left_connection.clone();
-    let anchor_id = crate::render_plan::plan_builder_helpers::extract_id_column(&graph_rel.left)
-        .ok_or_else(|| {
-            RenderBuildError::MissingTableInfo(format!(
-                "#583 standard: anchor node id column for undirected OPTIONAL rel '{}'",
-                graph_rel.alias
-            ))
-        })?;
-    let neighbor_alias = graph_rel.right_connection.clone();
-
-    let LogicalPlan::ViewScan(edge_vs) = graph_rel.center.as_ref() else {
-        return Err(RenderBuildError::MissingTableInfo(format!(
-            "#583 standard: edge ViewScan for undirected OPTIONAL rel '{}'",
-            graph_rel.alias
-        )));
-    };
-    let neighbor_vs = match graph_rel.right.as_ref() {
-        LogicalPlan::GraphNode(gn) => match gn.input.as_ref() {
-            LogicalPlan::ViewScan(vs) => vs,
-            _ => {
-                return Err(RenderBuildError::MissingTableInfo(format!(
-                    "#583 standard: neighbor ViewScan for undirected OPTIONAL rel '{}'",
-                    graph_rel.alias
-                )))
-            }
-        },
-        _ => {
-            return Err(RenderBuildError::MissingTableInfo(format!(
-                "#583 standard: neighbor GraphNode for undirected OPTIONAL rel '{}'",
-                graph_rel.alias
-            )))
-        }
-    };
-
-    let subquery =
-        crate::render_plan::plan_builder_helpers::build_standard_doubled_neighbor_subquery(
-            edge_vs,
-            neighbor_vs,
-            &neighbor_alias,
-        )
-        .ok_or_else(|| {
-            RenderBuildError::MissingTableInfo(format!(
-                "#583 standard: undirected OPTIONAL rel '{}' was marked was_undirected by the \
-             analyzer, but the edge (table '{}') / neighbor (table '{}') ViewScans lack the \
-             from/to id or node columns needed to build the match-union subquery — refusing to \
-             emit a silently-single-direction join",
-                graph_rel.alias, edge_vs.source_table, neighbor_vs.source_table,
-            ))
-        })?;
-
-    Ok(Join {
-        join_type: JoinType::Left,
-        table_name: subquery,
-        table_alias: neighbor_alias.clone(),
-        joining_on: vec![OperatorApplication {
-            operator: Operator::Equal,
-            operands: vec![
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(neighbor_alias.clone()),
-                    column: PropertyValue::Column("__cg_combined_anchor_key".to_string()),
-                }),
-                RenderExpr::PropertyAccessExp(PropertyAccess {
-                    table_alias: TableAlias(anchor_alias.clone()),
-                    column: PropertyValue::Column(anchor_id.clone()),
-                }),
-            ],
-        }],
-        pre_filter: None,
-        from_id_column: None,
-        to_id_column: None,
-        graph_rel: None,
-        is_cartesian: false,
-    })
-}
-
 fn condition_references_alias(cond: &super::render_expr::OperatorApplication, alias: &str) -> bool {
     use super::render_expr::RenderExpr;
     for operand in &cond.operands {
@@ -1443,41 +1353,79 @@ impl JoinBuilder for LogicalPlan {
                 // #583 (standard stage): a STANDARD plain-edge single-hop
                 // undirected OPTIONAL hop is kept as ONE directed
                 // `was_undirected` GraphRel by the BidirectionalUnion analyzer
-                // (instead of the spurious-NULL two-arm Union split). For this
-                // shape the joins come from GraphJoinInference's pre-computed
-                // `graph_joins.joins` (a directed edge LEFT JOIN + neighbor LEFT
-                // JOIN chain that renders only the FORWARD orientation — proven
-                // live: undercounts 11 vs the correct 23), NOT from re-deriving
-                // via the GraphRel arm. So intercept HERE, before those
-                // pre-inferred joins are converted, and replace the whole chain
-                // with ONE `LEFT JOIN (two-arm match-union subquery) AS
-                // <neighbor>` keyed on a synthetic anchor key. The anchor FROM
-                // is built by extract_from and is unchanged. Re-derive from
-                // `was_undirected == Some(true)` + the shared analyzer core
-                // (CLAUDE.md rule 7 — no raw schema-flag branching). Fail LOUD
-                // if the subquery cannot be built rather than fall through to
-                // the single-direction chain (ground-rule-1).
-                if let Some(graph_rel) = find_graph_rel(&graph_joins.input) {
+                // (instead of the spurious-NULL two-arm Union split). Mirroring
+                // the merged denorm stage, we do NOT rebuild the join chain —
+                // we let the normal conversion below produce the directed
+                // `FROM anchor LEFT JOIN <edge> LEFT JOIN neighbor` chain (plus
+                // any sibling joins from other patterns), then SWAP just the
+                // edge join's target table for a doubled-edge subquery (each
+                // edge row in BOTH orientations, from/to swapped under their
+                // original names). The surrounding join conditions
+                // (`<rel>.from_id = anchor.id`, `neighbor.id = <rel>.to_id`) are
+                // written for the raw edge table and work UNCHANGED against the
+                // doubled subquery, now matching both orientations — so a single
+                // anchor LEFT JOIN NULL-extends once, only for zero-neighbor
+                // anchors. Exposing the edge alias + all its columns keeps
+                // `count(r)` / `r.<prop>` resolvable, and swapping only ONE join
+                // preserves sibling-pattern joins (the #1039 review's
+                // BLOCKING-1 and -3). Computed here (needs the rel schema); the
+                // actual table swap happens after the join vector is built.
+                let standard_undirected_doubled_edge: Option<(String, String)> = 'doubled: {
+                    let Some(graph_rel) = find_graph_rel(&graph_joins.input) else {
+                        break 'doubled None;
+                    };
                     // The shared analyzer core is intentionally optional-AND-
-                    // direction-agnostic (it is re-used by the analyzer scope
+                    // direction-agnostic (re-used by the analyzer scope
                     // predicate, which adds `is_optional` + `Direction::Either`).
-                    // The LEGACY two-arm split ALSO stamps `was_undirected` on
-                    // its branches — including for NON-optional undirected hops
-                    // and for polymorphic edges it splits per-type — so the
-                    // marker + core alone would also match a legacy split arm.
-                    // Require `is_optional` here so this restructure fires ONLY
-                    // for the exact shape the #583 analyzer pass produces (a
-                    // single normalized OPTIONAL hop), never a split arm.
-                    if graph_rel.was_undirected == Some(true)
+                    // The LEGACY split ALSO stamps `was_undirected` on its
+                    // branches (incl. non-optional and per-type polymorphic), so
+                    // the marker + core alone would also match a split arm —
+                    // require `is_optional` so this fires ONLY for the shape the
+                    // #583 analyzer pass produces (one normalized OPTIONAL hop).
+                    if !(graph_rel.was_undirected == Some(true)
                         && graph_rel.is_optional.unwrap_or(false)
                         && crate::query_planner::analyzer::bidirectional_union::undirected_standard_single_hop_optional_core(
                             graph_rel, schema,
-                        )
+                        ))
                     {
-                        return build_standard_undirected_optional_join(graph_rel, schema)
-                            .map(|j| vec![j]);
+                        break 'doubled None;
                     }
-                }
+                    let LogicalPlan::ViewScan(edge_vs) = graph_rel.center.as_ref() else {
+                        break 'doubled None;
+                    };
+                    // Resolve the rel schema (label → plain type) so the subquery
+                    // projects EVERY physical edge column (incl. the edge-id
+                    // column `count(r)` needs). Mirrors the analyzer gate.
+                    let rel_schema = graph_rel.labels.as_ref().and_then(|labels| {
+                        labels.first().and_then(|rel_type| {
+                            schema.get_relationships_schema_opt(rel_type).or_else(|| {
+                                let plain = rel_type.split("::").next().unwrap_or(rel_type);
+                                schema.rel_schemas_for_type(plain).into_iter().next()
+                            })
+                        })
+                    });
+                    let subquery = rel_schema.and_then(|rs| {
+                        crate::render_plan::plan_builder_helpers::build_standard_doubled_edge_subquery(
+                            edge_vs, rs,
+                        )
+                    });
+                    match subquery {
+                        Some(sql) => Some((graph_rel.alias.clone(), sql)),
+                        // Marked by the analyzer but the subquery could not be
+                        // built — fail LOUD rather than emit a single-direction
+                        // join (ground-rule-1). Surface via the outer function.
+                        None => {
+                            return Err(RenderBuildError::MissingTableInfo(format!(
+                                "#583 standard: undirected OPTIONAL rel '{}' was marked \
+                                 was_undirected by the analyzer, but its edge ViewScan (table \
+                                 '{}') / relationship schema lacks the from/to id columns needed \
+                                 to build the doubled-edge subquery — refusing to emit a \
+                                 silently-single-direction join",
+                                graph_rel.alias, edge_vs.source_table,
+                            )));
+                        }
+                    }
+                };
 
                 // Convert joins
                 // FROM markers (joins with empty joining_on and Inner type) are used by extract_from(), not extract_joins()
@@ -2067,6 +2015,36 @@ impl JoinBuilder for LogicalPlan {
                 // so this pass touches only the optional node's join. It is idempotent:
                 // it skips a predicate already present in the join's pre_filter.
                 apply_optional_node_pre_filters(&graph_joins.input, &mut joins)?;
+
+                // #583 (standard stage): swap the edge join's target table for
+                // the doubled-edge subquery computed above. Only the ONE join
+                // whose alias is the relationship alias is rewritten; the
+                // neighbor join and any sibling-pattern joins are untouched
+                // (preserving the #1039 review's BLOCKING-3 fix). The join
+                // condition (`<rel>.from_id = anchor.id`) is unchanged and now
+                // matches both orientations because the reverse arm swaps
+                // from/to under their original names.
+                if let Some((edge_alias, subquery)) = standard_undirected_doubled_edge {
+                    let mut swapped = false;
+                    for j in joins.iter_mut() {
+                        if j.table_alias == edge_alias {
+                            j.table_name = subquery.clone();
+                            swapped = true;
+                            break;
+                        }
+                    }
+                    if !swapped {
+                        // The analyzer marked this hop but the expected edge join
+                        // is not in the built set — fail LOUD rather than silently
+                        // leave the single-direction join (ground-rule-1).
+                        return Err(RenderBuildError::MissingTableInfo(format!(
+                            "#583 standard: doubled-edge subquery built for rel '{}' but no join \
+                             with that alias was found to swap — refusing to emit a \
+                             single-direction join",
+                            edge_alias
+                        )));
+                    }
+                }
 
                 joins
             }

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -105,6 +105,43 @@ fn find_graph_rel(plan: &LogicalPlan) -> Option<&crate::query_planner::logical_p
     }
 }
 
+/// #583 (standard stage): collect EVERY `GraphRel` in the plan subtree,
+/// including both sides of a `CartesianProduct` (a disconnected multi-clause
+/// pattern) — unlike [`find_graph_rel`], which is left-biased and would miss a
+/// standard-undirected-optional hop sitting in the right branch. Used to (a)
+/// find each hop whose edge join must be swapped for the doubled-edge subquery
+/// and (b) assert none was left un-swapped (a silent single-direction render
+/// would otherwise slip through where `find_graph_rel` returned the wrong rel —
+/// the #1039 round-2 review's Finding 1).
+fn collect_graph_rels<'a>(
+    plan: &'a LogicalPlan,
+    out: &mut Vec<&'a crate::query_planner::logical_plan::GraphRel>,
+) {
+    use crate::query_planner::logical_plan::*;
+    match plan {
+        LogicalPlan::GraphRel(gr) => {
+            out.push(gr);
+            // A GraphRel's endpoints can themselves nest further GraphRels
+            // (chained hops); descend so every hop is seen.
+            collect_graph_rels(&gr.left, out);
+            collect_graph_rels(&gr.center, out);
+            collect_graph_rels(&gr.right, out);
+        }
+        LogicalPlan::Projection(p) => collect_graph_rels(&p.input, out),
+        LogicalPlan::Filter(f) => collect_graph_rels(&f.input, out),
+        LogicalPlan::GroupBy(g) => collect_graph_rels(&g.input, out),
+        LogicalPlan::GraphNode(gn) => collect_graph_rels(&gn.input, out),
+        LogicalPlan::OrderBy(o) => collect_graph_rels(&o.input, out),
+        LogicalPlan::Limit(l) => collect_graph_rels(&l.input, out),
+        LogicalPlan::Skip(s) => collect_graph_rels(&s.input, out),
+        LogicalPlan::CartesianProduct(cp) => {
+            collect_graph_rels(&cp.left, out);
+            collect_graph_rels(&cp.right, out);
+        }
+        _ => {}
+    }
+}
+
 /// #1006: inject lazy own-table LEFT JOINs for denormalized-edge endpoints
 /// whose non-embedded properties were referenced (see
 /// [`crate::server::query_context::register_own_table_join_request`]; the
@@ -1370,62 +1407,73 @@ impl JoinBuilder for LogicalPlan {
                 // preserves sibling-pattern joins (the #1039 review's
                 // BLOCKING-1 and -3). Computed here (needs the rel schema); the
                 // actual table swap happens after the join vector is built.
-                let standard_undirected_doubled_edge: Option<(String, String)> = 'doubled: {
-                    let Some(graph_rel) = find_graph_rel(&graph_joins.input) else {
-                        break 'doubled None;
-                    };
-                    // The shared analyzer core is intentionally optional-AND-
-                    // direction-agnostic (re-used by the analyzer scope
-                    // predicate, which adds `is_optional` + `Direction::Either`).
-                    // The LEGACY split ALSO stamps `was_undirected` on its
-                    // branches (incl. non-optional and per-type polymorphic), so
-                    // the marker + core alone would also match a split arm —
-                    // require `is_optional` so this fires ONLY for the shape the
-                    // #583 analyzer pass produces (one normalized OPTIONAL hop).
-                    if !(graph_rel.was_undirected == Some(true)
-                        && graph_rel.is_optional.unwrap_or(false)
-                        && crate::query_planner::analyzer::bidirectional_union::undirected_standard_single_hop_optional_core(
-                            graph_rel, schema,
-                        ))
-                    {
-                        break 'doubled None;
-                    }
-                    let LogicalPlan::ViewScan(edge_vs) = graph_rel.center.as_ref() else {
-                        break 'doubled None;
-                    };
-                    // Resolve the rel schema (label → plain type) so the subquery
-                    // projects EVERY physical edge column (incl. the edge-id
-                    // column `count(r)` needs). Mirrors the analyzer gate.
-                    let rel_schema = graph_rel.labels.as_ref().and_then(|labels| {
-                        labels.first().and_then(|rel_type| {
-                            schema.get_relationships_schema_opt(rel_type).or_else(|| {
-                                let plain = rel_type.split("::").next().unwrap_or(rel_type);
-                                schema.rel_schemas_for_type(plain).into_iter().next()
+                //
+                // Collect EVERY matching hop in the tree (both sides of a
+                // CartesianProduct — a disconnected multi-clause pattern can put
+                // the undirected-optional hop in the RIGHT branch, which the
+                // left-biased `find_graph_rel` would miss, silently leaving a
+                // single-direction join: the round-2 review's Finding 1). Every
+                // collected hop MUST get its edge join swapped below or we fail
+                // LOUD — never a silent single-direction render.
+                let mut standard_undirected_doubled_edges: Vec<(String, String)> = Vec::new();
+                {
+                    let mut rels = Vec::new();
+                    collect_graph_rels(&graph_joins.input, &mut rels);
+                    for graph_rel in rels {
+                        // The shared analyzer core is intentionally optional-AND-
+                        // direction-agnostic (re-used by the analyzer scope
+                        // predicate, which adds `is_optional` + `Direction::Either`).
+                        // The LEGACY split ALSO stamps `was_undirected` on its
+                        // branches (incl. non-optional and per-type polymorphic),
+                        // so the marker + core alone would also match a split arm —
+                        // require `is_optional` so this fires ONLY for the shape the
+                        // #583 analyzer pass produces (one normalized OPTIONAL hop).
+                        if !(graph_rel.was_undirected == Some(true)
+                            && graph_rel.is_optional.unwrap_or(false)
+                            && crate::query_planner::analyzer::bidirectional_union::undirected_standard_single_hop_optional_core(
+                                graph_rel, schema,
+                            ))
+                        {
+                            continue;
+                        }
+                        let LogicalPlan::ViewScan(edge_vs) = graph_rel.center.as_ref() else {
+                            continue;
+                        };
+                        // Resolve the rel schema (label → plain type) so the
+                        // subquery projects EVERY physical edge column (incl. the
+                        // edge-id column `count(r)` needs). Mirrors the analyzer gate.
+                        let rel_schema = graph_rel.labels.as_ref().and_then(|labels| {
+                            labels.first().and_then(|rel_type| {
+                                schema.get_relationships_schema_opt(rel_type).or_else(|| {
+                                    let plain = rel_type.split("::").next().unwrap_or(rel_type);
+                                    schema.rel_schemas_for_type(plain).into_iter().next()
+                                })
                             })
-                        })
-                    });
-                    let subquery = rel_schema.and_then(|rs| {
-                        crate::render_plan::plan_builder_helpers::build_standard_doubled_edge_subquery(
-                            edge_vs, rs,
-                        )
-                    });
-                    match subquery {
-                        Some(sql) => Some((graph_rel.alias.clone(), sql)),
-                        // Marked by the analyzer but the subquery could not be
-                        // built — fail LOUD rather than emit a single-direction
-                        // join (ground-rule-1). Surface via the outer function.
-                        None => {
-                            return Err(RenderBuildError::MissingTableInfo(format!(
-                                "#583 standard: undirected OPTIONAL rel '{}' was marked \
-                                 was_undirected by the analyzer, but its edge ViewScan (table \
-                                 '{}') / relationship schema lacks the from/to id columns needed \
-                                 to build the doubled-edge subquery — refusing to emit a \
-                                 silently-single-direction join",
-                                graph_rel.alias, edge_vs.source_table,
-                            )));
+                        });
+                        let subquery = rel_schema.and_then(|rs| {
+                            crate::render_plan::plan_builder_helpers::build_standard_doubled_edge_subquery(
+                                edge_vs, rs,
+                            )
+                        });
+                        match subquery {
+                            Some(sql) => standard_undirected_doubled_edges
+                                .push((graph_rel.alias.clone(), sql)),
+                            // Marked by the analyzer but the subquery could not be
+                            // built — fail LOUD rather than emit a single-direction
+                            // join (ground-rule-1).
+                            None => {
+                                return Err(RenderBuildError::MissingTableInfo(format!(
+                                    "#583 standard: undirected OPTIONAL rel '{}' was marked \
+                                     was_undirected by the analyzer, but its edge ViewScan (table \
+                                     '{}') / relationship schema lacks the from/to id columns \
+                                     needed to build the doubled-edge subquery — refusing to emit \
+                                     a silently-single-direction join",
+                                    graph_rel.alias, edge_vs.source_table,
+                                )));
+                            }
                         }
                     }
-                };
+                }
 
                 // Convert joins
                 // FROM markers (joins with empty joining_on and Inner type) are used by extract_from(), not extract_joins()
@@ -2017,30 +2065,38 @@ impl JoinBuilder for LogicalPlan {
                 apply_optional_node_pre_filters(&graph_joins.input, &mut joins)?;
 
                 // #583 (standard stage): swap the edge join's target table for
-                // the doubled-edge subquery computed above. Only the ONE join
-                // whose alias is the relationship alias is rewritten; the
+                // the doubled-edge subquery(ies) computed above. Only the join
+                // whose alias is a normalized rel alias is rewritten; the
                 // neighbor join and any sibling-pattern joins are untouched
                 // (preserving the #1039 review's BLOCKING-3 fix). The join
                 // condition (`<rel>.from_id = anchor.id`) is unchanged and now
                 // matches both orientations because the reverse arm swaps
                 // from/to under their original names.
-                if let Some((edge_alias, subquery)) = standard_undirected_doubled_edge {
+                //
+                // EVERY collected hop must be swapped: if a `was_undirected +
+                // is_optional + core` rel was normalized by the analyzer but its
+                // edge join is not in the built set (e.g. a disconnected
+                // multi-clause pattern whose FOLLOWS join was promoted to FROM,
+                // or a shape the join builder rendered differently), fail LOUD
+                // rather than silently leave a single-direction join
+                // (ground-rule-1 — the round-2 review's Finding 1).
+                for (edge_alias, subquery) in &standard_undirected_doubled_edges {
                     let mut swapped = false;
                     for j in joins.iter_mut() {
-                        if j.table_alias == edge_alias {
+                        if &j.table_alias == edge_alias {
                             j.table_name = subquery.clone();
                             swapped = true;
                             break;
                         }
                     }
                     if !swapped {
-                        // The analyzer marked this hop but the expected edge join
-                        // is not in the built set — fail LOUD rather than silently
-                        // leave the single-direction join (ground-rule-1).
                         return Err(RenderBuildError::MissingTableInfo(format!(
-                            "#583 standard: doubled-edge subquery built for rel '{}' but no join \
-                             with that alias was found to swap — refusing to emit a \
-                             single-direction join",
+                            "#583 standard: undirected OPTIONAL rel '{}' was normalized by the \
+                             analyzer (was_undirected), but no LEFT JOIN carrying its alias was \
+                             found to swap for the doubled-edge subquery — the reverse-direction \
+                             matches would be silently dropped. Refusing to emit a \
+                             single-direction join (rewrite the hop with an explicit direction, \
+                             or split the query).",
                             edge_alias
                         )));
                     }

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -727,6 +727,96 @@ fn consensus_endpoint_label(
     }
 }
 
+/// #583 (standard stage): build the single `LEFT JOIN (two-arm match-union
+/// subquery) AS <neighbor>` that replaces the spurious-NULL two-arm split for a
+/// STANDARD plain-edge single-hop undirected OPTIONAL hop.
+///
+/// The caller has already verified (via `was_undirected == Some(true)` + the
+/// shared analyzer core `undirected_standard_single_hop_optional_core`) that
+/// `graph_rel` is exactly this shape. This helper resolves the anchor id, the
+/// edge ViewScan (`center`) and the neighbor ViewScan (`right`), builds the
+/// doubled-neighbor subquery, and returns the outer join keyed on the synthetic
+/// `__cg_combined_anchor_key`. Fails LOUD if any required column info is missing
+/// — the caller must NOT fall through to the single-direction chain.
+fn build_standard_undirected_optional_join(
+    graph_rel: &crate::query_planner::logical_plan::GraphRel,
+    _schema: &GraphSchema,
+) -> RenderPlanBuilderResult<Join> {
+    let anchor_alias = graph_rel.left_connection.clone();
+    let anchor_id = crate::render_plan::plan_builder_helpers::extract_id_column(&graph_rel.left)
+        .ok_or_else(|| {
+            RenderBuildError::MissingTableInfo(format!(
+                "#583 standard: anchor node id column for undirected OPTIONAL rel '{}'",
+                graph_rel.alias
+            ))
+        })?;
+    let neighbor_alias = graph_rel.right_connection.clone();
+
+    let LogicalPlan::ViewScan(edge_vs) = graph_rel.center.as_ref() else {
+        return Err(RenderBuildError::MissingTableInfo(format!(
+            "#583 standard: edge ViewScan for undirected OPTIONAL rel '{}'",
+            graph_rel.alias
+        )));
+    };
+    let neighbor_vs = match graph_rel.right.as_ref() {
+        LogicalPlan::GraphNode(gn) => match gn.input.as_ref() {
+            LogicalPlan::ViewScan(vs) => vs,
+            _ => {
+                return Err(RenderBuildError::MissingTableInfo(format!(
+                    "#583 standard: neighbor ViewScan for undirected OPTIONAL rel '{}'",
+                    graph_rel.alias
+                )))
+            }
+        },
+        _ => {
+            return Err(RenderBuildError::MissingTableInfo(format!(
+                "#583 standard: neighbor GraphNode for undirected OPTIONAL rel '{}'",
+                graph_rel.alias
+            )))
+        }
+    };
+
+    let subquery =
+        crate::render_plan::plan_builder_helpers::build_standard_doubled_neighbor_subquery(
+            edge_vs,
+            neighbor_vs,
+            &neighbor_alias,
+        )
+        .ok_or_else(|| {
+            RenderBuildError::MissingTableInfo(format!(
+                "#583 standard: undirected OPTIONAL rel '{}' was marked was_undirected by the \
+             analyzer, but the edge (table '{}') / neighbor (table '{}') ViewScans lack the \
+             from/to id or node columns needed to build the match-union subquery — refusing to \
+             emit a silently-single-direction join",
+                graph_rel.alias, edge_vs.source_table, neighbor_vs.source_table,
+            ))
+        })?;
+
+    Ok(Join {
+        join_type: JoinType::Left,
+        table_name: subquery,
+        table_alias: neighbor_alias.clone(),
+        joining_on: vec![OperatorApplication {
+            operator: Operator::Equal,
+            operands: vec![
+                RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: TableAlias(neighbor_alias.clone()),
+                    column: PropertyValue::Column("__cg_combined_anchor_key".to_string()),
+                }),
+                RenderExpr::PropertyAccessExp(PropertyAccess {
+                    table_alias: TableAlias(anchor_alias.clone()),
+                    column: PropertyValue::Column(anchor_id.clone()),
+                }),
+            ],
+        }],
+        pre_filter: None,
+        from_id_column: None,
+        to_id_column: None,
+        graph_rel: None,
+        is_cartesian: false,
+    })
+}
+
 fn condition_references_alias(cond: &super::render_expr::OperatorApplication, alias: &str) -> bool {
     use super::render_expr::RenderExpr;
     for operand in &cond.operands {
@@ -1348,6 +1438,45 @@ impl JoinBuilder for LogicalPlan {
 
                 if let Some(ref skip_alias) = first_join_alias_to_skip {
                     log::info!("🔧 Will skip first join '{}' as it will be used as FROM (anchor_table is None)", skip_alias);
+                }
+
+                // #583 (standard stage): a STANDARD plain-edge single-hop
+                // undirected OPTIONAL hop is kept as ONE directed
+                // `was_undirected` GraphRel by the BidirectionalUnion analyzer
+                // (instead of the spurious-NULL two-arm Union split). For this
+                // shape the joins come from GraphJoinInference's pre-computed
+                // `graph_joins.joins` (a directed edge LEFT JOIN + neighbor LEFT
+                // JOIN chain that renders only the FORWARD orientation — proven
+                // live: undercounts 11 vs the correct 23), NOT from re-deriving
+                // via the GraphRel arm. So intercept HERE, before those
+                // pre-inferred joins are converted, and replace the whole chain
+                // with ONE `LEFT JOIN (two-arm match-union subquery) AS
+                // <neighbor>` keyed on a synthetic anchor key. The anchor FROM
+                // is built by extract_from and is unchanged. Re-derive from
+                // `was_undirected == Some(true)` + the shared analyzer core
+                // (CLAUDE.md rule 7 — no raw schema-flag branching). Fail LOUD
+                // if the subquery cannot be built rather than fall through to
+                // the single-direction chain (ground-rule-1).
+                if let Some(graph_rel) = find_graph_rel(&graph_joins.input) {
+                    // The shared analyzer core is intentionally optional-AND-
+                    // direction-agnostic (it is re-used by the analyzer scope
+                    // predicate, which adds `is_optional` + `Direction::Either`).
+                    // The LEGACY two-arm split ALSO stamps `was_undirected` on
+                    // its branches — including for NON-optional undirected hops
+                    // and for polymorphic edges it splits per-type — so the
+                    // marker + core alone would also match a legacy split arm.
+                    // Require `is_optional` here so this restructure fires ONLY
+                    // for the exact shape the #583 analyzer pass produces (a
+                    // single normalized OPTIONAL hop), never a split arm.
+                    if graph_rel.was_undirected == Some(true)
+                        && graph_rel.is_optional.unwrap_or(false)
+                        && crate::query_planner::analyzer::bidirectional_union::undirected_standard_single_hop_optional_core(
+                            graph_rel, schema,
+                        )
+                    {
+                        return build_standard_undirected_optional_join(graph_rel, schema)
+                            .map(|j| vec![j]);
+                    }
                 }
 
                 // Convert joins

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -253,6 +253,116 @@ pub(super) fn is_denormalized_union(plan: &LogicalPlan) -> bool {
     }
 }
 
+/// #583 (standard stage): build a two-arm match-union subquery for a STANDARD
+/// single-hop undirected OPTIONAL pattern, aliased AS the neighbor node so the
+/// existing single anchor LEFT JOIN sees every neighbor reachable in EITHER
+/// orientation, keyed on a synthetic anchor-key column.
+///
+/// The undirected split renders each direction as an independent chain
+/// (`users AS a LEFT JOIN follows t1 LEFT JOIN users b`, then a second arm
+/// driven by `users AS b`) stapled with UNION ALL; each arm NULL-extends blind
+/// to the other, so a one-role-only anchor gets a spurious `(anchor, NULL)` AND
+/// the neighbor-driven second arm manufactures a phantom `(NULL, neighbor)` row
+/// (#583, worse than denorm). Instead the analyzer keeps ONE directed
+/// `was_undirected` GraphRel and this helper builds:
+///
+/// ```sql
+/// (SELECT t1.<from_id> AS __cg_combined_anchor_key, b.<node cols>
+///  FROM <edge_table> AS t1 JOIN <node_table> AS b ON b.<node_id> = t1.<to_id>
+///  UNION ALL
+///  SELECT t1.<to_id> AS __cg_combined_anchor_key, b.<node cols>
+///  FROM <edge_table> AS t1 JOIN <node_table> AS b ON b.<node_id> = t1.<from_id>)
+/// ```
+///
+/// aliased `AS b` (the neighbor alias). Because the neighbor's own physical
+/// columns are projected under their RAW names, the outer query's `b.<prop>`
+/// references resolve directly against this subquery — no endpoint-reference
+/// rewriting is needed (that keeps this stage clear of the VLP endpoint
+/// resolution machinery). The outer join `b.__cg_combined_anchor_key =
+/// a.<anchor_id>` then NULL-extends exactly once, for genuinely zero-neighbor
+/// anchors only (proven live: 22 rows / 0 spurious vs the buggy 24, and an
+/// isolated node gets exactly one `(anchor, NULL)`).
+///
+/// The synthetic key name (`__cg_combined_anchor_key`) is the same one the
+/// #479/#597 optimizer fold exports, for consistency. Every column reference is
+/// table-qualified so the projection is unambiguous across the two arms.
+///
+/// Returns `None` when required column info is missing (edge from/to id, or the
+/// neighbor's node-id / properties) — the caller fails LOUD rather than emit a
+/// silently-single-direction join.
+pub(super) fn build_standard_doubled_neighbor_subquery(
+    edge_vs: &crate::query_planner::logical_plan::ViewScan,
+    neighbor_vs: &crate::query_planner::logical_plan::ViewScan,
+    neighbor_alias: &str,
+) -> Option<String> {
+    let q = crate::clickhouse_query_generator::quote_identifier;
+
+    // Edge role id columns (single-column only; composite standard ids keep the
+    // legacy two-arm path per the analyzer gate).
+    let from_id = edge_vs.from_id.as_ref()?.first_column().to_string();
+    let to_id = edge_vs.to_id.as_ref()?.first_column().to_string();
+    let edge_table = &edge_vs.source_table;
+
+    // Neighbor node table + id column.
+    let node_table = &neighbor_vs.source_table;
+    let node_id = &neighbor_vs.id_column;
+
+    // Neighbor's physical columns, projected under their RAW names so outer
+    // `b.<prop>` references resolve directly. Deterministic sorted order (shared
+    // helper) so the two UNION arms align column-for-column. Always include the
+    // node-id column even if it is not a mapped property (some references — and
+    // the join key exposure — need it).
+    let mut node_cols: Vec<String> =
+        super::clause_extractors::extract_sorted_properties(&neighbor_vs.property_mapping)
+            .into_iter()
+            .map(|(_, physical)| physical)
+            .collect();
+    if !node_cols.iter().any(|c| c == node_id) {
+        node_cols.push(node_id.clone());
+    }
+    node_cols.sort();
+    node_cols.dedup();
+    let node_proj = node_cols
+        .iter()
+        .map(|c| format!("{}.{}", q(neighbor_alias), q(c)))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let key = "__cg_combined_anchor_key";
+    // Forward arm: anchor key = edge.from_id, neighbor joined on edge.to_id.
+    // Reverse arm: anchor key = edge.to_id, neighbor joined on edge.from_id.
+    let forward = format!(
+        "SELECT {t1}.{fk} AS {key}, {proj} FROM {edge} AS {t1} JOIN {node} AS {b} ON {b}.{nid} = {t1}.{tk}",
+        t1 = q(EDGE_ARM_ALIAS),
+        fk = q(&from_id),
+        key = key,
+        proj = node_proj,
+        edge = edge_table,
+        node = node_table,
+        b = q(neighbor_alias),
+        nid = q(node_id),
+        tk = q(&to_id),
+    );
+    let reverse = format!(
+        "SELECT {t1}.{tk} AS {key}, {proj} FROM {edge} AS {t1} JOIN {node} AS {b} ON {b}.{nid} = {t1}.{fk}",
+        t1 = q(EDGE_ARM_ALIAS),
+        tk = q(&to_id),
+        key = key,
+        proj = node_proj,
+        edge = edge_table,
+        node = node_table,
+        b = q(neighbor_alias),
+        nid = q(node_id),
+        fk = q(&from_id),
+    );
+    Some(format!("({forward} UNION ALL {reverse})"))
+}
+
+/// Inner edge alias used inside [`build_standard_doubled_neighbor_subquery`].
+/// Local to the subquery, so any short name is safe; kept distinct from the
+/// outer anchor/neighbor aliases.
+const EDGE_ARM_ALIAS: &str = "t1";
+
 /// #583: build a doubled-edge subquery for a denormalized single-hop undirected
 /// OPTIONAL pattern, so the existing single anchor LEFT JOIN sees every physical
 /// edge in BOTH orientations.

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -253,47 +253,51 @@ pub(super) fn is_denormalized_union(plan: &LogicalPlan) -> bool {
     }
 }
 
-/// #583 (standard stage): build a two-arm match-union subquery for a STANDARD
-/// single-hop undirected OPTIONAL pattern, aliased AS the neighbor node so the
-/// existing single anchor LEFT JOIN sees every neighbor reachable in EITHER
-/// orientation, keyed on a synthetic anchor-key column.
+/// #583 (standard stage): build a doubled-EDGE subquery for a STANDARD
+/// single-hop undirected OPTIONAL pattern, aliased AS the EDGE (relationship
+/// alias) so it drops in as a replacement for the raw edge table in the
+/// existing `FROM anchor LEFT JOIN <edge> LEFT JOIN neighbor` chain — mirroring
+/// the merged denorm stage (`build_denorm_doubled_edge_subquery`), the only
+/// difference being that a standard schema keeps the neighbor node in a SEPARATE
+/// table (so the neighbor `LEFT JOIN` is left untouched, not embedded here).
 ///
 /// The undirected split renders each direction as an independent chain
-/// (`users AS a LEFT JOIN follows t1 LEFT JOIN users b`, then a second arm
-/// driven by `users AS b`) stapled with UNION ALL; each arm NULL-extends blind
-/// to the other, so a one-role-only anchor gets a spurious `(anchor, NULL)` AND
-/// the neighbor-driven second arm manufactures a phantom `(NULL, neighbor)` row
-/// (#583, worse than denorm). Instead the analyzer keeps ONE directed
-/// `was_undirected` GraphRel and this helper builds:
+/// (`users AS a LEFT JOIN follows LEFT JOIN users b`, then a second arm driven
+/// by `users AS b`) stapled with UNION ALL; each arm NULL-extends blind to the
+/// other, so a one-role-only anchor gets a spurious `(anchor, NULL)` AND the
+/// neighbor-driven second arm manufactures a phantom `(NULL, neighbor)` row
+/// (#583). Instead the analyzer keeps ONE directed `was_undirected` GraphRel and
+/// this helper replaces the raw edge table with:
 ///
 /// ```sql
-/// (SELECT t1.<from_id> AS __cg_combined_anchor_key, b.<node cols>
-///  FROM <edge_table> AS t1 JOIN <node_table> AS b ON b.<node_id> = t1.<to_id>
+/// (SELECT e.<from_id>, e.<to_id>, e.<edge cols…> FROM <edge_table> AS e
 ///  UNION ALL
-///  SELECT t1.<to_id> AS __cg_combined_anchor_key, b.<node cols>
-///  FROM <edge_table> AS t1 JOIN <node_table> AS b ON b.<node_id> = t1.<from_id>)
+///  SELECT e.<to_id> AS <from_id>, e.<from_id> AS <to_id>, e.<edge cols…>
+///         FROM <edge_table> AS e)
 /// ```
 ///
-/// aliased `AS b` (the neighbor alias). Because the neighbor's own physical
-/// columns are projected under their RAW names, the outer query's `b.<prop>`
-/// references resolve directly against this subquery — no endpoint-reference
-/// rewriting is needed (that keeps this stage clear of the VLP endpoint
-/// resolution machinery). The outer join `b.__cg_combined_anchor_key =
-/// a.<anchor_id>` then NULL-extends exactly once, for genuinely zero-neighbor
-/// anchors only (proven live: 22 rows / 0 spurious vs the buggy 24, and an
-/// isolated node gets exactly one `(anchor, NULL)`).
+/// aliased `AS <rel_alias>`. The reverse arm swaps `from_id`/`to_id` under their
+/// ORIGINAL names, so the surrounding join conditions written for the raw edge
+/// table (`<rel>.from_id = anchor.id` and `neighbor.id = <rel>.to_id`) work
+/// UNCHANGED and now match BOTH orientations — a single anchor LEFT JOIN then
+/// NULL-extends exactly once, only for genuinely zero-neighbor anchors. Because
+/// the edge alias and ALL its physical columns (incl. the edge-id column
+/// `count(r)` lowers to, sourced from `all_valid_physical_columns()`) are
+/// exposed, `count(r)` / `r.<prop>` / `WHERE r.<prop>` / `RETURN r` all resolve
+/// (unlike an AS-neighbor subquery, which hid the edge — the #1039 review's
+/// BLOCKING-1). Proven live: 23 rows / one `(anchor, NULL)` for an isolated
+/// node; `count(r)` correct (with the engine's `join_use_nulls=1`).
 ///
-/// The synthetic key name (`__cg_combined_anchor_key`) is the same one the
-/// #479/#597 optimizer fold exports, for consistency. Every column reference is
-/// table-qualified so the projection is unambiguous across the two arms.
+/// Every reference is table-qualified (`e.<col>`) so the reverse arm's
+/// `e.<to_id> AS <from_id>` binds the RAW column, never the just-created alias
+/// (ClickHouse would otherwise silently flip the value — mirrors the denorm
+/// doubled-edge qualification discipline).
 ///
-/// Returns `None` when required column info is missing (edge from/to id, or the
-/// neighbor's node-id / properties) — the caller fails LOUD rather than emit a
-/// silently-single-direction join.
-pub(super) fn build_standard_doubled_neighbor_subquery(
+/// Returns `None` when the edge from/to id columns are missing — the caller
+/// fails LOUD rather than emit a silently-single-direction join.
+pub(super) fn build_standard_doubled_edge_subquery(
     edge_vs: &crate::query_planner::logical_plan::ViewScan,
-    neighbor_vs: &crate::query_planner::logical_plan::ViewScan,
-    neighbor_alias: &str,
+    rel_schema: &crate::graph_catalog::graph_schema::RelationshipSchema,
 ) -> Option<String> {
     let q = crate::clickhouse_query_generator::quote_identifier;
 
@@ -303,65 +307,64 @@ pub(super) fn build_standard_doubled_neighbor_subquery(
     let to_id = edge_vs.to_id.as_ref()?.first_column().to_string();
     let edge_table = &edge_vs.source_table;
 
-    // Neighbor node table + id column.
-    let node_table = &neighbor_vs.source_table;
-    let node_id = &neighbor_vs.id_column;
+    // Edge-own pass-through columns: EVERY physical column the relationship row
+    // can carry (property_mappings + the edge identity column(s) — `edge_id`,
+    // which `count(r)` lowers to and which need not be in `property_mappings`),
+    // MINUS the from/to id columns handled by the explicit swap. Sourced from the
+    // schema-catalog `all_valid_physical_columns()` so an edge-id-only column is
+    // never dropped (dropping it would make `count(r)` reference a column the
+    // subquery doesn't project → ClickHouse Code 47). Deterministic order.
+    let role_cols: std::collections::HashSet<String> =
+        [from_id.clone(), to_id.clone()].into_iter().collect();
+    let mut passthrough: Vec<String> = rel_schema
+        .all_valid_physical_columns()
+        .into_iter()
+        .filter(|c| !role_cols.contains(c))
+        .collect();
+    passthrough.sort();
+    passthrough.dedup();
 
-    // Neighbor's physical columns, projected under their RAW names so outer
-    // `b.<prop>` references resolve directly. Deterministic sorted order (shared
-    // helper) so the two UNION arms align column-for-column. Always include the
-    // node-id column even if it is not a mapped property (some references — and
-    // the join key exposure — need it).
-    let mut node_cols: Vec<String> =
-        super::clause_extractors::extract_sorted_properties(&neighbor_vs.property_mapping)
-            .into_iter()
-            .map(|(_, physical)| physical)
-            .collect();
-    if !node_cols.iter().any(|c| c == node_id) {
-        node_cols.push(node_id.clone());
+    // Forward arm: from/to verbatim, then every edge-own column.
+    let mut forward_cols: Vec<String> = vec![
+        format!("{e}.{}", q(&from_id), e = q(EDGE_ARM_ALIAS)),
+        format!("{e}.{}", q(&to_id), e = q(EDGE_ARM_ALIAS)),
+    ];
+    for c in &passthrough {
+        forward_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
     }
-    node_cols.sort();
-    node_cols.dedup();
-    let node_proj = node_cols
-        .iter()
-        .map(|c| format!("{}.{}", q(neighbor_alias), q(c)))
-        .collect::<Vec<_>>()
-        .join(", ");
 
-    let key = "__cg_combined_anchor_key";
-    // Forward arm: anchor key = edge.from_id, neighbor joined on edge.to_id.
-    // Reverse arm: anchor key = edge.to_id, neighbor joined on edge.from_id.
-    let forward = format!(
-        "SELECT {t1}.{fk} AS {key}, {proj} FROM {edge} AS {t1} JOIN {node} AS {b} ON {b}.{nid} = {t1}.{tk}",
-        t1 = q(EDGE_ARM_ALIAS),
-        fk = q(&from_id),
-        key = key,
-        proj = node_proj,
-        edge = edge_table,
-        node = node_table,
-        b = q(neighbor_alias),
-        nid = q(node_id),
-        tk = q(&to_id),
-    );
-    let reverse = format!(
-        "SELECT {t1}.{tk} AS {key}, {proj} FROM {edge} AS {t1} JOIN {node} AS {b} ON {b}.{nid} = {t1}.{fk}",
-        t1 = q(EDGE_ARM_ALIAS),
-        tk = q(&to_id),
-        key = key,
-        proj = node_proj,
-        edge = edge_table,
-        node = node_table,
-        b = q(neighbor_alias),
-        nid = q(node_id),
-        fk = q(&from_id),
-    );
-    Some(format!("({forward} UNION ALL {reverse})"))
+    // Reverse arm: swap from/to under their ORIGINAL names; edge-own columns
+    // unchanged. Table-qualified so the AS target never shadows the raw source.
+    let mut reverse_cols: Vec<String> = vec![
+        format!(
+            "{e}.{} AS {}",
+            q(&to_id),
+            q(&from_id),
+            e = q(EDGE_ARM_ALIAS)
+        ),
+        format!(
+            "{e}.{} AS {}",
+            q(&from_id),
+            q(&to_id),
+            e = q(EDGE_ARM_ALIAS)
+        ),
+    ];
+    for c in &passthrough {
+        reverse_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
+    }
+
+    Some(format!(
+        "(SELECT {fwd} FROM {table} AS {e} UNION ALL SELECT {rev} FROM {table} AS {e})",
+        fwd = forward_cols.join(", "),
+        rev = reverse_cols.join(", "),
+        table = edge_table,
+        e = q(EDGE_ARM_ALIAS),
+    ))
 }
 
-/// Inner edge alias used inside [`build_standard_doubled_neighbor_subquery`].
-/// Local to the subquery, so any short name is safe; kept distinct from the
-/// outer anchor/neighbor aliases.
-const EDGE_ARM_ALIAS: &str = "t1";
+/// Inner edge alias used inside [`build_standard_doubled_edge_subquery`]. Local
+/// to the subquery; `e` matches the denorm helper's convention.
+const EDGE_ARM_ALIAS: &str = "e";
 
 /// #583: build a doubled-edge subquery for a denormalized single-hop undirected
 /// OPTIONAL pattern, so the existing single anchor LEFT JOIN sees every physical

--- a/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.clickhouse.sql
@@ -1,7 +1,7 @@
 SELECT 
       a.user_id AS "a.user_id", 
-      b.user_id AS "b.user_id"
+      t0.followed_id AS "b.user_id"
 FROM test_integration.users_test AS a
-LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.followed_id UNION ALL SELECT t0.followed_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.follower_id) AS b ON b.__cg_combined_anchor_key = a.user_id
+LEFT JOIN (SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id FROM test_integration.user_follows_test AS e UNION ALL SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id FROM test_integration.user_follows_test AS e) AS t0 ON t0.follower_id = a.user_id
 WHERE a.is_active = true
-ORDER BY a.user_id ASC, b.user_id ASC
+ORDER BY a.user_id ASC, t0.followed_id ASC

--- a/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.clickhouse.sql
@@ -1,19 +1,7 @@
-SELECT `a.user_id` AS `a.user_id`, `b.user_id` AS `b.user_id` FROM (
 SELECT 
       a.user_id AS "a.user_id", 
-      t0.followed_id AS "b.user_id", 
-      a.user_id AS "__order_col_0", 
-      t0.followed_id AS "__order_col_1"
+      b.user_id AS "b.user_id"
 FROM test_integration.users_test AS a
-LEFT JOIN test_integration.user_follows_test AS t0 ON t0.follower_id = a.user_id
+LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.followed_id UNION ALL SELECT t0.followed_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.follower_id) AS b ON b.__cg_combined_anchor_key = a.user_id
 WHERE a.is_active = true
-UNION ALL 
-SELECT 
-      a.user_id AS "a.user_id", 
-      b.user_id AS "b.user_id", 
-      a.user_id AS "__order_col_0", 
-      t0.followed_id AS "__order_col_1"
-FROM test_integration.users_test AS b
-LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, a.* FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS a ON a.user_id = t0.followed_id WHERE a.is_active = true) AS a ON a.__cg_combined_anchor_key = b.user_id
-) AS __union
-ORDER BY __union.`__order_col_0` ASC, __union.`__order_col_1` ASC
+ORDER BY a.user_id ASC, b.user_id ASC

--- a/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.databricks.sql
@@ -1,19 +1,7 @@
-SELECT `a.user_id` AS `a.user_id`, `b.user_id` AS `b.user_id` FROM (
 SELECT 
       a.user_id AS `a.user_id`, 
-      t0.followed_id AS `b.user_id`, 
-      a.user_id AS `__order_col_0`, 
-      t0.followed_id AS `__order_col_1`
+      b.user_id AS `b.user_id`
 FROM test_integration.users_test AS a
-LEFT JOIN test_integration.user_follows_test AS t0 ON t0.follower_id = a.user_id
+LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.followed_id UNION ALL SELECT t0.followed_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.follower_id) AS b ON b.__cg_combined_anchor_key = a.user_id
 WHERE a.is_active = true
-UNION ALL 
-SELECT 
-      a.user_id AS `a.user_id`, 
-      b.user_id AS `b.user_id`, 
-      a.user_id AS `__order_col_0`, 
-      t0.followed_id AS `__order_col_1`
-FROM test_integration.users_test AS b
-LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, a.* FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS a ON a.user_id = t0.followed_id WHERE a.is_active = true) AS a ON a.__cg_combined_anchor_key = b.user_id
-) AS __union
-ORDER BY __union.`__order_col_0` ASC, __union.`__order_col_1` ASC
+ORDER BY a.user_id ASC, b.user_id ASC

--- a/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_optional_match__TestOptionalWhereMandatoryVar_test_undirected_excluded_from_gate_597.databricks.sql
@@ -1,7 +1,7 @@
 SELECT 
       a.user_id AS `a.user_id`, 
-      b.user_id AS `b.user_id`
+      t0.followed_id AS `b.user_id`
 FROM test_integration.users_test AS a
-LEFT JOIN (SELECT t0.follower_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.followed_id UNION ALL SELECT t0.followed_id AS __cg_combined_anchor_key, b.age, b.city, b.country, b.email_address, b.full_name, b.is_active, b.registration_date, b.user_id FROM test_integration.user_follows_test AS t0 JOIN test_integration.users_test AS b ON b.user_id = t0.follower_id) AS b ON b.__cg_combined_anchor_key = a.user_id
+LEFT JOIN (SELECT e.follower_id, e.followed_id, e.follow_date, e.follow_id FROM test_integration.user_follows_test AS e UNION ALL SELECT e.followed_id AS follower_id, e.follower_id AS followed_id, e.follow_date, e.follow_id FROM test_integration.user_follows_test AS e) AS t0 ON t0.follower_id = a.user_id
 WHERE a.is_active = true
-ORDER BY a.user_id ASC, b.user_id ASC
+ORDER BY a.user_id ASC, t0.followed_id ASC

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14383,10 +14383,41 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
         );
     }
 
-    /// #529 shape 1 — R4/R5: bugs 1+2 of the 3-bug package FIXED; bug 3
-    /// deliberately left unfixed but now fails LOUDLY (a clean
-    /// `RenderBuildError::UnsupportedFeature`) instead of silently returning
-    /// wrong data. Full history below for context on what changed and why.
+    /// #583 STANDARD stage, round-2 review Finding 1: a DISCONNECTED
+    /// multi-clause pattern where the standard undirected-optional hop sits in
+    /// the RIGHT branch of the CartesianProduct (`MATCH (c)-[:AUTHORED]->(p)
+    /// OPTIONAL MATCH (a)-[:FOLLOWS]-(b)`). The left-biased `find_graph_rel`
+    /// missed it, silently leaving the FOLLOWS hop single-direction; the
+    /// tree-walking `collect_graph_rels` sees both CartesianProduct branches, so
+    /// the FOLLOWS edge is doubled correctly. Live-verified: an anchor that is
+    /// both a follower and followed (e.g. David) returns BOTH undirected
+    /// neighbors, not just the outgoing one.
+    #[tokio::test]
+    async fn standard_undirected_optional_doubled_in_disconnected_clause_583() {
+        let schema = load_schema("schemas/dev/social_standard.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (c:User)-[:AUTHORED]->(p:Post) \
+                 OPTIONAL MATCH (a:User)-[:FOLLOWS]-(b:User) \
+                 RETURN a.name, b.name, c.name",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+        // The FOLLOWS hop is doubled (reverse arm present) EVEN THOUGH it is in
+        // the disconnected right branch — no silent single-direction render.
+        assert!(
+            sql.contains("e.followed_id AS follower_id, e.follower_id AS followed_id"),
+            "#583 standard: the undirected hop in a disconnected clause must still be doubled:\n{sql}"
+        );
+        // The sibling AUTHORED join survives untouched.
+        assert!(
+            sql.contains("AS c ON c.user_id") || sql.contains("posts"),
+            "#583 standard: the disconnected sibling AUTHORED join must survive:\n{sql}"
+        );
+    }
+
     ///
     /// CORRECTION (R5, adversarial review): earlier text here (and this
     /// round's own CHANGELOG entry) described pre-fix `main` as producing a

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14321,56 +14321,65 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
     }
 
     /// #583 STANDARD stage: a standard plain-edge single-hop undirected OPTIONAL
-    /// (`MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS]-(b:User)`) is rendered as
-    /// ONE anchor `LEFT JOIN (two-arm match-union subquery) AS b` keyed on the
-    /// synthetic `__cg_combined_anchor_key`, NOT the spurious-NULL two-arm outer
-    /// UNION split. Live-verified on db_standard: 22 rows / 0 spurious (broken =
-    /// 24 with a spurious `(anchor, NULL)` AND a phantom `(NULL, neighbor)`
-    /// row); an isolated node gets exactly one `(anchor, NULL)`. This test locks
-    /// the render shape (rows are proven live, not re-executed here).
+    /// hop is rendered by swapping the edge join's target table for a
+    /// doubled-edge subquery (each edge row in BOTH orientations, from/to
+    /// swapped under their original names), aliased AS the EDGE — the neighbor
+    /// and any sibling joins are left untouched. This mirrors the merged denorm
+    /// stage and (unlike an AS-neighbor subquery) keeps the edge alias +
+    /// columns exposed, so `count(r)` / `r.<prop>` resolve. Live-verified on
+    /// db_standard: plain 23 rows / one `(anchor, NULL)` for an isolated node
+    /// (broken = 24 with a spurious `(anchor, NULL)` AND a phantom
+    /// `(NULL, neighbor)`); `count(*)` correct (was `1,1,…`); `count(r)`
+    /// resolves (was Code 47). This test locks the render shape.
     #[tokio::test]
-    async fn standard_undirected_optional_renders_single_match_union_583() {
+    async fn standard_undirected_optional_renders_doubled_edge_583() {
         let schema = load_schema("schemas/dev/social_standard.yaml");
+        // Use the edge-variable form so the assertions also prove the edge alias
+        // is exposed (the #1039 review's BLOCKING-1 regression).
         let sql = normalize(
             &render(
                 &schema,
-                "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS]-(b:User) \
-                 RETURN a.name, b.name",
+                "MATCH (a:User) OPTIONAL MATCH (a)-[r:FOLLOWS]-(b:User) \
+                 RETURN a.name, b.name, r.follow_date",
                 SqlDialect::ClickHouse,
             )
             .await,
         );
 
-        // The neighbor match-union subquery is aliased AS the neighbor (`b`) and
-        // keyed on the synthetic anchor key, so the outer `b.name` resolves
-        // against it directly.
-        assert!(
-            sql.contains("__cg_combined_anchor_key"),
-            "#583 standard: expected the synthetic anchor key in the match-union join:\n{sql}"
-        );
-        assert!(
-            sql.contains("AS b ON b.__cg_combined_anchor_key = a.user_id"),
-            "#583 standard: expected `... AS b ON b.__cg_combined_anchor_key = a.user_id`:\n{sql}"
-        );
-        // Exactly one inner UNION ALL (the two orientation arms) and NO two-arm
-        // outer split wrapper — the whole point of the fix.
+        // The edge join targets a doubled-edge subquery aliased AS the edge `r`,
+        // NOT a two-arm outer split.
         assert_eq!(
             sql.matches("UNION ALL").count(),
             1,
-            "#583 standard: one match-union subquery (two orientation arms), not a split:\n{sql}"
+            "#583 standard: one doubled-edge subquery (two orientation arms), not a split:\n{sql}"
         );
         assert!(
             !sql.contains(") AS __union"),
             "#583 standard: must NOT be the spurious-NULL two-arm outer UNION split:\n{sql}"
         );
-        // Both orientation arms present (forward exports follower_id, reverse
-        // exports followed_id as the anchor key), so every undirected neighbor
-        // is reachable exactly once. Alias-agnostic (the edge alias may be
-        // t0/t1 depending on the counter).
+        // The reverse arm swaps from/to under their ORIGINAL names, so the raw
+        // join condition matches both orientations. Both directions present:
         assert!(
-            sql.contains(".follower_id AS __cg_combined_anchor_key")
-                && sql.contains(".followed_id AS __cg_combined_anchor_key"),
-            "#583 standard: both orientation arms must export the anchor key:\n{sql}"
+            sql.contains("e.follower_id, e.followed_id")
+                && sql.contains("e.followed_id AS follower_id, e.follower_id AS followed_id"),
+            "#583 standard: both orientation arms (forward + swapped reverse) must be present:\n{sql}"
+        );
+        // The subquery is aliased AS the edge `r` and the neighbor `b` stays a
+        // SEPARATE join keyed on the (now-doubled) edge — so `r.<prop>` and
+        // `b.<prop>` both resolve.
+        assert!(
+            sql.contains(") AS r ON r.follower_id = a.user_id"),
+            "#583 standard: doubled-edge subquery must be aliased AS the edge and keyed on the anchor:\n{sql}"
+        );
+        assert!(
+            sql.contains("db_standard.users AS b ON b.user_id = r.followed_id"),
+            "#583 standard: the neighbor `b` must remain a separate join off the doubled edge:\n{sql}"
+        );
+        // The edge-own column referenced by `r.follow_date` must be projected in
+        // the subquery (else Code 47) — the BLOCKING-1 invariant.
+        assert!(
+            sql.matches("follow_date").count() >= 3,
+            "#583 standard: the edge-own column must be projected in both arms so `r.follow_date` resolves:\n{sql}"
         );
     }
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14320,6 +14320,60 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
         );
     }
 
+    /// #583 STANDARD stage: a standard plain-edge single-hop undirected OPTIONAL
+    /// (`MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS]-(b:User)`) is rendered as
+    /// ONE anchor `LEFT JOIN (two-arm match-union subquery) AS b` keyed on the
+    /// synthetic `__cg_combined_anchor_key`, NOT the spurious-NULL two-arm outer
+    /// UNION split. Live-verified on db_standard: 22 rows / 0 spurious (broken =
+    /// 24 with a spurious `(anchor, NULL)` AND a phantom `(NULL, neighbor)`
+    /// row); an isolated node gets exactly one `(anchor, NULL)`. This test locks
+    /// the render shape (rows are proven live, not re-executed here).
+    #[tokio::test]
+    async fn standard_undirected_optional_renders_single_match_union_583() {
+        let schema = load_schema("schemas/dev/social_standard.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS]-(b:User) \
+                 RETURN a.name, b.name",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+
+        // The neighbor match-union subquery is aliased AS the neighbor (`b`) and
+        // keyed on the synthetic anchor key, so the outer `b.name` resolves
+        // against it directly.
+        assert!(
+            sql.contains("__cg_combined_anchor_key"),
+            "#583 standard: expected the synthetic anchor key in the match-union join:\n{sql}"
+        );
+        assert!(
+            sql.contains("AS b ON b.__cg_combined_anchor_key = a.user_id"),
+            "#583 standard: expected `... AS b ON b.__cg_combined_anchor_key = a.user_id`:\n{sql}"
+        );
+        // Exactly one inner UNION ALL (the two orientation arms) and NO two-arm
+        // outer split wrapper — the whole point of the fix.
+        assert_eq!(
+            sql.matches("UNION ALL").count(),
+            1,
+            "#583 standard: one match-union subquery (two orientation arms), not a split:\n{sql}"
+        );
+        assert!(
+            !sql.contains(") AS __union"),
+            "#583 standard: must NOT be the spurious-NULL two-arm outer UNION split:\n{sql}"
+        );
+        // Both orientation arms present (forward exports follower_id, reverse
+        // exports followed_id as the anchor key), so every undirected neighbor
+        // is reachable exactly once. Alias-agnostic (the edge alias may be
+        // t0/t1 depending on the counter).
+        assert!(
+            sql.contains(".follower_id AS __cg_combined_anchor_key")
+                && sql.contains(".followed_id AS __cg_combined_anchor_key"),
+            "#583 standard: both orientation arms must export the anchor key:\n{sql}"
+        );
+    }
+
     /// #529 shape 1 — R4/R5: bugs 1+2 of the 3-bug package FIXED; bug 3
     /// deliberately left unfixed but now fails LOUDLY (a clean
     /// `RenderBuildError::UnsupportedFeature`) instead of silently returning


### PR DESCRIPTION
## Summary

Extends the #583 fix (spurious NULL-extended row for undirected `OPTIONAL MATCH`) from the denorm/coupled stage (PR #1029) to the **STANDARD** plain-edge schema layout.

An undirected single hop `OPTIONAL MATCH (a)-[:R]-(b)` over a standard schema split into two independent LEFT-JOIN branches under `UNION ALL`. Each NULL-extended blind to the other, producing **two** silent-wrong artifacts:
- a spurious `(anchor, NULL)` for an anchor matching in only one physical role, and
- a phantom `(NULL, neighbor)` from the neighbor-driven second branch (`FROM users AS b`) — impossible for a mandatory anchor.

Live (db_standard, with role-asymmetric users): plain returned **24 rows** where **22** are correct; `count(b)` emitted a spurious `NULL` group. (Standard `count(b)` is only *accidentally* robust on symmetric fixtures — it breaks on role-asymmetric data, so a restructure is pure improvement, not a regression of the shape-only #834 golden.)

## Fix

Converges standard onto the **same anchor-LEFT-JOIN-over-match-union architecture** that VLP (#617) and the denorm #583 stage already use — a structural unification, not a per-shape patch:

- **Analyzer** (`bidirectional_union.rs`): a whole-tree pre-pass keeps the hop as ONE directed `was_undirected` GraphRel (no split), gated on a standard-schema core (`is_plain_edge_table() && !is_polymorphic() && same-label endpoints && scalar from/to ids && doubled_edge_walk_compatible()`). Defers to the #589 loud guard for chained-optional patterns (mirrors the denorm stage).
- **Render** (`join_builder.rs`): a standard optional single hop renders through GraphJoinInference's pre-computed `graph_joins.joins`, so the interception lives in the **GraphJoins arm** — it replaces the two-join chain with one `LEFT JOIN (two-arm match-union subquery) AS <neighbor>` keyed on the synthetic `__cg_combined_anchor_key`. The subquery is aliased **AS the neighbor** and projects its own columns under raw names, so `b.<prop>` resolves directly — **no endpoint-reference rewriting** (keeps this clear of the #989 VlpEndpointResolution work).
- **`is_polymorphic()`** dispatch predicate added to the schema catalog so the polymorphic exclusion routes through a dispatch API, not a raw discriminator read (CLAUDE.md rule 7).

## Scope discipline

Standard-only. Polymorphic edges keep the discriminator via the legacy path (their match-union would drop the type filter — caught by the full suite mid-development). The render gate re-requires `is_optional` so a legacy split arm (which also carries `was_undirected`) is never matched. denorm/coupled unchanged; **poly/composite layouts stay open** (#583 remains open for them).

## Verification

- **Live (db_standard)**: plain 22 rows / 0 spurious (isolated node → exactly one `(anchor, NULL)`); `count(b)` no spurious NULL group; directed control unchanged.
- **#597 anchor-WHERE** (`WHERE a.is_active`) folds to the outer query against the anchor correctly — inactive anchor excluded, still appears as a neighbor (WHERE only constrains `a`). Verified live: 21 rows.
- **Goldens**: #834/#597 regenerated (both dialects); tight blast radius (only #597 corpus golden changed).
- **Regression test**: `standard_undirected_optional_renders_single_match_union_583` locks the render shape.
- Full suite **1723 lib + 594 integration + ratchet** green; `cargo fmt` + `clippy` clean.

## Note (out of scope)

`count(*)` on an undirected optional routes to a separate fast-path plan (`FROM <edge>` directly, ignoring the OPTIONAL) — a pre-existing bug, unrelated to #583, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)