### PR TITLE
fix(#1057): comparison/predicate results render as boolean true/false in projections, not UInt8 1/0

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -4019,7 +4019,23 @@ fn build_union_inner_select(
 
     for item in &non_agg_items {
         sql.push_str("      ");
-        sql.push_str(&item.expression.to_sql());
+        // #1057: a boolean-typed projection must surface as true/false, not CH
+        // UInt8 1/0. This aggregate-over-UNION inner SELECT is a SECOND
+        // projection emitter (distinct from `SelectItems::to_sql`), so it needs
+        // the same wrap. Wrapping the INNER item is sufficient: the outer
+        // aggregate SELECT (`build_outer_aggregate_select`) only re-references
+        // this column by alias, so it inherits the Nullable(Bool) type — exactly
+        // as the WITH-barrier CTE case works. Conservative-None: only
+        // proven-Boolean top-level items wrap.
+        let rendered = item.expression.to_sql();
+        let rendered = if super::type_inference::infer_render_type(&item.expression)
+            == Some(super::type_inference::RenderType::Boolean)
+        {
+            crate::sql_generator::function_mapper::current_function_mapper().cast_bool(&rendered)
+        } else {
+            rendered
+        };
+        sql.push_str(&rendered);
         if let Some(alias) = &item.col_alias {
             sql.push_str(&format!(
                 " AS {}",
@@ -6430,6 +6446,24 @@ impl SelectItems {
                 }
             } else {
                 item.expression.to_sql()
+            };
+
+            // #1057: a projection item whose Cypher-semantic type is Boolean
+            // must surface on the wire as true/false, not ClickHouse's UInt8
+            // 1/0 (comparisons, IN, STARTS WITH, IS NULL, boolean fns, and
+            // schema-declared Boolean columns all render as UInt8). Wrap ONLY
+            // when the render-site classifier PROVES the top-level item is
+            // Boolean (conservative-None: unknown stays unchanged, so a
+            // comparison nested inside if()/CASE/a lambda condition — which is
+            // not itself the item's type — is untouched). The `.*`-expanded
+            // TableAlias forms never classify Boolean, so they are unaffected.
+            let rendered_expr = if super::type_inference::infer_render_type(&item.expression)
+                == Some(super::type_inference::RenderType::Boolean)
+            {
+                crate::sql_generator::function_mapper::current_function_mapper()
+                    .cast_bool(&rendered_expr)
+            } else {
+                rendered_expr
             };
 
             sql.push_str(&rendered_expr);

--- a/src/sql_generator/function_mapper/clickhouse.rs
+++ b/src/sql_generator/function_mapper/clickhouse.rs
@@ -75,6 +75,13 @@ impl FunctionMapper for ClickhouseFunctionMapper {
         "toString"
     }
 
+    fn cast_bool(&self, expr: &str) -> String {
+        // Nullable(Bool) preserves NULL (bare `CAST(NULL>2 AS Bool)` throws
+        // Code 70) and is physically UInt8, so this changes only the wire
+        // display (1/0 → true/false), never downstream semantics. #1057.
+        format!("CAST({expr} AS Nullable(Bool))")
+    }
+
     fn array_concat(&self) -> &'static str {
         "arrayConcat"
     }
@@ -207,6 +214,17 @@ mod tests {
         assert_eq!(
             m.cast_as("NULL", "Nullable(Int64)"),
             "CAST(NULL, 'Nullable(Int64)')"
+        );
+    }
+
+    #[test]
+    fn cast_bool_uses_nullable_bool_for_null_safety() {
+        // #1057: Nullable(Bool), not bare Bool — CAST(NULL>2 AS Bool) throws
+        // Code 70. Nullable preserves NULL and prints true/false.
+        let m = ClickhouseFunctionMapper;
+        assert_eq!(
+            m.cast_bool("u.user_id > 2"),
+            "CAST(u.user_id > 2 AS Nullable(Bool))"
         );
     }
 

--- a/src/sql_generator/function_mapper/databricks.rs
+++ b/src/sql_generator/function_mapper/databricks.rs
@@ -147,6 +147,12 @@ impl FunctionMapper for DatabricksFunctionMapper {
         "string"
     }
 
+    fn cast_bool(&self, expr: &str) -> String {
+        // Spark BOOLEAN is already nullable and prints true/false, so a plain
+        // ANSI cast suffices — no OrNull dance needed. #1057.
+        format!("CAST({expr} AS BOOLEAN)")
+    }
+
     fn array_concat(&self) -> &'static str {
         // Spark's `concat` is overloaded for arrays — same call shape as CH's
         // `arrayConcat(a, b)`.
@@ -308,6 +314,7 @@ mod tests {
         assert_eq!(m.cast_uint16(), "int");
         assert_eq!(m.cast_float64(), "double");
         assert_eq!(m.cast_string(), "string");
+        assert_eq!(m.cast_bool("x > 2"), "CAST(x > 2 AS BOOLEAN)");
         assert_eq!(m.array_concat(), "concat");
         assert_eq!(m.array_contains(), "array_contains");
         assert_eq!(m.integer_division(), "div");

--- a/src/sql_generator/function_mapper/mod.rs
+++ b/src/sql_generator/function_mapper/mod.rs
@@ -146,6 +146,24 @@ pub(crate) trait FunctionMapper: Send + Sync {
     /// Cast to string. CH: `toString`. Spark: `string` (function-call alias).
     fn cast_string(&self) -> &'static str;
 
+    /// Cast a boolean-typed expression to the dialect's native boolean so it
+    /// surfaces on the wire as `true`/`false` rather than `1`/`0` (#1057).
+    ///
+    /// Applied ONLY at projection emit to expressions the render-site classifier
+    /// proves `RenderType::Boolean` (comparisons, `IN`, `STARTS WITH`, `IS NULL`,
+    /// boolean scalar fns, `EXISTS`), whose ClickHouse result type is `UInt8`
+    /// (`3 > 2` → `1`). Cypher requires a boolean there; Neo4j returns
+    /// `true`/`false`.
+    ///
+    /// NULL-safety is mandatory: `x IS NULL`-adjacent comparisons like
+    /// `n.missing > 2` must stay `null`, and CH `CAST(NULL > 2 AS Bool)` THROWS
+    /// (Code 70, non-nullable). CH therefore uses `Nullable(Bool)`, which
+    /// preserves `null` and is otherwise physically `UInt8` — transparent to
+    /// every downstream op (`= 1`, arithmetic, `sum`, `AND`, GROUP/ORDER/DISTINCT
+    /// all identical), so only the wire display changes. Spark `BOOLEAN` is
+    /// already nullable. `expr` is a pre-rendered SQL fragment.
+    fn cast_bool(&self, expr: &str) -> String;
+
     /// Concatenate two arrays. CH: `arrayConcat`. Spark: `concat`
     /// (overloaded for arrays).
     fn array_concat(&self) -> &'static str;

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.clickhouse.sql
@@ -1,3 +1,3 @@
 SELECT 
-      u.full_name IS NOT NULL AS "has"
+      CAST(u.full_name IS NOT NULL AS Nullable(Bool)) AS "has"
 FROM test_integration.users_test AS u

--- a/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.databricks.sql
+++ b/tests/rust/integration/golden/corpus/standard/test_995b_scalar_exists_property_return_is_not_null.databricks.sql
@@ -1,3 +1,3 @@
 SELECT 
-      u.full_name IS NOT NULL AS `has`
+      CAST(u.full_name IS NOT NULL AS BOOLEAN) AS `has`
 FROM test_integration.users_test AS u

--- a/tests/rust/integration/golden/sql_ir/standard/bool_projection_1057__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/bool_projection_1057__clickhouse.sql
@@ -1,0 +1,7 @@
+SELECT 
+      u.user_id AS "u.user_id", 
+      CAST(u.user_id > 2 AS Nullable(Bool)) AS "gt", 
+      CAST(startsWith(u.full_name, 'A') AS Nullable(Bool)) AS "sw", 
+      CAST(u.email_address IS NULL AS Nullable(Bool)) AS "isn"
+FROM social.users_bench AS u
+WHERE u.user_id > 0

--- a/tests/rust/integration/golden/sql_ir/standard/bool_projection_1057__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/bool_projection_1057__databricks.sql
@@ -1,0 +1,7 @@
+SELECT 
+      u.user_id AS `u.user_id`, 
+      CAST(u.user_id > 2 AS BOOLEAN) AS `gt`, 
+      CAST(startswith(u.full_name, 'A') AS BOOLEAN) AS `sw`, 
+      CAST(u.email_address IS NULL AS BOOLEAN) AS `isn`
+FROM social.users_bench AS u
+WHERE u.user_id > 0

--- a/tests/rust/integration/golden/sql_ir/standard/bool_projection_agg_union_1057__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/bool_projection_agg_union_1057__clickhouse.sql
@@ -1,0 +1,16 @@
+SELECT `gt` AS "gt", count(*) AS "c" FROM (
+SELECT 
+      CAST(v.user_id > 2 AS Nullable(Bool)) AS "gt",
+      v.user_id AS "v.user_id"
+FROM social.users_bench AS u
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = u.user_id
+INNER JOIN social.users_bench AS v ON v.user_id = t0.followed_id
+UNION ALL 
+SELECT 
+      CAST(v.user_id > 2 AS Nullable(Bool)) AS "gt",
+      v.user_id AS "v.user_id"
+FROM social.users_bench AS v
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = v.user_id
+) AS __union
+GROUP BY `gt`
+ORDER BY `gt` ASC

--- a/tests/rust/integration/golden/sql_ir/standard/bool_projection_agg_union_1057__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/bool_projection_agg_union_1057__databricks.sql
@@ -1,0 +1,16 @@
+SELECT `gt` AS `gt`, count(*) AS `c` FROM (
+SELECT 
+      CAST(v.user_id > 2 AS BOOLEAN) AS `gt`,
+      v.user_id AS `v.user_id`
+FROM social.users_bench AS u
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = u.user_id
+INNER JOIN social.users_bench AS v ON v.user_id = t0.followed_id
+UNION ALL 
+SELECT 
+      CAST(v.user_id > 2 AS BOOLEAN) AS `gt`,
+      v.user_id AS `v.user_id`
+FROM social.users_bench AS v
+INNER JOIN social.user_follows_bench AS t0 ON t0.follower_id = v.user_id
+) AS __union
+GROUP BY `gt`
+ORDER BY `gt` ASC

--- a/tests/rust/integration/golden/sql_ir/standard/fn_toboolean__clickhouse.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/fn_toboolean__clickhouse.sql
@@ -1,3 +1,3 @@
 SELECT 
-      toBool('true') AS "r"
+      CAST(toBool('true') AS Nullable(Bool)) AS "r"
 FROM social.users_bench AS u

--- a/tests/rust/integration/golden/sql_ir/standard/fn_toboolean__databricks.sql
+++ b/tests/rust/integration/golden/sql_ir/standard/fn_toboolean__databricks.sql
@@ -1,3 +1,3 @@
 SELECT 
-      boolean('true') AS `r`
+      CAST(boolean('true') AS BOOLEAN) AS `r`
 FROM social.users_bench AS u

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -778,6 +778,31 @@ const CORPUS: &[(&str, &str)] = &[
     // (it is the path Phase 2 of the IR refactor unifies). Likewise composite
     // node-ID, denormalized, multi-label, and UNWIND/arrayJoin shapes need
     // additional schemas / not-yet-implemented Spark structural support.
+    //
+    // #1057: a boolean-typed PROJECTION item (comparison, IN, STARTS WITH, IS
+    // NULL) must render as the dialect's native boolean so it surfaces on the
+    // wire as true/false, not ClickHouse's UInt8 1/0. CH wraps in
+    // `CAST(... AS Nullable(Bool))` (NULL-safe: `n.x > 2` on a null stays null);
+    // Databricks wraps in `CAST(... AS BOOLEAN)`. The comparison INSIDE the
+    // WHERE clause (`u.user_id > 0`) is the position control — it stays a bare
+    // UInt8 predicate, NEVER wrapped, since only SELECT-position booleans are
+    // surfaced to a client. `u.user_id` (an integer projection) is the type
+    // control — untouched.
+    (
+        "bool_projection_1057",
+        "MATCH (u:User) WHERE u.user_id > 0 RETURN u.user_id, u.user_id > 2 AS gt, u.name STARTS WITH 'A' AS sw, u.email IS NULL AS isn",
+    ),
+    // #1057 (aggregate-over-UNION path): an undirected relationship + aggregation
+    // renders the pre-aggregation rows through a SEPARATE projection emitter
+    // (`build_union_inner_select`), not `SelectItems::to_sql`. A boolean grouping
+    // key there must ALSO wrap to the native boolean. Wrapping the INNER select
+    // is sufficient — the outer aggregate SELECT re-references the column by
+    // alias and inherits Nullable(Bool). Locks both UNION arms wrap and the
+    // outer `count(*)` stays integer.
+    (
+        "bool_projection_agg_union_1057",
+        "MATCH (u:User)-[:FOLLOWS]-(v:User) RETURN v.user_id > 2 AS gt, count(*) AS c ORDER BY gt",
+    ),
 ];
 
 /// Browser-shaped patterns (Phase 0 slice P0.5): the fully/partially


### PR DESCRIPTION
## Summary

A boolean-valued expression in a RETURN/WITH **projection** — comparison (`>`/`<`/`=`/`<>`/…), `IN`, `STARTS WITH`/`CONTAINS`/`ENDS WITH`, `=~`, `IS NULL`/`IS NOT NULL`, boolean scalar fns (`toBoolean`/`isEmpty`/…), `EXISTS`, and schema-declared Boolean columns — was emitted as a bare ClickHouse expression whose result type is `UInt8`, so the wire value was `1`/`0` instead of Neo4j's boolean `true`/`false`. **Silent type-fidelity divergence** (ground-rule #1). Closes #1057. Sibling of #851 (head/last) and #1051 (max/min-empty).

## Oracle

Neo4j `RETURN n.age > 30 AS x` yields boolean `true`/`false` ([manual](https://neo4j.com/docs/cypher-manual/current/expressions/predicates/boolean-operators/)); NULL-propagation preserved (`null > 2` → `null`, not `false`).

## Root & fix

The render-site classifier (`type_inference.rs`) already proves these `RenderType::Boolean`; that type just wasn't applied at projection emit.

**Fix (Rule #7 dispatch):** wrap a SELECT item in the dialect's native boolean cast when `infer_render_type` proves it Boolean, routed through a new `FunctionMapper::cast_bool` (CH `CAST(expr AS Nullable(Bool))`; Databricks `CAST(expr AS BOOLEAN)`), not inline branching. Applied at the **two** projection emitters:
- `SelectItems::to_sql` — the main path, which also renders inner CTE / non-aggregate UNION-branch projections (so WITH-barrier and UNION cases are covered).
- `build_union_inner_select` — the aggregate-over-UNION pre-aggregation rows (undirected/bidirectional + aggregation, polymorphic/multi-source), a separate emitter `SelectItems::to_sql` does not reach. Wrapping the inner item suffices; the outer aggregate SELECT re-references by alias and inherits `Nullable(Bool)`. *(Coverage gap caught in adversarial review and closed.)*

Ratchet green, no baseline bump.

## Correctness boundary

- CH `Bool` is physically `UInt8`, so the wrap is transparent to every downstream op (`= 1`, arithmetic, `sum`, `AND`, GROUP/ORDER/DISTINCT) — only the wire display changes. GROUP BY on a wrapped boolean key preserves counts (verified undirected+agg 9/9, polymorphic 11/9; NULL group preserved).
- `Nullable(Bool)` is NULL-safe: `n.x > 2` on null stays `null` (bare `CAST(NULL>2 AS Bool)` throws Code 70). Verified live.
- Conservative-None: only PROVEN-Boolean top-level items wrap, so a comparison nested inside `if()`/`CASE`/a lambda condition stays `UInt8`, and WHERE-position predicates are untouched.
- A Boolean column needs a schema `property_types` declaration to be typed; an undeclared `UInt8` column (indistinguishable from a small int) is left as-is — the honest under-specified-schema outcome.

## Tests

- New discriminating goldens `bool_projection_1057` (SELECT booleans wrap both dialects; WHERE comparison + integer projection are controls) and `bool_projection_agg_union_1057` (undirected+aggregate: both UNION arms wrap, outer `count(*)` stays integer).
- `cast_bool` unit tests both dialects.
- 4 pre-existing goldens regenerated (`IS NOT NULL` / `toBoolean` projections — pure bool-wrap).
- Full suite green: 1727 lib + 603 integration + ratchet (no bump) + clippy + fmt.
- Adversarial review (2 rounds): APPROVE — found + verified fix for the aggregate-over-UNION coverage gap; confirmed no other user-facing scalar-boolean projection emitter is bypassed (VLP CTEs emit structural columns only; json_builder/formatRowNoNewline is node-object-only and cannot carry a scalar boolean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)