### PR TITLE
fix(#1051): max()/min() over empty set return null, not CH type default

### DIFF
--- a/src/sql_generator/emitters/clickhouse/function_registry.rs
+++ b/src/sql_generator/emitters/clickhouse/function_registry.rs
@@ -1192,19 +1192,30 @@ lazy_static::lazy_static! {
             arg_transform: None,
         });
 
-        // min() -> min() [1:1]
+        // min() -> minOrNull() on ClickHouse; min() on Spark.
+        // Neo4j `min` over an EMPTY input set returns NULL. ClickHouse's bare
+        // `min` returns the type default (0 / '' / epoch) instead — silent-wrong
+        // (a user reading "min = 0" believes a real 0 exists). `minOrNull`
+        // returns NULL on empty input, matching Neo4j. Non-empty groups are
+        // byte-identical (`min` == `minOrNull` when ≥1 row), and an all-NULL
+        // input already returns NULL under bare `min`, so ONLY the zero-row case
+        // changes. Spark/ANSI `min` already returns NULL on empty, so Databricks
+        // keeps plain `min` (byte-identical output). Same silent-wrong class as
+        // #851 (head([])/last([]) type-default → NULL).
         m.insert("min", FunctionMapping {
             neo4j_name: "min",
-            clickhouse_name: "min",
-            databricks_name: None,
+            clickhouse_name: "minOrNull",
+            databricks_name: Some("min"),
             arg_transform: None,
         });
 
-        // max() -> max() [1:1]
+        // max() -> maxOrNull() on ClickHouse; max() on Spark. See `min` above:
+        // Neo4j `max` over an empty set is NULL; CH bare `max` returns the type
+        // default. `maxOrNull` matches Neo4j; Databricks `max` already does.
         m.insert("max", FunctionMapping {
             neo4j_name: "max",
-            clickhouse_name: "max",
-            databricks_name: None,
+            clickhouse_name: "maxOrNull",
+            databricks_name: Some("max"),
             arg_transform: None,
         });
 

