### PR TITLE
fix(#583): polymorphic single-hop undirected OPTIONAL spurious NULL row (poly stage)

### DIFF
--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -69,6 +69,15 @@ impl AnalyzerPass for BidirectionalUnion {
             normalize_undirected_standard_single_hop_optional_rels(&base, graph_schema)
                 .or_else(|| (!Arc::ptr_eq(&base, &logical_plan)).then_some(base))
         };
+        // #583 (polymorphic stage): polymorphic single-hop undirected OPTIONAL
+        // hops get the same treatment — the render doubles the discriminator-
+        // FILTERED edge set (both orientations) so NULL-extension happens once.
+        // Compose after the standard pass.
+        let normalized = {
+            let base = normalized.unwrap_or_else(|| logical_plan.clone());
+            normalize_undirected_polymorphic_single_hop_optional_rels(&base, graph_schema)
+                .or_else(|| (!Arc::ptr_eq(&base, &logical_plan)).then_some(base))
+        };
         match normalized {
             Some(plan) => {
                 let inner = transform_bidirectional(&plan, plan_ctx, graph_schema)?;
@@ -413,6 +422,92 @@ pub(crate) fn undirected_standard_single_hop_optional_core(
         && rel_schema.doubled_edge_walk_compatible()
 }
 
+/// #583 (polymorphic stage): scope predicate for a POLYMORPHIC single-hop
+/// undirected OPTIONAL rewrite — the analog of
+/// [`undirected_standard_single_hop_optional_scope`] for an edge whose types
+/// all share one table discriminated by a type column. In scope → the render
+/// layer doubles the discriminator-FILTERED edge set (both orientations) under
+/// one anchor LEFT JOIN, folding the type/label predicate into each arm.
+pub(crate) fn undirected_polymorphic_single_hop_optional_scope(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    graph_rel.direction == Direction::Either
+        && graph_rel.is_optional.unwrap_or(false)
+        && undirected_polymorphic_single_hop_optional_core(graph_rel, graph_schema)
+}
+
+/// #583 (polymorphic stage): direction-agnostic core, shared with the RENDER
+/// layer (re-derived from `was_undirected == Some(true)` + this core). Mirrors
+/// [`undirected_standard_single_hop_optional_core`] with two poly-specific
+/// changes:
+///
+///  1. Gate on `is_polymorphic()` (TRUE) instead of `!is_polymorphic()`.
+///     `is_plain_edge_table()` is ALSO true for a poly edge (no denorm role
+///     maps), so it stays in the conjunction as the "not FK-edge, not denorm"
+///     guard.
+///  2. **Same-label is checked on the QUERY endpoints, not the rel schema.** A
+///     polymorphic edge's `from_node`/`to_node` are the `$any` sentinel
+///     (`build_polymorphic_edge_schemas`), so `rel_schema.from_node ==
+///     rel_schema.to_node` is VACUOUSLY true for every poly edge — including a
+///     genuinely cross-label one like `AUTHORED` (User→Post). Doubling a
+///     cross-label edge with a symmetric `from_type = X AND to_type = X` filter
+///     would be wrong (the reverse arm needs the swapped labels). So instead we
+///     require the two query GraphNodes to carry the SAME concrete label — then
+///     the discriminator filter is symmetric across both arms and the swap is
+///     sound. A `MATCH (a:User) OPTIONAL MATCH (a)-[:AUTHORED]-(b:Post)` (mixed
+///     query labels) fails this and keeps the legacy two-arm path.
+pub(crate) fn undirected_polymorphic_single_hop_optional_core(
+    graph_rel: &GraphRel,
+    graph_schema: &GraphSchema,
+) -> bool {
+    if graph_rel.variable_length.is_some()
+        || graph_rel.shortest_path_mode.is_some()
+        || graph_rel.pattern_combinations.is_some()
+    {
+        return false;
+    }
+    // Endpoints must be plain single-node scans (bare GraphNodes), as for standard.
+    let (LogicalPlan::GraphNode(left_node), LogicalPlan::GraphNode(right_node)) =
+        (graph_rel.left.as_ref(), graph_rel.right.as_ref())
+    else {
+        return false;
+    };
+    // Poly same-label check on the QUERY endpoints (see doc): both GraphNodes
+    // must carry the SAME concrete label. A missing label on either side is not
+    // provably same-label → out of scope (keep legacy path).
+    match (left_node.label.as_deref(), right_node.label.as_deref()) {
+        (Some(l), Some(r)) if l == r => {}
+        _ => return false,
+    }
+    let Some(labels) = graph_rel.labels.as_ref() else {
+        return false;
+    };
+    let [rel_type] = labels.as_slice() else {
+        return false;
+    };
+    let rel_schema = if let Some(rs) = graph_schema.get_relationships_schema_opt(rel_type) {
+        rs
+    } else {
+        let plain_type = rel_type.split("::").next().unwrap_or(rel_type);
+        let rel_schemas = graph_schema.rel_schemas_for_type(plain_type);
+        if rel_schemas.len() != 1 {
+            return false;
+        }
+        rel_schemas[0]
+    };
+    // Polymorphic edge (shared table + type discriminator) with scalar from/to
+    // id columns. `is_polymorphic()` and `is_plain_edge_table()` are both
+    // schema-catalog dispatch predicates (CLAUDE.md rule 7). The query-endpoint
+    // same-label check above (NOT the vacuous rel_schema.from_node ==
+    // rel_schema.to_node) keeps the doubled discriminator filter symmetric.
+    rel_schema.is_plain_edge_table()
+        && rel_schema.is_polymorphic()
+        && matches!(rel_schema.from_id, Identifier::Single(_))
+        && matches!(rel_schema.to_id, Identifier::Single(_))
+        && rel_schema.doubled_edge_walk_compatible()
+}
+
 /// #583: rewrite every in-scope denormalized single-hop undirected OPTIONAL
 /// GraphRel (see [`undirected_denorm_single_hop_optional_scope`]) to
 /// `direction: Outgoing` + `was_undirected: Some(true)`. Returns `None` when
@@ -493,6 +588,42 @@ fn normalize_undirected_standard_single_hop_optional_rels(
             if undirected_standard_single_hop_optional_scope(graph_rel, graph_schema) {
                 crate::debug_print!(
                     "🔄 BidirectionalUnion(#583 standard): standard single-hop undirected OPTIONAL '{}' → match-union single anchor LEFT JOIN (no Union split)",
+                    graph_rel.alias
+                );
+                *changed = true;
+                return LogicalPlan::GraphRel(GraphRel {
+                    direction: Direction::Outgoing,
+                    was_undirected: Some(true),
+                    ..graph_rel.clone()
+                });
+            }
+        }
+        mapped
+    }
+    let mut changed = false;
+    let new_plan = walk(plan, graph_schema, &mut changed);
+    changed.then(|| Arc::new(new_plan))
+}
+
+/// #583 (polymorphic stage): rewrite every in-scope POLYMORPHIC single-hop
+/// undirected OPTIONAL GraphRel (see
+/// [`undirected_polymorphic_single_hop_optional_scope`]) to `direction:
+/// Outgoing` + `was_undirected: Some(true)`. Identical structure to the
+/// standard pass; only the scope predicate differs (poly gate + query-endpoint
+/// same-label). Same chained-optional #589 deferral.
+fn normalize_undirected_polymorphic_single_hop_optional_rels(
+    plan: &Arc<LogicalPlan>,
+    graph_schema: &GraphSchema,
+) -> Option<Arc<LogicalPlan>> {
+    if has_chained_optional_nested_undirected_edge(plan) {
+        return None;
+    }
+    fn walk(plan: &LogicalPlan, graph_schema: &GraphSchema, changed: &mut bool) -> LogicalPlan {
+        let mapped = plan.map_children(|child| walk(child, graph_schema, changed));
+        if let LogicalPlan::GraphRel(graph_rel) = &mapped {
+            if undirected_polymorphic_single_hop_optional_scope(graph_rel, graph_schema) {
+                crate::debug_print!(
+                    "🔄 BidirectionalUnion(#583 poly): polymorphic single-hop undirected OPTIONAL '{}' → doubled discriminator-filtered edge single anchor LEFT JOIN (no Union split)",
                     graph_rel.alias
                 );
                 *changed = true;

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -1475,6 +1475,31 @@ impl JoinBuilder for LogicalPlan {
                     }
                 }
 
+                // #583 (polymorphic stage): collect the aliases of polymorphic
+                // undirected-optional hops. Unlike the standard case, the poly
+                // doubled-edge subquery folds the type/label discriminator (which
+                // lives in the edge join's `pre_filter`) into both arms — and
+                // `pre_filter` only exists after the joins are built below — so we
+                // record just the aliases here and build+swap in the swap loop.
+                // Same `collect_graph_rels` (both CartesianProduct branches) so a
+                // disconnected poly hop is not silently missed.
+                let mut polymorphic_undirected_aliases: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                {
+                    let mut rels = Vec::new();
+                    collect_graph_rels(&graph_joins.input, &mut rels);
+                    for graph_rel in rels {
+                        if graph_rel.was_undirected == Some(true)
+                            && graph_rel.is_optional.unwrap_or(false)
+                            && crate::query_planner::analyzer::bidirectional_union::undirected_polymorphic_single_hop_optional_core(
+                                graph_rel, schema,
+                            )
+                        {
+                            polymorphic_undirected_aliases.insert(graph_rel.alias.clone());
+                        }
+                    }
+                }
+
                 // Convert joins
                 // FROM markers (joins with empty joining_on and Inner type) are used by extract_from(), not extract_joins()
                 // But optional entry points (joins with empty joining_on and Left type) need to be rendered as LEFT JOIN ... ON 1=1
@@ -2099,6 +2124,87 @@ impl JoinBuilder for LogicalPlan {
                              or split the query).",
                             edge_alias
                         )));
+                    }
+                }
+
+                // #583 (polymorphic stage): swap the poly edge join's target for
+                // a doubled discriminator-filtered subquery. The type/label
+                // discriminator lives in the join's `pre_filter` (the SQL
+                // generator would otherwise wrap it as `(SELECT * FROM <table>
+                // WHERE <pre_filter>)`); we fold it into BOTH arms of the doubled
+                // subquery and CLEAR `pre_filter` so it is not double-wrapped.
+                // The rel's edge ViewScan + schema are re-resolved by alias from
+                // the plan. Same loud-if-unswapped discipline as standard.
+                if !polymorphic_undirected_aliases.is_empty() {
+                    let mut rels = Vec::new();
+                    collect_graph_rels(&graph_joins.input, &mut rels);
+                    for edge_alias in &polymorphic_undirected_aliases {
+                        // Resolve this hop's edge ViewScan + rel schema.
+                        let graph_rel = rels.iter().find(|gr| &gr.alias == edge_alias);
+                        let (edge_vs, rel_schema) = match graph_rel.and_then(|gr| {
+                            let LogicalPlan::ViewScan(evs) = gr.center.as_ref() else {
+                                return None;
+                            };
+                            let rs = gr.labels.as_ref().and_then(|labels| {
+                                labels.first().and_then(|rel_type| {
+                                    schema.get_relationships_schema_opt(rel_type).or_else(|| {
+                                        let plain = rel_type.split("::").next().unwrap_or(rel_type);
+                                        schema.rel_schemas_for_type(plain).into_iter().next()
+                                    })
+                                })
+                            })?;
+                            Some((evs, rs))
+                        }) {
+                            Some(pair) => pair,
+                            None => {
+                                return Err(RenderBuildError::MissingTableInfo(format!(
+                                    "#583 poly: undirected OPTIONAL rel '{}' normalized by the \
+                                     analyzer, but its edge ViewScan / relationship schema could \
+                                     not be resolved — refusing to emit a single-direction join",
+                                    edge_alias
+                                )));
+                            }
+                        };
+
+                        // Find the edge join and lift its discriminator pre_filter.
+                        let Some(j) = joins.iter_mut().find(|j| &j.table_alias == edge_alias)
+                        else {
+                            return Err(RenderBuildError::MissingTableInfo(format!(
+                                "#583 poly: undirected OPTIONAL rel '{}' normalized by the \
+                                 analyzer, but no LEFT JOIN carrying its alias was found to swap \
+                                 — the reverse-direction matches would be silently dropped. \
+                                 Refusing to emit a single-direction join.",
+                                edge_alias
+                            )));
+                        };
+                        let Some(pre_filter) = j.pre_filter.as_ref() else {
+                            return Err(RenderBuildError::MissingTableInfo(format!(
+                                "#583 poly: undirected OPTIONAL rel '{}' has no discriminator \
+                                 pre_filter on its edge join — a polymorphic edge must carry its \
+                                 type/label filter; refusing to emit an untyped doubled edge \
+                                 (would match every edge type)",
+                                edge_alias
+                            )));
+                        };
+                        // Render the discriminator without a table alias — bare
+                        // column names resolve inside the `e`-aliased arm scans.
+                        let filter_sql = pre_filter.to_sql_without_table_alias();
+                        let Some(subquery) =
+                            crate::render_plan::plan_builder_helpers::build_polymorphic_doubled_edge_subquery(
+                                edge_vs, rel_schema, &filter_sql,
+                            )
+                        else {
+                            return Err(RenderBuildError::MissingTableInfo(format!(
+                                "#583 poly: undirected OPTIONAL rel '{}' (table '{}') lacks the \
+                                 from/to id columns needed to build the doubled-edge subquery — \
+                                 refusing to emit a silently-single-direction join",
+                                edge_alias, edge_vs.source_table,
+                            )));
+                        };
+                        j.table_name = subquery;
+                        // Discriminator is now folded into both arms — clear the
+                        // pre_filter so `Join::to_sql` does not double-wrap it.
+                        j.pre_filter = None;
                     }
                 }
 

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -366,6 +366,93 @@ pub(super) fn build_standard_doubled_edge_subquery(
 /// to the subquery; `e` matches the denorm helper's convention.
 const EDGE_ARM_ALIAS: &str = "e";
 
+/// #583 (polymorphic stage): build a doubled-edge subquery for a POLYMORPHIC
+/// single-hop undirected OPTIONAL pattern. Same shape as
+/// [`build_standard_doubled_edge_subquery`] (each edge row in both
+/// orientations, from/to swapped under their original names, aliased AS the
+/// edge), with TWO poly-specific differences:
+///
+///  1. **The type/label discriminator is folded into BOTH arms' WHERE.** A
+///     polymorphic edge stores all types in one shared table
+///     (`interactions`) discriminated by a type column plus per-endpoint label
+///     columns. In the two-arm split path that predicate lives in the edge
+///     join's `pre_filter`, which the SQL generator wraps as
+///     `(SELECT * FROM <table> WHERE <pre_filter>)`. Here we fold it directly
+///     into each arm and the caller CLEARS the join's `pre_filter` (otherwise
+///     `Join::to_sql` would double-wrap). The filter string is the already-
+///     dispatch-built `pre_filter` rendered without a table alias (bare column
+///     names resolve inside the subquery), so no filter is reconstructed here
+///     (CLAUDE.md rule 7 — the predicate came through the schema-catalog
+///     `EdgeAccessStrategy` type/label filter APIs). The analyzer gate scopes
+///     this to same-QUERY-LABEL endpoints, so the same symmetric filter is
+///     correct on both arms (a cross-label poly edge would need different
+///     endpoint-label predicates per arm and is excluded).
+///  2. **Passthrough columns come from `doubled_edge_passthrough_columns()`**
+///     (not `all_valid_physical_columns()`), because the former includes the
+///     poly discriminator/label columns — needed so `RETURN r` / any
+///     discriminator reference resolves, and harmless otherwise.
+pub(super) fn build_polymorphic_doubled_edge_subquery(
+    edge_vs: &crate::query_planner::logical_plan::ViewScan,
+    rel_schema: &crate::graph_catalog::graph_schema::RelationshipSchema,
+    discriminator_filter: &str,
+) -> Option<String> {
+    let q = crate::clickhouse_query_generator::quote_identifier;
+
+    let from_id = edge_vs.from_id.as_ref()?.first_column().to_string();
+    let to_id = edge_vs.to_id.as_ref()?.first_column().to_string();
+    let edge_table = &edge_vs.source_table;
+
+    // Poly discriminator columns MUST be in the passthrough set (unlike the
+    // standard helper) so downstream references and the arms stay column-aligned.
+    let role_cols: std::collections::HashSet<String> =
+        [from_id.clone(), to_id.clone()].into_iter().collect();
+    let mut passthrough: Vec<String> = rel_schema
+        .doubled_edge_passthrough_columns()
+        .into_iter()
+        .filter(|c| !role_cols.contains(c))
+        .collect();
+    passthrough.sort();
+    passthrough.dedup();
+
+    let mut forward_cols: Vec<String> = vec![
+        format!("{e}.{}", q(&from_id), e = q(EDGE_ARM_ALIAS)),
+        format!("{e}.{}", q(&to_id), e = q(EDGE_ARM_ALIAS)),
+    ];
+    for c in &passthrough {
+        forward_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
+    }
+
+    let mut reverse_cols: Vec<String> = vec![
+        format!(
+            "{e}.{} AS {}",
+            q(&to_id),
+            q(&from_id),
+            e = q(EDGE_ARM_ALIAS)
+        ),
+        format!(
+            "{e}.{} AS {}",
+            q(&from_id),
+            q(&to_id),
+            e = q(EDGE_ARM_ALIAS)
+        ),
+    ];
+    for c in &passthrough {
+        reverse_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
+    }
+
+    // The discriminator filter is rendered without a table alias, so it applies
+    // to the `e`-aliased scan inside each arm via bare column names.
+    Some(format!(
+        "(SELECT {fwd} FROM {table} AS {e} WHERE {filter} \
+         UNION ALL SELECT {rev} FROM {table} AS {e} WHERE {filter})",
+        fwd = forward_cols.join(", "),
+        rev = reverse_cols.join(", "),
+        table = edge_table,
+        e = q(EDGE_ARM_ALIAS),
+        filter = discriminator_filter,
+    ))
+}
+
 /// #583: build a doubled-edge subquery for a denormalized single-hop undirected
 /// OPTIONAL pattern, so the existing single anchor LEFT JOIN sees every physical
 /// edge in BOTH orientations.

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14418,6 +14418,57 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
         );
     }
 
