### PR TITLE
fix(vlp): #1100 VLP endpoint re-matched across WITH/UNWIND barrier

### DIFF
--- a/src/render_plan/plan_builder_utils.rs
+++ b/src/render_plan/plan_builder_utils.rs
@@ -1889,6 +1889,24 @@ pub(crate) fn rewrite_vlp_union_branch_aliases(
         }
     }
 
+    // #1100 (re-match shape): when a VLP endpoint is carried across a WITH/UNWIND
+    // barrier and then re-matched (`MATCH (friend)<-[:...]-(m)`), the barrier's
+    // WITH CTE is JOINed in (not in FROM), e.g. `INNER JOIN with_friend_cte_0 AS
+    // friend`. Its columns are already the aliased `p{N}_{alias}_{prop}` form, so
+    // the endpoint alias must NOT be VLP-rewritten (which would prepend `end_` and
+    // swap to the VLP FROM alias, yielding a bogus `t.end_p6_friend_id`). Mirror
+    // the FROM-clause detection above over the JOIN list.
+    for join in &plan.joins.0 {
+        if is_generated_cte_name(&join.table_name) {
+            aliases_covered_by_with_cte.insert(join.table_alias.clone());
+            log::info!(
+                "🔧 VLP: JOIN uses WITH CTE '{}' with alias '{}' - excluding from rewrite (#1100 re-match)",
+                join.table_name,
+                join.table_alias
+            );
+        }
+    }
+
     for cte in &plan.ctes.0 {
         if let (Some(start), Some(end)) = (&cte.vlp_cypher_start_alias, &cte.vlp_cypher_end_alias) {
             vlp_endpoint_aliases.insert(start.clone());

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -683,3 +683,111 @@ async fn ldbc_bi_18() {
     assert!(!sql.is_empty());
     assert!(sql.contains("SELECT"));
 }
+
+// ---------------------------------------------------------------------------
+// #1100 — VLP endpoint referenced across a WITH / UNWIND barrier
+//
+// A variable-length path compiles to a recursive CTE (`vlp_*`). When a later
+// clause carries the VLP's endpoint across a WITH/UNWIND barrier and re-matches
+// it (`MATCH (friend)<-[:...]-(m)`), the barrier's WITH CTE is JOINed in (not in
+// FROM). The endpoint alias must resolve to that WITH CTE's aliased column
+// (`friend.p6_friend_id`), NOT be VLP-rewritten into a bogus `t.end_p6_friend_id`
+// (VLP FROM alias `t` + `end_` prefix), which references a table not in the
+// outer SELECT's scope and fails at execution (ClickHouse Code 47).
+// ---------------------------------------------------------------------------
+
+/// Render an inline Cypher string through the full pipeline (no CH connection).
+async fn generate_sql_inline(schema: &GraphSchema, cypher: &str) -> String {
+    let schema = schema.clone();
+    let cypher = cypher.to_string();
+    let ctx = QueryContext::new(Some("default".to_string()));
+    with_query_context(ctx, async {
+        set_current_schema(Arc::new(schema.clone()));
+        let cleaned = strip_comments(&cypher);
+        let (_rem, statement) = clickgraph::open_cypher_parser::parse_cypher_statement(&cleaned)
+            .unwrap_or_else(|e| panic!("parse: {e:?}"));
+        let (logical_plan, plan_ctx) =
+            evaluate_read_statement(statement, &schema, None, None, None)
+                .unwrap_or_else(|e| panic!("plan: {e:?}"));
+        let render_plan =
+            logical_plan_to_render_plan_with_ctx(logical_plan, &schema, Some(&plan_ctx))
+                .unwrap_or_else(|e| panic!("render: {e:?}"));
+        render_plan.to_sql()
+    })
+    .await
+}
+
+/// #1100 sub-shape 1 (WITH barrier + re-MATCH): the re-matched endpoint's
+/// property must reference the WITH CTE alias, never the VLP FROM alias `t`
+/// with an `end_` prefix.
+#[tokio::test]
+async fn ldbc_1100_vlp_endpoint_rematch_after_with() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..2]-(friend:Person)
+         WITH friend
+         MATCH (friend)<-[:HAS_CREATOR]-(m:Message)
+         RETURN m.id, friend.id LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("friend.p6_friend_id"),
+        "#1100: re-matched endpoint `friend.id` must resolve to the WITH CTE \
+         column `friend.p6_friend_id`:\n{sql}"
+    );
+    assert!(
+        !sql.contains("t.end_p6_friend_id"),
+        "#1100: endpoint must NOT be VLP-rewritten to the bogus \
+         `t.end_p6_friend_id` (VLP FROM alias + end_ prefix):\n{sql}"
+    );
+}
+
+/// #1100 sub-shape 1 (collect + UNWIND barrier, IC9-min): identical resolution
+/// requirement when the endpoint crosses a `collect(...)` / `UNWIND` barrier.
+#[tokio::test]
+async fn ldbc_1100_vlp_endpoint_rematch_after_collect_unwind() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..2]-(friend:Person)
+         WITH collect(distinct friend) AS friends
+         UNWIND friends AS friend
+         MATCH (friend)<-[:HAS_CREATOR]-(message:Message)
+         RETURN friend.id LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("friend.p6_friend_id"),
+        "#1100: post-UNWIND `friend.id` must resolve to the WITH CTE column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("t.end_p6_friend_id"),
+        "#1100: endpoint must NOT be VLP-rewritten to `t.end_p6_friend_id`:\n{sql}"
+    );
+}
+
+/// #1100 regression guard: the aggregation shape where the WITH CTE is the FROM
+/// table (not a JOIN) must stay correct — the endpoint keeps resolving to the
+/// WITH CTE alias, unaffected by the JOIN-list exclusion added for the re-match
+/// shape.
+#[tokio::test]
+async fn ldbc_1100_vlp_endpoint_aggregation_from_cte_unaffected() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (person:Person {id:14})-[:KNOWS*1..2]-(friend:Person)
+         WITH DISTINCT friend
+         RETURN count(friend) AS c",
+    )
+    .await;
+    assert!(
+        sql.contains("count(friend.p6_friend_id)"),
+        "#1100 guard: aggregation over the endpoint must reference the WITH CTE \
+         column `friend.p6_friend_id`:\n{sql}"
+    );
+    assert!(
+        !sql.contains("t.end_p6_friend_id"),
+        "#1100 guard: no bogus VLP-rewritten endpoint reference:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the **projection sub-shape** of #1100 (VLP endpoint referenced across a WITH/UNWIND barrier).

When a variable-length path's endpoint is carried across a `WITH`/`UNWIND` barrier and re-matched (`MATCH (friend)<-[:...]-(m)`), the barrier's WITH CTE is added as a **JOIN** (not in `FROM`), e.g. `INNER JOIN with_friend_cte_0 AS friend`. The endpoint's properties are already exposed as that CTE's aliased `p{N}_{alias}_{prop}` columns, so `friend.id` must resolve to `friend.p6_friend_id`.

`rewrite_vlp_union_branch_aliases` only excluded WITH-CTE-covered aliases detected from the **FROM** clause, so this re-match shape (WITH CTE in a JOIN) left the endpoint's stale VLP mapping active. The projection then rendered `friend.id` as `t.end_p6_friend_id` (VLP FROM alias `t` + `end_` prefix) — a table not in the outer SELECT's scope — failing at execution with **ClickHouse Code 47**.

## Fix

Mirror the existing FROM-clause coverage detection over the JOIN list: any JOIN whose table is a generated `with_*_cte_*` excludes its alias from VLP endpoint rewriting. Uses `is_generated_cte_name` dispatch (ratchet-clean), not raw flag branching.

## Scope

This closes the **re-match projection** shape (IS2/IC9/IC5). The bare-node-identity-in-VLP-WHERE defect (`WHERE friend <> root` rendered literally inside the recursive CTE) is a **separate, pre-existing** root cause and remains tracked in #1100 for IC9/IC5 end-to-end.

## Testing

- Full `cargo test` green (1738 lib + integration); ratchet green; fmt/clippy clean.
- 3 new golden-SQL regression tests in `ldbc_regression_tests.rs`: WITH-barrier re-match, `collect`/`UNWIND` re-match (IC9-min), and a guard that the FROM-CTE aggregation shape stays correct.
- Verified executing **live** against LDBC SF1 (ClickHouse 26.7): IS2-min and IC9-min return rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)