### PR TITLE
fix(vlp): #1088 query-scoped VLP CTE FROM alias (remove #1085 loud gate)

### DIFF
--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -1032,8 +1032,7 @@ impl GraphJoinInference {
                     .map(|info| info.vlp_alias.clone())
                     .collect();
                 if !vlp_available.is_empty() {
-                    vlp_available
-                        .insert(crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string());
+                    vlp_available.insert(crate::server::query_context::vlp_from_alias());
                 }
 
                 // Reorder JOINs using clean topological sort
@@ -3435,9 +3434,7 @@ impl GraphJoinInference {
             let vlp_alias = join_ctx
                 .get_vlp_endpoint(&right_alias)
                 .map(|info| info.vlp_alias.clone())
-                .unwrap_or_else(|| {
-                    crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string()
-                });
+                .unwrap_or_else(crate::server::query_context::vlp_from_alias);
 
             // #922: a CLOSED OPTIONAL VLP (`(a)-[*..]->(a)`,
             // `left_connection == right_connection`) must pin the CTE path back
@@ -3710,37 +3707,36 @@ impl GraphJoinInference {
             }
         }
 
-        // #1085: the VLP CTE's outer FROM alias is a fixed reserved name
-        // (VLP_CTE_FROM_ALIAS = "t"), threaded as a string-level protocol through
-        // the render + SQL-emit phases (endpoint join resolution, `t.start_*`/
-        // `t.end_*` column references, the reverse-branch `swap_vlp_start_end`
-        // text substitution, etc.). If a user names a VLP endpoint exactly "t",
-        // that reserved alias becomes indistinguishable from the user's node:
-        // the endpoint rewriters re-resolve an already-correct `t.end_id` back to
-        // `t.start_id`, so a chained hop after the VLP silently returns the wrong
-        // rows (docs of the START, not the endpoint — #1085). Making the reserved
-        // alias query-scoped to eliminate the collision is the multi-VLP-aliasing
-        // work tracked in TODO(multi-vlp); until that lands, reject the colliding
-        // pattern LOUDLY rather than emit silently-wrong SQL (ground rule 1). The
-        // fix is a one-character rename of the user's variable.
-        let reserved = crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
-        if let Some((l, r, rel)) = required_vlps
-            .iter()
-            .find(|(l, r, _)| l == reserved || r == reserved)
-        {
-            let which = if l == reserved { l } else { r };
-            return Err(AnalyzerError::UnsupportedPattern {
-                message: format!(
-                    "variable-length path endpoint is named '{which}' in \
-                     ({l})-[{rel}*..]->({r}), which collides with ClickGraph's \
-                     reserved internal alias for variable-length-path CTEs \
-                     ('{reserved}'). This collision would silently produce wrong \
-                     results for a chained hop after the path (issue #1085). \
-                     Rename the '{reserved}' variable (e.g. to '{reserved}1') and \
-                     re-run."
-                ),
-            });
-        }
+        // #1088: the VLP CTE's outer FROM alias is a query-scoped name (default
+        // `VLP_CTE_FROM_ALIAS = "t"`), threaded as a string-level protocol through
+        // the render + SQL-emit phases (endpoint join resolution, `<alias>.start_*`/
+        // `<alias>.end_*` column references, the reverse-branch `swap_vlp_start_end`
+        // text substitution, etc.) via `server::query_context::vlp_from_alias()`.
+        // If a user declares a variable literally named "t" it would collide with
+        // this reserved internal alias — silently re-resolving an already-correct
+        // `t.end_id` back to `t.start_id` and returning the wrong rows for a chained
+        // hop after the path (#1085). Instead of rejecting the query (the old #1085
+        // loud gate), pick a collision-free alias and register it query-scoped so
+        // every emit/detect site agrees. `reserved_aliases` (#1084) is the set of
+        // all user-declared variables, populated up front in `build_logical_plan`
+        // and inherited by every scope, so this decision is identical across the
+        // per-branch `pre_register_vlp_endpoints` calls.
+        let default_alias = crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
+        let vlp_from_alias = if plan_ctx.reserved_aliases().contains(default_alias) {
+            // Collision: choose the first `vlpt`, `vlpt2`, … not taken by a user
+            // variable. `vlpt` is deliberately not confusable with the internal
+            // `vt{N}` / `vlp_` / `with_` alias families (see `is_vlp_or_cte_alias`).
+            let mut n: u32 = 1;
+            let mut candidate = String::from("vlpt");
+            while plan_ctx.reserved_aliases().contains(&candidate) {
+                n += 1;
+                candidate = format!("vlpt{n}");
+            }
+            candidate
+        } else {
+            default_alias.to_string()
+        };
+        crate::server::query_context::register_vlp_from_alias(&vlp_from_alias);
 
         for (left_alias, right_alias, rel_alias) in required_vlps {
             plan_ctx.register_vlp_endpoint(

--- a/src/query_planner/analyzer/projection_tagging.rs
+++ b/src/query_planner/analyzer/projection_tagging.rs
@@ -869,7 +869,7 @@ impl ProjectionTagging {
                                         // pass could rewrite for us.
                                         item.expression = LogicalExpr::PropertyAccessExp(PropertyAccess {
                                             table_alias: TableAlias(
-                                                crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string(),
+                                                crate::server::query_context::vlp_from_alias(),
                                             ),
                                             column: crate::graph_catalog::expression_parser::PropertyValue::Column("end_type".to_string()),
                                         });
@@ -947,7 +947,8 @@ impl ProjectionTagging {
                                             {
                                                 alias.clone()
                                             } else {
-                                                "t".to_string() // VLP CTE uses 't' alias
+                                                crate::server::query_context::vlp_from_alias()
+                                                // #1088: query-scoped VLP alias
                                             };
                                             item.expression = LogicalExpr::ArraySubscript {
                                                 array: Box::new(LogicalExpr::PropertyAccessExp(PropertyAccess {
@@ -1064,7 +1065,7 @@ impl ProjectionTagging {
                                             // always rendered as `FROM vlp_multi_type_... AS t`).
                                             let end_type_expr = LogicalExpr::PropertyAccessExp(PropertyAccess {
                                                 table_alias: TableAlias(
-                                                    crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string(),
+                                                    crate::server::query_context::vlp_from_alias(),
                                                 ),
                                                 column: crate::graph_catalog::expression_parser::PropertyValue::Column("end_type".to_string()),
                                             });
@@ -1167,7 +1168,7 @@ impl ProjectionTagging {
                                             // Cypher alias — see the labels() fix above.
                                             item.expression = LogicalExpr::PropertyAccessExp(PropertyAccess {
                                                 table_alias: TableAlias(
-                                                    crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string(),
+                                                    crate::server::query_context::vlp_from_alias(),
                                                 ),
                                                 column: crate::graph_catalog::expression_parser::PropertyValue::Column("end_type".to_string()),
                                             });
@@ -1635,8 +1636,7 @@ impl ProjectionTagging {
                                     let access = |col: &str| {
                                         LogicalExpr::PropertyAccessExp(PropertyAccess {
                                             table_alias: TableAlias(
-                                                crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
-                                                    .to_string(),
+                                                crate::server::query_context::vlp_from_alias(),
                                             ),
                                             column: crate::graph_catalog::expression_parser::PropertyValue::Column(
                                                 col.to_string(),

--- a/src/query_planner/join_context.rs
+++ b/src/query_planner/join_context.rs
@@ -39,7 +39,9 @@ pub fn is_vlp_planning_alias(alias: &str) -> bool {
 /// be treated as a stale/dead reference during plan cleanup.
 pub fn is_vlp_or_cte_alias(alias: &str) -> bool {
     alias.starts_with("with_")
-        || alias == VLP_CTE_FROM_ALIAS
+        // #1088: compare against the query-scoped VLP FROM alias (default "t"),
+        // so a collision-bumped alias is still recognized as a VLP/CTE alias.
+        || alias == crate::server::query_context::vlp_from_alias()
         || alias.starts_with("vlp_")
         || is_vlp_planning_alias(alias)
 }

--- a/src/query_planner/plan_ctx/mod.rs
+++ b/src/query_planner/plan_ctx/mod.rs
@@ -1351,11 +1351,12 @@ impl PlanCtx {
     /// - For VLP endpoints: returns ("t", "start_id"/"end_id")
     pub fn get_vlp_join_reference(&self, alias: &str, default_column: &str) -> (String, String) {
         if let Some(vlp_info) = self.vlp_endpoints.get(alias) {
-            // Use VLP_CTE_FROM_ALIAS ("t") instead of per-VLP alias ("vt0", "vt1")
-            // because the render phase always aliases VLP CTEs as "t" in FROM clauses.
-            // TODO(multi-vlp): When render phase supports per-VLP aliases, use vlp_info.vlp_alias
+            // #1088: the render phase aliases the VLP CTE as the query-scoped VLP
+            // FROM alias (`vlp_from_alias()`, default "t"), so resolve endpoint
+            // joins to that same alias for consistency.
+            // TODO(multi-vlp): When render supports per-VLP aliases, use vlp_info.vlp_alias
             (
-                crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string(),
+                crate::server::query_context::vlp_from_alias(),
                 vlp_info.cte_column().to_string(),
             )
         } else {

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -6,9 +6,7 @@ use crate::graph_catalog::config::Identifier;
 use crate::graph_catalog::expression_parser::PropertyValue;
 use crate::graph_catalog::graph_schema::GraphSchema;
 use crate::graph_catalog::pattern_schema::{JoinStrategy, PatternSchemaContext};
-use crate::query_planner::join_context::{
-    VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
-};
+use crate::query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN};
 use crate::query_planner::logical_expr::expression_rewriter::{
     rewrite_projection_items_with_property_mapping, ExpressionRewriteContext,
 };
@@ -4601,7 +4599,7 @@ pub fn extract_ctes_with_context(
                                             vlp_position: Some(crate::render_plan::cte_manager::VlpColumnPosition::End),
                                         },
                                     ],
-                                    from_alias: Some(VLP_CTE_FROM_ALIAS.to_string()),
+                                    from_alias: Some(crate::server::query_context::vlp_from_alias()),
                                     outer_where_filters: None, // Multi-type VLP doesn't need outer filters
                                     with_exported_aliases: Vec::new(),
                                     variable_registry: None,

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -12,9 +12,7 @@ use crate::graph_catalog::{
     config::Identifier, graph_schema::GraphSchema, EdgeAccessStrategy, JoinStrategy,
     NodeAccessStrategy, PatternSchemaContext,
 };
-use crate::query_planner::join_context::{
-    VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
-};
+use crate::query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN};
 use crate::query_planner::logical_plan::VariableLengthSpec;
 use crate::render_plan::cte_extraction::collect_parameters_from_filters;
 use crate::render_plan::cte_generation::CteGenerationContext;
@@ -630,7 +628,7 @@ impl DenormalizedCteStrategy {
             parameters: collect_parameters_from_filters(filters),
             cte_name,
             recursive: true,
-            from_alias: VLP_CTE_FROM_ALIAS.to_string(),
+            from_alias: crate::server::query_context::vlp_from_alias(),
             columns,
             vlp_endpoint: Some(vlp_endpoint),
             // ⚠️ CRITICAL: For denormalized VLP, end_node_filters must be applied in outer SELECT
@@ -1751,7 +1749,7 @@ impl VariableLengthCteStrategy {
             parameters: vec![],
             cte_name,
             recursive: true,
-            from_alias: VLP_CTE_FROM_ALIAS.to_string(),
+            from_alias: crate::server::query_context::vlp_from_alias(),
             columns,
             vlp_endpoint: Some(vlp_endpoint),
             outer_where_filters: None,

--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -291,7 +291,7 @@ impl FilterBuilder for LogicalPlan {
                             // CTE only.
                             if graph_rel.left_connection == graph_rel.right_connection {
                                 use crate::query_planner::join_context::{
-                                    VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
+                                    VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
                                 };
                                 // #628: a closed `*0..N` on a STANDARD schema is now
                                 // supported. The recursive CTE switches to
@@ -427,7 +427,7 @@ impl FilterBuilder for LogicalPlan {
                                 );
                                 return Ok(Some(RenderExpr::Raw(format!(
                                     "{a}.{s} = {a}.{e}",
-                                    a = VLP_CTE_FROM_ALIAS,
+                                    a = crate::server::query_context::vlp_from_alias(),
                                     s = VLP_START_ID_COLUMN,
                                     e = VLP_END_ID_COLUMN,
                                 ))));

--- a/src/render_plan/from_builder.rs
+++ b/src/render_plan/from_builder.rs
@@ -33,17 +33,18 @@
 //! - **Week 5: from_builder.rs** ← Current
 //! - Week 6: group_by_builder.rs (planned)
 
-use crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
 use crate::query_planner::logical_plan::{GraphRel, LogicalPlan};
 use crate::utils::cte_naming::{extract_cte_base_name, is_generated_cte_name};
 use log::debug;
 use std::sync::Arc;
 
-/// Get the outer-query alias for a VLP CTE, using query context registry first,
-/// then falling back to the default VLP_CTE_FROM_ALIAS constant.
+/// Get the outer-query alias for a VLP CTE, using the per-CTE query-context
+/// registry first, then falling back to the query-scoped VLP FROM alias
+/// (`vlp_from_alias()`, which is the default `"t"` unless a user variable named
+/// `"t"` forced a collision-free value — #1088).
 fn vlp_cte_alias_for(cte_name: &str) -> String {
     crate::server::query_context::get_vlp_cte_outer_alias(cte_name)
-        .unwrap_or_else(|| VLP_CTE_FROM_ALIAS.to_string())
+        .unwrap_or_else(crate::server::query_context::vlp_from_alias)
 }
 
 /// Check if a GraphRel with variable_length is a fixed-length VLP (*2..2, *3..3)

--- a/src/render_plan/join_builder.rs
+++ b/src/render_plan/join_builder.rs
@@ -26,7 +26,6 @@ use crate::utils::cte_column_naming::{cte_column_name, is_cte_column};
 use std::sync::Arc;
 
 // Helper function imports from plan_builder_helpers
-use crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
 use crate::render_plan::cte_extraction::{
     build_vlp_context, expand_fixed_length_joins_with_context, extract_node_label_from_viewscan,
     extract_relationship_columns, table_to_id_column, VlpSchemaType,
@@ -1361,7 +1360,7 @@ impl JoinBuilder for LogicalPlan {
                                     if let crate::query_planner::logical_expr::LogicalExpr::PropertyAccessExp(pa) = operand {
                                         let alias = &pa.table_alias.0;
                                         crate::query_planner::join_context::is_vlp_planning_alias(alias)
-                                            || alias.as_str() == crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
+                                            || *alias == crate::server::query_context::vlp_from_alias()
                                     } else {
                                         false
                                     }
@@ -2346,7 +2345,7 @@ impl JoinBuilder for LogicalPlan {
                             // Look up per-VLP unique alias from query context
                             let vlp_alias =
                                 crate::server::query_context::get_vlp_cte_outer_alias(&cte_name)
-                                    .unwrap_or_else(|| VLP_CTE_FROM_ALIAS.to_string());
+                                    .unwrap_or_else(crate::server::query_context::vlp_from_alias);
 
                             // Get the start node's ID column
                             let start_id_col = extract_id_column(&graph_rel.left)

--- a/src/render_plan/mod.rs
+++ b/src/render_plan/mod.rs
@@ -72,9 +72,7 @@ pub use crate::server::query_context::{
     clear_denormalized_aliases, get_denormalized_alias_mapping, register_denormalized_alias,
 };
 
-use crate::query_planner::join_context::{
-    VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN,
-};
+use crate::query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN};
 use crate::query_planner::logical_plan::{
     Join as LogicalJoin, JoinType as LogicalJoinType, OrderByItem as LogicalOrderByItem,
     OrderByOrder as LogicalOrderByOrder, UnionType as LogicalUnionType,
@@ -478,7 +476,7 @@ impl Cte {
                     vlp_position: Some(cte_manager::VlpColumnPosition::End),
                 },
             ],
-            from_alias: Some(VLP_CTE_FROM_ALIAS.to_string()), // VLP CTEs use standard FROM alias
+            from_alias: Some(crate::server::query_context::vlp_from_alias()), // #1088: query-scoped VLP FROM alias
             outer_where_filters: None,
             with_exported_aliases: Vec::new(),
             variable_registry: None,

--- a/src/render_plan/plan_builder_helpers.rs
+++ b/src/render_plan/plan_builder_helpers.rs
@@ -14,7 +14,6 @@ use super::render_expr::{
     ScalarFnCall, TableAlias,
 };
 use crate::graph_catalog::expression_parser::PropertyValue;
-use crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
 use crate::render_plan::cte_extraction::{
     get_node_label_for_alias, get_relationship_type_for_alias,
 };
@@ -5383,8 +5382,10 @@ pub(super) fn collect_schema_filters(
     match plan {
         LogicalPlan::ViewScan(scan) => {
             if let Some(ref schema_filter) = scan.schema_filter {
-                let table_alias = alias_hint.unwrap_or(VLP_CTE_FROM_ALIAS);
-                if let Ok(sql) = schema_filter.to_sql(table_alias) {
+                let table_alias = alias_hint
+                    .map(str::to_string)
+                    .unwrap_or_else(crate::server::query_context::vlp_from_alias);
+                if let Ok(sql) = schema_filter.to_sql(&table_alias) {
                     log::debug!(
                         "Collected schema filter for table '{}' with alias '{}': {}",
                         scan.source_table,
@@ -5425,8 +5426,10 @@ pub(super) fn collect_schema_filters_with_alias(
     match plan {
         LogicalPlan::ViewScan(scan) => {
             if let Some(ref schema_filter) = scan.schema_filter {
-                let table_alias = alias_hint.unwrap_or(VLP_CTE_FROM_ALIAS);
-                if let Ok(sql) = schema_filter.to_sql(table_alias) {
+                let table_alias = alias_hint
+                    .map(str::to_string)
+                    .unwrap_or_else(crate::server::query_context::vlp_from_alias);
+                if let Ok(sql) = schema_filter.to_sql(&table_alias) {
                     filters.push((
                         RenderExpr::Raw(sql),
                         table_alias.to_string(),

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2089,14 +2089,14 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             .iter()
             .find(|j| j.table_name.starts_with("vlp_"))
             .map(|j| j.table_alias.clone())
-            .unwrap_or_else(|| "t".to_string())
+            .unwrap_or_else(crate::server::query_context::vlp_from_alias)
     } else {
         plan.from
             .0
             .as_ref()
             .and_then(|from_ref| from_ref.alias.as_ref())
             .cloned()
-            .unwrap_or_else(|| "t".to_string())
+            .unwrap_or_else(crate::server::query_context::vlp_from_alias)
     };
 
     // The alias to use for the WHERE / GROUP BY endpoint rewrite. Use the
@@ -2364,8 +2364,7 @@ fn detect_vlp_endpoint_from_plan(plan: &LogicalPlan, alias: &str) -> Option<VlpE
                         position: VlpPosition::Start,
                         other_endpoint_alias: rel.right_connection.clone(),
                         rel_alias: rel.alias.clone(),
-                        vlp_alias: crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
-                            .to_string(),
+                        vlp_alias: crate::server::query_context::vlp_from_alias(),
                     });
                 }
 
@@ -2380,8 +2379,7 @@ fn detect_vlp_endpoint_from_plan(plan: &LogicalPlan, alias: &str) -> Option<VlpE
                         position: VlpPosition::End,
                         other_endpoint_alias: rel.left_connection.clone(),
                         rel_alias: rel.alias.clone(),
-                        vlp_alias: crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
-                            .to_string(),
+                        vlp_alias: crate::server::query_context::vlp_from_alias(),
                     });
                 }
             }
@@ -3308,7 +3306,7 @@ pub(crate) fn expand_table_alias_to_group_by_id_only(
                 // ⚠️ FALLBACK: CTE metadata lookup FAILED - using constants from join_context.rs
                 // This indicates a gap in CTE metadata propagation. The deterministic path
                 // via CteColumnMetadata should have found this alias.
-                let vlp_alias = VLP_CTE_FROM_ALIAS;
+                let vlp_alias = crate::server::query_context::vlp_from_alias();
                 let id_column = if is_start {
                     VLP_START_ID_COLUMN
                 } else {

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -628,7 +628,7 @@ impl SelectBuilder for LogicalPlan {
                                     let cte_alias = if has_pattern_combinations {
                                         gr.alias.clone()
                                     } else {
-                                        "t".to_string()
+                                        crate::server::query_context::vlp_from_alias()
                                     };
                                     let position = if gr.left_connection == prop.table_alias.0 {
                                         "start"
@@ -699,7 +699,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "path_relationships".to_string(),
                                                     ),
@@ -713,7 +713,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "rel_properties".to_string(),
                                                     ),
@@ -727,7 +727,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "start_id".to_string(),
                                                     ),
@@ -741,7 +741,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "end_id".to_string(),
                                                     ),
@@ -756,7 +756,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "start_type".to_string(),
                                                     ),
@@ -770,7 +770,7 @@ impl SelectBuilder for LogicalPlan {
                                         select_items.push(SelectItem {
                                             expression: RenderExpr::PropertyAccessExp(
                                                 PropertyAccess {
-                                                    table_alias: RenderTableAlias("t".to_string()),
+                                                    table_alias: RenderTableAlias(crate::server::query_context::vlp_from_alias()),
                                                     column: PropertyValue::Column(
                                                         "end_type".to_string(),
                                                     ),
@@ -1065,7 +1065,7 @@ impl SelectBuilder for LogicalPlan {
                                     let cte_alias = if has_pattern_combinations {
                                         gr.alias.clone()
                                     } else {
-                                        "t".to_string()
+                                        crate::server::query_context::vlp_from_alias()
                                     };
                                     let position = if gr.left_connection == *cypher_alias {
                                         "start"
@@ -1704,8 +1704,7 @@ impl SelectBuilder for LogicalPlan {
                                             if let Some(vlp_info) = ctx.get_vlp_endpoint(&alias.0)
                                             {
                                                 let from_alias =
-                                                    crate::query_planner::join_context::VLP_CTE_FROM_ALIAS
-                                                        .to_string();
+                                                    crate::server::query_context::vlp_from_alias();
                                                 let id_col = vlp_info.cte_column();
                                                 log::debug!(
                                                     "🔍 SelectBuilder: id({}) -> VLP CTE '{}'.'{}' (#538)",
@@ -2618,9 +2617,9 @@ impl LogicalPlan {
                         "🔀 PatternResolver 2.0: Using relationship alias '{}' for CTE reference",
                         alias
                     );
-                    alias // Pattern combinations use relationship alias
+                    alias.to_string() // Pattern combinations use relationship alias
                 } else {
-                    "t" // VLP uses VLP_CTE_FROM_ALIAS
+                    crate::server::query_context::vlp_from_alias() // #1088: query-scoped VLP alias
                 };
 
                 // Add all CTE columns needed to reconstruct the relationship
@@ -3247,9 +3246,8 @@ impl LogicalPlan {
         let is_vlp = path_var.length_bounds.is_some() || path_var.is_shortest_path;
 
         if is_vlp {
-            // VLP path - use VLP CTE columns
-            use crate::query_planner::join_context::VLP_CTE_FROM_ALIAS;
-            let cte_alias = VLP_CTE_FROM_ALIAS;
+            // VLP path - use VLP CTE columns (#1088: query-scoped FROM alias)
+            let cte_alias = crate::server::query_context::vlp_from_alias();
 
             log::info!(
                 "🔍 Expanding VLP path variable '{}' using CTE columns from '{}'",

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -3272,7 +3272,7 @@ fn apply_weighted_shortest_path_restructure(render_plan: &mut RenderPlan) {
                 render_plan.from = FromTableItem(Some(ViewTableRef {
                     source: std::sync::Arc::new(LogicalPlan::Empty),
                     name: vlp_cte_name,
-                    alias: Some("t".to_string()),
+                    alias: Some(crate::server::query_context::vlp_from_alias()),
                     use_final: false,
                 }));
 

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -142,6 +142,15 @@ pub struct QueryContext {
     /// NOTE: Currently not populated — see TODO(multi-vlp) in cte_extraction.rs.
     pub vlp_cte_outer_aliases: HashMap<String, String>,
 
+    /// #1088: The query-scoped VLP CTE FROM alias. `None` ⇒ the default `"t"`
+    /// (`VLP_CTE_FROM_ALIAS`). Set once during analysis (`pre_register_vlp_endpoints`)
+    /// to a collision-free value when the query declares a user variable literally
+    /// named `"t"` (which would otherwise collide with this reserved internal alias,
+    /// #1085). Every render/emit site that constructs or detects the VLP FROM alias
+    /// reads it via `vlp_from_alias()` so the single value stays consistent across
+    /// the ~100 string-protocol sites. Reset per query in `clear_all_render_contexts`.
+    pub vlp_from_alias: Option<String>,
+
     /// Current variable registry for SQL rendering.
     /// Set from the CTE or RenderPlan being rendered; used by PropertyAccessExp::to_sql()
     /// to resolve cypher_alias.property → correct SQL column.
@@ -775,6 +784,28 @@ pub fn get_vlp_cte_outer_alias(cte_name: &str) -> Option<String> {
         .flatten()
 }
 
+/// #1088: Register the query-scoped VLP CTE FROM alias. Called once during
+/// analysis (`pre_register_vlp_endpoints`) with either the default `"t"` or a
+/// collision-free value when a user variable is named `"t"`.
+pub fn register_vlp_from_alias(alias: &str) {
+    let _ = QUERY_CONTEXT.try_with(|ctx| {
+        ctx.borrow_mut().vlp_from_alias = Some(alias.to_string());
+    });
+}
+
+/// #1088: The query-scoped VLP CTE FROM alias, or the default
+/// [`VLP_CTE_FROM_ALIAS`](crate::query_planner::join_context::VLP_CTE_FROM_ALIAS)
+/// (`"t"`) when none was registered (no VLP, or no collision). Every render/emit
+/// site that constructs or detects the VLP FROM alias MUST read it through this
+/// getter so the single query-scoped value stays consistent across all sites.
+pub fn vlp_from_alias() -> String {
+    QUERY_CONTEXT
+        .try_with(|ctx| ctx.borrow().vlp_from_alias.clone())
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string())
+}
+
 /// Check if an alias is a multi-type VLP endpoint
 pub fn is_multi_type_vlp_alias(alias: &str) -> bool {
     QUERY_CONTEXT
@@ -1155,6 +1186,9 @@ pub fn clear_all_render_contexts() {
         ctx.cte_alias_to_cte_name.clear();
         ctx.all_cte_names.clear();
         ctx.weight_cte_config = None;
+        // #1088: reset the query-scoped VLP FROM alias so the next query starts
+        // from the default `"t"` and re-registers its own value if it collides.
+        ctx.vlp_from_alias = None;
     });
 }
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    query_planner::join_context::{VLP_CTE_FROM_ALIAS, VLP_END_ID_COLUMN, VLP_START_ID_COLUMN},
+    query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN},
     query_planner::logical_plan::LogicalPlan,
     render_plan::{
         cte_extraction::merge_cte_deduping_by_name_content,
@@ -18,7 +18,7 @@ use crate::{
     server::query_context::{
         clear_all_render_contexts, get_relationship_columns, is_multi_type_vlp_alias,
         restore_branch_context, set_alias_label_map, set_all_render_contexts,
-        set_multi_type_vlp_aliases, snapshot_branch_context,
+        set_multi_type_vlp_aliases, snapshot_branch_context, vlp_from_alias,
     },
     utils::cte_naming::is_generated_cte_name,
 };
@@ -1414,7 +1414,7 @@ fn unify_mixed_anchor_branch_selects(plan: &mut RenderPlan) {
                 .0
                 .as_ref()
                 .and_then(|f| f.alias.clone())
-                .unwrap_or_else(|| VLP_CTE_FROM_ALIAS.to_string());
+                .unwrap_or_else(vlp_from_alias);
             let unified: Vec<crate::render_plan::SelectItem> = base_items
                 .iter()
                 .filter_map(|base_item| {
@@ -1516,7 +1516,7 @@ fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
             plan.from = FromTableItem(Some(ViewTableRef {
                 source: std::sync::Arc::new(LogicalPlan::Empty),
                 name: first.cte_name.clone(),
-                alias: Some(VLP_CTE_FROM_ALIAS.to_string()),
+                alias: Some(vlp_from_alias()),
                 use_final: false,
             }));
 
@@ -1537,7 +1537,7 @@ fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
                                     ),
                             }),
                             RenderExpr::PropertyAccessExp(PropertyAccess {
-                                table_alias: TableAlias(VLP_CTE_FROM_ALIAS.to_string()),
+                                table_alias: TableAlias(vlp_from_alias()),
                                 column:
                                     crate::graph_catalog::expression_parser::PropertyValue::Column(
                                         VLP_END_ID_COLUMN.to_string(),
@@ -1747,7 +1747,7 @@ fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
                         if let RenderExpr::Column(Column(PropertyValue::Column(col))) =
                             &item.expression
                         {
-                            if col == "t.start_id" {
+                            if *col == format!("{}.start_id", vlp_from_alias()) {
                                 let rv = col_alias.0.trim_end_matches(".start_id").to_string();
                                 if !rv.is_empty() {
                                     rel_var_name = Some(rv);
@@ -1779,15 +1779,17 @@ fn rewrite_vlp_select_aliases(mut plan: RenderPlan) -> RenderPlan {
                 });
                 if !already_injected {
                     plan.select.items.push(SelectItem {
-                        expression: RenderExpr::Column(Column(PropertyValue::Column(
-                            "t.r_from_id".to_string(),
-                        ))),
+                        expression: RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{}.r_from_id",
+                            vlp_from_alias()
+                        )))),
                         col_alias: Some(ColumnAlias(format!("{}.r_from_id", rv))),
                     });
                     plan.select.items.push(SelectItem {
-                        expression: RenderExpr::Column(Column(PropertyValue::Column(
-                            "t.r_to_id".to_string(),
-                        ))),
+                        expression: RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{}.r_to_id",
+                            vlp_from_alias()
+                        )))),
                         col_alias: Some(ColumnAlias(format!("{}.r_to_id", rv))),
                     });
                     log::info!("🔧 Injected r_from_id/r_to_id projections for rel '{}'", rv);
@@ -2281,6 +2283,12 @@ pub(crate) fn rewrite_expr_for_vlp(
 ) -> RenderExpr {
     use crate::graph_catalog::expression_parser::PropertyValue;
 
+    // #1088: the VLP CTE FROM alias is query-scoped (defaults "t"). Read it once
+    // and build every `<alias>.start_*`/`<alias>.end_*`/`<alias>.<path_col>`
+    // reference from it so this whole rewriter stays consistent with the FROM
+    // clause emitted elsewhere.
+    let vlp_alias = crate::server::query_context::vlp_from_alias();
+
     match expr {
         RenderExpr::TableAlias(alias) => {
             // For VLP, TableAlias references to VLP endpoints should be rewritten to CTE columns
@@ -2289,16 +2297,16 @@ pub(crate) fn rewrite_expr_for_vlp(
                     if skip_start_alias {
                         return expr.clone();
                     }
-                    return RenderExpr::Column(Column(PropertyValue::Column(
-                        "t.start_id".to_string(),
-                    )));
+                    return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                        "{vlp_alias}.start_id"
+                    ))));
                 }
             }
             if let Some(end) = end_alias {
                 if &alias.0 == end {
-                    return RenderExpr::Column(Column(PropertyValue::Column(
-                        "t.end_id".to_string(),
-                    )));
+                    return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                        "{vlp_alias}.end_id"
+                    ))));
                 }
             }
             // Handle bare path variable: p -> tuple(t.path_nodes, t.path_relationships, t.hop_count)
@@ -2307,22 +2315,19 @@ pub(crate) fn rewrite_expr_for_vlp(
                 log::info!(
                     "VLP path variable expansion: {} -> tuple({}.path_nodes, ...)",
                     alias.0,
-                    VLP_CTE_FROM_ALIAS,
+                    vlp_alias,
                 );
                 return RenderExpr::ScalarFnCall(ScalarFnCall {
                     name: "tuple".to_string(),
                     args: vec![
                         RenderExpr::Column(Column(PropertyValue::Column(format!(
-                            "{}.path_nodes",
-                            VLP_CTE_FROM_ALIAS
+                            "{vlp_alias}.path_nodes"
                         )))),
                         RenderExpr::Column(Column(PropertyValue::Column(format!(
-                            "{}.path_relationships",
-                            VLP_CTE_FROM_ALIAS
+                            "{vlp_alias}.path_relationships"
                         )))),
                         RenderExpr::Column(Column(PropertyValue::Column(format!(
-                            "{}.hop_count",
-                            VLP_CTE_FROM_ALIAS
+                            "{vlp_alias}.hop_count"
                         )))),
                     ],
                 });
@@ -2354,8 +2359,7 @@ pub(crate) fn rewrite_expr_for_vlp(
                                     col_name
                                 );
                                 return RenderExpr::Column(Column(PropertyValue::Column(format!(
-                                    "t.{}",
-                                    col_name
+                                    "{vlp_alias}.{col_name}"
                                 ))));
                             }
                         }
@@ -2416,9 +2420,9 @@ pub(crate) fn rewrite_expr_for_vlp(
                         || col_raw.contains(".resp_")
                     {
                         // This is the ID column - use t.start_id directly
-                        return RenderExpr::Column(Column(PropertyValue::Column(
-                            "t.start_id".to_string(),
-                        )));
+                        return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{vlp_alias}.start_id"
+                        ))));
                     }
 
                     // This is accessing start node property
@@ -2426,8 +2430,7 @@ pub(crate) fn rewrite_expr_for_vlp(
                     // The FROM clause has the CTE aliased as 't', so use t.start_xxx
                     let prop_name = derive_cypher_property_name(col_raw);
                     return RenderExpr::Column(Column(PropertyValue::Column(format!(
-                        "t.start_{}",
-                        prop_name
+                        "{vlp_alias}.start_{prop_name}"
                     ))));
                 }
             }
@@ -2443,16 +2446,15 @@ pub(crate) fn rewrite_expr_for_vlp(
                         || col_raw.contains(".resp_")
                     {
                         // This is the ID column - use t.end_id directly
-                        return RenderExpr::Column(Column(PropertyValue::Column(
-                            "t.end_id".to_string(),
-                        )));
+                        return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{vlp_alias}.end_id"
+                        ))));
                     }
 
                     // This is accessing end node property
                     let prop_name = derive_cypher_property_name(col_raw);
                     return RenderExpr::Column(Column(PropertyValue::Column(format!(
-                        "t.end_{}",
-                        prop_name
+                        "{vlp_alias}.end_{prop_name}"
                     ))));
                 }
             }
@@ -2471,8 +2473,7 @@ pub(crate) fn rewrite_expr_for_vlp(
                     | "end_type"
             ) {
                 return RenderExpr::Column(Column(PropertyValue::Column(format!(
-                    "t.{}",
-                    col_name
+                    "{vlp_alias}.{col_name}"
                 ))));
             }
 
@@ -2539,23 +2540,20 @@ pub(crate) fn rewrite_expr_for_vlp(
             log::info!(
                 "🔧 VLP path variable expansion (ColumnAlias): {} → tuple({}.path_nodes, ...)",
                 alias_str,
-                VLP_CTE_FROM_ALIAS,
+                vlp_alias,
             );
-            // Expand to tuple of path components using VLP_CTE_FROM_ALIAS constant
+            // Expand to tuple of path components using the query-scoped VLP alias
             RenderExpr::ScalarFnCall(ScalarFnCall {
                 name: "tuple".to_string(),
                 args: vec![
                     RenderExpr::Column(Column(PropertyValue::Column(format!(
-                        "{}.path_nodes",
-                        VLP_CTE_FROM_ALIAS
+                        "{vlp_alias}.path_nodes"
                     )))),
                     RenderExpr::Column(Column(PropertyValue::Column(format!(
-                        "{}.path_relationships",
-                        VLP_CTE_FROM_ALIAS
+                        "{vlp_alias}.path_relationships"
                     )))),
                     RenderExpr::Column(Column(PropertyValue::Column(format!(
-                        "{}.hop_count",
-                        VLP_CTE_FROM_ALIAS
+                        "{vlp_alias}.hop_count"
                     )))),
                 ],
             })
@@ -2602,7 +2600,7 @@ pub(crate) fn rewrite_expr_for_vlp(
                                 args: vec![RenderExpr::AggregateFnCall(AggregateFnCall {
                                     name: min_or_null,
                                     args: vec![RenderExpr::Column(Column(PropertyValue::Column(
-                                        "t.hop_count".to_string(),
+                                        format!("{}.hop_count", vlp_from_alias()),
                                     )))],
                                 })],
                             }),
@@ -5157,13 +5155,19 @@ fn rewrite_joins_for_vlp(
 /// Used for reverse VLP UNION branches where the direction is swapped.
 /// Uses placeholder-based approach to avoid double-swap issues.
 fn swap_vlp_start_end(sql: &str) -> String {
-    // Phase 1: Replace all t.start_* with placeholder
+    // #1088: the VLP FROM alias is query-scoped (defaults "t"); build the
+    // `<alias>.start_`/`<alias>.end_` prefixes from it so this text substitution
+    // matches the columns actually emitted for a bumped alias.
+    let a = vlp_from_alias();
+    let start_prefix = format!("{a}.start_");
+    let end_prefix = format!("{a}.end_");
+    // Phase 1: Replace all <alias>.start_* with placeholder
     let placeholder = "__VLP_SWAP_PLACEHOLDER_";
-    let result = sql.replace("t.start_", &format!("{}start_", placeholder));
-    // Phase 2: Replace all t.end_* with t.start_*
-    let result = result.replace("t.end_", "t.start_");
-    // Phase 3: Replace placeholders with t.end_*
-    result.replace(&format!("{}start_", placeholder), "t.end_")
+    let result = sql.replace(&start_prefix, &format!("{}start_", placeholder));
+    // Phase 2: Replace all <alias>.end_* with <alias>.start_*
+    let result = result.replace(&end_prefix, &start_prefix);
+    // Phase 3: Replace placeholders with <alias>.end_*
+    result.replace(&format!("{}start_", placeholder), &end_prefix)
 }
 
 /// Recursively collect all CTE definitions from a RenderPlan tree,
@@ -6522,9 +6526,9 @@ impl ToSql for FromTableItem {
                 match view_ref.source.as_ref() {
                     LogicalPlan::ViewScan(_) => {
                         // ViewScan fallback - should not reach here if alias is properly set
-                        VLP_CTE_FROM_ALIAS.to_string()
+                        vlp_from_alias()
                     }
-                    _ => VLP_CTE_FROM_ALIAS.to_string(), // Default fallback
+                    _ => vlp_from_alias(), // Default fallback
                 }
             };
 

--- a/tests/rust/integration/cross_schema_pattern_tests.rs
+++ b/tests/rust/integration/cross_schema_pattern_tests.rs
@@ -128,6 +128,7 @@ async fn generate_sql(schema: &GraphSchema, cypher: &str) -> String {
 
 /// Fallible variant of [`generate_sql`]: returns the analyzer/render error as a
 /// String instead of panicking, for tests that assert a pattern is loud-gated.
+#[allow(dead_code)] // retained for loud-gate assertions (e.g. #544 multi-VLP)
 async fn try_generate_sql(schema: &GraphSchema, cypher: &str) -> Result<String, String> {
     let schema = schema.clone();
     let cypher = cypher.to_string();
@@ -837,8 +838,9 @@ async fn cs_standard_1081_anonymous_alias_collision() {
     // Endpoint deliberately named `t2` — collides with the generated alias for
     // the anonymous `-[:AUTHORED]->` relationship unless generation avoids it.
     // Start node is `a`, NOT `t`: a VLP endpoint literally named `t` is a
-    // separate collision with the reserved VLP CTE alias and is loud-gated
-    // (#1085, see `cs_standard_1085_vlp_endpoint_named_t_is_loud`); this test
+    // separate collision with the VLP CTE FROM alias, now handled by the
+    // query-scoped alias (#1088, see
+    // `cs_standard_1088_vlp_endpoint_named_t_is_query_scoped`); this test
     // isolates the #1081 anonymous-relationship-alias collision.
     let cypher = "MATCH path = (a:User)-[:FOLLOWS*1..2]->(t2:User)-[:AUTHORED]->(d:Post) \
                   RETURN t2.name, d.content, length(path) AS hops LIMIT 5";
@@ -848,26 +850,33 @@ async fn cs_standard_1081_anonymous_alias_collision() {
     assert_contains(&sql, "standard/1081", "cs_test.authored");
 }
 
-/// #1085: a variable-length-path endpoint named exactly `t` collides with the
-/// reserved VLP CTE FROM alias (`VLP_CTE_FROM_ALIAS`), which is threaded as a
-/// string-level protocol through the render/emit phases. Left unguarded, a
-/// chained hop after the VLP silently anchors on the VLP *start* instead of the
-/// endpoint (returning the wrong rows). Until the reserved alias is made
-/// query-scoped (TODO(multi-vlp)), the collision is rejected LOUDLY at plan time
-/// rather than emitted as silently-wrong SQL (ground rule 1). Exposed by the
-/// #1081 fix, which made this exact shape plan for the first time.
+/// #1088 (was #1085): a variable-length-path endpoint named exactly `t` used to
+/// collide with the VLP CTE FROM alias (`VLP_CTE_FROM_ALIAS = "t"`), which is
+/// threaded as a string-level protocol through the render/emit phases — a chained
+/// hop after the VLP then silently anchored on the VLP *start* instead of the
+/// endpoint. #1085 rejected the shape loudly as an interim measure; #1088 makes
+/// the FROM alias query-scoped, so a user variable named `t` bumps it to a
+/// collision-free value (`vlpt`) and the query now runs CORRECTLY. Regression
+/// guard: the VLP CTE is aliased `vlpt` and the chained AUTHORED hop joins the
+/// VLP *endpoint* (`vlpt.end_id`), never a bare `t.end_id`/`t.start_id`.
 #[tokio::test]
-async fn cs_standard_1085_vlp_endpoint_named_t_is_loud() {
+async fn cs_standard_1088_vlp_endpoint_named_t_is_query_scoped() {
     let schema = load_schema(SCHEMA_STANDARD);
     let cypher = "MATCH (t:User)-[:FOLLOWS*1..2]->(t2:User)-[:AUTHORED]->(d:Post) \
                   RETURN d.content, t2.name";
-    let result = try_generate_sql(&schema, cypher).await;
-    let err = result.expect_err("VLP endpoint named 't' must be rejected, not silently wrong");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("reserved") && msg.contains("#1085"),
-        "expected an actionable #1085 collision error, got: {msg}"
-    );
+    let sql = generate_sql(&schema, cypher).await;
+    assert_valid_sql(&sql, "standard", "1088-vlp-endpoint-t");
+    // FROM alias bumped away from the colliding user variable `t`.
+    assert_contains(&sql, "standard/1088", "AS vlpt");
+    // The chained hop must anchor on the VLP ENDPOINT via the bumped alias
+    // (the #1085 bug anchored on the start instead).
+    assert_contains(&sql, "standard/1088", "vlpt.end_id");
+    assert_contains(&sql, "standard/1088", "vlpt.end_name");
+    // No bare `t`-aliased VLP FROM clause should remain. (`assert_not_contains`
+    // on `t.end_id` is unsafe — it is a substring of the correct `vlpt.end_id`;
+    // check the FROM alias instead, which cannot be a substring of `AS vlpt`.)
+    assert_not_contains(&sql, "standard/1088", "AS t ");
+    assert_not_contains(&sql, "standard/1088", "AS t\n");
 }
 
 /// #1081-adjacent latent bug: `GraphSchema::rel_type_index` (and the

--- a/tests/rust/integration/cross_schema_pattern_tests.rs
+++ b/tests/rust/integration/cross_schema_pattern_tests.rs
@@ -879,6 +879,27 @@ async fn cs_standard_1088_vlp_endpoint_named_t_is_query_scoped() {
     assert_not_contains(&sql, "standard/1088", "AS t\n");
 }
 
+/// #1088: the query-scoped VLP FROM alias must also stay consistent on the
+/// MULTI-TYPE VLP path, whose CTE reconstructs endpoint columns via JSON
+/// extraction (`JSONExtractString(<alias>.end_properties, …)`) and detection keyed
+/// on the endpoint alias. With a colliding endpoint named `t`, the FROM alias
+/// bumps to `vlpt` and the JSON extraction must reference `vlpt.end_properties`,
+/// not a bare `t.end_properties` that the FROM no longer defines.
+#[tokio::test]
+async fn cs_standard_1088_multi_type_vlp_endpoint_t() {
+    let schema = load_schema(SCHEMA_STANDARD);
+    // `[:FOLLOWS|LIVES_IN*1..2]` from a User has a genuine multi-label endpoint
+    // (User via FOLLOWS, City via LIVES_IN) → the multi-type VLP CTE path.
+    let cypher = "MATCH (a:User)-[:FOLLOWS|LIVES_IN*1..2]->(t) RETURN t.name LIMIT 5";
+    let sql = generate_sql(&schema, cypher).await;
+    assert_valid_sql(&sql, "standard", "1088-multi-type-vlp-t");
+    assert_contains(&sql, "standard/1088-mt", "AS vlpt");
+    // The JSON endpoint-property extraction must use the bumped alias.
+    assert_contains(&sql, "standard/1088-mt", "vlpt.end_properties");
+    assert_not_contains(&sql, "standard/1088-mt", "AS t ");
+    assert_not_contains(&sql, "standard/1088-mt", "AS t\n");
+}
+
 /// #1081-adjacent latent bug: `GraphSchema::rel_type_index` (and the
 /// denormalized-node metadata) are `#[serde(skip)]`, so a schema recovered from
 /// the `graph_catalog` JSON persistence path / the `monitor_schema_updates`


### PR DESCRIPTION
## #1088 — make the VLP CTE FROM alias query-scoped

The VLP CTE outer FROM alias was a fixed `const VLP_CTE_FROM_ALIAS = "t"`, threaded as a **string-level protocol** through ~100 render/emit sites (79 const refs + raw `"t."` literals that bypass the const). A user variable named `t` collided with it: **#1085** loud-gated a VLP endpoint named `t` because a chained hop after the path silently anchored on the VLP *start* instead of the endpoint.

### The fix (Level A: single query-scoped alias)
- **New task-local `vlp_from_alias()`** getter (default `"t"`) + `register_vlp_from_alias`, reset per query in `clear_all_render_contexts`.
- **`pre_register_vlp_endpoints`** computes the alias from **#1084's `PlanCtx::reserved_aliases`** (all user-declared variables): keep `"t"` unless a user variable is named `t`, else bump to the first collision-free `vlpt`/`vlpt2`/… (deliberately not confusable with the `vt{N}`/`vlp_`/`with_` alias families). This **replaces** the #1085 loud gate — the shape now runs correctly.
- **Every VLP-FROM-alias site routed through the getter**: all 79 const refs plus the raw-literal hazards — `rewrite_expr_for_vlp`'s 8 `t.`-column builders, the `swap_vlp_start_end` text substitution, the `select_builder` multi-type cluster, `projection_tagging`, `plan_ctx::get_vlp_join_reference`, join/from/filter builders. `vlp_rewrite.rs`'s `"t"` uses are internal, self-consistent mapping keys and are deliberately left unchanged (reviewer-confirmed they never emit a bare `t` table alias).

### Verification
- **Byte-identical** for any query without a `t` collision (getter returns `"t"`) — the full golden suite is the completeness gate: **1738 unit + 613 integration + ratchet, 0 failures**, `fmt`/`clippy` clean.
- **Bump-consistency** verified live across **directed, path-variable, undirected, and multi-type** VLP shapes: `FROM vlp_x AS vlpt`, endpoint joins on `vlpt.end_id`, JSON extraction on `vlpt.end_properties`, no stray bare `t.`.
- **#544/#623 multi-VLP loud gates preserved.**
- Tests: `cs_standard_1088_vlp_endpoint_named_t_is_query_scoped` (directed, replaces the old `_is_loud`) + `cs_standard_1088_multi_type_vlp_endpoint_t`.

### Adversarial review
All three findings resolved as **non-defects** (verified): the multi-type path emits `vlpt` correctly (now regression-tested); the `with_to_cte` `unwrap_or("t")` fallbacks are unreachable (VLP CTE from-alias is always `Some(vlp_from_alias())`); a VLP inside `EXISTS { }` is loud-gated entirely by #574, so a colliding endpoint-`t` there can never reach render.

### Scope
This is **Level A** — a single query-scoped alias. Per-VLP *distinct* FROM aliases for **#643/#544** (multiple recursive VLPs in one scope) remain future work that this getter infrastructure now enables.

Closes #1088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)