### PR TITLE
fix(vlp): #643 chained OPTIONAL VLP endpoint alias + topology

### DIFF
--- a/src/query_planner/analyzer/graph_join/inference.rs
+++ b/src/query_planner/analyzer/graph_join/inference.rs
@@ -3414,20 +3414,53 @@ impl GraphJoinInference {
                 });
             }
 
-            // 1. Create FROM marker for the anchor node
-            helpers::JoinBuilder::from_marker(anchor_schema.full_table_name(), anchor_alias)
-                .build_and_push(collected_graph_joins);
-
-            // 2. Create LEFT JOIN to VLP CTE.
-            // CTE name is always `vlp_{start}_{end}` (start = left_connection,
-            // end = right_connection) regardless of which endpoint is the anchor.
-            let cte_name = format!("vlp_{}_{}", left_alias, right_alias);
             let anchor_id_col = anchor_schema
                 .node_id
                 .columns()
                 .first()
                 .expect("Node ID must have at least one column")
                 .to_string();
+
+            // #643: if the anchor node is itself the endpoint of a PRECEDING VLP
+            // in a chained optional pattern (`(a)-[*]->(b) OPTIONAL MATCH
+            // (b)-[*]->(c)` — `b` is VLP1's END and VLP2's START), it must be
+            // JOINed to that VLP's CTE endpoint (`b.id = vt0.end_id`), NOT emitted
+            // as a bare FROM marker that the render turns into a spurious
+            // `ON 1 = 1` cartesian (join_builder.rs). This mirrors the non-VLP
+            // chained-optional path, where the endpoint node is joined off the
+            // preceding hop's target column (`b.id = t1.followed_id`). The
+            // preceding VLP already marked `b` in the join context from the
+            // sibling clause (`should_skip_for_vlp`), so `get_vlp_endpoint` yields
+            // its alias (`vt0`) and position (`end`). Detected via a DIFFERENT
+            // `rel_alias` — a same-rel mark is THIS VLP's own endpoint, not a
+            // preceding one — so single / non-chained VLPs fall through to the
+            // original bare marker and stay byte-identical.
+            let anchor_prev_vlp = join_ctx
+                .get_vlp_endpoint(anchor_alias)
+                .filter(|info| info.rel_alias != rel_alias)
+                .cloned();
+
+            // 1. Create the anchor node join (real LEFT JOIN when it chains off a
+            //    preceding VLP endpoint, else a bare FROM marker).
+            if let Some(prev) = &anchor_prev_vlp {
+                helpers::JoinBuilder::new(anchor_schema.full_table_name(), anchor_alias)
+                    .join_type(JoinType::Left)
+                    .add_condition(
+                        anchor_alias,
+                        &anchor_id_col,
+                        &prev.vlp_alias,
+                        prev.cte_column(),
+                    )
+                    .build_and_push(collected_graph_joins);
+            } else {
+                helpers::JoinBuilder::from_marker(anchor_schema.full_table_name(), anchor_alias)
+                    .build_and_push(collected_graph_joins);
+            }
+
+            // 2. Create LEFT JOIN to VLP CTE.
+            // CTE name is always `vlp_{start}_{end}` (start = left_connection,
+            // end = right_connection) regardless of which endpoint is the anchor.
+            let cte_name = format!("vlp_{}_{}", left_alias, right_alias);
 
             // Get the unique VLP alias from the endpoint marked in should_skip_for_vlp
             // (`should_skip_for_vlp` marks the END endpoint = right_alias).

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2077,12 +2077,6 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
     // every clause agrees — previously WHERE and GROUP BY hardcoded `"t"`, which
     // dangled for OPTIONAL VLP where the join alias is `vt0` (#630; SELECT/ORDER
     // BY already used this value).
-    let vlp_join_count = plan
-        .joins
-        .0
-        .iter()
-        .filter(|j| j.table_name.starts_with("vlp_"))
-        .count();
     let vlp_from_alias = if is_optional_vlp {
         plan.joins
             .0
@@ -2099,20 +2093,48 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             .unwrap_or_else(crate::server::query_context::vlp_from_alias)
     };
 