--- a/tests/rust/integration/complex_feature_tests.rs
+++ b/tests/rust/integration/complex_feature_tests.rs
@@ -745,18 +745,20 @@ async fn test_complex_aggregations_with_group_by() {
     let sql = render_plan.to_sql();
     println!("Generated SQL:\n{}", sql);
 
-    // Verify the query contains expected elements
+    // Verify the query contains expected elements. On ClickHouse, MAX/MIN
+    // render as `maxOrNull`/`minOrNull` so an empty input set yields NULL
+    // (Neo4j semantics) rather than CH's bare-`max` type default of 0.
     assert!(
         sql.to_lowercase().contains("count("),
         "Should contain COUNT functions"
     );
     assert!(
-        sql.to_lowercase().contains("max("),
-        "Should contain MAX function"
+        sql.to_lowercase().contains("maxornull("),
+        "Should contain MAX function (as maxOrNull on ClickHouse)"
     );
     assert!(
-        sql.to_lowercase().contains("min("),
-        "Should contain MIN function"
+        sql.to_lowercase().contains("minornull("),
+        "Should contain MIN function (as minOrNull on ClickHouse)"
     );
     assert!(
         sql.to_lowercase().contains("distinct"),

--- a/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_min_max_aggregate.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/data_security/test_security_graph__TestAggregateQueries_test_min_max_aggregate.clickhouse.sql
@@ -1,4 +1,4 @@
 SELECT 
-      min(u.name) AS "first_alpha", 
-      max(u.name) AS "last_alpha"
+      minOrNull(u.name) AS "first_alpha", 
+      maxOrNull(u.name) AS "last_alpha"
 FROM data_security.ds_users AS u

--- a/tests/rust/integration/golden/corpus/standard/test_638_stdev_post_with_multi_agg.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_638_stdev_post_with_multi_agg.clickhouse.sql
@@ -5,8 +5,8 @@ INNER JOIN test_integration.user_follows_test AS t0 ON t0.follower_id = a.user_i
 GROUP BY a.user_id
 )
 SELECT 
-      min(a_fc.fc) AS "min(fc)", 
-      max(a_fc.fc) AS "max(fc)", 
+      minOrNull(a_fc.fc) AS "min(fc)", 
+      maxOrNull(a_fc.fc) AS "max(fc)", 
       sum(a_fc.fc) AS "sum(fc)", 
       stddevSamp(a_fc.fc) AS "stDev(fc)"
 FROM with_a_fc_cte_0 AS a_fc

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_aggregations__TestBasicAggregations_test_min_max_aggregation.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_aggregations__TestBasicAggregations_test_min_max_aggregation.clickhouse.sql
@@ -1,4 +1,4 @@
 SELECT 
-      min(n.age) AS "youngest", 
-      max(n.age) AS "oldest"
+      minOrNull(n.age) AS "youngest", 
+      maxOrNull(n.age) AS "oldest"
 FROM test_integration.users AS n

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_aggregations__TestRelationshipAggregations_test_aggregate_relationship_properties.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_aggregations__TestRelationshipAggregations_test_aggregate_relationship_properties.clickhouse.sql
@@ -1,4 +1,4 @@
 SELECT 
-      min(r.since) AS "earliest", 
-      max(r.since) AS "latest"
+      minOrNull(r.since) AS "earliest", 
+      maxOrNull(r.since) AS "latest"
 FROM test_integration.follows AS r

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_basic_queries__TestBasicAggregation_test_min_max.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_basic_queries__TestBasicAggregation_test_min_max.clickhouse.sql
@@ -1,4 +1,4 @@
 SELECT 
-      min(u.age) AS "min_age", 
-      max(u.age) AS "max_age"
+      minOrNull(u.age) AS "min_age", 
+      maxOrNull(u.age) AS "max_age"
 FROM test_integration.users AS u

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_error_handling__TestVariableLengthPathErrors_test_relationship_variable_with_length_function.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_error_handling__TestVariableLengthPathErrors_test_relationship_variable_with_length_function.clickhouse.sql
@@ -32,7 +32,7 @@ vlp_a_b AS (
 ), 
 with_b_distance_cte_0 AS (SELECT 
       anyLast(end_name) AS "p1_b_name", 
-      min(length(path)) AS "distance"
+      minOrNull(length(path)) AS "distance"
 FROM vlp_a_b AS t
 GROUP BY t.end_id
 )

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestLengthFunction_test_length_in_aggregation.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestLengthFunction_test_length_in_aggregation.clickhouse.sql
@@ -25,7 +25,7 @@ WITH RECURSIVE vlp_a_b AS (
       AND NOT has(vp.path_edges, tuple(rel.follower_id, rel.followed_id))
 )
 SELECT 
-      min(t.hop_count) AS "min_length", 
-      max(t.hop_count) AS "max_length", 
+      minOrNull(t.hop_count) AS "min_length", 
+      maxOrNull(t.hop_count) AS "max_length", 
       avg(t.hop_count) AS "avg_length"
 FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathFunctionsInReturn_test_path_functions_with_aggregation.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathFunctionsInReturn_test_path_functions_with_aggregation.clickhouse.sql
@@ -26,6 +26,6 @@ WITH RECURSIVE vlp_a_b AS (
 )
 SELECT 
       avg(t.hop_count) AS "avg_path_length", 
-      min(t.hop_count) AS "min_path_length", 
-      max(t.hop_count) AS "max_path_length"
+      minOrNull(t.hop_count) AS "min_path_length", 
+      maxOrNull(t.hop_count) AS "max_path_length"
 FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathWithShortestPath_test_all_shortest_paths_length.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathWithShortestPath_test_all_shortest_paths_length.clickhouse.sql
@@ -35,5 +35,5 @@ vlp_a_b AS (
 )
 SELECT 
       count(*) AS "path_count", 
-      min(t.hop_count) AS "min_length"
+      minOrNull(t.hop_count) AS "min_length"
 FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_performance__TestAggregationPerformance_test_multiple_aggregations_performance.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_performance__TestAggregationPerformance_test_multiple_aggregations_performance.clickhouse.sql
@@ -1,6 +1,6 @@
 SELECT 
       count(n.user_id) AS "total", 
       avg(n.age) AS "avg_age", 
-      min(n.age) AS "min_age", 
-      max(n.age) AS "max_age"
+      minOrNull(n.age) AS "min_age", 
+      maxOrNull(n.age) AS "max_age"
 FROM test_integration.users AS n

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthAggregation_test_max_min_on_paths.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthAggregation_test_max_min_on_paths.clickhouse.sql
@@ -27,6 +27,6 @@ WITH RECURSIVE vlp_a_b AS (
       AND NOT has(vp.path_edges, tuple(rel.follower_id, rel.followed_id))
 )
 SELECT 
-      min(t.end_age) AS "min_age", 
-      max(t.end_age) AS "max_age"
+      minOrNull(t.end_age) AS "min_age", 
+      maxOrNull(t.end_age) AS "max_age"
 FROM vlp_a_b AS t

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -18860,14 +18860,65 @@ async fn chained_with_rename_of_property_non_count_aggregate_914() {
         );
         // The outer aggregate resolves against the renamed CTE column `b.b`,
         // NOT the node-id form (`b.p{N}_b_user_id`) — this is a scalar, not a node.
-        let rendered_fn = if func == "collect" {
-            "groupArray"
-        } else {
-            func
+        // On ClickHouse, collect→groupArray and min/max→minOrNull/maxOrNull
+        // (the latter so an empty input set yields NULL, matching Neo4j).
+        let rendered_fn = match func {
+            "collect" => "groupArray",
+            "min" => "minOrNull",
+            "max" => "maxOrNull",
+            other => other,
         };
         assert!(
             sql.contains(&format!("{rendered_fn}(b.b)")),
             "{func}: outer aggregate must resolve to the scalar CTE column b.b, got:\n{sql}"
+        );
+    }
+}
+
+/// Regression: Cypher `max()`/`min()` over an EMPTY input set must return NULL
+/// (Neo4j semantics — per the Neo4j KB, on zero rows sum→0 but min/max/avg→null),
+/// NOT ClickHouse's bare-`max` type default (0 / '' / epoch), which is silently
+/// wrong. On ClickHouse the fix routes both through the FunctionMapper registry to
+/// `maxOrNull`/`minOrNull`; on Databricks/Spark the ANSI `min`/`max` already
+/// return NULL on empty, so those stay byte-identical as plain `min`/`max`.
+///
+/// This is a pure structural check on the emitted SQL — it discriminates the fix
+/// (pre-fix SQL contained `max(`/`min(`; post-fix ClickHouse contains
+/// `maxOrNull(`/`minOrNull(`). Covers the direct SELECT and the WITH-barrier CTE
+/// path (both render through the canonical Path-A registry arm), plus the
+/// dialect split. See the `min`/`max` entries in `function_registry.rs`.
+#[tokio::test]
+async fn max_min_empty_set_returns_null_via_or_null_1051() {
+    let schema = load_schema(SchemaId::Standard.yaml_path());
+
+    // Direct (pure aggregation) and WITH-barrier (CTE aggregation) both route
+    // through the registry-backed Path-A aggregate renderer.
+    let cyphers = [
+        "MATCH (u:User) RETURN max(u.user_id) AS mx, min(u.user_id) AS mn",
+        "MATCH (u:User) WITH max(u.user_id) AS mx, min(u.user_id) AS mn RETURN mx, mn",
+    ];
+
+    for cypher in cyphers {
+        // ClickHouse: the NULL-on-empty combinator, never the bare form.
+        let ch = render(&schema, cypher, SqlDialect::ClickHouse).await;
+        assert!(
+            ch.contains("maxOrNull(") && ch.contains("minOrNull("),
+            "ClickHouse must emit maxOrNull/minOrNull for `{cypher}`, got:\n{ch}"
+        );
+        assert!(
+            !ch.contains("max(u") && !ch.contains("min(u"),
+            "ClickHouse must NOT emit bare max(/min( over the node column for `{cypher}`, got:\n{ch}"
+        );
+
+        // Databricks/Spark: plain min/max (ANSI already NULL-on-empty), never OrNull.
+        let dbx = render(&schema, cypher, SqlDialect::Databricks).await;
+        assert!(
+            !dbx.contains("maxOrNull(") && !dbx.contains("minOrNull("),
+            "Databricks must keep plain max/min (Spark is NULL-on-empty) for `{cypher}`, got:\n{dbx}"
+        );
+        assert!(
+            dbx.contains("max(") && dbx.contains("min("),
+            "Databricks must emit plain max(/min( for `{cypher}`, got:\n{dbx}"
         );
     }
 }


