### PR TITLE
docs(demos): GraphRAG scenario 6 — hybrid vector + graph retrieval

### DIFF
--- a/demos/mcp-agent/GRAPHRAG_SCENARIOS.md
+++ b/demos/mcp-agent/GRAPHRAG_SCENARIOS.md
@@ -8,9 +8,12 @@ and ground its answer in the rows that come back.
 
 The scenarios below are an **escalating** set. The first is ordinary retrieval a
 vector store could approximate. Everything after it depends on *traversal* —
-following edges across the warehouse — which similarity search cannot do. Each was
-run **live against the Databricks / DeltaGraph social graph** (Bolt `:7688`); the
-results shown are the actual rows returned.
+following edges across the warehouse — which similarity search cannot do.
+Scenarios 1–5 were run **live against the Databricks / DeltaGraph social graph**
+(Bolt `:7688`); scenario 6 adds **hybrid vector + graph retrieval** on a
+knowledge-base graph via the **ClickGraph / ClickHouse** endpoint (Bolt `:7687`),
+where the vector-distance functions are native. In every case the results shown are
+the actual rows returned.
 
 > The agent always starts by calling `get_neo4j_schema`, which returns the labels
 > (`User`, `Post`), their properties, and the relationships
@@ -141,6 +144,85 @@ ORDER BY likes DESC, post LIMIT 5
 
 ---
 
