### PR TITLE
fix(release): Windows long-path checkout + fail-fast:false

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ jobs:
     needs: create_release
     runs-on: ${{ matrix.runner }}
     strategy:
+      # Don't let one platform's failure cancel the others — each produces
+      # independent release assets, and a partial upload is better than none.
+      fail-fast: false
       matrix:
         include:
           - name: linux-amd64
@@ -59,6 +62,13 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
+      # Windows checkout of this repo fails without long-path support: some
+      # golden corpus filenames exceed the legacy 260-char MAX_PATH limit.
+      # Must run BEFORE actions/checkout, which does its own clone.
+      - name: Enable Git long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Checkout tag
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The `v0.6.8-deltagraph-prev` tag's **Release Pipeline** failed. Root cause is **not** the deltagraph/cg packaging change — the **win-amd64** leg died at the `git checkout` step, *before any build ran*:

```
error: unable to create file tests/rust/integration/golden/corpus/sqlgen_composite_id/
  test_schema_sql_generation__TestCrossSchemaPatterns_..._LIMIT_5.databricks.sql: Filename too long
```

Several golden corpus filenames exceed Windows' legacy 260-char `MAX_PATH` limit (longest = **269 chars**). These were introduced by `fcc3db93` (P0.6 corpus sweep) **after** `v0.6.7-dev` — a pre-existing regression the tag merely surfaced. `v0.6.7-dev` shipped Windows assets fine; the corpus files landed since.

Then `fail-fast` (default true) cancelled the **healthy linux-amd64 / macos-amd64 / macos-arm64** legs because Windows failed first — so the release got **zero** binary assets.

## Fix

1. **Windows long paths** — a `runner.os == 'Windows'` step runs `git config --system core.longpaths true` **before** `actions/checkout` (which does its own clone). No-op on Linux/macOS.
2. **`fail-fast: false`** on the build matrix — one platform's failure no longer cancels the others; each produces independent assets.

## Note

Docker Publish (the primary preview channel) is unaffected — it builds on Linux. This only fixes the cross-platform **tarball** release job.

After merge, the release can be re-cut by re-running the failed workflow or re-pushing the tag (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)