### PR TITLE
fix(vlp): #544 fan-in second-spoke start-alias projection + ORDER BY

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -2170,6 +2170,63 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
         }
     }
 
+    // #544 (fan-in): a REQUIRED same-end fan-in `(a)-[*]->(x), (b)-[*]->(x)`
+    // renders as multiple VLP CTEs the emit phase (`to_sql_query.rs`
+    // `rewrite_vlp_select_aliases`) makes the FIRST such CTE the FROM (alias `t`)
+    // and INNER-JOINs the rest as `t_fi_{i}` on `end_id`. Those joins are added
+    // AFTER render, so the join-based override above is empty for the required
+    // path — every spoke's START property would collapse onto the single shared
+    // `vlp_from_alias` (`t`), projecting the FROM spoke's start for EVERY spoke
+    // (silently wrong: `b.name` came out as `a.name`). Mirror the emit phase's
+    // deterministic alias assignment here so each spoke's start resolves to ITS
+    // OWN CTE alias. Scope tightly to the fan-in shape the emit phase and the
+    // #544 analyzer gate actually support (>1 VLP CTE, all same end alias, >1
+    // distinct start alias); every other required multi-VLP shape is still
+    // loud-gated at analysis (#544), so this never fires for them, and the
+    // single-VLP shape (len == 1) is untouched → byte-identical.
+    let mut is_required_fan_in = false;
+    if !is_optional_vlp {
+        let fan_in_ctes: Vec<_> = plan
+            .ctes
+            .0
+            .iter()
+            .filter(|c| c.vlp_cypher_start_alias.is_some() && c.vlp_cypher_end_alias.is_some())
+            .collect();
+        let first_end = fan_in_ctes
+            .first()
+            .and_then(|c| c.vlp_cypher_end_alias.as_deref());
+        let all_same_end = first_end.is_some()
+            && fan_in_ctes
+                .iter()
+                .all(|c| c.vlp_cypher_end_alias.as_deref() == first_end);
+        let distinct_starts: std::collections::HashSet<&str> = fan_in_ctes
+            .iter()
+            .filter_map(|c| c.vlp_cypher_start_alias.as_deref())
+            .collect();
+        if fan_in_ctes.len() > 1 && all_same_end && distinct_starts.len() > 1 {
+            is_required_fan_in = true;
+            // Byte-identical to the emit phase's fan-in aliasing: ctes[0] is the
+            // FROM (`t`); ctes[i>=1] are `t_fi_{i-1}`. The shared end stays on the
+            // FROM alias (all CTEs project the same `end_id`).
+            for (i, cte) in fan_in_ctes.iter().enumerate() {
+                if let Some(start) = cte.vlp_cypher_start_alias.as_ref() {
+                    let alias = if i == 0 {
+                        crate::server::query_context::vlp_from_alias()
+                    } else {
+                        format!("t_fi_{}", i - 1)
+                    };
+                    endpoint_alias_override.insert(start.clone(), alias);
+                }
+            }
+            if let Some(end) = first_end {
+                endpoint_alias_override.insert(
+                    end.to_string(),
+                    crate::server::query_context::vlp_from_alias(),
+                );
+            }
+        }
+    }
+
     // The alias to use for the WHERE / GROUP BY endpoint rewrite. Endpoint
     // references resolve per-endpoint via `endpoint_alias_override` (above), so a
     // fully-materialized chained multi-VLP no longer needs the historical `"t"`
@@ -2244,7 +2301,14 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
         // `vlp_from_alias` is the VLP CTE's JOIN alias, e.g. `vt0`). The anchor
         // property (`a.name`) is excluded by the OPTIONAL-VLP start-alias
         // filter, so ORDER BY on the anchor is unaffected.
