### PR TITLE
fix(vlp): #1100 bare-node identity in a VLP filter predicate

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1710,18 +1710,35 @@ fn render_in_list_rhs(
 }
 
 /// #1100: Normalize bare-node-identity comparisons in a VLP filter predicate
-/// into the `.id` property-access form.
+/// into property-access comparisons on the node's real `node_id` column(s).
 ///
-/// Rewrites `TableAlias(a) =/<> TableAlias(b)` → `a.id =/<> b.id` in place,
-/// but ONLY when both operands are bare node aliases and BOTH are the VLP's
-/// endpoint aliases (`start_alias`/`end_alias`). Bare-node identity between a
-/// VLP endpoint and some unrelated alias, or any other expression, is left
-/// untouched. Recurses through boolean/nested operators so a node-identity
-/// conjunct inside `AND`/`OR`/`NOT` is reached. The resulting `.id` form flows
-/// through the existing property- and alias-mapping machinery, which resolves
-/// it to `end_node.id`/`start_node.id` (schema-appropriate for renamed or
-/// composite node ids).
-fn normalize_bare_node_identity_to_id(expr: &mut RenderExpr, start_alias: &str, end_alias: &str) {
+/// Rewrites `TableAlias(a) =/<> TableAlias(b)` in place, but ONLY when both
+/// operands are bare node aliases and BOTH are the VLP's endpoint aliases
+/// (`start_alias`/`end_alias`). Left as bare aliases they render as the literal
+/// alias names (`friend != root`) inside the recursive CTE, where those aliases
+/// are not in scope — ClickHouse Code 47.
+///
+/// The rewrite targets the schema-declared `node_id` column(s) — NOT a
+/// hardcoded `.id` — so it is correct on renamed (`user_id`) and composite
+/// (`[bank_id, account_number]`) node ids (axis-dispatch rule, CLAUDE.md §7):
+/// - single column: `a =/<> b` → `a.col =/<> b.col`
+/// - composite `a = b`  → `(a.c1 = b.c1 AND a.c2 = b.c2 …)`
+/// - composite `a <> b` → `NOT (a.c1 = b.c1 AND a.c2 = b.c2 …)`
+///
+/// The resulting property-access form flows through the existing property- and
+/// alias-mapping machinery (→ `end_node.<col>`/`start_node.<col>`). Recurses
+/// through boolean operators so a node-identity conjunct nested under
+/// `AND`/`OR`/`NOT` is reached without disturbing sibling filters. `start_id_cols`
+/// / `end_id_cols` are the resolved node_id columns for each endpoint; when
+/// either is empty (label/schema unresolved) the predicate is left untouched so
+/// behavior falls back to the prior (loud) path rather than emitting wrong SQL.
+fn normalize_bare_node_identity_to_id(
+    expr: &mut RenderExpr,
+    start_alias: &str,
+    end_alias: &str,
+    start_id_cols: &[String],
+    end_id_cols: &[String],
+) {
     if let RenderExpr::OperatorApplicationExp(op) = expr {
         let is_eq = matches!(op.operator, Operator::Equal | Operator::NotEqual);
         if is_eq && op.operands.len() == 2 {
@@ -1731,22 +1748,68 @@ fn normalize_bare_node_identity_to_id(expr: &mut RenderExpr, start_alias: &str, 
                 let both_endpoints = (l.0 == start_alias || l.0 == end_alias)
                     && (r.0 == start_alias || r.0 == end_alias);
                 if both_endpoints {
-                    let to_id = |a: &super::render_expr::TableAlias| {
+                    // Resolve each side's node_id columns by which endpoint it is.
+                    let cols_for = |alias: &str| -> &[String] {
+                        if alias == start_alias {
+                            start_id_cols
+                        } else {
+                            end_id_cols
+                        }
+                    };
+                    let (lcols, rcols) = (cols_for(&l.0), cols_for(&r.0));
+                    // Both endpoints must resolve to the same arity; otherwise
+                    // leave untouched (loud fallback, never wrong SQL).
+                    if lcols.is_empty() || rcols.is_empty() || lcols.len() != rcols.len() {
+                        return;
+                    }
+                    let prop = |a: &super::render_expr::TableAlias, col: &str| {
                         RenderExpr::PropertyAccessExp(PropertyAccess {
                             table_alias: a.clone(),
-                            column: PropertyValue::Column("id".to_string()),
+                            column: PropertyValue::Column(col.to_string()),
                         })
                     };
-                    let (lid, rid) = (to_id(l), to_id(r));
-                    op.operands[0] = lid;
-                    op.operands[1] = rid;
+                    // Build per-column equality conjunction.
+                    let eqs: Vec<RenderExpr> = lcols
+                        .iter()
+                        .zip(rcols.iter())
+                        .map(|(lc, rc)| {
+                            RenderExpr::OperatorApplicationExp(OperatorApplication {
+                                operator: Operator::Equal,
+                                operands: vec![prop(l, lc), prop(r, rc)],
+                            })
+                        })
+                        .collect();
+                    let all_eq = if eqs.len() == 1 {
+                        eqs.into_iter().next().unwrap()
+                    } else {
+                        RenderExpr::OperatorApplicationExp(OperatorApplication {
+                            operator: Operator::And,
+                            operands: eqs,
+                        })
+                    };
+                    *expr = if op.operator == Operator::Equal {
+                        all_eq
+                    } else {
+                        // `a <> b` ≡ NOT(all id columns equal). VLP endpoints are
+                        // always bound (non-null id), so NOT(=) matches `<>`.
+                        RenderExpr::OperatorApplicationExp(OperatorApplication {
+                            operator: Operator::Not,
+                            operands: vec![all_eq],
+                        })
+                    };
                     return;
                 }
             }
         }
         // Recurse into nested operators (AND/OR/NOT and comparison operands).
         for operand in &mut op.operands {
-            normalize_bare_node_identity_to_id(operand, start_alias, end_alias);
+            normalize_bare_node_identity_to_id(
+                operand,
+                start_alias,
+                end_alias,
+                start_id_cols,
+                end_id_cols,
+            );
         }
     }
 }
@@ -3422,18 +3485,38 @@ pub fn extract_ctes_with_context(
                         // (`RenderExpr::TableAlias`). Left as-is they render as the
                         // literal alias names (`friend != root`) inside the recursive
                         // CTE, where those aliases are not in scope (its node columns
-                        // are `start_node`/`end_node`) — ClickHouse Code 47. The `.id`
-                        // property-access form (`friend.id <> root.id`) already
-                        // resolves correctly (→ `end_node.id != start_node.id`) via
-                        // property + alias mapping, so normalize the bare form into it
-                        // for the two VLP endpoint aliases before categorization. `.id`
-                        // is Cypher's generic node-identity synonym and is resolved
-                        // schema-appropriately downstream (renamed/composite ids
-                        // included), so no schema lookup is needed here.
+                        // are `start_node`/`end_node`) — ClickHouse Code 47. Rewrite
+                        // to property-access comparisons on the schema-declared
+                        // `node_id` column(s) (renamed/composite included — NOT a
+                        // hardcoded `.id`, per axis-dispatch rule §7), which the
+                        // existing property/alias mapping resolves correctly. Resolve
+                        // each endpoint's node_id columns from its label; on any
+                        // unresolved label the predicate is left untouched (loud
+                        // fallback, never wrong SQL).
+                        let node_id_cols = |label: &str| -> Vec<String> {
+                            if label.is_empty() {
+                                return Vec::new();
+                            }
+                            schema
+                                .node_schema_opt(label)
+                                .map(|ns| {
+                                    ns.node_id
+                                        .id
+                                        .columns()
+                                        .iter()
+                                        .map(|c| c.to_string())
+                                        .collect()
+                                })
+                                .unwrap_or_default()
+                        };
+                        let start_id_cols = node_id_cols(&start_label);
+                        let end_id_cols = node_id_cols(&end_label);
                         normalize_bare_node_identity_to_id(
                             &mut render_expr,
                             &start_alias,
                             &end_alias,
+                            &start_id_cols,
+                            &end_id_cols,
                         );
 
                         // ⚠️ CRITICAL FIX (Jan 10, 2026): Schema-aware categorization for ALL schema variations!

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -1709,6 +1709,48 @@ fn render_in_list_rhs(
     )
 }
 
+/// #1100: Normalize bare-node-identity comparisons in a VLP filter predicate
+/// into the `.id` property-access form.
+///
+/// Rewrites `TableAlias(a) =/<> TableAlias(b)` → `a.id =/<> b.id` in place,
+/// but ONLY when both operands are bare node aliases and BOTH are the VLP's
+/// endpoint aliases (`start_alias`/`end_alias`). Bare-node identity between a
+/// VLP endpoint and some unrelated alias, or any other expression, is left
+/// untouched. Recurses through boolean/nested operators so a node-identity
+/// conjunct inside `AND`/`OR`/`NOT` is reached. The resulting `.id` form flows
+/// through the existing property- and alias-mapping machinery, which resolves
+/// it to `end_node.id`/`start_node.id` (schema-appropriate for renamed or
+/// composite node ids).
+fn normalize_bare_node_identity_to_id(expr: &mut RenderExpr, start_alias: &str, end_alias: &str) {
+    if let RenderExpr::OperatorApplicationExp(op) = expr {
+        let is_eq = matches!(op.operator, Operator::Equal | Operator::NotEqual);
+        if is_eq && op.operands.len() == 2 {
+            if let (RenderExpr::TableAlias(l), RenderExpr::TableAlias(r)) =
+                (&op.operands[0], &op.operands[1])
+            {
+                let both_endpoints = (l.0 == start_alias || l.0 == end_alias)
+                    && (r.0 == start_alias || r.0 == end_alias);
+                if both_endpoints {
+                    let to_id = |a: &super::render_expr::TableAlias| {
+                        RenderExpr::PropertyAccessExp(PropertyAccess {
+                            table_alias: a.clone(),
+                            column: PropertyValue::Column("id".to_string()),
+                        })
+                    };
+                    let (lid, rid) = (to_id(l), to_id(r));
+                    op.operands[0] = lid;
+                    op.operands[1] = rid;
+                    return;
+                }
+            }
+        }
+        // Recurse into nested operators (AND/OR/NOT and comparison operands).
+        for operand in &mut op.operands {
+            normalize_bare_node_identity_to_id(operand, start_alias, end_alias);
+        }
+    }
+}
+
 /// Convert a RenderExpr to a SQL string for use in CTE WHERE clauses
 pub fn render_expr_to_sql_string(expr: &RenderExpr, alias_mapping: &[(String, String)]) -> String {
     match expr {
@@ -3366,12 +3408,33 @@ pub fn extract_ctes_with_context(
 
                     if let Some(cleaned_predicate) = cleaned_predicate {
                         // Convert LogicalExpr to RenderExpr
-                        let render_expr = RenderExpr::try_from(cleaned_predicate).map_err(|e| {
-                            RenderBuildError::UnsupportedFeature(format!(
-                                "Failed to convert LogicalExpr to RenderExpr: {}",
-                                e
-                            ))
-                        })?;
+                        let mut render_expr =
+                            RenderExpr::try_from(cleaned_predicate).map_err(|e| {
+                                RenderBuildError::UnsupportedFeature(format!(
+                                    "Failed to convert LogicalExpr to RenderExpr: {}",
+                                    e
+                                ))
+                            })?;
+
+                        // #1100 (bare-node identity in a VLP filter): a predicate
+                        // like `friend <> root` / `friend = root` compares node
+                        // IDENTITY, but both sides are BARE node aliases
+                        // (`RenderExpr::TableAlias`). Left as-is they render as the
+                        // literal alias names (`friend != root`) inside the recursive
+                        // CTE, where those aliases are not in scope (its node columns
+                        // are `start_node`/`end_node`) — ClickHouse Code 47. The `.id`
+                        // property-access form (`friend.id <> root.id`) already
+                        // resolves correctly (→ `end_node.id != start_node.id`) via
+                        // property + alias mapping, so normalize the bare form into it
+                        // for the two VLP endpoint aliases before categorization. `.id`
+                        // is Cypher's generic node-identity synonym and is resolved
+                        // schema-appropriately downstream (renamed/composite ids
+                        // included), so no schema lookup is needed here.
+                        normalize_bare_node_identity_to_id(
+                            &mut render_expr,
+                            &start_alias,
+                            &end_alias,
+                        );
 
                         // ⚠️ CRITICAL FIX (Jan 10, 2026): Schema-aware categorization for ALL schema variations!
                         //

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -809,8 +809,9 @@ async fn ldbc_1100_vlp_endpoint_aggregation_from_cte_unaffected() {
 /// node identity with BARE node aliases. Inside the recursive VLP CTE those
 /// aliases are not in scope (its node columns are `start_node`/`end_node`), so
 /// the bare form would render literally as `friend != root` → ClickHouse Code
-/// 47. It must normalize to the `.id` form → `end_node.id != start_node.id`.
-/// This unblocks LDBC IC9/IC5, which both filter `WHERE NOT friend = root`.
+/// 47. It must normalize to a comparison on the schema `node_id` column(s) →
+/// `NOT (end_node.id = start_node.id)`. Unblocks LDBC IC9/IC5, which both
+/// filter `WHERE NOT friend = root`.
 #[tokio::test]
 async fn ldbc_1100_bare_node_identity_in_vlp_filter() {
     let schema = load_ldbc_schema();
@@ -822,10 +823,9 @@ async fn ldbc_1100_bare_node_identity_in_vlp_filter() {
     )
     .await;
     assert!(
-        sql.contains("end_node.id != start_node.id")
-            || sql.contains("start_node.id != end_node.id"),
+        sql.contains("end_node.id = start_node.id") || sql.contains("start_node.id = end_node.id"),
         "#1100: bare-node identity `friend <> root` must normalize to the VLP \
-         endpoint id columns:\n{sql}"
+         endpoint node_id columns:\n{sql}"
     );
     assert!(
         !sql.contains("friend != root") && !sql.contains("friend = root"),
@@ -854,5 +854,67 @@ async fn ldbc_1100_bare_node_identity_nested_in_and() {
     assert!(
         sql.contains("'Bob'"),
         "#1100: sibling property conjunct must not be dropped:\n{sql}"
+    );
+}
+
+/// Load any GraphSchema from a YAML path (for schema-axis coverage).
+fn load_schema_from(path: &str) -> GraphSchema {
+    GraphSchemaConfig::from_yaml_file(path)
+        .unwrap_or_else(|e| panic!("load {path}: {e:?}"))
+        .to_graph_schema()
+        .unwrap_or_else(|e| panic!("convert {path}: {e:?}"))
+}
+
+/// #1100 axis coverage — RENAMED node_id (`User.node_id: user_id`): the
+/// bare-node identity must normalize to the schema's real id column, NOT a
+/// hardcoded `.id`. A `.id` here fails live (`db_standard.users` has no `id`
+/// column). Regression for the reviewer-found axis-dispatch defect.
+#[tokio::test]
+async fn ldbc_1100_bare_node_identity_renamed_node_id() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:User)-[:FOLLOWS*1..2]->(friend:User)
+         WHERE friend <> root
+         RETURN friend.user_id LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("end_node.user_id = start_node.user_id")
+            || sql.contains("start_node.user_id = end_node.user_id"),
+        "#1100: renamed node_id must compare `user_id`, not `.id`:\n{sql}"
+    );
+    assert!(
+        !sql.contains("node.id = ") && !sql.contains(".id !="),
+        "#1100: must NOT emit a hardcoded `.id` for a renamed node_id:\n{sql}"
+    );
+}
+
+/// #1100 axis coverage — COMPOSITE node_id (`Account.node_id: [bank_id,
+/// account_number]`): `a2 <> a1` must expand to `NOT (all id columns equal)`,
+/// which a single `.id` cannot express. Regression for the reviewer-found
+/// axis-dispatch defect.
+#[tokio::test]
+async fn ldbc_1100_bare_node_identity_composite_node_id() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a1:Account)-[:TRANSFERRED*1..2]->(a2:Account)
+         WHERE a2 <> a1
+         RETURN a2.account_type LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("bank_id = ") && sql.contains("account_number = "),
+        "#1100: composite node_id identity must compare BOTH key columns:\n{sql}"
+    );
+    // Both key-column equalities must be conjoined under a single NOT.
+    assert!(
+        sql.contains("bank_id") && sql.contains("account_number") && sql.contains(" AND "),
+        "#1100: composite identity must be an AND of per-column equalities:\n{sql}"
+    );
+    assert!(
+        !sql.contains(".id = ") && !sql.contains(".id !="),
+        "#1100: must NOT collapse a composite node_id to `.id`:\n{sql}"
     );
 }

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -316,6 +316,19 @@ async fn ldbc_complex_9() {
     .await;
     assert!(!sql.is_empty());
     assert!(sql.contains("SELECT"));
+    // #1100: IC9 filters `WHERE NOT friend = root` (bare-node identity) on a
+    // `KNOWS*1..2` VLP and re-matches `friend` across a collect/UNWIND barrier.
+    // The bare identity must resolve to the VLP endpoint id columns, never leak
+    // the bare alias names into the recursive CTE body (which fails Code 47),
+    // and the re-matched endpoint must resolve to its WITH-CTE column.
+    assert!(
+        !sql.contains("friend = root") && !sql.contains("friend != root"),
+        "#1100: IC9 bare-node identity must not leak bare aliases into SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("t.end_p6_friend_id"),
+        "#1100: IC9 re-matched endpoint must not VLP-rewrite to `t.end_*`:\n{sql}"
+    );
 }
 
 #[tokio::test]
@@ -789,5 +802,57 @@ async fn ldbc_1100_vlp_endpoint_aggregation_from_cte_unaffected() {
     assert!(
         !sql.contains("t.end_p6_friend_id"),
         "#1100 guard: no bogus VLP-rewritten endpoint reference:\n{sql}"
+    );
+}
+
+/// #1100 (bare-node identity in a VLP filter): `WHERE friend <> root` compares
+/// node identity with BARE node aliases. Inside the recursive VLP CTE those
+/// aliases are not in scope (its node columns are `start_node`/`end_node`), so
+/// the bare form would render literally as `friend != root` → ClickHouse Code
+/// 47. It must normalize to the `.id` form → `end_node.id != start_node.id`.
+/// This unblocks LDBC IC9/IC5, which both filter `WHERE NOT friend = root`.
+#[tokio::test]
+async fn ldbc_1100_bare_node_identity_in_vlp_filter() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..2]-(friend:Person)
+         WHERE friend <> root
+         RETURN friend.id LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("end_node.id != start_node.id")
+            || sql.contains("start_node.id != end_node.id"),
+        "#1100: bare-node identity `friend <> root` must normalize to the VLP \
+         endpoint id columns:\n{sql}"
+    );
+    assert!(
+        !sql.contains("friend != root") && !sql.contains("friend = root"),
+        "#1100: bare alias names must NOT survive into the VLP CTE body:\n{sql}"
+    );
+}
+
+/// #1100 (bare-node identity, `=` variant + nested in AND): the normalization
+/// must reach a node-identity conjunct nested under `AND` and leave sibling
+/// property filters intact.
+#[tokio::test]
+async fn ldbc_1100_bare_node_identity_nested_in_and() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..2]-(friend:Person)
+         WHERE friend = root AND friend.firstName = 'Bob'
+         RETURN friend.id LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("end_node.id = start_node.id") || sql.contains("start_node.id = end_node.id"),
+        "#1100: `=` node identity nested in AND must normalize:\n{sql}"
+    );
+    // The sibling property filter must survive (applied on the endpoint).
+    assert!(
+        sql.contains("'Bob'"),
+        "#1100: sibling property conjunct must not be dropped:\n{sql}"
     );
 }