-    // The alias to use for the WHERE / GROUP BY endpoint rewrite. Use the
-    // resolved `vlp_from_alias` ONLY when there is a single VLP join (or the
-    // required-VLP FROM case) so the endpoint reference is UNAMBIGUOUS. With TWO
-    // OR MORE VLP joins (`OPTIONAL MATCH (a)-[*]->(b) OPTIONAL MATCH (b)-[*]->(c)`)
-    // `vlp_from_alias` is just the FIRST vlp join — using it for GROUP BY on the
-    // SECOND endpoint would silently group by the WRONG VLP (a separate,
-    // deeper endpoint-resolution defect, tracked as #643). Keep the historical
-    // `"t"` there so that shape continues to FAIL LOUD (Code 47) rather than
-    // return a silently-wrong aggregate (#630 must not trade loud for silent).
-    let group_where_alias: &str = if is_optional_vlp && vlp_join_count > 1 {
-        "t"
-    } else {
-        &vlp_from_alias
+    // #643: each VLP endpoint Cypher alias → its OWN VLP CTE's outer JOIN alias,
+    // so a chained pattern's 2nd+ endpoint resolves to its own `vt1`/`vt2` rather
+    // than the single FIRST-join `vlp_from_alias`. Keyed prefer-END: a node that
+    // is BOTH one CTE's end and another's start (the shared intermediate) takes
+    // the END mapping, consistent with `cte_column_mapping` / `endpoint_position`.
+    // Only VLP CTEs that are actually JOINed (OPTIONAL VLP) contribute; a required
+    // VLP's CTE is the FROM (no join) so the map is empty and the shared
+    // `vlp_from_alias` default applies → single-VLP shapes stay byte-identical.
+    let cte_join_alias = |cte_name: &str| -> Option<String> {
+        plan.joins
+            .0
+            .iter()
+            .find(|j| j.table_name == cte_name)
+            .map(|j| j.table_alias.clone())
     };
+    let mut endpoint_alias_override: HashMap<String, String> = HashMap::new();
+    for cte in &plan.ctes.0 {
+        if let (Some(end), Some(join_alias)) = (
+            cte.vlp_cypher_end_alias.as_ref(),
+            cte_join_alias(&cte.cte_name),
+        ) {
+            endpoint_alias_override.insert(end.clone(), join_alias);
+        }
+    }
+    for cte in &plan.ctes.0 {
+        if let (Some(start), Some(join_alias)) = (
+            cte.vlp_cypher_start_alias.as_ref(),
+            cte_join_alias(&cte.cte_name),
+        ) {
+            endpoint_alias_override
+                .entry(start.clone())
+                .or_insert(join_alias);
+        }
+    }
+
+    // The alias to use for the WHERE / GROUP BY endpoint rewrite. Endpoint
+    // references now resolve per-endpoint via `endpoint_alias_override` (above),
+    // so a chained multi-VLP no longer needs the historical `"t"` loud-guard
+    // (#630/#643 — it forced Code 47 rather than group by the WRONG VLP). The
+    // shared `vlp_from_alias` remains the default for non-endpoint (path-var)
+    // references not present in the override.
+    let group_where_alias: &str = &vlp_from_alias;
 
     // 🔧 CRITICAL: Check if this is a multi-type VLP (from CTE name)
     // Multi-type VLP CTEs use Cypher aliases directly in SELECT (e.g., x.end_type)
@@ -2152,6 +2174,7 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
                 &endpoint_position,
                 &cte_column_mapping,
                 &id_property_by_alias,
+                &endpoint_alias_override,
             );
         }
 
@@ -2185,6 +2208,7 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
                     &endpoint_position,
                     &cte_column_mapping,
                     &id_property_by_alias,
+                    &endpoint_alias_override,
                 );
             }
         }
@@ -2202,6 +2226,7 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             &endpoint_position,
             &cte_column_mapping,
             &id_property_by_alias,
+            &endpoint_alias_override,
         );
     }
 
@@ -2221,6 +2246,7 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             &endpoint_position,
             &cte_column_mapping,
             &id_property_by_alias,
+            &endpoint_alias_override,
         );
     }
 

--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2093,6 +2093,45 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             .unwrap_or_else(crate::server::query_context::vlp_from_alias)
     };
 
