### PR TITLE
fix(planner): #1084 query-scoped anonymous-alias reservation

### DIFF
--- a/src/query_planner/analyzer/graph_traversal_planning.rs
+++ b/src/query_planner/analyzer/graph_traversal_planning.rs
@@ -333,6 +333,11 @@ impl GraphTRaversalPlanning {
         graph_schema: &GraphSchema,
         is_anchor_traversal: bool,
     ) -> AnalyzerResult<(GraphRel, Vec<CtxToUpdate>)> {
+        // #1084: snapshot the query-scoped user-declared aliases up front (cheap
+        // clone) so later anonymous-alias generation in the edge-list path avoids
+        // them without holding a borrow on `plan_ctx`.
+        let reserved_aliases = plan_ctx.reserved_aliases().clone();
+
         // Check for $any nodes - skip graph traversal planning for polymorphic wildcards
         let left_alias = &graph_rel.left_connection;
         let right_alias = &graph_rel.right_connection;
@@ -438,6 +443,7 @@ impl GraphTRaversalPlanning {
             left_projections,
             right_projections,
             is_anchor_traversal,
+            &reserved_aliases,
         )
     }
 
@@ -448,6 +454,8 @@ impl GraphTRaversalPlanning {
         left_projections: Vec<ProjectionItem>,
         right_projections: Vec<ProjectionItem>,
         is_anchor_traversal: bool,
+        // #1084: user-declared variables to avoid when generating anonymous aliases.
+        reserved_aliases: &std::collections::HashSet<String>,
     ) -> AnalyzerResult<(GraphRel, Vec<CtxToUpdate>)> {
         let mut ctxs_to_update: Vec<CtxToUpdate> = vec![];
 
@@ -459,6 +467,7 @@ impl GraphTRaversalPlanning {
             graph_context.right.cte_name.clone(),
             graph_context.right.id_column.clone(),
             graph_rel.is_rel_anchor,
+            reserved_aliases,
         );
         let rel_cte_name: String = r_cte_name;
         rel_ctxs_to_update = r_ctxs_to_update;
@@ -597,6 +606,8 @@ impl GraphTRaversalPlanning {
         connected_node_cte_name: String,
         connected_node_id_column: String,
         is_rel_anchor: bool,
+        // #1084: user-declared variables to avoid when generating anonymous aliases.
+        reserved_aliases: &std::collections::HashSet<String>,
     ) -> (String, Arc<LogicalPlan>, Vec<CtxToUpdate>) {
         let star_found = graph_context
             .rel
@@ -629,8 +640,12 @@ impl GraphTRaversalPlanning {
                 graph_rel.left_connection, graph_rel.right_connection
             );
 
-            let outgoing_alias = logical_plan::generate_id();
-            let incoming_alias = logical_plan::generate_id();
+            // #1084: skip user-declared variables so these anonymous UNION-branch
+            // table aliases never collide with a user variable named `t{N}` (which
+            // would corrupt the qualified column references built from them below).
+            let mut used_aliases: std::collections::HashSet<String> = reserved_aliases.clone();
+            let outgoing_alias = logical_plan::generate_id_avoiding(&mut used_aliases);
+            let incoming_alias = logical_plan::generate_id_avoiding(&mut used_aliases);
 
             let rel_plan: Arc<LogicalPlan> = Arc::new(LogicalPlan::Union(Union {
                 inputs: vec![Arc::new(LogicalPlan::Empty), Arc::new(LogicalPlan::Empty)],

--- a/src/query_planner/logical_plan/match_clause/traversal.rs
+++ b/src/query_planner/logical_plan/match_clause/traversal.rs
@@ -16,7 +16,6 @@ use crate::{
     },
 };
 
-use crate::query_planner::logical_plan::generate_id;
 use std::collections::{HashMap, HashSet};
 
 /// Generate an anonymous alias (`t1`, `t2`, …) that does NOT collide with any
@@ -30,12 +29,7 @@ use std::collections::{HashMap, HashSet};
 /// label — the #1081 `(TYPE::From::To)-[:TYPE::From::To]->(...)` corruption.
 /// The generated candidate is recorded in `used` so later generation skips it too.
 fn generate_unique_alias(used: &mut HashSet<String>) -> String {
-    loop {
-        let candidate = generate_id();
-        if used.insert(candidate.clone()) {
-            return candidate;
-        }
-    }
+    crate::query_planner::logical_plan::generate_id_avoiding(used)
 }
 
 // Import from sibling modules
@@ -116,6 +110,11 @@ fn traverse_connected_pattern_with_mode<'a>(
     for (alias, _) in plan_ctx.iter_table_contexts() {
         used_aliases.insert(alias.clone());
     }
+    // #1084: Also avoid every user variable declared anywhere in the statement,
+    // not just this pattern. A later comma-separated pattern's variable (e.g. the
+    // `t2` in `MATCH (a)-[]->(x), (t2)-[]->(y)`) is not yet bound in `plan_ctx`
+    // while this pattern is lowered, so per-pattern collection alone cannot see it.
+    used_aliases.extend(plan_ctx.reserved_aliases().iter().cloned());
 
     // Use usize from Rc::as_ptr() cast as the key for pointer-based identity
     let mut node_alias_map: HashMap<usize, String> = HashMap::new();
@@ -1889,10 +1888,15 @@ pub(super) fn traverse_node_pattern(
 ) -> LogicalPlanResult<Arc<LogicalPlan>> {
     // Generate anonymous alias for nodes without names
     // This supports Neo4j Browser "dot" feature: MATCH () RETURN *
-    let node_alias = node_pattern
-        .name
-        .map(|n| n.to_string())
-        .unwrap_or_else(generate_id);
+    // #1084: skip the query-scoped user variables (and any already-bound aliases)
+    // so a generated `t{N}` never clobbers a user variable of the same name.
+    let node_alias = node_pattern.name.map(|n| n.to_string()).unwrap_or_else(|| {
+        let mut used: HashSet<String> = plan_ctx.reserved_aliases().clone();
+        for (alias, _) in plan_ctx.iter_table_contexts() {
+            used.insert(alias.clone());
+        }
+        crate::query_planner::logical_plan::generate_id_avoiding(&mut used)
+    });
     let mut node_label: Option<String> = node_pattern.first_label().map(|val| val.to_string());
 
     // === SINGLE-NODE-SCHEMA INFERENCE ===

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -333,6 +333,24 @@ pub fn generate_id() -> String {
     format!("t{}", n)
 }
 
+/// Generate a simple alias (`t{N}`) that does NOT collide with any name already
+/// present in `used` — the query-scoped set of user-declared variables plus any
+/// aliases generated earlier in the same batch. The chosen candidate is recorded
+/// in `used` so a subsequent call in the same batch skips it too.
+///
+/// Anonymous nodes/edges draw from the shared `t{N}` counter (`generate_id`); a
+/// user variable named exactly `t{N}` would otherwise collide with a generated
+/// alias, corrupting the node/relationship it aliases (#1081, #1084). Callers seed
+/// `used` from `PlanCtx::reserved_aliases()` (and any locally-bound aliases).
+pub fn generate_id_avoiding(used: &mut std::collections::HashSet<String>) -> String {
+    loop {
+        let candidate = generate_id();
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+}
+
 /// Reset the alias counter (useful for testing to get predictable aliases)
 #[allow(dead_code)]
 pub fn reset_alias_counter() {

--- a/src/query_planner/logical_plan/plan_builder.rs
+++ b/src/query_planner/logical_plan/plan_builder.rs
@@ -28,7 +28,7 @@
 //! - Unsupported syntax
 //! - Type inference errors
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::{
@@ -46,6 +46,92 @@ use crate::{
 
 pub type LogicalPlanResult<T> = Result<T, LogicalPlanError>;
 
+/// #1084: Collect every alias the user explicitly declared anywhere in the
+/// statement — node/relationship/path-pattern variables plus UNWIND and WITH
+/// aliases — into a single query-scoped set. Anonymous-alias generation
+/// (`generate_id` → `t{N}`) consults this so a generated alias never clobbers a
+/// user variable of the same name, including across comma-separated patterns and
+/// clause boundaries that per-pattern `used_aliases` collection cannot see
+/// (#1081/#1084).
+fn collect_declared_aliases(query_ast: &OpenCypherQueryAst) -> HashSet<String> {
+    use crate::open_cypher_parser::ast::{PathPattern, ReadingClause};
+
+    fn walk_path_pattern(pattern: &PathPattern, out: &mut HashSet<String>) {
+        match pattern {
+            PathPattern::Node(node) => {
+                if let Some(name) = node.name {
+                    out.insert(name.to_string());
+                }
+            }
+            PathPattern::ConnectedPattern(connected) => {
+                for cp in connected {
+                    if let Some(name) = cp.start_node.borrow().name {
+                        out.insert(name.to_string());
+                    }
+                    if let Some(name) = cp.end_node.borrow().name {
+                        out.insert(name.to_string());
+                    }
+                    if let Some(name) = cp.relationship.name {
+                        out.insert(name.to_string());
+                    }
+                }
+            }
+            PathPattern::ShortestPath(inner) | PathPattern::AllShortestPaths(inner) => {
+                walk_path_pattern(inner, out);
+            }
+        }
+    }
+
+    let mut reserved: HashSet<String> = HashSet::new();
+
+    // `reading_clauses` preserves MATCH/OPTIONAL MATCH order and is the canonical
+    // source when populated; the split `match_clauses`/`optional_match_clauses`
+    // vecs are the fallback path. Walking every available source is idempotent
+    // (a set), so we cover whichever the parser populated.
+    for reading_clause in &query_ast.reading_clauses {
+        match reading_clause {
+            ReadingClause::Match(m) => {
+                for (path_var, pattern) in &m.path_patterns {
+                    if let Some(v) = path_var {
+                        reserved.insert(v.to_string());
+                    }
+                    walk_path_pattern(pattern, &mut reserved);
+                }
+            }
+            ReadingClause::OptionalMatch(om) => {
+                for pattern in &om.path_patterns {
+                    walk_path_pattern(pattern, &mut reserved);
+                }
+            }
+        }
+    }
+    for m in &query_ast.match_clauses {
+        for (path_var, pattern) in &m.path_patterns {
+            if let Some(v) = path_var {
+                reserved.insert(v.to_string());
+            }
+            walk_path_pattern(pattern, &mut reserved);
+        }
+    }
+    for om in &query_ast.optional_match_clauses {
+        for pattern in &om.path_patterns {
+            walk_path_pattern(pattern, &mut reserved);
+        }
+    }
+    for unwind in &query_ast.unwind_clauses {
+        reserved.insert(unwind.alias.to_string());
+    }
+    if let Some(with_clause) = &query_ast.with_clause {
+        for item in &with_clause.with_items {
+            if let Some(alias) = item.alias {
+                reserved.insert(alias.to_string());
+            }
+        }
+    }
+
+    reserved
+}
+
 pub fn build_logical_plan(
     query_ast: &OpenCypherQueryAst,
     schema: &GraphSchema,
@@ -60,6 +146,12 @@ pub fn build_logical_plan(
         view_parameter_values,
         max_inferred_types.unwrap_or(20), // Default 20 for Neo4j Browser compatibility
     );
+
+    // #1084: Reserve every user-declared alias up front so anonymous-alias
+    // generation (`t{N}`) never collides with a user variable — including across
+    // comma-separated patterns and clause boundaries that per-pattern collection
+    // cannot see. Inherited by WITH child scopes (see `PlanCtx::with_parent_scope`).
+    plan_ctx.set_reserved_aliases(collect_declared_aliases(query_ast));
 
     log::debug!(
         "build_logical_plan: Processing query with {} MATCH clauses, {} optional_match_clauses",

--- a/src/query_planner/logical_plan/plan_builder.rs
+++ b/src/query_planner/logical_plan/plan_builder.rs
@@ -54,7 +54,9 @@ pub type LogicalPlanResult<T> = Result<T, LogicalPlanError>;
 /// clause boundaries that per-pattern `used_aliases` collection cannot see
 /// (#1081/#1084).
 fn collect_declared_aliases(query_ast: &OpenCypherQueryAst) -> HashSet<String> {
-    use crate::open_cypher_parser::ast::{PathPattern, ReadingClause};
+    use crate::open_cypher_parser::ast::{
+        MatchClause, OptionalMatchClause, PathPattern, ReadingClause, WithClause,
+    };
 
     fn walk_path_pattern(pattern: &PathPattern, out: &mut HashSet<String>) {
         match pattern {
@@ -82,6 +84,45 @@ fn collect_declared_aliases(query_ast: &OpenCypherQueryAst) -> HashSet<String> {
         }
     }
 
+    fn collect_match(m: &MatchClause, out: &mut HashSet<String>) {
+        for (path_var, pattern) in &m.path_patterns {
+            if let Some(v) = path_var {
+                out.insert(v.to_string());
+            }
+            walk_path_pattern(pattern, out);
+        }
+    }
+
+    fn collect_optional(om: &OptionalMatchClause, out: &mut HashSet<String>) {
+        for pattern in &om.path_patterns {
+            walk_path_pattern(pattern, out);
+        }
+    }
+
+    // A `WITH` carries a whole chain of subsequent clauses (`WITH … MATCH … WITH …`),
+    // each lowered on a child scope that inherits the reserved set. Their variables
+    // must be reserved too, or an anonymous alias generated for a post-WITH pattern
+    // can still collide with a user variable there (#1084 across a WITH barrier).
+    fn collect_with(w: &WithClause, out: &mut HashSet<String>) {
+        for item in &w.with_items {
+            if let Some(alias) = item.alias {
+                out.insert(alias.to_string());
+            }
+        }
+        if let Some(unwind) = &w.subsequent_unwind {
+            out.insert(unwind.alias.to_string());
+        }
+        if let Some(m) = &w.subsequent_match {
+            collect_match(m, out);
+        }
+        for om in &w.subsequent_optional_matches {
+            collect_optional(om, out);
+        }
+        if let Some(next) = &w.subsequent_with {
+            collect_with(next, out);
+        }
+    }
+
     let mut reserved: HashSet<String> = HashSet::new();
 
     // `reading_clauses` preserves MATCH/OPTIONAL MATCH order and is the canonical
@@ -90,41 +131,26 @@ fn collect_declared_aliases(query_ast: &OpenCypherQueryAst) -> HashSet<String> {
     // (a set), so we cover whichever the parser populated.
     for reading_clause in &query_ast.reading_clauses {
         match reading_clause {
-            ReadingClause::Match(m) => {
-                for (path_var, pattern) in &m.path_patterns {
-                    if let Some(v) = path_var {
-                        reserved.insert(v.to_string());
-                    }
-                    walk_path_pattern(pattern, &mut reserved);
-                }
-            }
-            ReadingClause::OptionalMatch(om) => {
-                for pattern in &om.path_patterns {
-                    walk_path_pattern(pattern, &mut reserved);
-                }
-            }
+            ReadingClause::Match(m) => collect_match(m, &mut reserved),
+            ReadingClause::OptionalMatch(om) => collect_optional(om, &mut reserved),
         }
     }
     for m in &query_ast.match_clauses {
-        for (path_var, pattern) in &m.path_patterns {
-            if let Some(v) = path_var {
-                reserved.insert(v.to_string());
-            }
-            walk_path_pattern(pattern, &mut reserved);
-        }
+        collect_match(m, &mut reserved);
     }
     for om in &query_ast.optional_match_clauses {
-        for pattern in &om.path_patterns {
-            walk_path_pattern(pattern, &mut reserved);
-        }
+        collect_optional(om, &mut reserved);
     }
     for unwind in &query_ast.unwind_clauses {
         reserved.insert(unwind.alias.to_string());
     }
     if let Some(with_clause) = &query_ast.with_clause {
-        for item in &with_clause.with_items {
-            if let Some(alias) = item.alias {
-                reserved.insert(alias.to_string());
+        collect_with(with_clause, &mut reserved);
+    }
+    if let Some(call) = &query_ast.call_clause {
+        if let Some(yields) = &call.yield_items {
+            for y in yields {
+                reserved.insert(y.to_string());
             }
         }
     }
@@ -591,5 +617,66 @@ fn extract_source_alias_from_expr(
 
         // All other expressions (aggregations, arithmetic, etc.) are not simple aliases
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod reserved_alias_tests {
+    use super::collect_declared_aliases;
+    use crate::open_cypher_parser::parse_query;
+
+    fn declared(cypher: &str) -> std::collections::HashSet<String> {
+        let ast = parse_query(cypher).expect("parse should succeed");
+        collect_declared_aliases(&ast)
+    }
+
+    /// #1084: every node/relationship variable across comma-separated patterns in
+    /// one MATCH is reserved — the shape that the analyzer's anonymous-alias
+    /// generation must avoid across the comma boundary.
+    #[test]
+    fn collects_cross_comma_pattern_variables() {
+        let set = declared(
+            "MATCH (a:User)-[r:FOLLOWS]->(x), (t1:User)-[:AUTHORED]->(d:Post) RETURN t1.name",
+        );
+        for v in ["a", "r", "x", "t1", "d"] {
+            assert!(
+                set.contains(v),
+                "expected reserved set to contain {v:?}: {set:?}"
+            );
+        }
+    }
+
+    /// #1084 (post-WITH): variables declared in clauses chained after a WITH —
+    /// `WITH … MATCH …` — must be reserved too, or an anonymous alias generated for
+    /// a post-WITH pattern can still collide with a user variable there.
+    #[test]
+    fn collects_post_with_subsequent_match_variables() {
+        let set = declared(
+            "MATCH (a:User) WITH a \
+             MATCH (a)-[:FOLLOWS]->(), (t1:User)-[:AUTHORED]->(d:Post) RETURN t1.name",
+        );
+        assert!(set.contains("a"), "leading MATCH var missing: {set:?}");
+        assert!(
+            set.contains("t1"),
+            "post-WITH subsequent-MATCH var `t1` missing — #1084 across a WITH barrier: {set:?}"
+        );
+        assert!(
+            set.contains("d"),
+            "post-WITH subsequent-MATCH var `d` missing: {set:?}"
+        );
+    }
+
+    /// #1084: UNWIND aliases and chained `WITH … WITH …` projection aliases are
+    /// reserved (a user could name either `t{N}`).
+    #[test]
+    fn collects_unwind_and_chained_with_aliases() {
+        let set = declared(
+            "UNWIND [1, 2, 3] AS t2 \
+             MATCH (a:User) WITH a AS t3 \
+             MATCH (t3)-[:AUTHORED]->(p:Post) RETURN p.content",
+        );
+        assert!(set.contains("t2"), "UNWIND alias missing: {set:?}");
+        assert!(set.contains("t3"), "chained WITH alias missing: {set:?}");
+        assert!(set.contains("p"), "post-WITH pattern var missing: {set:?}");
     }
 }

--- a/src/query_planner/plan_ctx/builder.rs
+++ b/src/query_planner/plan_ctx/builder.rs
@@ -210,6 +210,7 @@ impl PlanCtxBuilder {
             pattern_contexts: self.pattern_contexts,
             vlp_endpoints: self.vlp_endpoints,
             vlp_alias_counter: 0,
+            reserved_aliases: std::sync::Arc::new(std::collections::HashSet::new()),
             variables: self.variables,
             cte_alias_sources: self.cte_alias_sources,
             where_property_requirements: self.where_property_requirements,

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -129,6 +129,15 @@ pub struct PlanCtx {
     /// Counter for generating unique per-VLP CTE outer aliases (vt0, vt1, vt2, ...).
     /// Scoped to this PlanCtx (per-query), avoiding global static race conditions.
     vlp_alias_counter: usize,
+    /// #1084: Query-scoped set of every alias the user explicitly declared anywhere
+    /// in the statement (node/relationship/path-pattern variables, UNWIND and WITH
+    /// aliases). Anonymous-alias generation (`generate_id` → `t{N}`) must skip these
+    /// so a generated alias never clobbers a user variable of the same name (#1081).
+    /// Populated once up front in `build_logical_plan` and inherited by WITH child
+    /// scopes, so it protects across comma-separated patterns and clause boundaries
+    /// that per-pattern `used_aliases` collection cannot see. Wrapped in `Arc` so
+    /// the frequent `PlanCtx::clone()` (parent-scope boxing) stays cheap.
+    reserved_aliases: Arc<HashSet<String>>,
     /// **NEW (Jan 2026)**: Typed variable registry for unified variable tracking
     /// This is the single source of truth for variable types across the query.
     /// Replaces fragmented type tracking in TableCtx and ScopeContext.
@@ -541,6 +550,7 @@ impl PlanCtx {
             pattern_contexts: HashMap::new(),
             vlp_endpoints: HashMap::new(),
             vlp_alias_counter: 0,
+            reserved_aliases: Arc::new(HashSet::new()),
             variables: VariableRegistry::new(),
             cte_alias_sources: HashMap::new(),
             where_property_requirements: HashMap::new(),
@@ -574,6 +584,7 @@ impl PlanCtx {
             pattern_contexts: HashMap::new(),
             vlp_endpoints: HashMap::new(),
             vlp_alias_counter: 0,
+            reserved_aliases: Arc::new(HashSet::new()),
             variables: VariableRegistry::new(),
             cte_alias_sources: HashMap::new(),
             where_property_requirements: HashMap::new(),
@@ -637,6 +648,7 @@ impl PlanCtx {
             pattern_contexts: HashMap::new(),
             vlp_endpoints: HashMap::new(),
             vlp_alias_counter: 0,
+            reserved_aliases: Arc::new(HashSet::new()),
             variables: VariableRegistry::new(),
             cte_alias_sources: HashMap::new(),
             where_property_requirements: HashMap::new(),
@@ -682,6 +694,9 @@ impl PlanCtx {
             pattern_contexts: HashMap::new(), // New scope - patterns computed fresh
             vlp_endpoints: parent.vlp_endpoints.clone(), // Inherit VLP endpoint info from parent
             vlp_alias_counter: parent.vlp_alias_counter, // Continue counter from parent scope
+            // #1084: inherit the query-scoped reserved-alias set (cheap Arc clone) so
+            // anonymous-alias generation after a WITH barrier still avoids user vars.
+            reserved_aliases: parent.reserved_aliases.clone(),
             variables: VariableRegistry::new(), // Fresh variable registry for new scope
             cte_alias_sources: HashMap::new(),
             where_property_requirements: HashMap::new(),
@@ -718,6 +733,7 @@ impl PlanCtx {
             pattern_contexts: HashMap::new(),
             vlp_endpoints: HashMap::new(),
             vlp_alias_counter: 0,
+            reserved_aliases: Arc::new(HashSet::new()),
             variables: VariableRegistry::new(),
             cte_alias_sources: HashMap::new(),
             where_property_requirements: HashMap::new(),
@@ -1303,6 +1319,19 @@ impl PlanCtx {
         let idx = self.vlp_alias_counter;
         self.vlp_alias_counter += 1;
         format!("vt{}", idx)
+    }
+
+    /// #1084: Record the query-scoped set of user-declared aliases. Called once
+    /// per statement from `build_logical_plan`; inherited by WITH child scopes.
+    pub fn set_reserved_aliases(&mut self, reserved: HashSet<String>) {
+        self.reserved_aliases = Arc::new(reserved);
+    }
+
+    /// #1084: The query-scoped set of user-declared aliases that anonymous-alias
+    /// generation (`generate_id`) must avoid. Empty until `set_reserved_aliases`
+    /// is called (e.g. in tests that construct a `PlanCtx` directly).
+    pub fn reserved_aliases(&self) -> &HashSet<String> {
+        &self.reserved_aliases
     }
 
     /// Get the proper (table_alias, column) for a JOIN condition, accounting for VLP endpoints.

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -846,6 +846,16 @@ impl PlanCtx {
 
         // Merge status messages from other context
         self.status_messages.extend(other.status_messages);
+
+        // #1084: union the query-scoped reserved-alias sets. For a Cypher UNION the
+        // combined ctx is the first branch's ctx, but the analyzer then runs over
+        // the merged plan and generates anonymous aliases for every branch. Without
+        // this, branch ≥2's user variables would not be reserved and could collide.
+        if !other.reserved_aliases.is_empty() {
+            let mut merged: HashSet<String> = (*self.reserved_aliases).clone();
+            merged.extend(other.reserved_aliases.iter().cloned());
+            self.reserved_aliases = Arc::new(merged);
+        }
     }
 
     /// Register columns exported by a CTE

--- a/tests/rust/integration/cross_schema_pattern_tests.rs
+++ b/tests/rust/integration/cross_schema_pattern_tests.rs
@@ -894,3 +894,31 @@ async fn cs_standard_1081_vlp_chain_after_serde_roundtrip() {
         "1081-serde-vlp-chain",
     );
 }
+
+/// #1084: the #1081 fix collected anonymous-alias avoidance only per connected
+/// pattern (plus whatever was already bound in `plan_ctx`). A user variable in a
+/// *later* comma-separated pattern is not yet bound while an *earlier* pattern is
+/// lowered, so its name was not protected — an anonymous alias generated for the
+/// first pattern could still collide with it across the comma boundary. Here the
+/// first pattern's anonymous end node draws the generated alias `t1` (the counter
+/// resets to 1 per query) while the second pattern names a node `t1`. The fix
+/// reserves every user-declared variable query-wide up front, so generation skips
+/// `t1`. Regression guard: both comma patterns must lower — proven by both edge
+/// tables appearing — with the user's `t1` resolving as its own `User` node.
+#[tokio::test]
+async fn cs_standard_1084_cross_comma_anonymous_alias_collision() {
+    let schema = load_schema(SCHEMA_STANDARD);
+    let cypher = "MATCH (a:User)-[:FOLLOWS]->(), (t1:User)-[:AUTHORED]->(d:Post) \
+                  RETURN t1.name, d.content LIMIT 5";
+    let sql = generate_sql(&schema, cypher).await;
+    assert_valid_sql(&sql, "standard", "1084-cross-comma-alias");
+    // Both relationship tables must be present: proof both comma patterns lowered.
+    assert_contains(&sql, "standard/1084", "cs_test.authored");
+    assert_contains(&sql, "standard/1084", "cs_test.follows");
+    // The two comma-separated patterns are disconnected, so the user's `t1` node
+    // must join as an independent cartesian product (`AS t1 ON 1 = 1`). Under the
+    // pre-#1084 collision the first pattern's anonymous end node took alias `t1`
+    // and FUSED with the user's node — `t1` would instead be joined on the FOLLOWS
+    // relationship's `followed_id`. Assert the cartesian join to lock the fix.
+    assert_contains(&sql, "standard/1084", "AS t1 ON 1 = 1");
+}


### PR DESCRIPTION
## #1084 — close the remaining `generate_id()` alias-collision sites

Follow-up to #1081 / #1083. The #1081 fix made anonymous alias generation (`generate_id` → `t{N}`) skip already-used aliases, but collected them only **per connected pattern** (plus whatever was already bound in `plan_ctx`). Three sites in the same bug class remained unguarded; this PR closes all of them uniformly via the query-scoped reservation the issue recommends.

### The fix
- **New `PlanCtx.reserved_aliases: Arc<HashSet<String>>`** — every alias the user declares anywhere in the statement, collected once up front (`collect_declared_aliases`, a single AST walk) in `build_logical_plan`. Per-query state (an `Arc` cheap-cloned into WITH child scopes), **not** a new process-global — the issue explicitly cautioned against another global like `ALIAS_COUNTER`.
- **Three sites now consult it:**
  1. `traverse_connected_pattern_with_mode` seeds `used_aliases` from the reserved set → closes the **cross-comma-pattern** gap (a later pattern's var isn't yet bound while an earlier one is lowered).
  2. `traverse_node_pattern` (lone node) generates a reserved-avoiding alias.
  3. `get_rel_ctx_for_edge_list` (undirected `Either` same-type-anchor UNION) receives the set threaded from `infer_traversal` — the analyzer pass shares the same `plan_ctx`.
- **New shared `logical_plan::generate_id_avoiding()`** centralizes the skip-loop; `generate_unique_alias` delegates to it.

### Review-driven follow-ups (2nd commit)
An adversarial review found two residual gaps (both strictly better than pre-fix):
- **Post-WITH clauses** (`subsequent_match` / `subsequent_optional_matches` / `subsequent_unwind` / `subsequent_with`) weren't walked → #1084 reproduced across a WITH barrier. Now recursed; `CALL … YIELD` aliases collected too.
- **`PlanCtx::merge` dropped `reserved_aliases`** → UNION branch ≥2 under-protected at the analyzer edge-list site. Now unioned.

### Semantics / safety
Output is **byte-identical** except in the collision case: `generate_id_avoiding` only ever *advances* the global monotonic counter, so skipping a reserved name can only push a generated alias to a higher unused number — never onto another generated alias, and never onto a user var (given a complete reserved set). The only queries whose aliases shift are exactly the bug case.

### Tests
- Integration `cs_standard_1084_cross_comma_anonymous_alias_collision`: asserts the two comma patterns join as an **independent cartesian product** (`AS t1 ON 1 = 1`) instead of fusing on the FOLLOWS `followed_id`. Verified it **fails pre-fix, passes post-fix**.
- Unit `reserved_alias_tests` (×3): lock collector completeness across comma patterns, post-WITH `subsequent_match`, and UNWIND + chained-WITH aliases. The post-WITH cases fail without the recursion.
- Full suite green: **1738 unit + 612 integration + ratchet**, 0 failures. `cargo fmt` + `clippy --all-targets` clean.

### Out of scope / follow-up
Correctly not-fusing the post-WITH disconnected-comma shape now reaches a **pre-existing loud render guard** (cartesian join between a WITH-CTE-correlated pattern and a disconnected fresh pattern) — an orthogonal render-plan limitation, filed as **#1089**. Loud error is honest vs. the prior silent fusion (ground rule 1).

Closes #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)