### PR DESCRIPTION
## Summary

Second slice of #1100. Unblocks LDBC **IC9** and **IC5** end-to-end.

A predicate like `WHERE friend <> root` / `friend = root` compares node **identity**, but both sides are **bare** node aliases. In a variable-length path this predicate lands in the recursive CTE's WHERE, where the aliases aren't in scope (the CTE's node columns are `start_node`/`end_node`). `render_expr_to_sql_string` renders a bare `TableAlias` as the literal alias name, emitting `friend != root` inside the CTE body → **ClickHouse Code 47**.

## Fix

At the VLP `where_predicate` render seam (right after conversion to `RenderExpr`, before categorization), normalize a bare-node-identity comparison into property-access comparisons on the endpoints' **schema-declared `node_id` column(s)**:

- single column: `a =/<> b` → `a.col =/<> b.col`
- composite `a = b`  → `(a.c1 = b.c1 AND a.c2 = b.c2 …)`
- composite `a <> b` → `NOT (a.c1 = b.c1 AND …)`

This uses the real `node_id` (resolved from `start_label`/`end_label` + schema, both already in scope), **not** a hardcoded `.id` — correct on renamed and composite node ids per the axis-dispatch rule (CLAUDE.md §7). The resulting property-access form flows through the existing property + alias mapping. Tightly guarded: fires only when **both** operands are bare node aliases **and** both are the VLP's own endpoints; recurses through `AND`/`OR`/`NOT`; leaves the predicate untouched (loud fallback) on any unresolved label.

## Validation

- **Schema-axis coverage**: verified LDBC (`id`), renamed (`User.node_id: user_id`), composite (`Account.node_id: [bank_id, account_number]`) — each emits the correct column(s) and executes live with no Code 47.
- IC9/IC5 execute end-to-end live against LDBC SF1 (IC9 friend/message rows ordered by date; IC5 forum post counts).
- Full `cargo test` green (1738 lib + integration); ratchet green; fmt/clippy clean.
- 5 new golden tests: bare `<>`, `=` nested in AND (sibling filter survives), renamed node_id, composite node_id, plus a strengthened `ldbc_complex_9` guard.

## Review response

An adversarial review caught that the first cut hardcoded `.id` (broken on renamed/composite schemas). The reworked commit resolves the real `node_id` instead, with dedicated axis tests. The review also flagged a pre-existing cyclic self-path leak (both-endpoint filter applied only in the base case) — confirmed independent of this fix (the `.id` property form shows the identical leak) and filed as **#1103**; LDBC IC9/IC5 use `*1..2` and are unaffected.

## Remaining under #1100

IS2 (compound-alias endpoint), IC10 (pattern predicate), IC3 (Code 62), BI12 (endpoint property projection) have distinct root causes and stay tracked in #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)