### PR TITLE
docs(#1062): flag pattern-comprehension aggregate scalar forms as interim, not Neo4j-correct

### DIFF
--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -2457,6 +2457,14 @@ pub(crate) fn build_pattern_comprehension_sql(
                 format!("{collect}(1)")
             }
         }
+        // INTERIM (#1062): this whole match models "aggregate the comprehension's
+        // inner rows, GROUP BY node_id". The Neo4j-correct model is "aggregate the
+        // per-outer-row LIST VALUE, cross-row": `min`/`max` return the whole list,
+        // `collect` nests to a list-of-lists, `sum`/`avg` over lists ERROR, `count`
+        // is 1 per outer row. The scalar forms below are a documented stepping-stone
+        // (strictly better than the prior constant-`1` fold) — NOT verified-correct
+        // output; the `*_1053` goldens lock interim behavior. Fix under #1062.
+        //
         // #1053: numeric aggregates must fold over the projected target value
         // (`target_prop`) when a target JOIN was emitted — mirroring the
         // `GroupArray` arm above. Without this they folded over the constant `1`


### PR DESCRIPTION
## What

Comment-only. Adds an `INTERIM (#1062)` caveat at the aggregate-over-pattern-comprehension emit site in `pattern_comprehension_sql.rs`, and files/links the design-cycle tracking issue #1062.

## Why

The tip of main (#1058, `2121fa0b`) fixed the constant-`1` fold (`MIN(1)`→`MIN(target_prop)`) — a real improvement — but settled on a **scalar** answer that is **not Neo4j-correct**, and locked it into 8 new goldens:

| agg | merged #1058 (live) | Neo4j-correct |
|---|---|---|
| `min([...])` | scalar `2` | **`[2,3]`** (whole list) |
| `max([...])` | scalar `3` | **`[2,3]`** (whole list) |
| `collect([...])` | `[2,3]` | **`[[2,3]]`** (list-of-lists) |
| `sum`/`avg([...])` | `5` / `2.5` | **error** |
| `count([...])` | `2` (inner rows) | **`1`** (per outer row) |
| empty `min` | `0` | **`null`** |

Oracle: [Neo4j aggregating functions](https://neo4j.com/docs/cypher-manual/current/functions/aggregating/) — `min()` over a set of lists returns the whole list; a pattern comprehension is one list per outer row. Live-verified on `db_standard` @ `2121fa0b`.

The full fix (model list-values; `sum`/`avg`→loud error; empty→null) is design-cycle-shaped and tracked on **#1062**. Per maintainer decision, #1058's scalar behavior stays as a documented stepping-stone; this PR ensures the code and goldens are not mistaken for verified-correct output.

## Scope

- Comment-only in `pattern_comprehension_sql.rs`; no functional change, no golden churn.
- Tracking issue #1062 filed; #1053 cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)