+    // #643/#630: the per-endpoint override + lifted WHERE/GROUP guard below are
+    // only SOUND when the chained topology is fully materialized. The #643 fix
+    // handles the FORWARD orientation (`(a)-[*]->(b) OPTIONAL MATCH (b)-[*]->(c)`
+    // — `b` becomes a real `LEFT JOIN … ON b.id = vt0.end_id`), but a multi-VLP
+    // shape it does NOT yet handle — notably the REVERSED-arrow chain
+    // `(a)<-[*]-(b) OPTIONAL MATCH (b)<-[*]-(c)` (the #840 family) — still emits
+    // the shared intermediate as a bare `ON 1 = 1` cartesian. For such a shape the
+    // #630 `"t"` loud-guard MUST remain: lifting it would let a cartesian-inflated
+    // aggregate execute silently-wrong instead of failing Code 47 (ground rule 1).
+    // Detect a REMAINING bare cartesian (empty `joining_on`, not a deliberate #601
+    // user comma-cartesian) among multiple VLP joins and, for that unhandled shape
+    // only, fall back to the historical single-alias + dangling-`t` behavior.
+    let vlp_join_count = plan
+        .joins
+        .0
+        .iter()
+        .filter(|j| j.table_name.starts_with("vlp_"))
+        .count();
+    // A bare cross-join renders as `ON 1 = 1` — an `Equal(1, 1)` tautology with
+    // no real correlation (and NOT flagged as a deliberate #601 user
+    // comma-cartesian). Its presence among multiple VLP joins means the chained
+    // topology was NOT materialized (the unhandled reversed-arrow shape), so the
+    // endpoint aggregate must stay loud rather than group a cartesian silently.
+    let is_cartesian_tautology = |j: &Join| -> bool {
+        !j.is_cartesian
+            && j.joining_on.len() == 1
+            && j.joining_on[0].operator == crate::render_plan::render_expr::Operator::Equal
+            && j.joining_on[0].operands.len() == 2
+            && matches!(
+                (&j.joining_on[0].operands[0], &j.joining_on[0].operands[1]),
+                (
+                    RenderExpr::Literal(crate::render_plan::render_expr::Literal::Integer(_)),
+                    RenderExpr::Literal(crate::render_plan::render_expr::Literal::Integer(_)),
+                )
+            )
+    };
+    let has_unhandled_vlp_cartesian = plan.joins.0.iter().any(is_cartesian_tautology);
+    let keep_loud_multi_vlp = is_optional_vlp && vlp_join_count > 1 && has_unhandled_vlp_cartesian;
+
     // #643: each VLP endpoint Cypher alias → its OWN VLP CTE's outer JOIN alias,
     // so a chained pattern's 2nd+ endpoint resolves to its own `vt1`/`vt2` rather
     // than the single FIRST-join `vlp_from_alias`. Keyed prefer-END: a node that
@@ -2101,6 +2140,7 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
     // Only VLP CTEs that are actually JOINed (OPTIONAL VLP) contribute; a required
     // VLP's CTE is the FROM (no join) so the map is empty and the shared
     // `vlp_from_alias` default applies → single-VLP shapes stay byte-identical.
+    // Left empty for the unhandled-cartesian shape so its endpoints dangle loud.
     let cte_join_alias = |cte_name: &str| -> Option<String> {
         plan.joins
             .0
@@ -2109,32 +2149,39 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
             .map(|j| j.table_alias.clone())
     };
     let mut endpoint_alias_override: HashMap<String, String> = HashMap::new();