+    /// #583 POLYMORPHIC stage: an undirected single-hop OPTIONAL over a
+    /// polymorphic edge (all types in one `interactions` table, discriminated by
+    /// a type column + per-endpoint label columns) is rendered by doubling the
+    /// DISCRIMINATOR-FILTERED edge set — the type/label predicate is folded into
+    /// BOTH orientation arms and the join's `pre_filter` is cleared (so
+    /// `Join::to_sql` does not double-wrap). Live-verified on db_polymorphic:
+    /// plain 25 rows / one `(anchor, NULL)` for an isolated node (broken = 24
+    /// with a spurious `(anchor, NULL)` + phantom `(NULL, neighbor)`); `count(r)`
+    /// correct with no spurious NULL group; discriminator preserved (only
+    /// FOLLOWS counted, not the other interaction types sharing the table).
+    #[tokio::test]
+    async fn polymorphic_undirected_optional_renders_doubled_filtered_edge_583() {
+        let schema = load_schema("schemas/dev/social_polymorphic.yaml");
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS]-(b:User) \
+                 RETURN a.name, b.name",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+        // Doubled edge (one inner UNION ALL), not a two-arm outer split.
+        assert_eq!(
+            sql.matches("UNION ALL").count(),
+            1,
+            "#583 poly: one doubled-edge subquery (two orientation arms), not a split:\n{sql}"
+        );
+        assert!(
+            !sql.contains(") AS __union"),
+            "#583 poly: must NOT be the spurious-NULL two-arm outer UNION split:\n{sql}"
+        );
+        // The discriminator is folded into BOTH arms' WHERE (type + label
+        // predicate present twice, once per orientation arm) — NOT left in an
+        // outer pre_filter wrapper (which would double-wrap).
+        assert_eq!(
+            sql.matches("interaction_type = 'FOLLOWS'").count(),
+            2,
+            "#583 poly: the type discriminator must be folded into BOTH arms:\n{sql}"
+        );
+        assert!(
+            !sql.contains("(SELECT * FROM"),
+            "#583 poly: pre_filter must be cleared (no `(SELECT * FROM ... WHERE)` double-wrap):\n{sql}"
+        );
+        // The from/to swap under original names (both orientations reachable).
+        assert!(
+            sql.contains("e.to_id AS from_id, e.from_id AS to_id"),
+            "#583 poly: the reverse arm must swap from/to under their original names:\n{sql}"
+        );
+    }
+
     ///
     /// CORRECTION (R5, adversarial review): earlier text here (and this
     /// round's own CHANGELOG entry) described pre-fix `main` as producing a


