### PR TITLE
fix(#583): composite single-hop undirected OPTIONAL spurious NULL (composite stage — folds into standard path)

### DIFF
--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -564,15 +564,26 @@ impl RelationshipSchema {
     /// read the orientation-swapped value in reverse rows) or when the table
     /// itself uses the reserved original-identity column names. Such schemas
     /// stay on the legacy two-arm path.
+    ///
+    /// Single- AND composite-id edges are both accepted (#583 composite stage):
+    /// the doubled subquery swaps from/to POSITIONALLY (`to_id[i] AS from_id[i]`,
+    /// `from_id[i] AS to_id[i]`), so the from/to keys must have EQUAL arity — a
+    /// mismatched-arity edge (which could not be a same-label self-ref anyway,
+    /// the only shape the #583 cores scope) stays on the legacy two-arm path.
     pub fn doubled_edge_walk_compatible(&self) -> bool {
-        let endpoint_cols: Vec<&String> = match (&self.from_id, &self.to_id) {
-            (Identifier::Single(f), Identifier::Single(t)) => vec![f, t],
-            _ => return false,
-        };
-        let maps_onto_endpoint = self
-            .property_mappings
-            .values()
-            .any(|pv| matches!(pv, PropertyValue::Column(c) if endpoint_cols.contains(&c)));
+        // Positional from↔to swap requires equal-arity keys.
+        if self.from_id.columns().len() != self.to_id.columns().len() {
+            return false;
+        }
+        let endpoint_cols: Vec<&str> = self
+            .from_id
+            .columns()
+            .into_iter()
+            .chain(self.to_id.columns())
+            .collect();
+        let maps_onto_endpoint = self.property_mappings.values().any(
+            |pv| matches!(pv, PropertyValue::Column(c) if endpoint_cols.contains(&c.as_str())),
+        );
         let reserved = [DOUBLED_EDGES_ORIG_FROM, DOUBLED_EDGES_ORIG_TO];
         let reserved_collision =
             self.column_names

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -389,19 +389,21 @@ pub(crate) fn undirected_standard_single_hop_optional_core(
         }
         rel_schemas[0]
     };
-    // Plain (separate) edge table with same-label endpoints and SINGLE-column
-    // from/to ids. `is_plain_edge_table()` consumes the schema-catalog
-    // classification (not FK-edge, neither role-property map present), never a
-    // raw plan-level flag (CLAUDE.md rule 7) — the exact gate
+    // Plain (separate) edge table with same-label endpoints and single- OR
+    // composite-column from/to ids. `is_plain_edge_table()` consumes the
+    // schema-catalog classification (not FK-edge, neither role-property map
+    // present), never a raw plan-level flag (CLAUDE.md rule 7) — the exact gate
     // `undirected_vlp_single_walk_core` (#617) uses for the standard VLP walk.
-    // Same-label endpoints keep the match-union role swap type-consistent; the
-    // single-column-id requirement keeps the gate in lockstep with the render
-    // helper, which builds the anchor key from `from_id.first_column()` only.
-    // Composite-id standard edges keep the legacy two-arm behavior (#583 stays
-    // open for them). `doubled_edge_walk_compatible()` rejects property mappings
-    // that target the from/to columns (a reverse-arm row would read the swapped
-    // value) — the same hazard the #617 doubled-edge walk guards against, and
-    // this match-union performs the identical orientation swap.
+    // Same-label endpoints keep the match-union role swap type-consistent.
+    // Composite-id standard edges (#583 composite stage) are IN scope: the
+    // render helper swaps every from/to column POSITIONALLY and the surrounding
+    // per-column composite join equality works unchanged against the doubled
+    // subquery (single-column is the arity-1 special case, byte-identical SQL).
+    // `doubled_edge_walk_compatible()` enforces the equal-arity requirement the
+    // positional swap needs and rejects property mappings that target the
+    // from/to columns (a reverse-arm row would read the swapped value) — the
+    // same hazard the #617 doubled-edge walk guards against, and this
+    // match-union performs the identical orientation swap.
     //
     // POLYMORPHIC exclusion (`!is_polymorphic()`): a polymorphic edge stores
     // ALL edge types in one shared table discriminated by a type column (e.g.
@@ -417,8 +419,7 @@ pub(crate) fn undirected_standard_single_hop_optional_core(
     rel_schema.is_plain_edge_table()
         && !rel_schema.is_polymorphic()
         && rel_schema.from_node == rel_schema.to_node
-        && matches!(rel_schema.from_id, Identifier::Single(_))
-        && matches!(rel_schema.to_id, Identifier::Single(_))
+        // Single- OR composite-id (arity enforced by doubled_edge_walk_compatible).
         && rel_schema.doubled_edge_walk_compatible()
 }
 

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -301,10 +301,28 @@ pub(super) fn build_standard_doubled_edge_subquery(
 ) -> Option<String> {
     let q = crate::clickhouse_query_generator::quote_identifier;
 
-    // Edge role id columns (single-column only; composite standard ids keep the
-    // legacy two-arm path per the analyzer gate).
-    let from_id = edge_vs.from_id.as_ref()?.first_column().to_string();
-    let to_id = edge_vs.to_id.as_ref()?.first_column().to_string();
+    // Edge role id columns — single- OR composite-column (#583 composite stage).
+    // The reverse arm swaps from↔to POSITIONALLY (`to[i] AS from[i]`), so the
+    // two key vectors must have EQUAL arity (the analyzer's
+    // `doubled_edge_walk_compatible()` gate already enforces this; re-check here
+    // so the helper fails LOUD via `None` rather than emit a misaligned swap).
+    let from_cols: Vec<String> = edge_vs
+        .from_id
+        .as_ref()?
+        .columns()
+        .into_iter()
+        .map(|c| c.to_string())
+        .collect();
+    let to_cols: Vec<String> = edge_vs
+        .to_id
+        .as_ref()?
+        .columns()
+        .into_iter()
+        .map(|c| c.to_string())
+        .collect();
+    if from_cols.is_empty() || from_cols.len() != to_cols.len() {
+        return None;
+    }
     let edge_table = &edge_vs.source_table;
 
     // Edge-own pass-through columns: EVERY physical column the relationship row
@@ -315,7 +333,7 @@ pub(super) fn build_standard_doubled_edge_subquery(
     // never dropped (dropping it would make `count(r)` reference a column the
     // subquery doesn't project → ClickHouse Code 47). Deterministic order.
     let role_cols: std::collections::HashSet<String> =
-        [from_id.clone(), to_id.clone()].into_iter().collect();
+        from_cols.iter().chain(&to_cols).cloned().collect();
     let mut passthrough: Vec<String> = rel_schema
         .all_valid_physical_columns()
         .into_iter()
@@ -324,31 +342,29 @@ pub(super) fn build_standard_doubled_edge_subquery(
     passthrough.sort();
     passthrough.dedup();
 
-    // Forward arm: from/to verbatim, then every edge-own column.
-    let mut forward_cols: Vec<String> = vec![
-        format!("{e}.{}", q(&from_id), e = q(EDGE_ARM_ALIAS)),
-        format!("{e}.{}", q(&to_id), e = q(EDGE_ARM_ALIAS)),
-    ];
+    // Forward arm: from/to columns verbatim (all N of each), then every edge-own
+    // column.
+    let mut forward_cols: Vec<String> = Vec::new();
+    for c in from_cols.iter().chain(&to_cols) {
+        forward_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
+    }
     for c in &passthrough {
         forward_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
     }
 
-    // Reverse arm: swap from/to under their ORIGINAL names; edge-own columns
-    // unchanged. Table-qualified so the AS target never shadows the raw source.
-    let mut reverse_cols: Vec<String> = vec![
-        format!(
-            "{e}.{} AS {}",
-            q(&to_id),
-            q(&from_id),
-            e = q(EDGE_ARM_ALIAS)
-        ),
-        format!(
-            "{e}.{} AS {}",
-            q(&from_id),
-            q(&to_id),
-            e = q(EDGE_ARM_ALIAS)
-        ),
-    ];
+    // Reverse arm: swap from↔to POSITIONALLY under their ORIGINAL names
+    // (`to[i] AS from[i]`, `from[i] AS to[i]`); edge-own columns unchanged.
+    // Table-qualified so the AS target never shadows the raw source (ClickHouse
+    // would otherwise silently flip the value).
+    let mut reverse_cols: Vec<String> = Vec::new();
+    for (f, t) in from_cols.iter().zip(&to_cols) {
+        // The from[i] slot now carries the row's to[i] value.
+        reverse_cols.push(format!("{e}.{} AS {}", q(t), q(f), e = q(EDGE_ARM_ALIAS)));
+    }
+    for (f, t) in from_cols.iter().zip(&to_cols) {
+        // The to[i] slot now carries the row's from[i] value.
+        reverse_cols.push(format!("{e}.{} AS {}", q(f), q(t), e = q(EDGE_ARM_ALIAS)));
+    }
     for c in &passthrough {
         reverse_cols.push(format!("{}.{}", q(EDGE_ARM_ALIAS), q(c)));
     }

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -14469,6 +14469,70 @@ mod coupled_anchor_optional_family_504_508_529_530_471 {
         );
     }
 
+    /// #583 COMPOSITE stage: an undirected single-hop OPTIONAL over a COMPOSITE-
+    /// key self-ref edge (`(a:Account)-[:TRANSFERRED]-(b:Account)`, both
+    /// endpoints keyed by the TWO-column `[bank_id, account_number]`) is folded
+    /// into the SAME standard doubled-edge path — composite is "standard with
+    /// N-column keys", not a fourth parallel stage. The doubled subquery swaps
+    /// EVERY from/to column POSITIONALLY (`to[i] AS from[i]`), and the
+    /// surrounding per-column composite join equality works unchanged against it.
+    /// Live-verified on db_composite_id: plain 16 rows / 0 NULL (broken = 20 with
+    /// 2 spurious `(anchor, NULL)` + 2 phantom `(NULL, neighbor)`); an isolated
+    /// account gets exactly one `(anchor, NULL)`; a pure sink does NOT;
+    /// `count(r)` correct (isolated = 0, no spurious NULL group).
+    #[tokio::test]
+    async fn composite_undirected_optional_renders_doubled_edge_583() {
+        let schema = load_schema(SchemaId::CompositeId.yaml_path());
+        let sql = normalize(
+            &render(
+                &schema,
+                "MATCH (a:Account) OPTIONAL MATCH (a)-[:TRANSFERRED]-(b:Account) \
+                 RETURN a.account_number, b.account_number",
+                SqlDialect::ClickHouse,
+            )
+            .await,
+        );
+        // One doubled-edge subquery (two orientation arms), not a two-arm split.
+        assert_eq!(
+            sql.matches("UNION ALL").count(),
+            1,
+            "#583 composite: one doubled-edge subquery (two orientation arms), not a split:\n{sql}"
+        );
+        assert!(
+            !sql.contains(") AS __union"),
+            "#583 composite: must NOT be the spurious-NULL two-arm outer UNION split:\n{sql}"
+        );
+        // The reverse arm swaps BOTH composite key columns POSITIONALLY under
+        // their ORIGINAL names — this is the composite-specific invariant: a
+        // single-column swap here would silently drop one key component and fan
+        // rows out across accounts sharing a bank.
+        assert!(
+            sql.contains(
+                "e.to_bank_id AS from_bank_id, e.to_account_number AS from_account_number"
+            ) && sql.contains(
+                "e.from_bank_id AS to_bank_id, e.from_account_number AS to_account_number"
+            ),
+            "#583 composite: the reverse arm must swap BOTH composite key columns positionally:\n{sql}"
+        );
+        // The forward arm carries both key columns verbatim.
+        assert!(
+            sql.contains("e.from_bank_id, e.from_account_number, e.to_bank_id, e.to_account_number"),
+            "#583 composite: the forward arm must project both composite key columns verbatim:\n{sql}"
+        );
+        // The surrounding join condition is the per-column composite equality,
+        // unchanged and now matching both orientations.
+        assert!(
+            sql.contains(
+                "t0.from_bank_id = a.bank_id AND t0.from_account_number = a.account_number"
+            ),
+            "#583 composite: the anchor join must be the per-column composite equality:\n{sql}"
+        );
+        assert!(
+            sql.contains("b.bank_id = t0.to_bank_id AND b.account_number = t0.to_account_number"),
+            "#583 composite: the neighbor must remain a separate composite-key join off the doubled edge:\n{sql}"
+        );
+    }
+
     ///
     /// CORRECTION (R5, adversarial review): earlier text here (and this
     /// round's own CHANGELOG entry) described pre-fix `main` as producing a


### PR DESCRIPTION
## Summary

The **final #583 layout**. An undirected single-hop `OPTIONAL MATCH (a)-[:R]-(b)` over a **composite-key self-ref edge** (both endpoints keyed by a multi-column node id — e.g. `(a:Account)-[:TRANSFERRED]-(b:Account)` on `[bank_id, account_number]`) split into two independent LEFT-JOIN arms under `UNION ALL`, each NULL-extending blind → spurious `(anchor, NULL)` for pure sinks + phantom `(NULL, neighbor)` rows.

Live `db_composite_id`: **20 rows, 4 wrong**; correct = **16, 0 NULL**.

## The refactoring insight

Composite is **not a fourth parallel stage — it is "standard with N-column keys"**. A composite plain-edge self-ref is `is_plain_edge_table()`, non-polymorphic, same-label — identical to the standard #583 path in every respect *except key arity*, and the per-column composite join equality the builder already emits works UNCHANGED against a doubled subquery. So this **folds composite into the merged standard doubled-edge path** rather than adding a new stage (single-column is the arity-1 special case, byte-identical SQL). This is bug-driven refactoring: four schema layouts now converge on one mechanism.

## Changes (3 surgical edits + 1 test)

1. **`graph_schema.rs` `doubled_edge_walk_compatible()`**: accept composite endpoints (was early-return `false` for non-`Single`). Requires **equal from/to arity** (the positional swap needs it) and keeps the existing "no property maps onto an endpoint column" / reserved-name guards over the full multi-column endpoint set.
2. **`bidirectional_union.rs` `undirected_standard_single_hop_optional_core`**: drop the two `Identifier::Single` gates (arity now enforced by `doubled_edge_walk_compatible()`); scope now admits composite. The #617-VLP and #583-poly cores keep their own `Single` gates, so they stay composite-excluded.
3. **`plan_builder_helpers.rs` `build_standard_doubled_edge_subquery`**: swap **every** from/to column **positionally** (`to[i] AS from[i]`, `from[i] AS to[i]`) under original names; re-checks equal arity and fails **LOUD** (`None` → caller errors) rather than emit a misaligned swap.

The join-swap seam in `join_builder.rs` is **unchanged** — the standard collect/swap loop already handles this shape once the core admits it.

## Verification (live, db_composite_id)

- Plain: **16 rows / 0 NULL** (was 20 / 4 wrong)
- Isolated account (ISO-999) → **exactly one** `(anchor, NULL)`; pure sinks (SAV-002, WF-1003) → **none**
- `count(r)` correct: isolated = 0, **no spurious NULL group**
- `r.<prop>` resolves (edge alias exposed — the standard BLOCKING-1 invariant)
- Directed `->` control **unchanged** (existing goldens use it; out of `Direction::Either` scope)

Full suite green: **1723 lib + 597 integration** (incl. new golden `composite_undirected_optional_renders_doubled_edge_583`) **+ ratchet + clippy**. No axis-token bump — routes through `columns()` / `doubled_edge_walk_compatible()`, not raw flags (CLAUDE.md rule 7).

## Closes the #583 cluster

denorm (#1029) + standard (#1039) + poly (#1043) + **composite (this PR)** all now converge on one doubled-edge-AS-edge mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)