-    for cte in &plan.ctes.0 {
-        if let (Some(end), Some(join_alias)) = (
-            cte.vlp_cypher_end_alias.as_ref(),
-            cte_join_alias(&cte.cte_name),
-        ) {
-            endpoint_alias_override.insert(end.clone(), join_alias);
+    if !keep_loud_multi_vlp {
+        for cte in &plan.ctes.0 {
+            if let (Some(end), Some(join_alias)) = (
+                cte.vlp_cypher_end_alias.as_ref(),
+                cte_join_alias(&cte.cte_name),
+            ) {
+                endpoint_alias_override.insert(end.clone(), join_alias);
+            }
         }
-    }
-    for cte in &plan.ctes.0 {
-        if let (Some(start), Some(join_alias)) = (
-            cte.vlp_cypher_start_alias.as_ref(),
-            cte_join_alias(&cte.cte_name),
-        ) {
-            endpoint_alias_override
-                .entry(start.clone())
-                .or_insert(join_alias);
+        for cte in &plan.ctes.0 {
+            if let (Some(start), Some(join_alias)) = (
+                cte.vlp_cypher_start_alias.as_ref(),
+                cte_join_alias(&cte.cte_name),
+            ) {
+                endpoint_alias_override
+                    .entry(start.clone())
+                    .or_insert(join_alias);
+            }
         }
     }
 
     // The alias to use for the WHERE / GROUP BY endpoint rewrite. Endpoint
-    // references now resolve per-endpoint via `endpoint_alias_override` (above),
-    // so a chained multi-VLP no longer needs the historical `"t"` loud-guard
-    // (#630/#643 — it forced Code 47 rather than group by the WRONG VLP). The
-    // shared `vlp_from_alias` remains the default for non-endpoint (path-var)
-    // references not present in the override.
-    let group_where_alias: &str = &vlp_from_alias;
+    // references resolve per-endpoint via `endpoint_alias_override` (above), so a
+    // fully-materialized chained multi-VLP no longer needs the historical `"t"`
+    // loud-guard (#630/#643 — it forced Code 47 rather than group by the WRONG
+    // VLP). For an UNHANDLED multi-VLP cartesian shape keep the dangling `"t"` so
+    // it stays loud (see `keep_loud_multi_vlp` above). The shared `vlp_from_alias`
+    // remains the default for non-endpoint (path-var) references.
+    let group_where_alias: &str = if keep_loud_multi_vlp {
+        "t"
+    } else {
+        &vlp_from_alias
+    };
 
     // 🔧 CRITICAL: Check if this is a multi-type VLP (from CTE name)
     // Multi-type VLP CTEs use Cypher aliases directly in SELECT (e.g., x.end_type)

--- a/src/render_plan/vlp_rewrite.rs
+++ b/src/render_plan/vlp_rewrite.rs
@@ -109,6 +109,29 @@ pub fn rewrite_vlp_aggregate_aliases(plan: &mut RenderPlan) -> RenderPlanBuilder
                 );
                 continue;
             }
+            // #643: a chained optional VLP materializes its shared intermediate
+            // endpoint as a REAL base-table node LEFT JOIN (`(a)-[*]->(b) OPTIONAL
+            // MATCH (b)-[*]->(c)` → `LEFT JOIN users AS b ON b.id = vt0.end_id`,
+            // built in inference.rs so `b`'s properties read from the real node and
+            // `vt1` chains off it). `rewrite_vlp_union_branch_aliases` already
+            // EXCLUDES such an intermediate from endpoint rewriting (it is a CTE
+            // START alias), leaving `b.name` as the real `b.full_name`. Swapping it
+            // here to the CTE alias (`b → vt0`) would re-break it to the
+            // non-existent `vt0.full_name`. Skip any end alias that has a real
+            // (non-vlp) node join of its own. Single / terminal VLP endpoints have
+            // no such node join → unchanged (byte-identical).
+            if plan
+                .joins
+                .0
+                .iter()
+                .any(|j| j.table_alias == *cypher_end_alias && !j.table_name.starts_with("vlp_"))
+            {
+                log::debug!(
+                    "🔧 VLP aggregate rewrite: skipping chained intermediate end alias '{}' (materialized as a real node join, #643)",
+                    cypher_end_alias
+                );
+                continue;
+            }
             // Find the corresponding JOIN to get the CTE alias
             for join in &plan.joins.0 {
                 if join.table_name == cte.cte_name {
@@ -586,6 +609,13 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
     // `count(b)`-normalised `b.<logical_id>` reference and resolve it to the CTE's
     // canonical `start_id`/`end_id` rather than a non-existent `end_{logical_id}`.
     id_property_by_alias: &HashMap<String, String>,
+    // #643: per-endpoint Cypher alias → its OWN VLP CTE's outer JOIN alias (e.g.
+    // `c → "vt1"` for the SECOND VLP in a chained pattern). A single
+    // `vlp_from_alias` is only the FIRST vlp join, so it resolves every endpoint
+    // to that one alias — wrong for the 2nd+ endpoint. When an alias is present
+    // here its OWN join alias is used as the rewrite output; otherwise the shared
+    // `vlp_from_alias` default applies (single-VLP shapes stay byte-identical).
+    endpoint_alias_override: &HashMap<String, String>,
 ) {
     log::debug!("🔍 REWRITE: Processing expr with new lookup-based mapping (no splitting)");
     match expr {
@@ -641,6 +671,14 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                 let col_name = prop_access.column.raw();
                 let alias = prop_access.table_alias.0.clone();
 
+                // #643: resolve THIS endpoint's own VLP CTE alias (e.g. `c → vt1`),
+                // falling back to the shared `vlp_from_alias` when the alias isn't a
+                // per-endpoint-mapped VLP endpoint (single-VLP / path-var → identical).
+                let out_alias = endpoint_alias_override
+                    .get(alias.as_str())
+                    .map(|s| s.as_str())
+                    .unwrap_or(vlp_from_alias);
+
                 // NEW ALGORITHM: Direct lookup using DB column name
                 // No splitting, no guessing - just look up the exact DB column name
                 if let Some((cte_column_name, _position)) =
@@ -654,7 +692,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     );
 
                     // Rewrite to use the CTE column
-                    prop_access.table_alias.0 = vlp_from_alias.to_string();
+                    prop_access.table_alias.0 = out_alias.to_string();
                     prop_access.column = PropertyValue::Column(cte_column_name.clone());
                 } else {
                     // #659: a `count(<endpoint>)` normalises to `count(b.<logical_id>)`
@@ -683,7 +721,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                                     vlp_from_alias,
                                     id_col
                                 );
-                                prop_access.table_alias.0 = vlp_from_alias.to_string();
+                                prop_access.table_alias.0 = out_alias.to_string();
                                 prop_access.column = PropertyValue::Column(id_col.to_string());
                                 return;
                             }
@@ -706,7 +744,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                         fallback_col
                     );
 
