### PR TITLE
docs(demos): GraphRAG scenario 6 — single-statement hybrid fusion capstone

### DIFF
--- a/demos/mcp-agent/GRAPHRAG_SCENARIOS.md
+++ b/demos/mcp-agent/GRAPHRAG_SCENARIOS.md
@@ -211,15 +211,42 @@ Neither retrieval mode does this alone: **vectors find the entry point, the grap
 traverses and explains the connection, then vectors re-rank the grounded
 neighborhood.** That is GraphRAG that is both *relevant* and *explainable*.
 
+**The whole loop in one statement.** The three steps above read as an agent
+*thinking out loud*, but the traversal and the re-rank also compose into a single
+Cypher query — variable-length graph expansion feeding a vector re-rank, no
+round-trip to the client in between:
+
+```cypher
+MATCH (t:Topic {name:'Machine Learning'})-[:RELATED_TO*1..2]->(t2:Topic)
+WITH DISTINCT t2
+MATCH (t2)-[:DISCUSSES]->(d:Document)
+RETURN DISTINCT d.title AS document, t2.name AS via_topic,
+       round(1 - cosineDistance(d.embedding, $q), 4) AS similarity
+ORDER BY similarity DESC
+```
+
+| document | via_topic | similarity |
+|---|---|---|
+| Transformer Architecture Explained | Natural Language Processing | 0.6844 |
+| Deep Learning for NLP | Natural Language Processing | 0.0943 |
+| Object Detection with YOLO | Computer Vision | −0.0016 |
+
+The `RELATED_TO*1..2` frontier is expanded in a recursive CTE, its endpoints feed
+the `DISCUSSES` join, and `cosineDistance` re-ranks the result — one statement,
+translated to one ClickHouse query. This unblocked once
+[#1081](https://github.com/genezhang/clickgraph/issues/1081) (an anonymous-alias
+collision that corrupted variable-length-plus-chained patterns) was fixed in
+[#1083](https://github.com/genezhang/clickgraph/pull/1083).
+
 > **Scope note.** Vector distance functions (`cosineDistance`, `L2Distance`,
 > `dotProduct`, `gds.similarity.*`, `vector.similarity.*`) and the
 > `CALL db.index.vector.queryNodes(...)` procedure are **ClickHouse-native**; this
-> scenario runs on the ClickGraph/ClickHouse endpoint. Vector and traversal are
-> kept as **separate agentic steps** on purpose — fusing them into one query
-> (`… -[:RELATED_TO*1..2]->(t2)-[:DISCUSSES]->(d) … cosineDistance(…)`) can hit an
-> intermittent planner bug tracked in
-> [#1081](https://github.com/genezhang/clickgraph/issues/1081), which is
-> independent of the vector functions themselves.
+> scenario runs on the ClickGraph/ClickHouse endpoint. The single-statement form
+> above threads the variable-length traversal through a `WITH` barrier before the
+> chained `DISCUSSES` hop; the fully-inline form
+> (`… -[:RELATED_TO*1..2]->(t2)-[:DISCUSSES]->(d) …`) is tracked separately in
+> [#1085](https://github.com/genezhang/clickgraph/issues/1085) and should use the
+> `WITH`-barrier form until it lands.
 
 ---
 
@@ -232,7 +259,7 @@ neighborhood.** That is GraphRAG that is both *relevant* and *explainable*.
 | 3 · Content grounding | 2 hops, neighborhood-scoped | **No** — needs edge-scoping, not similarity |
 | 4 · Connection path | variable-length | **No** — not representable as a vector |
 | 5 · Engagement | 3-way join | **No** — relationship aggregation |
-| 6 · Hybrid vector + graph | vector seed → traverse → re-rank | **Only step 1** — traversal & explanation need the graph |
+| 6 · Hybrid vector + graph | vector seed → traverse → re-rank, one statement | **Only step 1** — traversal & re-rank compose in a single Cypher query |
 
 Same schema. Same warehouse tables. **Zero ETL, zero graph database.** The agent
 speaks Bolt to ClickGraph/DeltaGraph, which translates Cypher to ClickHouse or

--- a/demos/mcp-agent/graphrag-showcase.html
+++ b/demos/mcp-agent/graphrag-showcase.html
@@ -606,12 +606,35 @@
           <p style="margin:12px 0 0;color:var(--muted);font-size:14px">The graph scopes the candidates; the vector re-ranks them. The two foundational ML/NLP papers rise; the off-topic CV paper sinks. <b>Relevant <em>and</em> explainable.</b></p>
         </div>
 
+        <div class="step-label"><span class="step-n">4</span> ALL AT ONCE — the whole loop in one statement</div>
+<pre><span class="k">MATCH</span> (t:Topic {name:<span class="s">'Machine Learning'</span>})-[:RELATED_TO*1..2]-&gt;(t2:Topic)
+<span class="k">WITH</span> <span class="k">DISTINCT</span> t2
+<span class="k">MATCH</span> (t2)-[:DISCUSSES]-&gt;(d:Document)
+<span class="k">RETURN</span> <span class="k">DISTINCT</span> d.title <span class="k">AS</span> document, t2.name <span class="k">AS</span> via_topic,
+       <span class="f">round</span>(1 - <span class="f">cosineDistance</span>(d.embedding, $q), 4) <span class="k">AS</span> similarity
+<span class="k">ORDER BY</span> similarity <span class="k">DESC</span></pre>
+        <div class="result">
+          <div class="result-label">3 rows · unblocked by <a href="https://github.com/genezhang/clickgraph/pull/1083">#1083</a></div>
+          <div class="tbl-scroll"><table>
+            <thead><tr><th>document</th><th>via_topic</th><th>similarity</th></tr></thead>
+            <tbody>
+              <tr><td>Transformer Architecture Explained</td><td>Natural Language Processing</td><td class="num">0.6844</td></tr>
+              <tr><td>Deep Learning for NLP</td><td>Natural Language Processing</td><td class="num">0.0943</td></tr>
+              <tr><td>Object Detection with YOLO</td><td>Computer Vision</td><td class="num">−0.0016</td></tr>
+            </tbody>
+          </table></div>
+          <p style="margin:12px 0 0;color:var(--muted);font-size:14px">Variable-length graph expansion feeds a vector re-rank in <b>one Cypher statement</b> — no client round-trip between traversal and ranking. <span style="opacity:.8">The NLP-adjacent paper rises; the CV paper sinks.</span></p>
+        </div>
+
         <div class="note"><b>ClickHouse-native vectors.</b>
           <code>cosineDistance</code> / <code>L2Distance</code> / <code>gds.similarity.*</code> and
           <code>CALL db.index.vector.queryNodes(…)</code> run on the ClickGraph/ClickHouse endpoint.
-          Vector and traversal are kept as separate agentic steps on purpose — fusing them into one
-          query can hit an intermittent planner bug (<a href="https://github.com/genezhang/clickgraph/issues/1081">#1081</a>),
-          independent of the vector functions themselves.</div>
+          The single-statement form threads the variable-length traversal through a <code>WITH</code>
+          barrier before the chained <code>DISCUSSES</code> hop — which composes once the
+          anonymous-alias collision (<a href="https://github.com/genezhang/clickgraph/pull/1083">#1083</a>,
+          fixing <a href="https://github.com/genezhang/clickgraph/issues/1081">#1081</a>) is in place;
+          the fully-inline chain form is tracked in
+          <a href="https://github.com/genezhang/clickgraph/issues/1085">#1085</a>.</div>
       </div>
     </div>
   </div>
@@ -630,7 +653,7 @@
           <tr><td>03 · Content grounding</td><td>2 hops, scoped</td><td class="v-no">no — needs edge-scoping</td></tr>
           <tr><td>04 · Connection path</td><td>variable-length</td><td class="v-no">no — not a vector</td></tr>
           <tr><td>05 · Engagement</td><td>3-way join</td><td class="v-no">no — relationship aggregation</td></tr>
-          <tr><td>06 · Hybrid vector + graph</td><td>vector seed → traverse → re-rank</td><td class="v-no">step 1 only — traversal &amp; explanation need the graph</td></tr>
+          <tr><td>06 · Hybrid vector + graph</td><td>vector seed → traverse → re-rank, one statement</td><td class="v-no">step 1 only — traversal &amp; re-rank compose in one query</td></tr>
         </tbody>
       </table></div>
     </div>


### PR DESCRIPTION
Now that #1083 (fixing #1081's anonymous-alias collision) has landed, the hybrid vector + variable-length-graph loop composes into **one Cypher statement**. Adds a capstone to Scenario 6:

```cypher
MATCH (t:Topic {name:'Machine Learning'})-[:RELATED_TO*1..2]->(t2:Topic)
WITH DISTINCT t2
MATCH (t2)-[:DISCUSSES]->(d:Document)
RETURN DISTINCT d.title AS document, t2.name AS via_topic,
       round(1 - cosineDistance(d.embedding, $q), 4) AS similarity
ORDER BY similarity DESC
```

**Live on ClickHouse** → `Transformer Architecture Explained` (0.6844) · `Deep Learning for NLP` (0.0943) · `Object Detection with YOLO` (−0.0016) — the correct endpoint neighborhood (docs discussed by NLP/CV), re-ranked.

Replaces the old scope note (which framed vector + traversal as necessarily separate). Honest caveat retained: the **fully-inline** chain form `(t)-[:R*1..2]->(t2)-[:R2]->(d)` still has a separate endpoint-join bug (joins on VLP start, not endpoint) — filed as #1085 — so the capstone uses the `WITH`-barrier form, which is verified correct.

Updates both the markdown (`GRAPHRAG_SCENARIOS.md`) and the HTML showcase card (`graphrag-showcase.html`, structure validated 104/104 div balance). Artifact + gh-pages redeployed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)