### PR TITLE
fix(planner): #1081 anonymous-relationship alias collision corrupts chained/VLP patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **#1081 — anonymous-relationship alias collision corrupted chained/VLP patterns.** Anonymous nodes and relationships are auto-aliased from a shared `t{N}` counter (`logical_plan::generate_id`). When a query explicitly named a variable `t2` (etc.), the generated alias for an adjacent anonymous relationship collided with it, and that relationship's composite-key label (e.g. `AUTHORED::User::Post`) overwrote the user node's real label — surfacing as `AnalyzerError: Invalid relationship pattern (TYPE::From::To)-[:TYPE::From::To]->(…)` (masked as Bolt `50N42`). A variable-length hop forces adjacent anonymous relationships, so patterns like `(t)-[:REL*1..2]->(t2)-[:REL2]->(d)` reliably tripped it; it looked "intermittent" only because different hand-typed queries used different variable names. Fixed in `traversal.rs` by making anonymous alias generation skip any alias already used by the query (user pattern variables + plan-context bindings). This unblocks single-query hybrid vector + variable-length-graph retrieval (VLP traversal + chained hop + `cosineDistance` re-ranking in one statement).
+- **Latent: `GraphSchema` derived indexes dropped on deserialize.** `rel_type_index` and the denormalized-node metadata are `#[serde(skip)]` and were built only in `GraphSchema::build()`, so a schema recovered from the `graph_catalog` JSON persistence path (server startup restore, and the 60s `monitor_schema_updates` refresh of the `default` schema) came back with an empty `rel_type_index` — breaking relationship lookups by simple type name. Fixed by routing deserialize through an intermediate that rebuilds the derived indexes (`rebuild_derived_indexes`), also applied on the schema-mutation (DDL) path. (Found while investigating #1081; independent root cause.)
+
 ## [0.6.8-dev] - 2026-08-09
 
 ### ✨ Features

--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -1016,6 +1016,10 @@ impl ProcessedNodeMetadata {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+// Deserialize routes through `GraphSchemaDe`, which rebuilds the `#[serde(skip)]`
+// derived indexes below. `#[derive(Deserialize)]` alone would leave them empty on
+// every round-trip through the `graph_catalog` JSON persistence path (#1081).
+#[serde(from = "GraphSchemaDe")]
 pub struct GraphSchema {
     version: u32,
     database: String,
@@ -1042,6 +1046,44 @@ pub struct GraphSchema {
     /// Maps index name -> config (label, properties, analyzer)
     #[serde(skip)]
     fulltext_indexes: BTreeMap<String, FulltextIndexConfig>,
+}
+
+/// Deserialization shadow for [`GraphSchema`]: only the persisted (non-`skip`)
+/// fields. Serde deserializes into this, then [`From`] rebuilds the derived
+/// indexes via [`GraphSchema::rebuild_derived_indexes`]. This is what closes
+/// #1081 — a `GraphSchema` recovered from JSON otherwise had an empty
+/// `rel_type_index`, so simple relationship-type lookups silently failed. All
+/// fields default so older or partial persisted schemas still load.
+#[derive(Deserialize)]
+struct GraphSchemaDe {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    database: String,
+    #[serde(default)]
+    nodes: BTreeMap<String, NodeSchema>,
+    #[serde(default)]
+    relationships: BTreeMap<String, RelationshipSchema>,
+}
+
+impl From<GraphSchemaDe> for GraphSchema {
+    fn from(de: GraphSchemaDe) -> Self {
+        let mut schema = GraphSchema {
+            version: de.version,
+            database: de.database,
+            nodes: de.nodes,
+            relationships: de.relationships,
+            denormalized_nodes: BTreeMap::new(),
+            rel_type_index: BTreeMap::new(),
+            // Vector / full-text index configs are not derivable from
+            // relationships and are not persisted in graph_catalog JSON, so they
+            // come back empty here (unchanged from the previous derive behavior).
+            vector_indexes: BTreeMap::new(),
+            fulltext_indexes: BTreeMap::new(),
+        };
+        schema.rebuild_derived_indexes();
+        schema
+    }
 }
 
 /// Runtime vector index configuration (resolved from schema definition)
@@ -1202,6 +1244,19 @@ impl GraphSchema {
         }
 
         index
+    }
+
+    /// Recompute the `#[serde(skip)]` derived indexes (`rel_type_index` and
+    /// `denormalized_nodes`) from `self.relationships`.
+    ///
+    /// MUST be called after deserialization or after any mutation of
+    /// `relationships` — both leave the derived indexes empty/stale. `build()`
+    /// populates them at construction; this is the after-the-fact equivalent.
+    /// Vector / full-text index configs are NOT derivable from relationships and
+    /// are intentionally left untouched. See #1081.
+    pub(crate) fn rebuild_derived_indexes(&mut self) {
+        self.denormalized_nodes = Self::build_denormalized_metadata(&self.relationships);
+        self.rel_type_index = Self::build_rel_type_index(&self.relationships);
     }
 
     /// Build denormalized node metadata from relationships
@@ -2305,6 +2360,83 @@ mod tests {
         let rel_types = metadata.get_relationship_types();
         assert_eq!(rel_types.len(), 1);
         assert!(rel_types.contains(&"FLIGHT".to_string()));
+    }
+
+    /// #1081: `rel_type_index` is `#[serde(skip)]`, so a `GraphSchema` recovered
+    /// through serde (the `graph_catalog` JSON persistence path, and the 60s
+    /// `monitor_schema_updates` background refresh) came back with an EMPTY index.
+    /// Resolving a simple relationship type name (`RELATED_TO`) then fell off the
+    /// fast path — which, in a chained pattern `(a)-[:T]->(b)-[:T2]->(c)`,
+    /// corrupted the intermediate node's label to the relationship's own qualified
+    /// name (`RELATED_TO::Topic::Topic`). Intermittent in production (only after a
+    /// monitor tick replaced the built schema), deterministic here.
+    ///
+    /// This uses a standard (non-denormalized) self-referential relationship,
+    /// matching the `vector_graphrag` schema that surfaced #1081: its composite
+    /// keys survive serde as map keys, so rebuilding `rel_type_index` from
+    /// `relationships` is a complete fix. (Denormalized metadata is a separate,
+    /// deeper matter — most `RelationshipSchema` fields incl. `from_node_properties`
+    /// are themselves `#[serde(skip)]`, so denorm schemas do not survive a
+    /// `graph_catalog` round-trip at all; tracked separately, not #1081.)
+    #[test]
+    fn test_rel_type_index_survives_serde_roundtrip() {
+        let mut relationships = HashMap::new();
+        let related_to = RelationshipSchema {
+            database: "default".to_string(),
+            table_name: "topic_related_to".to_string(),
+            column_names: vec!["topic_id".to_string(), "related_topic_id".to_string()],
+            from_node: "Topic".to_string(),
+            to_node: "Topic".to_string(),
+            from_node_table: "topics".to_string(),
+            to_node_table: "topics".to_string(),
+            from_id: Identifier::from("topic_id"),
+            to_id: Identifier::from("related_topic_id"),
+            from_node_id_dtype: SchemaType::Integer,
+            to_node_id_dtype: SchemaType::Integer,
+            property_mappings: HashMap::new(),
+            view_parameters: None,
+            engine: None,
+            use_final: None,
+            filter: None,
+            edge_id: None,
+            type_column: None,
+            from_label_column: None,
+            to_label_column: None,
+            from_node_properties: None,
+            to_node_properties: None,
+            from_label_values: None,
+            to_label_values: None,
+            is_fk_edge: false,
+            constraints: None,
+            edge_id_types: None,
+            source: None,
+            property_types: HashMap::new(),
+        };
+        relationships.insert("RELATED_TO::Topic::Topic".to_string(), related_to);
+
+        let schema = GraphSchema::build(1, "default".to_string(), HashMap::new(), relationships);
+
+        // Freshly built schema resolves the simple type name via the fast path.
+        assert!(!schema.get_rel_type_index().is_empty());
+        assert!(schema
+            .get_rel_schema_with_nodes("RELATED_TO", Some("Topic"), Some("Topic"))
+            .is_ok());
+
+        // Round-trip through the graph_catalog JSON persistence path.
+        let json = serde_json::to_string(&schema).unwrap();
+        let restored: GraphSchema = serde_json::from_str(&json).unwrap();
+
+        // Both FAIL before the #1081 fix (empty rel_type_index after deserialize).
+        assert!(
+            !restored.get_rel_type_index().is_empty(),
+            "#1081: rel_type_index must be rebuilt after deserialize"
+        );
+        assert!(
+            restored
+                .get_rel_schema_with_nodes("RELATED_TO", Some("Topic"), Some("Topic"))
+                .is_ok(),
+            "#1081: simple relationship-type lookup must work after deserialize"
+        );
     }
 
     #[test]

--- a/src/query_planner/logical_plan/match_clause/traversal.rs
+++ b/src/query_planner/logical_plan/match_clause/traversal.rs
@@ -17,7 +17,26 @@ use crate::{
 };
 
 use crate::query_planner::logical_plan::generate_id;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+/// Generate an anonymous alias (`t1`, `t2`, …) that does NOT collide with any
+/// alias already in `used` — user-provided pattern variables plus aliases
+/// already bound in the plan context or generated earlier in this pattern.
+///
+/// Anonymous nodes/edges are auto-aliased from a shared `t{N}` counter (see
+/// `generate_id`). Without this guard a query that explicitly names a variable
+/// `t2` collides with the generated `t2` for an adjacent anonymous relationship,
+/// and the relationship's composite-key label overwrites the user node's real
+/// label — the #1081 `(TYPE::From::To)-[:TYPE::From::To]->(...)` corruption.
+/// The generated candidate is recorded in `used` so later generation skips it too.
+fn generate_unique_alias(used: &mut HashSet<String>) -> String {
+    loop {
+        let candidate = generate_id();
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+}
 
 // Import from sibling modules
 use super::helpers::{
@@ -78,6 +97,26 @@ fn traverse_connected_pattern_with_mode<'a>(
     // Use pointer equality to detect shared Rc instances.
     // Note: HashMap is already imported at the top of this file.
 
+    // Collect every alias the user explicitly wrote in this pattern (node and
+    // relationship variables), plus any alias already bound in the plan context
+    // from earlier clauses. Anonymous alias generation below must avoid these so
+    // a generated `t{N}` never clobbers a user variable of the same name (#1081).
+    let mut used_aliases: HashSet<String> = HashSet::new();
+    for connected_pattern in connected_patterns.iter() {
+        if let Some(name) = connected_pattern.start_node.borrow().name {
+            used_aliases.insert(name.to_string());
+        }
+        if let Some(name) = connected_pattern.end_node.borrow().name {
+            used_aliases.insert(name.to_string());
+        }
+        if let Some(name) = connected_pattern.relationship.name {
+            used_aliases.insert(name.to_string());
+        }
+    }
+    for (alias, _) in plan_ctx.iter_table_contexts() {
+        used_aliases.insert(alias.clone());
+    }
+
     // Use usize from Rc::as_ptr() cast as the key for pointer-based identity
     let mut node_alias_map: HashMap<usize, String> = HashMap::new();
 
@@ -89,7 +128,7 @@ fn traverse_connected_pattern_with_mode<'a>(
             let alias = if let Some(name) = start_node_ref.name {
                 name.to_string()
             } else {
-                generate_id()
+                generate_unique_alias(&mut used_aliases)
             };
             drop(start_node_ref);
             alias
@@ -102,7 +141,7 @@ fn traverse_connected_pattern_with_mode<'a>(
             let alias = if let Some(name) = end_node_ref.name {
                 name.to_string()
             } else {
-                generate_id()
+                generate_unique_alias(&mut used_aliases)
             };
             drop(end_node_ref);
             alias
@@ -123,7 +162,7 @@ fn traverse_connected_pattern_with_mode<'a>(
         let start_node_alias = node_alias_map
             .get(&(connected_pattern.start_node.as_ptr() as usize))
             .cloned()
-            .unwrap_or_else(generate_id);
+            .unwrap_or_else(|| generate_unique_alias(&mut used_aliases));
 
         // CRITICAL FIX: Label resolution order:
         // 1. If AST has explicit label (Some(...)), use it
@@ -178,7 +217,7 @@ fn traverse_connected_pattern_with_mode<'a>(
         let end_node_alias = node_alias_map
             .get(&(connected_pattern.end_node.as_ptr() as usize))
             .cloned()
-            .unwrap_or_else(generate_id);
+            .unwrap_or_else(|| generate_unique_alias(&mut used_aliases));
         let end_node_label_from_ast = end_node_ref.first_label().map(|val| val.to_string());
 
         log::debug!(
@@ -210,7 +249,7 @@ fn traverse_connected_pattern_with_mode<'a>(
         let rel_alias = if let Some(alias) = rel.name {
             alias.to_string()
         } else {
-            generate_id()
+            generate_unique_alias(&mut used_aliases)
         };
 
         // Handle anonymous edge patterns: [] (no type specified)

--- a/src/server/graph_catalog.rs
+++ b/src/server/graph_catalog.rs
@@ -740,6 +740,11 @@ pub async fn add_to_schema(
         }
     }
 
+    // The insert_* mutators above only touch `relationships`/`nodes`; the derived
+    // `rel_type_index`/`denormalized_nodes` must be rebuilt so subsequent lookups
+    // resolve simple relationship type names (same defect class as #1081).
+    graph_schema.rebuild_derived_indexes();
+
     let schema_json = serde_json::to_string(&*graph_schema)
         .map_err(|e| format!("Schema serialization error: {}", e))?;
 

--- a/tests/integration/test_graphrag_vector_similarity.py
+++ b/tests/integration/test_graphrag_vector_similarity.py
@@ -325,9 +325,19 @@ class TestVectorSimilarityWithGraphRAG:
         similarities = [row["similarity"] for row in rows]
         assert similarities == sorted(similarities), "Should be ordered by similarity"
     
-    @pytest.mark.xfail(reason="Code bug: VLP identifier resolution with vector similarity")
     def test_vector_similarity_with_vlp(self, vector_graphrag_schema):
-        """Variable-length path + vector similarity ranking."""
+        """Variable-length path + chained hop + vector similarity ranking.
+
+        Regression test for #1081. This previously xfailed with the reason
+        "VLP identifier resolution with vector similarity" — a misattribution.
+        The real bug was neither VLP- nor vector-specific: the chained anonymous
+        `-[:DISCUSSES]->` relationship was auto-aliased `t2` from the shared
+        `t{N}` counter, colliding with the user's explicitly-named endpoint `t2`,
+        so the relationship's composite-key label overwrote node `t2`'s real
+        label (AnalyzerError: Invalid relationship pattern
+        `(DISCUSSES::Topic::Document)-[...]->(Document)`). Fixed by making
+        anonymous alias generation avoid user-defined aliases.
+        """
         
         query_vec = generate_embedding(101)  # Similar to NLP
         query_vec_str = "[" + ",".join(map(str, query_vec)) + "]"

--- a/tests/rust/integration/cross_schema_pattern_tests.rs
+++ b/tests/rust/integration/cross_schema_pattern_tests.rs
@@ -785,3 +785,60 @@ async fn cs_composite_id_p12_inline_filter() {
     assert_contains(&sql, "composite_id/P12", "'Alice'");
     assert_contains(&sql, "composite_id/P12", "org_id");
 }
+
+// ===========================================================================
+// #1081 — anonymous-relationship alias collision with user variables
+// ===========================================================================
+
+/// #1081 root cause: anonymous nodes/edges are auto-aliased from a shared
+/// `t{N}` counter (`logical_plan::generate_id`). When a query explicitly names a
+/// variable `t2`, the generated alias for an adjacent anonymous relationship
+/// collided with it, and that relationship's composite-key label
+/// (`AUTHORED::User::Post`) overwrote node `t2`'s real label — surfacing as
+/// `AnalyzerError: Invalid relationship pattern:
+/// (AUTHORED::User::Post)-[:AUTHORED::User::Post]->(Post)`.
+///
+/// A variable-length hop forces adjacent anonymous relationships, which is how
+/// the GraphRAG demo's `(t)-[:RELATED_TO*1..2]->(t2)-[:DISCUSSES]->(d)` tripped
+/// it live. The failure is deterministic whenever a user variable matches a
+/// generated `t{N}` alias; it looked "intermittent" in production only because
+/// different hand-typed queries used different variable names. The fix makes
+/// anonymous alias generation skip any alias the user (or plan context) already
+/// uses. Regression guard: this exact shape must plan.
+#[tokio::test]
+async fn cs_standard_1081_anonymous_alias_collision() {
+    let schema = load_schema(SCHEMA_STANDARD);
+    // Endpoint deliberately named `t2` — collides with the generated alias for
+    // the anonymous `-[:AUTHORED]->` relationship unless generation avoids it.
+    let cypher = "MATCH path = (t:User)-[:FOLLOWS*1..2]->(t2:User)-[:AUTHORED]->(d:Post) \
+                  RETURN t2.name, d.content, length(path) AS hops LIMIT 5";
+    let sql = generate_sql(&schema, cypher).await;
+    assert_valid_sql(&sql, "standard", "1081-alias-collision");
+    // `t2` must resolve as the User node, and the AUTHORED edge table is present.
+    assert_contains(&sql, "standard/1081", "cs_test.authored");
+}
+
+/// #1081-adjacent latent bug: `GraphSchema::rel_type_index` (and the
+/// denormalized-node metadata) are `#[serde(skip)]`, so a schema recovered from
+/// the `graph_catalog` JSON persistence path / the `monitor_schema_updates`
+/// refresh came back with an EMPTY index. A relationship then looked up by
+/// SIMPLE type name — as the variable-length recursive-CTE path does, having no
+/// endpoint labels to reconstruct the composite key — could not be resolved
+/// (`RelationshipTypeNotFound`). Independent of the alias-collision bug above;
+/// the aliases here (`u`/`u2`/`p`) do not collide. The fix rebuilds the derived
+/// indexes on deserialize.
+#[tokio::test]
+async fn cs_standard_1081_vlp_chain_after_serde_roundtrip() {
+    let built = load_schema(SCHEMA_STANDARD);
+    let json = serde_json::to_string(&built).expect("schema should serialize");
+    let restored: GraphSchema = serde_json::from_str(&json).expect("schema should deserialize");
+
+    let cypher = "MATCH path = (u:User)-[:FOLLOWS*1..2]->(u2:User)-[:AUTHORED]->(p:Post) \
+                  RETURN u.name, p.content LIMIT 5";
+    let sql = generate_sql(&restored, cypher).await;
+    assert_valid_sql(
+        &sql,
+        "standard(serde-round-tripped)",
+        "1081-serde-vlp-chain",
+    );
+}


### PR DESCRIPTION
## Root cause (#1081)

Anonymous nodes and relationships are auto-aliased from a shared `t{N}` counter (`logical_plan::generate_id` → `t1`, `t2`, …). When a query **explicitly names a variable `t2`**, the generated alias for an *adjacent anonymous relationship* collided with it in the plan context, and the relationship's composite-key label (e.g. `AUTHORED::User::Post`) **overwrote the user node's real label**. This surfaced as:

```
AnalyzerError: Invalid relationship pattern:
(AUTHORED::User::Post)-[:AUTHORED::User::Post]->(Post)
```
(masked as Bolt `50N42`).

A **variable-length hop forces adjacent anonymous relationships**, so patterns like `(t)-[:REL*1..2]->(t2)-[:REL2]->(d)` reliably tripped it — which is exactly the GraphRAG demo shape `(t:Topic)-[:RELATED_TO*1..2]->(t2:Topic)-[:DISCUSSES]->(d:Document)`.

### Why it looked "intermittent"
It isn't. It is **fully deterministic** given a user variable that matches a generated `t{N}` alias. The earlier #1081 report saw it as intermittent/state-dependent only because different hand-typed queries used different variable names (the demo used `t/t2/d`; isolation probes used other names). The filed "shared planner state leak" and "serde `rel_type_index`" hypotheses were both wrong about the *root cause* — see below.

## Fix

In `traverse_connected_pattern_with_mode`, collect every alias the user wrote in the pattern (node + relationship variables) plus any alias already bound in the plan context, then generate anonymous aliases that **skip that set** (`generate_unique_alias`). Query-scoped by construction — no shared global reserved state (the alias counter's global-ness is a separate pre-existing matter, untouched).

## Secondary latent bug (independent, found during investigation)

`GraphSchema::rel_type_index` and the denormalized-node metadata are `#[serde(skip)]` and were built only in `GraphSchema::build()`. A schema recovered from the `graph_catalog` **JSON persistence path** — server-startup restore, and the 60s `monitor_schema_updates` refresh of the `default` schema — came back with an **empty `rel_type_index`**, breaking relationship lookups by simple type name (the VLP recursive-CTE path uses simple-name lookups). Deserialize now routes through an intermediate that rebuilds the derived indexes (`rebuild_derived_indexes`); also applied on the DDL mutation path. This is *not* the #1081 root cause (it needs the graph_catalog path; #1081 reproduces on any freshly-built schema) but is a real correctness bug for long-running multi-schema servers.

## Verification

- **Deterministic Rust repro → fix**, bisected from the live failure to the exact trigger (aliases, not labels/serde). New regression tests:
  - `cs_standard_1081_anonymous_alias_collision` — the root cause
  - `cs_standard_1081_vlp_chain_after_serde_roundtrip` — the serde latent bug
  - `graph_schema::tests::test_rel_type_index_survives_serde_roundtrip` — unit, serde
  - un-xfail'd + corrected the misattributed reason on `test_vector_similarity_with_vlp`
- **Live on ClickHouse** (rebuilt release, restarted server): the exact query that raised `InvalidRelationInQuery (DISCUSSES::Topic::Document)` now returns rows, including the **full single-query fusion** `VLP + chained hop + cosineDistance` re-ranking.
- `cargo fmt --all` ✅ · `cargo clippy --all-targets` clean ✅ · full workspace `cargo test` ✅ (lib 1735, integration 610, ratchet ✅)

Closes #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)