-                    prop_access.table_alias.0 = vlp_from_alias.to_string();
+                    prop_access.table_alias.0 = out_alias.to_string();
                     prop_access.column = PropertyValue::Column(fallback_col);
                 }
             }
@@ -722,6 +760,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
             for (when_expr, then_expr) in &mut case_expr.when_then {
@@ -732,6 +771,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
                 rewrite_render_expr_for_vlp_with_endpoint_info(
                     then_expr,
@@ -740,6 +780,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
             if let Some(else_expr) = &mut case_expr.else_expr {
@@ -750,6 +791,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
         }
@@ -762,6 +804,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
         }
@@ -774,6 +817,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
         }
@@ -786,6 +830,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                     endpoint_position,
                     cte_column_mapping,
                     id_property_by_alias,
+                    endpoint_alias_override,
                 );
             }
         }
@@ -797,6 +842,7 @@ pub fn rewrite_render_expr_for_vlp_with_endpoint_info(
                 endpoint_position,
                 cte_column_mapping,
                 id_property_by_alias,
+                endpoint_alias_override,
             );
         }
         _ => {

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -11423,10 +11423,13 @@ mod walker_drift_family_484_490_495_476_483 {
             "#630: a REQUIRED VLP (FROM alias t) must NOT be rewritten to vt0:\n{req}"
         );
 
-        // #630 guard (must NOT trade loud for silent): with TWO chained OPTIONAL
-        // VLPs the endpoint→alias mapping is ambiguous (a separate defect, #643).
-        // The GROUP BY must stay on the hardcoded `t` so the query FAILS LOUD
-        // (Code 47) rather than silently grouping by the wrong VLP's endpoint.
+        // #643 (was the #630 loud-guard): with TWO chained OPTIONAL VLPs the 2nd
+        // endpoint (`c`) is the END of the SECOND VLP (`vlp_b_c`, LEFT JOINed as
+        // `vt1`), so SELECT / GROUP BY / ORDER BY must ALL reference `vt1.end_name`
+        // — its OWN VLP's alias, resolved per-endpoint (`endpoint_alias_override`).
+        // This formerly stayed on the hardcoded `t` to FAIL LOUD (Code 47) rather
+        // than silently group by the FIRST VLP's endpoint; #643 fixes the
+        // resolution so it groups by the CORRECT endpoint instead of failing.
         let two_vlp = render(
             &schema,
             "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS*1..2]->(b:User) \
@@ -11436,9 +11439,88 @@ mod walker_drift_family_484_490_495_476_483 {
         )
         .await;
         assert!(
-            two_vlp.contains("GROUP BY t.end_name"),
-            "#630/#643: two chained OPTIONAL VLPs must keep GROUP BY on the \
-             hardcoded `t` (fails loud, not a silently-wrong endpoint):\n{two_vlp}"
+            two_vlp.contains("LEFT JOIN vlp_b_c AS vt1"),
+            "#643: the 2nd chained OPTIONAL VLP endpoint must LEFT JOIN as vt1:\n{two_vlp}"
+        );
+        assert!(
+            two_vlp.contains("GROUP BY vt1.end_name"),
+            "#643: GROUP BY must reference the 2nd VLP's OWN join alias vt1, not \
+             the 1st VLP's vt0 nor a dangling hardcoded t:\n{two_vlp}"
+        );
+        assert!(
+            two_vlp.contains("ORDER BY vt1.end_name"),
+            "#643: ORDER BY must reference vt1 too:\n{two_vlp}"
+        );
+        assert!(
+            !two_vlp.contains("vt0.end_name"),
+            "#643: the endpoint `c` must NOT resolve to the FIRST VLP's alias vt0:\n{two_vlp}"
+        );
+    }
+
+    /// #643: chained OPTIONAL variable-length paths
+    /// (`MATCH (a) OPTIONAL MATCH (a)-[*]->(b) OPTIONAL MATCH (b)-[*]->(c)`).
+    /// Three coupled defects on main: (1) `c.name` resolved to the FIRST VLP's
+    /// alias `vt0` instead of its own `vt1`; (2) the shared intermediate `b.name`
+    /// mis-rendered as `vt0.full_name` (a column the CTE never exposes); (3) `b`
+    /// was emitted as a bare `JOIN ... ON 1 = 1` cartesian instead of being sourced
+    /// from the first VLP's endpoint. The fix (Design A — the VLP plays the role of
+    /// the edge, the endpoint node is a real scan, mirroring the non-VLP chained
+    /// path) materializes `b` as `LEFT JOIN users AS b ON b.user_id = vt0.end_id`,
+    /// keeps `b.name` as the real `b.full_name`, and resolves `c` to `vt1.end_name`.
+    #[tokio::test]
+    async fn chained_optional_vlp_endpoint_alias_and_topology_643() {
+        let schema = load_schema(SchemaId::Standard.yaml_path());
+
+        let sql = render(
+            &schema,
+            "MATCH (a:User) \
+             OPTIONAL MATCH (a)-[:FOLLOWS*1..2]->(b) \
+             OPTIONAL MATCH (b)-[:FOLLOWS*1..2]->(c) \
+             RETURN a.name, b.name, c.name",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+
+        // Defect 3 (topology): the shared intermediate `b` is sourced from the
+        // FIRST VLP's endpoint, NOT a spurious cartesian.
+        assert!(
+            sql.contains("LEFT JOIN social.users_bench AS b ON b.user_id = vt0.end_id"),
+            "#643: intermediate `b` must be LEFT JOINed off vt0.end_id:\n{sql}"
+        );
+        assert!(
+            !sql.contains("ON 1 = 1"),
+            "#643: no spurious cartesian for the chained VLP endpoint:\n{sql}"
+        );
+        // Defect 2: `b` is a real node → its own column, not a VLP CTE column.
+        assert!(
+            sql.contains("b.full_name AS \"b.name\""),
+            "#643: b.name must read the real node column b.full_name:\n{sql}"
+        );
+        assert!(
+            !sql.contains("vt0.full_name"),
+            "#643: b.name must NOT mis-render as the non-existent vt0.full_name:\n{sql}"
+        );
+        // Defect 1: `c` (2nd VLP endpoint) resolves to its OWN alias vt1.
+        assert!(
+            sql.contains("vt1.end_name AS \"c.name\""),
+            "#643: c.name must resolve to the 2nd VLP's alias vt1.end_name:\n{sql}"
+        );
+        assert!(
+            sql.contains("LEFT JOIN vlp_b_c AS vt1 ON b.user_id = vt1.start_id"),
+            "#643: the 2nd VLP chains off the materialized `b`:\n{sql}"
+        );
+
+        // Single OPTIONAL VLP is unchanged (endpoint folds into the CTE, no node
+        // scan): the shared-intermediate handling must not perturb it.
+        let single = render(
+            &schema,
+            "MATCH (a:User) OPTIONAL MATCH (a)-[:FOLLOWS*1..2]->(b) RETURN a.name, b.name",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            single.contains("vt0.end_name AS \"b.name\"") && !single.contains("users_bench AS b"),
+            "#643: single OPTIONAL VLP stays folded into vt0.end_name (byte-identical):\n{single}"
         );
     }
 

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -11522,6 +11522,31 @@ mod walker_drift_family_484_490_495_476_483 {
             single.contains("vt0.end_name AS \"b.name\"") && !single.contains("users_bench AS b"),
             "#643: single OPTIONAL VLP stays folded into vt0.end_name (byte-identical):\n{single}"
         );
+
+        // Ground rule 1: the #643 topology fix handles the FORWARD orientation
+        // only. The REVERSED-arrow chained aggregate (`(a)<-[*]-(b)<-[*]-(c)`, the
+        // #840 family) still emits a bare `ON 1 = 1` cartesian, so it MUST stay
+        // LOUD — the lifted WHERE/GROUP guard is retained (dangling `t`) precisely
+        // for this unhandled shape rather than executing a silently-wrong
+        // cartesian-inflated aggregate. (Adversarial-review finding.)
+        let reversed_agg = render(
+            &schema,
+            "MATCH (a:User) OPTIONAL MATCH (a)<-[:FOLLOWS*1..2]-(b) \
+             OPTIONAL MATCH (b)<-[:FOLLOWS*1..2]-(c) \
+             RETURN b.name, count(*) AS cnt",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            reversed_agg.contains("ON 1 = 1"),
+            "#643/#840: reversed chained VLP still renders a bare cartesian:\n{reversed_agg}"
+        );
+        assert!(
+            reversed_agg.contains("GROUP BY t.end_name"),
+            "#643/#630: the unhandled reversed-cartesian shape must keep the \
+             dangling `t` GROUP BY so it fails LOUD, not silently group a \
+             cartesian:\n{reversed_agg}"
+        );
     }
 
     /// #788: a MULTI-TYPE VLP aggregate that ORDER-BYs a grouped endpoint


