### PR TITLE
fix(sql): node-identity comparison resolves schema node_id, not literal `.id`

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -7982,25 +7982,50 @@ impl RenderExpr {
                     }
                 }
 
-                // Node identity comparison: Cypher `a <> b` or `a = b` where both sides
-                // are bare node variables (TableAlias) should compare by node ID column.
+                // Node identity comparison: Cypher `a = b` / `a <> b` where both
+                // sides are bare node variables (TableAlias) compares node
+                // identity — i.e. the node's ID column(s). Resolve each alias's
+                // node_id from the schema (it may be a renamed column such as
+                // `user_id`, or composite) rather than assuming a literal `id`
+                // column, which usually does not exist and fails at execution
+                // (ClickHouse "cannot be resolved" / Databricks UNRESOLVED_COLUMN).
                 // ClickHouse doesn't understand bare table aliases as values.
                 if matches!(op.operator, Operator::Equal | Operator::NotEqual)
                     && op.operands.len() == 2
                 {
-                    let both_table_aliases = op
-                        .operands
-                        .iter()
-                        .all(|o| matches!(o, RenderExpr::TableAlias(_)));
-                    if both_table_aliases {
+                    if let (RenderExpr::TableAlias(l), RenderExpr::TableAlias(r)) =
+                        (&op.operands[0], &op.operands[1])
+                    {
+                        use crate::server::query_context::{
+                            get_current_schema, get_node_label_for_alias,
+                        };
+                        // Resolve a bare node alias to its schema node_id identifier.
+                        let node_id_of =
+                            |alias: &str| -> Option<crate::graph_catalog::config::Identifier> {
+                                let schema = get_current_schema()?;
+                                let label = get_node_label_for_alias(alias)?;
+                                schema
+                                    .node_schema_opt(&label)
+                                    .map(|ns| ns.node_id.id.clone())
+                            };
+                        if let (Some(lid), Some(rid)) = (node_id_of(&l.0), node_id_of(&r.0)) {
+                            // `to_sql_equality` pairs columns element-wise and is
+                            // dialect-aware; negate for `<>` (nodes always have a
+                            // non-null id, so NOT(=) matches `<>` semantics).
+                            let eq = lid.to_sql_equality(&l.0, &rid, &r.0);
+                            return if op.operator == Operator::Equal {
+                                eq
+                            } else {
+                                format!("NOT ({})", eq)
+                            };
+                        }
+                        // Label/schema unresolvable — preserve prior behavior.
                         let op_str = if op.operator == Operator::Equal {
                             "="
                         } else {
                             "<>"
                         };
-                        let lhs = op.operands[0].to_sql();
-                        let rhs = op.operands[1].to_sql();
-                        return format!("{}.id {} {}.id", lhs, op_str, rhs);
+                        return format!("{}.id {} {}.id", l.0, op_str, r.0);
                     }
                 }
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -19433,3 +19433,72 @@ async fn mixed_vlp_end_filter_deferred_to_wrapper_not_per_hop_1003() {
         }
     }
 }
+
+/// Node-identity comparison — Cypher `a = b` / `a <> b` between two bare node
+/// variables compares node identity, which must resolve to the schema's node_id
+/// column (`user_id`), NOT a hardcoded `.id` that no table has. Regression for the
+/// live-found bug where `WHERE a <> b` emitted `a.id <> b.id` → ClickHouse Code 47
+/// / Databricks UNRESOLVED_COLUMN. Both dialects, both operators.
+#[tokio::test]
+async fn node_identity_comparison_resolves_schema_node_id() {
+    let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Inequality: NOT (a.user_id = b.user_id), never a bare `.id`.
+        let neq = render(
+            &schema,
+            "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a <> b RETURN a.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            neq.contains("a.user_id") && neq.contains("b.user_id"),
+            "({dialect:?}) `a <> b` must compare the schema node_id column user_id:\n{neq}"
+        );
+        assert!(
+            !neq.contains("a.id") && !neq.contains("b.id"),
+            "({dialect:?}) `a <> b` must NOT emit a hardcoded `.id` column:\n{neq}"
+        );
+
+        // Equality: a.user_id = b.user_id.
+        let eq = render(
+            &schema,
+            "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a = b RETURN a.name",
+            dialect,
+        )
+        .await;
+        assert!(
+            eq.contains("a.user_id = b.user_id"),
+            "({dialect:?}) `a = b` must render `a.user_id = b.user_id`:\n{eq}"
+        );
+        assert!(
+            !eq.contains("a.id") && !eq.contains("b.id"),
+            "({dialect:?}) `a = b` must NOT emit a hardcoded `.id` column:\n{eq}"
+        );
+    }
+}
+
+/// Composite node-identity: `a <> b` on a node whose node_id is multi-column
+/// (`Account` = [bank_id, account_number]) must compare every id column pairwise
+/// (`NOT (a.bank_id = b.bank_id AND a.account_number = b.account_number)`), not a
+/// bare `.id`. Covers the `to_sql_equality` composite path the fix routes through.
+#[tokio::test]
+async fn node_identity_comparison_composite_node_id() {
+    let schema = load_schema("schemas/test/composite_node_ids.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH (a:Account)-[:TRANSFERRED]->(b:Account) WHERE a <> b RETURN a.account_type",
+            dialect,
+        )
+        .await;
+        assert!(
+            sql.contains("a.bank_id = b.bank_id")
+                && sql.contains("a.account_number = b.account_number"),
+            "({dialect:?}) composite `a <> b` must compare every node_id column pairwise:\n{sql}"
+        );
+        assert!(
+            !sql.contains("a.id") && !sql.contains("b.id"),
+            "({dialect:?}) composite `a <> b` must NOT emit a hardcoded `.id`:\n{sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Cypher `WHERE a = b` / `a <> b` between two bare node variables compares **node identity**, but ClickGraph emitted `a.id <> b.id`. A node's identity is its schema **node_id column** — usually renamed (`user_id`) or composite (`[bank_id, account_number]`) — so no `id` column exists and the query fails at execution on **both** backends:

- ClickHouse: `Code 47: Identifier 'a.id' cannot be resolved`
- Databricks: `UNRESOLVED_COLUMN: a.id ... did you mean a.user_id`

The `id(a) <> id(b)` **function** form already resolved correctly — only the bare-node form was broken.

## Fix

The emit-time node-identity handler in `to_sql_query.rs` hardcoded `.id` on both operands. It now resolves each bare node alias to its schema node_id (`get_node_label_for_alias` → `node_schema_opt(label).node_id.id`) and emits via `Identifier::to_sql_equality`, which pairs columns element-wise and is dialect-aware:

- single: `a.user_id = b.user_id` (and `NOT (...)` for `<>`)
- composite: `NOT (a.bank_id = b.bank_id AND a.account_number = b.account_number)`

Falls back to the prior `.id` only when a label/schema can't be resolved, so nothing regresses. Routes through schema-catalog + dialect dispatch APIs (ratchet green, no baseline bump).

## How it was found

Live, while driving the MCP agentic demo — a friend-of-friend query `MATCH (me)-[:FOLLOWS]->(f)-[:FOLLOWS]->(fof) WHERE fof <> me ...` failed on Databricks. Isolated to the bare-node identity comparison, confirmed identical failure on ClickHouse.

## Verification

- Live on ClickHouse **and** Databricks; standard (`user_id`) and composite (`[bank_id, account_number]`) schemas; `=` and `<>`.
- The originally-failing friend-of-friend query now returns correct results through the MCP tool.
- New regression tests (standard + composite, both dialects). **Full suite + ratchet green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)