+## 6 · Hybrid retrieval — "Semantic entry, then graph expansion"
+
+The one that puts vector search and the graph in the *same loop*. A pure vector
+store retrieves by similarity and stops. Here the agent uses similarity only to
+find the **entry point**, then the graph does what similarity cannot: traverse the
+neighborhood, read the connection back **by name**, and re-rank grounded results.
+
+Run against a knowledge-base graph (`Topic ─RELATED_TO→ Topic`,
+`Topic ─DISCUSSES→ Document`) where both node types carry 128-dim embeddings. The
+user's question ≈ *"deep learning that spans machine learning and NLP"*, encoded as
+the centroid of the ML + NLP topic vectors.
+
+**Step 1 — VECTOR: what is the question even about?** Rank topics by cosine
+similarity to the query embedding.
+
+```cypher
+MATCH (t:Topic)
+RETURN t.name AS topic, round(1 - cosineDistance(t.embedding, $q), 4) AS similarity
+ORDER BY similarity DESC LIMIT 3
+```
+
+| topic | similarity |
+|---|---|
+| Natural Language Processing | 0.6844 |
+| Machine Learning | 0.6844 |
+| Databases | −0.0001 |
+
+The two AI topics surface; unrelated topics sit at ~0. `cosineDistance` is
+ClickHouse-native. **A vector store stops here.**
+
+**Step 2 — GRAPH: how does that topic connect, read by name?** (the path readout
+shipped in [#1079](https://github.com/genezhang/clickgraph/pull/1079))
+
+```cypher
+MATCH path = (start:Topic {name:'Machine Learning'})-[:RELATED_TO*1..2]->(t2:Topic)
+RETURN [n IN nodes(path) | n.name] AS topic_chain, length(path) AS hops
+ORDER BY hops, topic_chain
+```
+
+| topic_chain | hops |
+|---|---|
+| ["Machine Learning", "Natural Language Processing"] | 1 |
+| ["Machine Learning", "Computer Vision"] | 1 |
+| ["Machine Learning", "Natural Language Processing", "Computer Vision"] | 2 |
+
+**Step 3 — HYBRID: of the documents in that neighborhood, which actually answer
+the question?** The graph scopes the candidate set; the vector re-ranks it.
+
+```cypher
+MATCH (t:Topic)-[:DISCUSSES]->(d:Document)
+WHERE t.name IN ['Machine Learning','Natural Language Processing','Computer Vision']
+RETURN d.title AS document, t.name AS via_topic,
+       round(1 - cosineDistance(d.embedding, $q), 4) AS similarity
+ORDER BY similarity DESC LIMIT 5
+```
+
+| document | via_topic | similarity |
+|---|---|---|
+| Introduction to Neural Networks | Machine Learning | 0.6844 |
+| Transformer Architecture Explained | Natural Language Processing | 0.6844 |
+| Object Detection with YOLO | Computer Vision | −0.0016 |
+
+The two foundational ML/NLP papers float to the top; the off-topic CV paper sinks.
+Neither retrieval mode does this alone: **vectors find the entry point, the graph
+traverses and explains the connection, then vectors re-rank the grounded
+neighborhood.** That is GraphRAG that is both *relevant* and *explainable*.
+
+> **Scope note.** Vector distance functions (`cosineDistance`, `L2Distance`,
+> `dotProduct`, `gds.similarity.*`, `vector.similarity.*`) and the
+> `CALL db.index.vector.queryNodes(...)` procedure are **ClickHouse-native**; this
+> scenario runs on the ClickGraph/ClickHouse endpoint. Vector and traversal are
+> kept as **separate agentic steps** on purpose — fusing them into one query
+> (`… -[:RELATED_TO*1..2]->(t2)-[:DISCUSSES]->(d) … cosineDistance(…)`) can hit an
+> intermittent planner bug tracked in
+> [#1081](https://github.com/genezhang/clickgraph/issues/1081), which is
+> independent of the vector functions themselves.
+
+---
+
 ## The point
 
 | Scenario | Traversal depth | Could a vector store do it? |
@@ -150,6 +232,7 @@ ORDER BY likes DESC, post LIMIT 5
 | 3 · Content grounding | 2 hops, neighborhood-scoped | **No** — needs edge-scoping, not similarity |
 | 4 · Connection path | variable-length | **No** — not representable as a vector |
 | 5 · Engagement | 3-way join | **No** — relationship aggregation |
+| 6 · Hybrid vector + graph | vector seed → traverse → re-rank | **Only step 1** — traversal & explanation need the graph |
 
 Same schema. Same warehouse tables. **Zero ETL, zero graph database.** The agent
 speaks Bolt to ClickGraph/DeltaGraph, which translates Cypher to ClickHouse or

--- a/demos/mcp-agent/graphrag-showcase.html
+++ b/demos/mcp-agent/graphrag-showcase.html
@@ -217,6 +217,20 @@
   }
   .toolcall .arrow { color: var(--border); }
 
+  .step-label {
+    display: flex; align-items: center; gap: 10px;
+    font-family: var(--mono); font-size: 12px; font-weight: 700;
+    letter-spacing: .08em; text-transform: uppercase; color: var(--muted);
+    padding: 16px 22px 12px; border-top: 1px solid var(--border);
+  }
+  .step-label:first-of-type { border-top: none; padding-top: 4px; }
+  .step-n {
+    flex: none; width: 20px; height: 20px; border-radius: 999px;
+    background: var(--accent-soft); color: var(--accent);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 800;
+  }
+
   pre {
     margin: 0; background: var(--code-bg); color: var(--code-text);
     font-family: var(--mono); font-size: 13.5px; line-height: 1.65;
@@ -352,7 +366,7 @@
 
 <section>
   <div class="wrap">
-    <div class="eyebrow">Five scenarios · verified live on Databricks</div>
+    <div class="eyebrow">Six scenarios · verified live</div>
     <h2>What traversal does that similarity can't</h2>
     <p class="section-intro">The first is ordinary retrieval. Everything after it
       depends on following edges across the warehouse — which a vector store cannot
@@ -531,6 +545,75 @@
         </div>
       </div>
     </div>
+
+    <!-- 6 -->
+    <div class="scenario reveal">
+      <div class="card">
+        <div class="card-head">
+          <div>
+            <div class="idx">06 · HYBRID — VECTOR + GRAPH</div>
+            <h3>Semantic entry, then graph expansion</h3>
+            <p class="ask">Use similarity to find the entry point; use the graph to traverse, explain, and re-rank. The question ≈ <em>"deep learning spanning ML and NLP"</em>, encoded as a query vector.</p>
+          </div>
+          <div class="badges">
+            <span class="badge hops">vector + traversal</span>
+            <span class="badge can">vector store: step 1 only</span>
+          </div>
+        </div>
+
+        <div class="step-label"><span class="step-n">1</span> VECTOR — what is the question about?</div>
+        <div class="toolcall"><span class="pill">read_neo4j_cypher</span><span class="arrow">→</span> warehouse</div>
+<pre><span class="k">MATCH</span> (t:Topic)
+<span class="k">RETURN</span> t.name <span class="k">AS</span> topic, <span class="f">round</span>(1 - <span class="f">cosineDistance</span>(t.embedding, $q), 4) <span class="k">AS</span> similarity
+<span class="k">ORDER BY</span> similarity <span class="k">DESC</span> <span class="k">LIMIT</span> 3</pre>
+        <div class="result">
+          <div class="result-label">3 rows</div>
+          <div class="tbl-scroll"><table>
+            <thead><tr><th>topic</th><th>similarity</th></tr></thead>
+            <tbody>
+              <tr><td>Natural Language Processing</td><td class="num">0.6844</td></tr>
+              <tr><td>Machine Learning</td><td class="num">0.6844</td></tr>
+              <tr><td>Databases</td><td class="num">−0.0001</td></tr>
+            </tbody>
+          </table></div>
+          <p style="margin:12px 0 0;color:var(--muted);font-size:14px">The two AI topics surface; unrelated topics sit at ~0. <b>A vector store stops here.</b></p>
+        </div>
+
+        <div class="step-label"><span class="step-n">2</span> GRAPH — how does that topic connect, by name?</div>
+<pre><span class="k">MATCH</span> path = (start:Topic {name:<span class="s">'Machine Learning'</span>})-[:RELATED_TO*1..2]-&gt;(t2:Topic)
+<span class="k">RETURN</span> [n <span class="k">IN</span> <span class="f">nodes</span>(path) | n.name] <span class="k">AS</span> topic_chain, <span class="f">length</span>(path) <span class="k">AS</span> hops</pre>
+        <div class="result">
+          <div class="result-label">3 rows · path readout <a href="https://github.com/genezhang/clickgraph/pull/1079">#1079</a></div>
+          <div class="chain"><span class="n">Machine Learning</span><span class="e">→</span><span class="n">Natural Language Processing</span><span class="e">→</span><span class="n">Computer Vision</span></div>
+          <p style="margin:12px 0 0;color:var(--muted);font-size:14px"><code>[n IN nodes(path) | n.name]</code> reads the neighborhood back in traversal order — similarity search cannot represent this.</p>
+        </div>
+
+        <div class="step-label"><span class="step-n">3</span> HYBRID — re-rank the grounded neighborhood</div>
+<pre><span class="k">MATCH</span> (t:Topic)-[:DISCUSSES]-&gt;(d:Document)
+<span class="k">WHERE</span> t.name <span class="k">IN</span> [<span class="s">'Machine Learning'</span>,<span class="s">'Natural Language Processing'</span>,<span class="s">'Computer Vision'</span>]
+<span class="k">RETURN</span> d.title <span class="k">AS</span> document, <span class="f">round</span>(1 - <span class="f">cosineDistance</span>(d.embedding, $q), 4) <span class="k">AS</span> similarity
+<span class="k">ORDER BY</span> similarity <span class="k">DESC</span> <span class="k">LIMIT</span> 5</pre>
+        <div class="result">
+          <div class="result-label">top 3 of 5</div>
+          <div class="tbl-scroll"><table>
+            <thead><tr><th>document</th><th>via_topic</th><th>similarity</th></tr></thead>
+            <tbody>
+              <tr><td>Introduction to Neural Networks</td><td>Machine Learning</td><td class="num">0.6844</td></tr>
+              <tr><td>Transformer Architecture Explained</td><td>Natural Language Processing</td><td class="num">0.6844</td></tr>
+              <tr><td>Object Detection with YOLO</td><td>Computer Vision</td><td class="num">−0.0016</td></tr>
+            </tbody>
+          </table></div>
+          <p style="margin:12px 0 0;color:var(--muted);font-size:14px">The graph scopes the candidates; the vector re-ranks them. The two foundational ML/NLP papers rise; the off-topic CV paper sinks. <b>Relevant <em>and</em> explainable.</b></p>
+        </div>
+
+        <div class="note"><b>ClickHouse-native vectors.</b>
+          <code>cosineDistance</code> / <code>L2Distance</code> / <code>gds.similarity.*</code> and
+          <code>CALL db.index.vector.queryNodes(…)</code> run on the ClickGraph/ClickHouse endpoint.
+          Vector and traversal are kept as separate agentic steps on purpose — fusing them into one
+          query can hit an intermittent planner bug (<a href="https://github.com/genezhang/clickgraph/issues/1081">#1081</a>),
+          independent of the vector functions themselves.</div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -547,6 +630,7 @@
           <tr><td>03 · Content grounding</td><td>2 hops, scoped</td><td class="v-no">no — needs edge-scoping</td></tr>
           <tr><td>04 · Connection path</td><td>variable-length</td><td class="v-no">no — not a vector</td></tr>
           <tr><td>05 · Engagement</td><td>3-way join</td><td class="v-no">no — relationship aggregation</td></tr>
+          <tr><td>06 · Hybrid vector + graph</td><td>vector seed → traverse → re-rank</td><td class="v-no">step 1 only — traversal &amp; explanation need the graph</td></tr>
         </tbody>
       </table></div>
     </div>
@@ -572,8 +656,9 @@
 
 <footer>
   <div class="wrap">
-    <p class="meta">All five scenarios verified live on 2026-08-16 against the DeltaGraph
-      Databricks social graph, via the <code>mcp-neo4j-cypher</code> server over Bolt.</p>
+    <p class="meta">Scenarios 1–5 verified live on 2026-08-16 against the DeltaGraph
+      Databricks social graph; scenario 6 (hybrid vector + graph) on the ClickGraph/ClickHouse
+      endpoint where the vector functions are native — all via the <code>mcp-neo4j-cypher</code> server over Bolt.</p>
     <p>ClickGraph is a read-only, drop-in Neo4j MCP target. Runbook:
       <code>demos/mcp-agent/</code> · Deterministic proof without an LLM:
       <code>verify_mcp.py</code>.</p>


### PR DESCRIPTION
Adds **Scenario 6** to the MCP/GraphRAG showcase — the one that puts vector search and the graph in the *same loop*:

1. **VECTOR** — `cosineDistance(t.embedding, \$q)` ranks topics → finds the semantic entry point.
2. **GRAPH** — `[n IN nodes(path) | n.name]` (shipped in #1079) reads the neighborhood back **by name** in traversal order.
3. **HYBRID** — the graph scopes the candidate documents; the vector re-ranks them. The two foundational ML/NLP papers rise; the off-topic CV paper sinks.

Verified live on the ClickGraph/ClickHouse endpoint (the vector-distance functions — `cosineDistance`/`L2Distance`/`dotProduct`/`gds.similarity.*` and `CALL db.index.vector.queryNodes(…)` — are ClickHouse-native), using the `vector_graphrag` fixture from `tests/integration/test_graphrag_vector_similarity.py`.

### Why vector + traversal are separate steps
Fusing them into one query (`… -[:RELATED_TO*1..2]->(t2)-[:DISCUSSES]->(d) … cosineDistance(…)`) can hit an **intermittent planner bug filed as #1081** — a chained-relationship pattern mis-resolving the intermediate node to the relationship's qualified name. Critically, that bug is **independent of the vector functions and VLP** (it reproduces with plain fixed-length hops), which corrects the misattributed `test_vector_similarity_with_vlp` xfail reason.

### Changes
- `demos/mcp-agent/GRAPHRAG_SCENARIOS.md` — scenario 6 + intro + summary table
- `demos/mcp-agent/graphrag-showcase.html` — theme-aware three-step card, `.step-label` styling, summary row, footer/eyebrow
- Companion gh-pages update (scenario 6 page + landing CTA) pushed separately; artifact redeployed to the same URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)