### PR DESCRIPTION
## Summary

The **polymorphic** stage of #583, following the denorm (#1029) and standard (#1039) stages. An undirected single-hop `OPTIONAL MATCH (a:User)-[:FOLLOWS]-(b:User)` over a polymorphic edge (all types in one `interactions` table, discriminated by a type column + per-endpoint label columns) split into two independent NULL-extending branches → a spurious `(anchor, NULL)` **and** a phantom `(NULL, neighbor)` row.

Live (db_polymorphic, role-asymmetric users): plain returned 24 rows where **25** is correct (one NULL for a genuinely isolated anchor); `count(r)` emitted a spurious `NULL` group.

## Fix

Mirrors the standard stage (same analyzer pre-pass keeping the hop as one `was_undirected` GraphRel; same doubled-edge swap over `collect_graph_rels` with loud-if-unswapped discipline), with two poly-specific differences the recon surfaced:

1. **The discriminator lives in `Join.pre_filter`, not `table_name`.** The type/label predicate is what the SQL generator wraps as `(SELECT * FROM <table> WHERE <pre_filter>)`. The poly swap folds that predicate into **both** orientation arms of the doubled subquery and **clears `pre_filter`** (else `Join::to_sql` double-wraps). The filter string is the already-dispatch-built `pre_filter` rendered without a table alias — nothing is reconstructed (rule 7). Passthrough columns come from `doubled_edge_passthrough_columns()` (includes the discriminator/label columns), not `all_valid_physical_columns()`.