-        if is_optional_vlp {
+        //
+        // #544 fan-in also needs this: `rewrite_vlp_select_aliases` returns EARLY
+        // for the required fan-in shape (it emits the `t`/`t_fi_N` joins and
+        // stops before the ORDER BY rewrite), so a `ORDER BY <spoke>.name` would
+        // otherwise dangle as the raw Cypher alias (`b.name` → Code 47). The
+        // per-endpoint `endpoint_alias_override` populated above resolves each
+        // spoke to its own `t`/`t_fi_N` alias here, exactly as the SELECT loop did.
+        if is_optional_vlp || is_required_fan_in {
             log::debug!("🔍 VLP: Rewriting {} ORDER BY items", plan.order_by.0.len());
             for (idx, order_item) in plan.order_by.0.iter_mut().enumerate() {
                 log::debug!("   ORDER BY[{}]: {:?}", idx, order_item.expression);

--- a/tests/rust/integration/sql_golden_tests.rs
+++ b/tests/rust/integration/sql_golden_tests.rs
@@ -17917,13 +17917,6 @@ mod vlp_family_remnants_544_545_528_525 {
     /// #544 (guard must NOT over-fire): same-end fan-in is the one multi-VLP
     /// configuration with genuine render support (`to_sql_query.rs` detects
     /// it and INNER JOINs the sibling CTEs on end_id). It must keep working.
-    ///
-    /// KNOWN REMAINING GAP (deliberately not locked here): projecting the
-    /// SECOND fan-in VLP's start-node properties (e.g. `RETURN b.name`) still
-    /// resolves to the shared `t` alias (`t.start_name`, i.e. `a`'s value)
-    /// instead of `t_fi_0.start_name` — same root cause as #544 (single
-    /// shared VLP alias), fixable only by the same render-phase multi-alias
-    /// work. End-alias projections (x) and the join structure are correct.
     #[tokio::test]
     async fn fan_in_same_end_vlps_still_render_544() {
         let schema = load_schema(SchemaId::Standard.yaml_path());
@@ -17941,6 +17934,48 @@ mod vlp_family_remnants_544_545_528_525 {
         assert!(
             sql.contains("ON t_fi_0.end_id = t.end_id"),
             "fan-in must still INNER JOIN the sibling CTE on end_id: {sql}"
+        );
+    }
+
+    /// #544 fan-in projection fix: each fan-in spoke's start-node property must
+    /// resolve to ITS OWN VLP CTE alias, not the shared FROM alias `t`. The
+    /// first spoke (`a`, the FROM) → `t.start_name`; the second spoke (`b`,
+    /// INNER-JOINed as `t_fi_0`) → `t_fi_0.start_name`. Previously BOTH rendered
+    /// as `t.start_name`, so `b.name` silently returned `a`'s value. The shared
+    /// end (`x`) stays on `t.end_name` (all CTEs share `end_id`). ORDER BY /
+    /// WHERE on the second spoke must get the same per-spoke alias (the emit
+    /// phase returns early for fan-in and never rewrote them).
+    #[tokio::test]
+    async fn fan_in_second_spoke_start_alias_distinct_544() {
+        let schema = load_schema(SchemaId::Standard.yaml_path());
+        let sql = render(
+            &schema,
+            "MATCH (a:User)-[:FOLLOWS*1..2]->(x:User), (b:User)-[:FOLLOWS*1..2]->(x:User) \
+             RETURN a.name, b.name, x.name ORDER BY b.name",
+            SqlDialect::ClickHouse,
+        )
+        .await;
+        assert!(
+            sql.contains("t.start_name AS \"a.name\""),
+            "first spoke a → t.start_name: {sql}"
+        );
+        assert!(
+            sql.contains("t_fi_0.start_name AS \"b.name\""),
+            "second spoke b → its OWN CTE alias t_fi_0.start_name (not t): {sql}"
+        );
+        assert!(
+            sql.contains("t.end_name AS \"x.name\""),
+            "shared end x → t.end_name: {sql}"
+        );
+        // ORDER BY on the second spoke must be rewritten to its own alias, not
+        // dangle as the raw Cypher alias `b.name` (Code 47 at execution).
+        assert!(
+            !sql.contains("ORDER BY b."),
+            "ORDER BY must not dangle the raw Cypher alias: {sql}"
+        );
+        assert!(
+            sql.contains("ORDER BY t_fi_0.start_name"),
+            "ORDER BY b.name → t_fi_0.start_name: {sql}"
         );
     }
 


### PR DESCRIPTION
## Summary
Same-end fan-in `(a)-[*..]->(x), (b)-[*..]->(x)` is the one multi-VLP shape ClickGraph renders (the emit phase INNER-JOINs sibling CTEs as `t_fi_N` on `end_id`). But every spoke's **start-node property collapsed onto the shared FROM alias `t`** — so `RETURN a.name, b.name` projected `t.start_name` for BOTH, silently returning `a`'s value for `b`. Only the shared end `x` was correct.

## Root cause
`endpoint_alias_override` (the per-endpoint map from #643) is populated from `plan.joins`, but the fan-in `t_fi_N` joins are added *later*, in the emit phase (`to_sql_query.rs`), after render. So for the required path the map was empty and every endpoint fell back to the single shared `vlp_from_alias`.

## Fix
- In `rewrite_vlp_union_branch_aliases`, detect the required fan-in shape (>1 VLP CTE, same end alias, >1 distinct start) and populate `endpoint_alias_override` with the emit phase's deterministic aliasing: `ctes[0]→t`, `ctes[i>=1]→t_fi_{i-1}`, shared end→`t`.
- Extend the OPTIONAL-VLP ORDER BY rewrite gate to the fan-in shape (the emit phase returns early for fan-in and never rewrote ORDER BY → `ORDER BY b.name` dangled Code 47).

Single-VLP shapes are **byte-identical** (guarded on `len > 1`); every other required multi-VLP shape stays #544 loud-gated at analysis.

## Verification
Full suite green (1738 unit + 615 integration + ratchet), clippy clean, fmt.

Live-verified on a controlled 5-node fixture: fan-in at `x=C` returns the correct cross-product `{A,A,B}×{A,A,B}` = AA×4/AB×2/BA×2/BB×1 with **independent a/b** (was AA×6/BB×3, `b` conflated onto `a`); `ORDER BY b.name` and `count(*) GROUP BY b.name` both correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)