### PR DESCRIPTION
## Problem

Cypher `max()`/`min()` over an **empty input set** (zero input rows) returned ClickHouse's bare-aggregate **type default** (`0` / `''` / epoch) instead of Neo4j's **`null`** — **silent-wrong** (a user reading `max(age) = 0` believes a real 0 exists). Fixes #1051.

Per the [Neo4j KB](https://neo4j.com/developer/kb/understanding-aggregations-on-zero-rows/): on zero rows `sum()`→0, `stDev()`→0.0, but **`avg()`/`min()`/`max()`/`percentile*()` → null**. Same silent-wrong class as #851 (`head([])`/`last([])`).

## Fix

Route the `min`/`max` registry entries through the existing dialect dispatch (`FunctionMapping::name_for`, CLAUDE.md Rule #7):
- ClickHouse: `clickhouse_name = minOrNull`/`maxOrNull`
- Databricks: `databricks_name = Some("min")`/`Some("max")` — Spark/ANSI already NULL-on-empty (DELTAGRAPH_PLAN.md), stays byte-identical.

The NULL-on-empty combinator (`min_or_null()`) already existed but was wired only into the VLP `length(path)` rewrite; this extends it to the general aggregate path. Both direct-SELECT and WITH-barrier CTE aggregates render through the registry (Path A), so a single seam fixes both.

## Correctness boundary (only the zero-row case changes)

| case | before | after | Neo4j |
|---|---|---|---|
| `max` over empty | `0` | `null` | `null` |
| `max` non-empty | value | value | value (byte-identical: `min`==`minOrNull` with ≥1 row) |
| `max` over all-NULL | `null` | `null` | `null` (already correct on CH) |
| grouping `max` over empty | 0 rows | 0 rows | 0 rows |

`avg`/`percentile`/`sum` unaffected (already Neo4j-correct).

## Verification

- Live on `db_standard`: empty→null (direct + WITH-barrier), non-empty/GROUP BY/string-max unchanged; Databricks dialect emits plain `max`/`min`.
- Full suite green: lib 1726, integration 599, ratchet (no baseline bump), clippy, fmt.
- 11 goldens regenerated (pure `max(`→`maxOrNull(` substitution — verified diff).
- New discriminating test `max_min_empty_set_returns_null_via_or_null_1051` (fails pre-fix; covers direct + WITH-barrier + dialect split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)