2. **Same-label is checked on the QUERY endpoints, not the rel schema.** A polymorphic edge's `from_node`/`to_node` are the `$any` sentinel, so `rel_schema.from_node == rel_schema.to_node` is *vacuously* true for every poly edge — including a genuinely cross-label one (AUTHORED User→Post), where a symmetric discriminator filter would be wrong on the reverse arm. The gate instead requires the two query GraphNodes to carry the same concrete label.

## Verification

- **Live (db_polymorphic)**: plain 25 rows / one isolated-anchor NULL; `count(r)` correct, no spurious NULL group (Zoe=0, Alice=8); **discriminator preserved** (only FOLLOWS counted, not the other interaction types sharing the table); directed control + poly cross-schema tests (P02/P05) unchanged.
- Render regression test `polymorphic_undirected_optional_renders_doubled_filtered_edge_583` (asserts one doubled subquery, discriminator folded into both arms, no `(SELECT * FROM` double-wrap, from/to swap).
- Full suite **1723 lib + 596 integration + ratchet** green; `cargo fmt` + `clippy` clean. Zero golden changes (corpus didn't cover this shape).

## Scope / residual

Scoped to same-label polymorphic single hops; cross-label and non-optional keep the legacy split. Same bounded **#1041**-class loud residual as standard (anchor-less projections like bare `RETURN count(*)` fail loud where the edge is promoted to FROM). **Composite** is the last remaining #583 layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)