### PR TITLE
fix(vlp): path-node property readout `[n IN nodes(path) | n.name]` (#1077)

### DIFF
--- a/docs/wiki/Cypher-Multi-Hop-Traversals.md
+++ b/docs/wiki/Cypher-Multi-Hop-Traversals.md
@@ -313,6 +313,34 @@ RETURN [node IN nodes(path) | node.name] AS route
 - Analyze alternative routes
 - Network redundancy analysis
 
+### Reading node properties along a path
+
+`nodes(path)` yields the nodes visited by a variable-length or shortest path.
+Extract a per-node property with a list comprehension:
+
+```cypher
+MATCH path = shortestPath((a:User {name: 'Alice'})-[:FOLLOWS*1..5]->(b:User {name: 'Rachel'}))
+RETURN [n IN nodes(path) | n.name] AS hops
+-- → ['Alice', 'David', 'Henry', 'Sam', 'Rachel']
+```
+
+The property is materialized in traversal order (start → … → end) by accumulating a
+parallel property array in the recursive traversal — no extra table scan, so it
+scales the same as the traversal itself. Works identically on ClickHouse
+(ClickGraph) and Databricks/Spark SQL (DeltaGraph).
+
+**Scope** (other forms fail loudly at plan time with an actionable message rather
+than returning wrong results):
+
+| Form | Supported |
+|---|---|
+| `[n IN nodes(path) \| n.prop]` (single property, identity body) | ✅ |
+| `[n IN nodes(path) \| n]` (node ids) | ✅ |
+| `[n IN nodes(path) \| f(n.prop)]` (composite body, e.g. `toUpper(n.name)`) | ❌ — map outside the comprehension |
+| `[r IN relationships(path) \| r.prop]` (relationship property) | ❌ — not yet |
+| Multi-label paths (nodes of different labels) | ❌ — the property→column mapping must be shared |
+| Denormalized / FK-edge / weighted variable-length paths | ❌ — project ids with `[n IN nodes(path) \| n]` |
+
 ### Shortest Path with Length Constraints
 
 ```cypher

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -524,6 +524,18 @@ impl ProjectionTagging {
                     property_access.column.raw()
                 );
 
+                // Lambda-binder shield (#1077): a comprehension binder (e.g. `n` in
+                // `[n IN nodes(path) | n.name]`) is registered as a projection alias by the
+                // `Lambda` arm for the duration of body tagging — it is NOT a graph table
+                // alias and has no `TableCtx`. The sibling `TableAlias` arm already returns
+                // early for such aliases; mirror that here so property access on the binder
+                // (`n.name`) is left intact for the render layer to resolve against the VLP
+                // `path_<prop>` accumulator array, rather than erroring with
+                // `No table context for alias 'n'`.
+                if plan_ctx.is_projection_alias(&property_access.table_alias.0) {
+                    return Ok(());
+                }
+
                 // ====================================================================
                 // CRITICAL: Check if this is a CTE-sourced variable (NEW Jan 2026)
                 // ====================================================================

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -571,6 +571,7 @@ pub fn generate_vlp_cte_via_manager(
     use_bfs_mode: bool,
     is_undirected: bool,
     undirected_single_walk: bool,
+    path_node_properties: Vec<NodeProperty>,
 ) -> Result<Cte, RenderBuildError> {
     use std::sync::Arc;
 
@@ -597,6 +598,7 @@ pub fn generate_vlp_cte_via_manager(
     context.use_bfs_mode = use_bfs_mode;
     context.is_undirected = is_undirected;
     context.undirected_single_walk = undirected_single_walk;
+    context.path_node_properties = path_node_properties;
 
     // Convert filters to CategorizedFilters format
     let filters = super::filter_pipeline::CategorizedFilters {
@@ -4882,6 +4884,95 @@ pub fn extract_ctes_with_context(
                         false
                     };
 
+                    // #1077: detect `[n IN nodes(path) | n.<prop>]` and request a parallel
+                    // per-node property array from the VLP CTE. Forms we cannot yet render
+                    // correctly (filtered/composite bodies, `relationships(path)` property
+                    // access, or a multi-label path where the binder ranges over nodes of
+                    // different labels) fail loudly here, never emitting broken SQL.
+                    let path_node_properties: Vec<NodeProperty> = if let Some(ref pv) =
+                        graph_rel.path_variable
+                    {
+                        // Prefer the outermost plan (thread-local) so the enclosing
+                        // RETURN/WITH projection is visible; fall back to context
+                        // root_plan, then the local subtree.
+                        let root = render_root_plan().or_else(|| context.root_plan.clone());
+                        let check: &LogicalPlan = root.as_deref().unwrap_or(plan);
+                        let access = analyze_path_node_property_access(check, pv);
+                        if let Some(reason) = access.unsupported {
+                            return Err(RenderBuildError::UnsupportedFeature(format!(
+                                "Path-node property access on `{}`: {}",
+                                pv, reason
+                            )));
+                        }
+                        // Route the emitter-variant gate through PatternSchemaContext /
+                        // schema-catalog APIs (node access strategy + join strategy), not
+                        // raw denormalized/fk-edge flags, per the axis-dispatch rule: the
+                        // parallel `path_<prop>` arrays are only emitted by the pure-standard
+                        // base/recursive/zero-hop arms (both endpoints own their table, not an
+                        // FK-edge join, not weighted).
+                        let is_pure_standard_pattern = {
+                            use crate::graph_catalog::pattern_schema::{
+                                JoinStrategy, NodeAccessStrategy,
+                            };
+                            let both_own_table = matches!(
+                                &pattern_ctx.left_node,
+                                NodeAccessStrategy::OwnTable { .. }
+                            ) && matches!(
+                                &pattern_ctx.right_node,
+                                NodeAccessStrategy::OwnTable { .. }
+                            );
+                            let fk_edge = matches!(
+                                &pattern_ctx.join_strategy,
+                                JoinStrategy::FkEdgeJoin { .. }
+                            );
+                            both_own_table && !fk_edge && weight_cte_config.is_none()
+                        };
+                        if access.node_props.is_empty() {
+                            Vec::new()
+                        } else if start_label.is_empty() || start_label != end_label {
+                            // The binder ranges over EVERY node on the path, so a single
+                            // `path_<prop>` column is only sound when all path nodes share
+                            // one label (one property→column mapping).
+                            return Err(RenderBuildError::UnsupportedFeature(format!(
+                                "Path-node property access on `{}` is only supported when all \
+                                 path nodes share one label; this path spans `{}`..`{}`. Use \
+                                 `[n IN nodes({}) | n]` for ids, or an explicit per-label pattern.",
+                                pv, start_label, end_label, pv
+                            )));
+                        } else if !is_pure_standard_pattern {
+                            return Err(RenderBuildError::UnsupportedFeature(format!(
+                                "Path-node property access on `{}` is only supported for standard \
+                                 single-label variable-length paths where both endpoints have \
+                                 their own node table; this pattern uses a denormalized/FK-edge/\
+                                 weighted strategy. Project node ids with `[n IN nodes({}) | n]` \
+                                 instead, or use an explicit fixed-length pattern.",
+                                pv, pv
+                            )));
+                        } else {
+                            access
+                                .node_props
+                                .iter()
+                                .map(|prop| {
+                                    let column_name =
+                                        crate::render_plan::cte_generation::map_property_to_column_with_schema(
+                                            prop,
+                                            &start_label,
+                                        )
+                                        .unwrap_or_else(|_| prop.clone());
+                                    NodeProperty {
+                                        // Sentinel alias: never matches start/end cypher aliases,
+                                        // so the endpoint-property gates in the emitter skip it.
+                                        cypher_alias: "__path_node__".to_string(),
+                                        column_name,
+                                        alias: prop.clone(),
+                                    }
+                                })
+                                .collect()
+                        }
+                    } else {
+                        Vec::new()
+                    };
+
                     // Detect lightweight BFS mode for shortestPath + length(path)-only queries.
                     // BFS tracks only distinct reachable node_ids per hop level instead of
                     // per-path visited arrays, reducing memory from ~500M rows to ~180K rows.
@@ -4979,6 +5070,7 @@ pub fn extract_ctes_with_context(
                         needs_bfs_mode,
                         is_undirected,
                         undirected_single_walk,
+                        path_node_properties,
                     )?;
 
                     // TODO(multi-vlp): Per-VLP unique aliases (vt0, vt1) are used in
@@ -6986,6 +7078,246 @@ pub fn plan_uses_nodes_fn(plan: &LogicalPlan, path_var: &str) -> bool {
     }
 
     plan_has_nodes(plan, path_var)
+}
+
+thread_local! {
+    /// The outermost plan currently being rendered, for #1077 path-node property
+    /// detection. CTE extraction runs at the subtree level (GraphRel/GraphJoins),
+    /// whose own `to_render_plan` resets `context.root_plan` to itself — hiding the
+    /// enclosing RETURN/WITH projection where `[n IN nodes(p) | n.<prop>]` lives.
+    /// Set at the outermost render entry (outermost wins), so detection always sees
+    /// the full tree regardless of which subtree owns the VLP CTE.
+    static RENDER_ROOT_PLAN: std::cell::RefCell<Option<std::sync::Arc<LogicalPlan>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Restores the previous outermost-plan value when dropped.
+pub struct RenderRootPlanGuard(Option<std::sync::Arc<LogicalPlan>>);
+impl Drop for RenderRootPlanGuard {
+    fn drop(&mut self) {
+        RENDER_ROOT_PLAN.with(|c| *c.borrow_mut() = self.0.take());
+    }
+}
+
+/// Record `plan` as the outermost render plan for path-node property detection,
+/// but only if none is set yet (outermost wins — nested renders don't clobber it).
+/// The returned guard restores the prior value on drop, so the slot is cleared
+/// once the outermost render returns.
+pub fn scoped_render_root_plan(plan: std::sync::Arc<LogicalPlan>) -> RenderRootPlanGuard {
+    RENDER_ROOT_PLAN.with(|c| {
+        let mut slot = c.borrow_mut();
+        let prev = slot.clone();
+        if slot.is_none() {
+            *slot = Some(plan);
+        }
+        RenderRootPlanGuard(prev)
+    })
+}
+
+/// The outermost render plan, if set (see [`scoped_render_root_plan`]).
+pub fn render_root_plan() -> Option<std::sync::Arc<LogicalPlan>> {
+    RENDER_ROOT_PLAN.with(|c| c.borrow().clone())
+}
+
+/// Result of scanning a plan for path-node property access (#1077).
+#[derive(Debug, Default)]
+pub struct PathNodePropAccess {
+    /// Property names read via the supported identity form
+    /// `[n IN nodes(path) | n.<prop>]` (deduped, stable order).
+    pub node_props: std::collections::BTreeSet<String>,
+    /// `Some(reason)` if an unsupported path-comprehension form was found
+    /// (filtered, non-identity/multi-prop body, or `relationships(path)`
+    /// property access). Drives a loud plan-time guard rather than emitting
+    /// broken SQL.
+    pub unsupported: Option<String>,
+}
+
+/// Scan the plan for list comprehensions over `nodes(path)` / `relationships(path)`
+/// that access a property of the binder (#1077). The comprehension lowers to
+/// `arrayMap(Lambda([b], body), <source>)`; we classify each occurrence:
+///   * source `nodes(path)`, body exactly `b.<prop>`  → supported (collect prop)
+///   * source `nodes(path)`, body references `b` otherwise (composite / multi-prop) → guard
+///   * source `arrayFilter(_, nodes/relationships(path))` (filtered) → guard
+///   * source `relationships(path)`, body references `b`             → guard
+///
+/// The bare form `[n IN nodes(path) | n]` (no property) is untouched (already works).
+pub fn analyze_path_node_property_access(plan: &LogicalPlan, path_var: &str) -> PathNodePropAccess {
+    use crate::query_planner::logical_expr::LogicalExpr;
+
+    #[derive(Clone, Copy, PartialEq)]
+    enum SourceKind {
+        Nodes,
+        Rels,
+    }
+
+    // Classify the arrayMap list argument as a path source over `path_var`.
+    // Returns the element kind and whether it is wrapped in an arrayFilter.
+    fn path_source_kind(
+        inner: &LogicalExpr,
+        path_var: &str,
+        filtered: bool,
+    ) -> Option<(SourceKind, bool)> {
+        if let LogicalExpr::ScalarFnCall(fc) = inner {
+            let hits_pv = |args: &[LogicalExpr]| {
+                args.iter().any(|a| match a {
+                    LogicalExpr::TableAlias(v) => v.0 == path_var,
+                    LogicalExpr::PropertyAccessExp(pa) => pa.table_alias.0 == path_var,
+                    _ => false,
+                })
+            };
+            match fc.name.as_str() {
+                "nodes" if hits_pv(&fc.args) => return Some((SourceKind::Nodes, filtered)),
+                "relationships" if hits_pv(&fc.args) => return Some((SourceKind::Rels, filtered)),
+                "arrayFilter" if fc.args.len() == 2 => {
+                    return path_source_kind(&fc.args[1], path_var, true);
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    // Does `expr` reference the lambda binder `b` anywhere (bare or property)?
+    fn references_binder(expr: &LogicalExpr, b: &str) -> bool {
+        match expr {
+            LogicalExpr::TableAlias(v) => v.0 == b,
+            LogicalExpr::PropertyAccessExp(pa) => pa.table_alias.0 == b,
+            LogicalExpr::ScalarFnCall(fc) => fc.args.iter().any(|a| references_binder(a, b)),
+            LogicalExpr::OperatorApplicationExp(op) => {
+                op.operands.iter().any(|o| references_binder(o, b))
+            }
+            LogicalExpr::Case(c) => {
+                c.expr.as_deref().is_some_and(|e| references_binder(e, b))
+                    || c.when_then
+                        .iter()
+                        .any(|(w, t)| references_binder(w, b) || references_binder(t, b))
+                    || c.else_expr
+                        .as_deref()
+                        .is_some_and(|e| references_binder(e, b))
+            }
+            LogicalExpr::Lambda(l) => references_binder(&l.body, b),
+            _ => false,
+        }
+    }
+
+    fn scan_expr(expr: &LogicalExpr, path_var: &str, out: &mut PathNodePropAccess) {
+        if let LogicalExpr::ScalarFnCall(fc) = expr {
+            if fc.name == "arrayMap" && fc.args.len() == 2 {
+                if let LogicalExpr::Lambda(lambda) = &fc.args[0] {
+                    if let Some(binder) = lambda.params.first() {
+                        if let Some((kind, filtered)) =
+                            path_source_kind(&fc.args[1], path_var, false)
+                        {
+                            match (kind, filtered) {
+                                (SourceKind::Nodes, false) => {
+                                    // Identity body `b.<prop>` is supported; anything
+                                    // else that touches the binder is guarded (v1).
+                                    match lambda.body.as_ref() {
+                                        LogicalExpr::PropertyAccessExp(pa)
+                                            if pa.table_alias.0 == *binder =>
+                                        {
+                                            out.node_props.insert(pa.column.raw().to_string());
+                                        }
+                                        // Bare identity `[n IN nodes(p) | n]` → array of
+                                        // node ids; already works, leave untouched.
+                                        LogicalExpr::TableAlias(v) if v.0 == *binder => {}
+                                        body if references_binder(body, binder) => {
+                                            out.unsupported.get_or_insert_with(|| {
+                                                "only the identity form \
+                                                 `[n IN nodes(p) | n.<prop>]` is supported; \
+                                                 wrap the property outside the comprehension \
+                                                 (e.g. `[n IN nodes(p) | n.name]` then map)"
+                                                    .to_string()
+                                            });
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                (SourceKind::Nodes, true) => {
+                                    if references_binder(&lambda.body, binder) {
+                                        out.unsupported.get_or_insert_with(|| {
+                                            "property access on a filtered `nodes(p)` \
+                                             comprehension is not supported yet"
+                                                .to_string()
+                                        });
+                                    }
+                                }
+                                (SourceKind::Rels, _) => {
+                                    if references_binder(&lambda.body, binder) {
+                                        out.unsupported.get_or_insert_with(|| {
+                                            "property access on `relationships(p)` is not \
+                                             supported yet; project the relationships or use \
+                                             an explicit pattern"
+                                                .to_string()
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            for a in &fc.args {
+                scan_expr(a, path_var, out);
+            }
+        } else {
+            match expr {
+                LogicalExpr::OperatorApplicationExp(op) => {
+                    for o in &op.operands {
+                        scan_expr(o, path_var, out);
+                    }
+                }
+                LogicalExpr::Case(c) => {
+                    if let Some(e) = c.expr.as_deref() {
+                        scan_expr(e, path_var, out);
+                    }
+                    for (w, t) in &c.when_then {
+                        scan_expr(w, path_var, out);
+                        scan_expr(t, path_var, out);
+                    }
+                    if let Some(e) = c.else_expr.as_deref() {
+                        scan_expr(e, path_var, out);
+                    }
+                }
+                LogicalExpr::Lambda(l) => scan_expr(&l.body, path_var, out),
+                _ => {}
+            }
+        }
+    }
+
+    fn scan_plan(plan: &LogicalPlan, path_var: &str, out: &mut PathNodePropAccess) {
+        match plan {
+            LogicalPlan::Projection(p) => {
+                for item in &p.items {
+                    scan_expr(&item.expression, path_var, out);
+                }
+            }
+            LogicalPlan::Filter(f) => scan_expr(&f.predicate, path_var, out),
+            LogicalPlan::WithClause(wc) => {
+                for item in &wc.items {
+                    scan_expr(&item.expression, path_var, out);
+                }
+            }
+            LogicalPlan::OrderBy(ob) => {
+                for item in &ob.items {
+                    scan_expr(&item.expression, path_var, out);
+                }
+            }
+            LogicalPlan::GraphRel(gr) => {
+                if let Some(p) = &gr.where_predicate {
+                    scan_expr(p, path_var, out);
+                }
+            }
+            _ => {}
+        }
+        for c in plan.children() {
+            scan_plan(c, path_var, out);
+        }
+    }
+
+    let mut out = PathNodePropAccess::default();
+    scan_plan(plan, path_var, &mut out);
+    out
 }
 
 /// Check if the path variable is used bare (as TableAlias/ColumnAlias) outside of

--- a/src/render_plan/cte_generation.rs
+++ b/src/render_plan/cte_generation.rs
@@ -63,6 +63,10 @@ pub struct CteGenerationContext {
     /// two-monotone-arm Union split). Distinct from `is_undirected`, which is
     /// also true for the individual arms of a legacy split.
     pub undirected_single_walk: bool,
+    /// #1077: per-path-node properties requested via `[n IN nodes(p) | n.<prop>]`.
+    /// Threaded to the VLP generator, which accumulates a parallel `path_<prop>`
+    /// array per entry. Empty unless the query reads path-node properties.
+    pub path_node_properties: Vec<NodeProperty>,
     /// Root plan reference for checking path variable usage across the entire query.
     /// Set at the top-level to_render_plan call so VLP extraction can check if path
     /// variables are used bare (preventing BFS optimization).

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1701,6 +1701,15 @@ impl VariableLengthCteStrategy {
         generator.is_undirected = context.is_undirected;
         generator.undirected_single_walk = context.undirected_single_walk;
 
+        // #1077: per-path-node property arrays (`[n IN nodes(p) | n.prop]`).
+        // Only ever non-empty for the pure-standard single-label pattern — the
+        // detection site in cte_extraction gates it via PatternSchemaContext
+        // (both endpoints OwnTable, not FK-edge, not weighted) and refuses other
+        // strategies with an actionable error, so setting it here unconditionally
+        // is safe: the parallel `path_<prop>` arrays are emitted only by the
+        // standard base/recursive/zero-hop arms.
+        generator.path_node_properties = context.path_node_properties.clone();
+
         // Generate the CTE using the comprehensive generator
         let cte = generator.generate_cte();
 

--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -1335,6 +1335,13 @@ impl RenderPlanBuilder for LogicalPlan {
     }
 
     fn to_render_plan(&self, schema: &GraphSchema) -> RenderPlanBuilderResult<RenderPlan> {
+        // #1077: record the outermost plan for path-node property detection
+        // (outermost wins; restored on drop). CTE extraction runs at the subtree
+        // level and would otherwise only see a GraphRel, hiding the RETURN/WITH
+        // projection where `[n IN nodes(p) | n.<prop>]` lives.
+        let _root_plan_guard =
+            super::cte_extraction::scoped_render_root_plan(std::sync::Arc::new(self.clone()));
+
         // CRITICAL: If the plan contains WITH clauses, use the specialized handler
         // build_chained_with_match_cte_plan handles chained/nested WITH correctly
         use super::plan_builder_utils::{
@@ -4044,6 +4051,11 @@ impl RenderPlanBuilder for LogicalPlan {
         plan_ctx: Option<&PlanCtx>,
         scope: Option<&super::variable_scope::VariableScope>,
     ) -> RenderPlanBuilderResult<RenderPlan> {
+        // #1077: record the outermost plan for path-node property detection
+        // (outermost wins; restored on drop) — see `to_render_plan`.
+        let _root_plan_guard =
+            super::cte_extraction::scoped_render_root_plan(std::sync::Arc::new(self.clone()));
+
         let mut render_plan = (|| -> RenderPlanBuilderResult<RenderPlan> {
             log::debug!(
                 "🔀🔀🔀 to_render_plan_with_ctx ENTRY - plan type: {:?}",

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -2382,6 +2382,43 @@ pub(super) fn rewrite_logical_path_functions(
 
     match expr {
         LogicalExpr::ScalarFnCall(fn_call) => {
+            // #1077: `[n IN nodes(path) | n.<prop>]` lowers to
+            // `arrayMap(Lambda([n], n.<prop>), nodes(path))`. When the body is the
+            // identity property access `n.<prop>`, the whole comprehension resolves
+            // to the VLP CTE's pre-accumulated `path_<prop>` array (built by the
+            // emitter). Rewrite it to the bare-column marker directly — consuming
+            // the arrayMap WHOLE, before its inner `nodes(path)` is independently
+            // rewritten to `path_nodes` (which would strand the `n.<prop>` body).
+            if fn_call.name == "arrayMap" && fn_call.args.len() == 2 {
+                if let LogicalExpr::Lambda(lambda) = &fn_call.args[0] {
+                    let inner_is_nodes_of_pv = matches!(
+                        &fn_call.args[1],
+                        LogicalExpr::ScalarFnCall(inner)
+                            if inner.name == "nodes"
+                                && inner.args.len() == 1
+                                && matches!(
+                                    &inner.args[0],
+                                    LogicalExpr::TableAlias(TableAlias(a)) if a == path_var_name
+                                )
+                    );
+                    if inner_is_nodes_of_pv {
+                        if let (Some(binder), LogicalExpr::PropertyAccessExp(pa)) =
+                            (lambda.params.first(), lambda.body.as_ref())
+                        {
+                            if pa.table_alias.0 == *binder {
+                                return LogicalExpr::PropertyAccessExp(PropertyAccess {
+                                    table_alias: TableAlias("__vlp_bare_col".to_string()),
+                                    column: PropertyValue::Column(format!(
+                                        "path_{}",
+                                        pa.column.raw()
+                                    )),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
             // Check if this is a path function call with the path variable as argument
             if fn_call.args.len() == 1 {
                 if let LogicalExpr::TableAlias(TableAlias(alias)) = &fn_call.args[0] {

--- a/src/render_plan/render_expr.rs
+++ b/src/render_plan/render_expr.rs
@@ -2110,7 +2110,49 @@ impl TryFrom<LogicalExpr> for RenderExpr {
                 }
             }
             LogicalExpr::AggregateFnCall(agg) => RenderExpr::AggregateFnCall(agg.try_into()?),
-            LogicalExpr::ScalarFnCall(fn_call) => RenderExpr::ScalarFnCall(fn_call.try_into()?),
+            LogicalExpr::ScalarFnCall(fn_call) => {
+                // #1077: `[n IN nodes(p) | n.<prop>]` lowered (ast_conversion) to
+                // `arrayMap(Lambda([n], n.<prop>), nodes(p))`. When the body is the
+                // identity property access, resolve the whole comprehension to the
+                // VLP CTE's accumulated `path_<prop>` array via the `__vlp_bare_col`
+                // bare-column marker (resolves against the single VLP FROM table).
+                // This MUST match here — before the lambda is flattened to `Raw`
+                // text (see the `LogicalExpr::Lambda` arm below) — so it covers the
+                // RETURN, WITH, and filter paths uniformly. The parallel `path_<prop>`
+                // column is emitted only when this comprehension is present (detected
+                // in cte_extraction), so a non-matching arrayMap is unaffected.
+                let path_node_marker = if fn_call.name == "arrayMap" && fn_call.args.len() == 2 {
+                    if let (LogicalExpr::Lambda(l), LogicalExpr::ScalarFnCall(inner)) =
+                        (&fn_call.args[0], &fn_call.args[1])
+                    {
+                        let inner_is_nodes = inner.name == "nodes"
+                            && inner.args.len() == 1
+                            && matches!(&inner.args[0], LogicalExpr::TableAlias(_));
+                        match (inner_is_nodes, l.params.first(), l.body.as_ref()) {
+                            (true, Some(binder), LogicalExpr::PropertyAccessExp(pa))
+                                if pa.table_alias.0 == *binder =>
+                            {
+                                Some(RenderExpr::PropertyAccessExp(PropertyAccess {
+                                    table_alias: TableAlias("__vlp_bare_col".to_string()),
+                                    column: PropertyValue::Column(format!(
+                                        "path_{}",
+                                        pa.column.raw()
+                                    )),
+                                }))
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                match path_node_marker {
+                    Some(marker) => marker,
+                    None => RenderExpr::ScalarFnCall(fn_call.try_into()?),
+                }
+            }
             LogicalExpr::PropertyAccessExp(pa) => RenderExpr::PropertyAccessExp(pa.try_into()?),
             LogicalExpr::OperatorApplicationExp(op) => {
                 // Special case: NOT (PathPattern) -> NOT EXISTS subquery

--- a/src/render_plan/vlp_rewrite.rs
+++ b/src/render_plan/vlp_rewrite.rs
@@ -351,11 +351,12 @@ pub fn rewrite_render_expr_for_vlp_with_from_alias(
             // Path functions use bare Column("path_nodes") that get qualified as t.path_nodes during SQL generation
             // We need to convert them to PropertyAccessExp so they can be rewritten
             // Check if this is a path function column (path_nodes, hop_count, path_relationships)
+            // plus the #1077 per-node property accumulators `path_<prop>` (e.g. `path_name`).
+            // A bare `Column` starting with `path_` only originates from the VLP path-function
+            // marker (`__vlp_bare_col`); real node properties are always alias-qualified, so
+            // this does not capture user columns.
             let col_name_str = column.0.raw().to_string(); // Clone to avoid borrow issues
-            if matches!(
-                col_name_str.as_str(),
-                "path_nodes" | "hop_count" | "path_relationships" | "path_edges"
-            ) {
+            if col_name_str == "hop_count" || col_name_str.starts_with("path_") {
                 log::info!(
                     "🔄 VLP: Converting Column({}) to PropertyAccessExp({}.{})",
                     col_name_str,

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -547,6 +547,14 @@ pub struct VariableLengthCteGenerator<'a> {
     /// `is_undirected` here would turn each monotone arm into a complete
     /// undirected walk and double-count every path.
     pub undirected_single_walk: bool,
+    /// #1077: per-path-node properties to accumulate as parallel `path_<alias>`
+    /// arrays (one per requested property), alongside the id-only `path_nodes`.
+    /// Populated only when a query does `[n IN nodes(path) | n.<prop>]`; empty
+    /// otherwise, so the emit is byte-identical for every other query. Each
+    /// entry's `column_name` is the resolved physical column on the (single,
+    /// shared) node label; `alias` is the Cypher property name, yielding a
+    /// `path_<alias>` column. Set post-construction (see cte_manager).
+    pub path_node_properties: Vec<NodeProperty>,
 }
 
 /// Configuration for weighted shortest path using a pre-computed edge weight CTE
@@ -769,6 +777,7 @@ impl<'a> VariableLengthCteGenerator<'a> {
             use_bfs_mode: false,
             is_undirected: false,
             undirected_single_walk: false,
+            path_node_properties: Vec::new(),
         }
     }
 
@@ -845,6 +854,7 @@ impl<'a> VariableLengthCteGenerator<'a> {
             use_bfs_mode: false,
             is_undirected: false,
             undirected_single_walk: false,
+            path_node_properties: Vec::new(),
         }
     }
 
@@ -2539,6 +2549,18 @@ impl<'a> VariableLengthCteGenerator<'a> {
             ),
         ];
 
+        // #1077: zero-hop parallel per-node property arrays — the path visits
+        // only the start node at hop 0, so a single-element `[start_node.<col>]`
+        // (mirrors the `path_nodes` singleton above). Column order matches the
+        // 1-hop base / recursive arms for UNION alignment.
+        for p in &self.path_node_properties {
+            select_items.push(format!(
+                "{} as path_{}",
+                arr(&format!("{}.{}", self.start_node_alias, p.column_name)),
+                p.alias
+            ));
+        }
+
         // #628: a CLOSED `*0..N` walk enforces EDGE-uniqueness (so real cycles
         // survive — see `uses_edge_uniqueness`). The zero-hop base has no edge,
         // so it seeds an EMPTY-but-typed `path_edges` array. A bare `[]` is
@@ -2721,6 +2743,22 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 select_items.push(format!("{empty_str_arr} as path_relationships"));
             }
             select_items.push(path_nodes_selection);
+
+            // #1077: seed parallel per-node property arrays for
+            // `[n IN nodes(p) | n.<prop>]`. Mirrors the 2-element `path_nodes`
+            // seed exactly ([start, end]) using the already-JOINed node rows —
+            // no extra scan. Empty (byte-identical) for every query that does
+            // not read path-node properties.
+            for p in &self.path_node_properties {
+                select_items.push(format!(
+                    "{} as path_{}",
+                    arr(&format!(
+                        "{}.{}, {}.{}",
+                        self.start_node_alias, p.column_name, self.end_node_alias, p.column_name
+                    )),
+                    p.alias
+                ));
+            }
 
             // #598 (part 2): seed path_edges with this hop's edge identity so the
             // recursive step can enforce relationship-uniqueness (Cypher default).
@@ -3014,6 +3052,20 @@ impl<'a> VariableLengthCteGenerator<'a> {
             select_items.push(format!("{empty_str_arr} as path_relationships"));
         }
         select_items.push(path_nodes_selection);
+
+        // #1077: accumulate parallel per-node property arrays, mirroring the
+        // `path_nodes` extension above. Appends this hop's end-node property
+        // value using the already-JOINed `end_node` row. Same order as the base
+        // case (Vec order) so recursive-CTE UNION columns line up. Empty for
+        // queries that do not read path-node properties → byte-identical.
+        for p in &self.path_node_properties {
+            select_items.push(format!(
+                "{ac}(vp.path_{}, {}) as path_{}",
+                p.alias,
+                arr(&format!("{}.{}", self.end_node_alias, p.column_name)),
+                p.alias
+            ));
+        }
 
         // #598 (part 2): accumulate this hop's edge identity so relationship-uniqueness
         // (Cypher default) can be enforced below. path_nodes is still accumulated

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -19502,3 +19502,104 @@ async fn node_identity_comparison_composite_node_id() {
         );
     }
 }
+
+/// #1077: `[n IN nodes(path) | n.<prop>]` (path-node property readout) must
+/// accumulate a parallel `path_<prop>` array in the VLP CTE — seeded from both
+/// endpoints in the base case and extended by `end_node.<col>` in the recursive
+/// case — and resolve the comprehension to that array (NOT leave a stranded
+/// `arrayMap(n -> n.name, path_nodes)` that fails at execution). Standard schema:
+/// `User.name` → `full_name`. Both dialects (CH `[..]`/`arrayConcat`, Databricks
+/// `array(..)`/`concat`).
+#[tokio::test]
+async fn path_node_property_readout_accumulates_parallel_array() {
+    let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH path = (a:User {name:'Alice'})-[:FOLLOWS*1..2]->(b) \
+             RETURN [n IN nodes(path) | n.name] AS names",
+            dialect,
+        )
+        .await;
+        // Parallel property array is emitted (base seed + recursive extension),
+        // keyed on the mapped physical column `full_name`.
+        assert!(
+            sql.contains("as path_name"),
+            "({dialect:?}) must emit a parallel `path_name` array:\n{sql}"
+        );
+        assert!(
+            sql.contains("start_node.full_name") && sql.contains("end_node.full_name"),
+            "({dialect:?}) `path_name` must accumulate the mapped `full_name` column:\n{sql}"
+        );
+        // The comprehension resolves to the accumulated array — no stranded arrayMap
+        // over the id-only `path_nodes`.
+        assert!(
+            !sql.contains("n.name"),
+            "({dialect:?}) `n.name` must be resolved to the `path_name` array, not left bare:\n{sql}"
+        );
+        assert!(
+            sql.contains("path_name AS") || sql.contains("path_name  AS"),
+            "({dialect:?}) final projection must select the `path_name` array:\n{sql}"
+        );
+    }
+}
+
+/// #1077: the id-only form `[n IN nodes(path) | n]` (no property access) is
+/// unchanged — it maps over the id array `path_nodes` and must NOT trigger the
+/// path-property accumulator or any guard.
+#[tokio::test]
+async fn path_node_id_list_is_unchanged() {
+    let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        let sql = render(
+            &schema,
+            "MATCH path = (a:User {name:'Alice'})-[:FOLLOWS*1..2]->(b) \
+             RETURN [n IN nodes(path) | n] AS ids",
+            dialect,
+        )
+        .await;
+        assert!(
+            !sql.contains("as path_name") && !sql.contains("path_full_name"),
+            "({dialect:?}) id-only comprehension must NOT emit a property accumulator:\n{sql}"
+        );
+        assert!(
+            sql.contains("path_nodes"),
+            "({dialect:?}) id-only comprehension still maps over `path_nodes`:\n{sql}"
+        );
+    }
+}
+
+/// #1077 guards: unsupported path-comprehension forms fail loudly at plan time
+/// with an actionable message (never opaque, never silently-wrong SQL).
+#[tokio::test]
+async fn path_node_property_readout_unsupported_forms_guarded() {
+    let schema = load_schema("benchmarks/social_network/schemas/social_benchmark.yaml");
+    for dialect in [SqlDialect::ClickHouse, SqlDialect::Databricks] {
+        // Composite / non-identity body.
+        let composite = try_render(
+            &schema,
+            "MATCH path = (a:User {name:'Alice'})-[:FOLLOWS*1..2]->(b) \
+             RETURN [n IN nodes(path) | toUpper(n.name)] AS r",
+            dialect,
+        )
+        .await;
+        assert!(
+            composite.is_err()
+                && composite.as_ref().unwrap_err().contains("identity form"),
+            "({dialect:?}) composite body must be guarded with an actionable message: {composite:?}"
+        );
+
+        // relationships(path) property access.
+        let rels = try_render(
+            &schema,
+            "MATCH path = (a:User {name:'Alice'})-[r:FOLLOWS*1..2]->(b) \
+             RETURN [x IN relationships(path) | x.created_at] AS r",
+            dialect,
+        )
+        .await;
+        assert!(
+            rels.is_err() && rels.as_ref().unwrap_err().contains("relationships(p)"),
+            "({dialect:?}) relationships(path) property must be guarded: {rels:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1077.

## What

`[n IN nodes(path) | n.name]` now returns the per-node property array in traversal order — e.g. `shortestPath(Alice → Rachel)` → `['Alice','David','Henry','Sam','Rachel']` — instead of failing at planning (`ProjectionTagging: No table context for alias 'n'`, masked as Bolt `50N42`).

## Root cause (two layers)

1. **Shield gap**: the comprehension lowers to `arrayMap(n -> n.name, nodes(path))`; the `PropertyAccessExp` arm of projection-tagging was unshielded, while its sibling bare-variable arm was — so `n.name` on the lambda binder errored.
2. **Representation gap**: `nodes(path)` materializes as `path_nodes`, an array of node **ids**, so `.name` had no column to resolve to. (This is also why `reduce`/`UNWIND` property-over-path forms silently failed at execution.)

## Fix — parallel property-array accumulation

Accumulate a `path_<prop>` array in the VLP recursive CTE, mirroring `path_nodes` and reusing the node row **already JOINed at each hop** (`end_node.<col>`) — zero extra table scan, so it scales with the traversal.

- `projection_tagging.rs` — shield lambda-binder property access (one-line gap).
- `render_expr.rs` — resolve `arrayMap(Lambda([n], n.prop), nodes(p))` → the accumulated `path_<prop>` array (via the `__vlp_bare_col` marker) at the single `LogicalExpr→RenderExpr` point, before the lambda flattens to `Raw`; covers RETURN/WITH/filter uniformly.
- `variable_length_cte.rs` — emit `path_<prop>` in base/recursive/zero-hop, gated on a non-empty request list → **byte-identical** output for every other query.
- `cte_extraction.rs` — detect the comprehension against the **outermost** plan (new thread-local so the enclosing projection is visible during subtree CTE extraction), thread the property list, and **guard** unsupported forms with actionable plan-time errors.
- `plan_builder.rs` — set the outermost-plan thread-local at both render entry points.

## Scope & guards (never silently wrong)

| Form | Result |
|---|---|
| `[n IN nodes(path) \| n.prop]` identity body, single label, standard schema | ✅ works, both backends |
| `[n IN nodes(path) \| n]` (ids) | ✅ unchanged |
| composite body (`toUpper(n.name)`), multi-prop body | ⛔ actionable guard |
| `relationships(path)` property | ⛔ actionable guard |
| multi-label path | ⛔ actionable guard |
| denormalized / FK-edge / weighted VLP | ⛔ actionable guard (routed via `PatternSchemaContext`, not raw flags — ratchet-clean) |

## Verification

- Live on **ClickHouse and Databricks**: identity readout, `shortestPath` readout, ids-unchanged control, and all guards firing with clear messages.
- New regression tests (`sql_golden_tests.rs`, both dialects): accumulator shape, ids-unchanged, guarded forms.
- `cargo fmt` + `cargo clippy` clean; **full suite (1734 + 608) + ratchet green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)