### PR DESCRIPTION
## Summary
Fixes **#643** — chained OPTIONAL variable-length paths
(`MATCH (a) OPTIONAL MATCH (a)-[*]->(b) OPTIONAL MATCH (b)-[*]->(c)`) rendered three coupled defects:
1. the 2nd VLP endpoint `c` resolved to the **first** VLP's alias `vt0` instead of its own `vt1`;
2. the shared intermediate `b.name` mis-rendered as `vt0.full_name` (a column the CTE never exposes);
3. `b` was emitted as a bare `JOIN … ON 1 = 1` **cartesian** rather than sourced from the first VLP's endpoint.

## Fix (Design A — VLP plays the role of the edge; endpoint node is a real scan, mirroring the proven non-VLP chained path)
- **Topology** (`inference.rs`): when an OPTIONAL VLP's anchor node is itself a **preceding** VLP's endpoint (marked in the join context from the sibling clause), emit `LEFT JOIN node ON node.id = <prev_vlp>.end_id` instead of a bare FROM marker. Detected via a *different* `rel_alias`, so single / non-chained VLPs fall through unchanged (byte-identical).
- **Per-endpoint alias** (`plan_builder_utils.rs` + `vlp_rewrite.rs`): build a `cypher-alias → own-VLP-CTE join-alias` map (prefer-END) and thread it into the endpoint rewriter, so each endpoint resolves to **its own** `vt0`/`vt1`/… . This lifts the #630 `group_where_alias="t"` loud-guard for the handled shapes.
- **Aggregate skip** (`vlp_rewrite.rs`): `rewrite_vlp_aggregate_aliases` no longer swaps an END alias materialized as a real (non-vlp) node join — the intermediate `b` stays the real `b.full_name`.

## Ground Rule 1 (adversarial-review fix, 2nd commit)
Review caught that lifting the guard *unconditionally* re-silenced the **reversed-arrow** chained aggregate (`(a)<-[*]-(b)<-[*]-(c)`, the #840 family), which the forward-only topology fix doesn't handle and still renders `ON 1 = 1`. The guard-lift is now **narrowed**: it only applies when no bare cartesian tautology remains among the VLP joins; the unhandled reversed shape keeps the dangling-`t` GROUP BY and **stays loud** (Code 47) rather than executing a silently-wrong cartesian aggregate.

## Verification
- Live-verified on a controlled fixture: SELECT form returns **all 13 correct rows** incl. OPTIONAL NULL-extension; the formerly-LOUD aggregate groups by the correct endpoint (C=1, D=3, F=1, NULL=8).
- Generalizes correctly (review-confirmed against parent) to **forward 2/3-deep, fan-out, undirected, and denormalized** chained shapes.
- Byte-identical for single-VLP shapes.
- Full Rust suite (2389) + ratchet + clippy green. Updated the #630 golden test; added a dedicated #643 regression test (incl. the reversed-stays-loud assertion).

**Scope:** OPTIONAL chained VLPs. Required multi-VLP-in-one-scope (#544) uses a different render path and remains gated (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)