### PR TITLE
docs(ldbc): post-fix re-run — 26/41 at SF1 and SF10 (#1100)

### DIFF
--- a/benchmarks/ldbc_snb/results/SF1_REAL_RUN_2026-08-30.md
+++ b/benchmarks/ldbc_snb/results/SF1_REAL_RUN_2026-08-30.md
@@ -1,0 +1,126 @@
+# LDBC SNB Official — Real SF1 Run
+
+**Date**: 2026-08-30
+**ClickGraph**: 0.6.8-dev
+**ClickHouse**: 26.7.1.1315
+**Host**: single node, 32 cores, 121 GB RAM, Linux 7.0.0
+**Scale factor**: SF1 (LDBC datagen 0.5.1, `composite-projected-fk` CSV, `--explode-edges`)
+**Protocol**: 5 iterations per query, median of measured runs (1 warm-up discarded), HTTP `/query`
+
+## Dataset (loaded into ClickHouse `ldbc` DB, verified row counts)
+
+| Entity | Rows |
+|---|---|
+| Person | 9,966 |
+| Person_knows_Person | 165,272 |
+| Post | 1,048,996 |
+| Comment | 1,660,671 |
+| Forum | 96,425 |
+| Forum_hasMember_Person | 2,869,358 |
+| Message (view = Post ∪ Comment) | 2,709,667 |
+
+These are canonical SF1 magnitudes.
+
+## Result: 24 / 41 official queries execute end-to-end
+
+| Category | Passed | n | min | median | max |
+|---|---|---|---|---|---|
+| Interactive Short (IS) | 5 / 7 | 5 | 3.6 ms | 20 ms | 124 ms |
+| Interactive Complex (IC) | 7 / 14 | 7 | 44 ms | 145 ms | 231 ms |
+| Business Intelligence (BI) | 12 / 20 | 12 | 45 ms | 278 ms | 1,600 ms |
+| **Total** | **24 / 41** | | | | |
+
+Sum of passing-query medians: **6.6 s**. **Zero OOM, zero timeout at SF1.**
+
+## The 17 failures, categorized honestly
+
+- **Require GDS/APOC procedure libraries (out of scope for a translation layer): 5** — IC14, BI10, BI15, BI19, BI20 (`CALL gds.graph.project.cypher`, `apoc.path.subgraphNodes`, and queries consuming projected-graph path weights).
+- **Require `CALL {}` subqueries (unimplemented Cypher feature): 2** — BI4, BI16.
+- **Schema-mapping gaps in the benchmark YAML (polymorphic `IS_LOCATED_IN` — `Company`→`Country` unmapped): 2** — IC1, IC11.
+- **Planner limitations we track: 2** — IS7 (chained undirected OPTIONAL hop), BI17 (#544 two VLPs in one scope; note: single-scope chained-forward multi-VLP was implemented in PRs #1094/#1095, but BI17's shape is outside that confined case).
+- **Genuine translation defects (identifier resolution, Code 47/62): 6** — IS2, IC3, IC5, IC9, IC10, BI12. E.g. IC9 uses `collect(distinct friend)` → `UNWIND` → re-`MATCH (friend)`, and the re-bound variable fails to resolve across the WITH/UNWIND barrier.
+
+## Reproduce
+
+```bash
+# 1. generate SF1
+benchmarks/ldbc_snb/scripts/download_data.sh sf1 --generate   # ldbc/datagen-standalone:0.5.1
+# 2. tables + views (HTTP, statement-split)
+#    schemas/clickhouse_ddl.sql  (37 tables + 7 Message views)
+# 3. load  (scratchpad/load_sf1.py — file() with |-delimiter, splitByChar for Person.speaks/email)
+# 4. server
+CLICKHOUSE_DATABASE=ldbc GRAPH_CONFIG_PATH=benchmarks/ldbc_snb/schemas/ldbc_snb.yaml \
+  ./target/release/clickgraph --http-port 7475
+# 5. run  (scratchpad/run_ldbc_sf1.py — 41 official queries + .params.json, 5 iters, median)
+```
+
+Raw JSON: `benchmarks/ldbc_snb/results/sf1_official_20260830_213214.json`
+
+## Note for the paper
+
+This **supersedes** all prior LDBC numbers in the outline draft, which were not backed by any actual SF1 run: there was no 37-query run, no "19.7 s total" (that traced to `is5: 19.7 ms`), no v0.6.5 measurement, and no SF10 "five queries exceed 70 GB / OOM" event (the SF10 files on disk show at most 1 timeout, 0 OOM). Report **24/41 at SF1** with the categorized breakdown above.
+
+---
+
+# LDBC SNB Official — Real SF10 Run (same session, 2026-08-30)
+
+**Scale factor**: SF10 (LDBC datagen 0.5.1), loaded into ClickHouse DB `ldbc_sf10`.
+Same host, versions, protocol (5 iterations, median) as the SF1 run above.
+Schema: `scratchpad/ldbc_snb_sf10.yaml` (SF1 yaml with `database: ldbc` → `ldbc_sf10`, 43 sites).
+Server: port 7476, `RUST_LOG=warn` (verbose INFO logging stalls the HTTP handler at scale).
+
+## Dataset (verified row counts — canonical SF10, ~10× SF1)
+
+| Entity | Rows |
+|---|---|
+| Person | 67,110 |
+| Person_knows_Person | 1,754,972 |
+| Post | 7,837,360 |
+| Comment | 17,411,262 |
+| Forum_hasMember_Person | 29,794,007 |
+| Message (view) | 25,248,622 |
+
+## Result: 24 / 41 — identical coverage to SF1
+
+The pass/fail set is **exactly the same** as SF1: the 17 failures are structural
+(unsupported GDS/APOC/subquery features, schema-mapping gaps, planner limits, and the
+6 translation defects), not scale-driven. **Zero OOM, zero timeout** at SF10.
+
+| Category | Passed | SF10 min / median / max |
+|---|---|---|
+| Interactive Short (IS) | 5/7 | 4 / 27 / 308 ms |
+| Interactive Complex (IC) | 7/14 | 81 / 372 / 613 ms |
+| Business Intelligence (BI) | 12/20 | 204 ms / 1.53 s / **240.8 s** |
+
+## Scaling SF1 → SF10 (10× data), the honest headline
+
+Median scaling across the 24 passing queries is **2.6×** for a 10× data increase —
+strongly **sub-linear**, the columnar-engine behavior the paper argues. Point lookups
+(IS1, IS4) are **flat** (~1.0×). Excluding one outlier, the worst scaling is 14.7× (BI6).
+
+**The one real scaling boundary is BI3: 1.6 s → 240.8 s (≈150×).** Not an OOM —
+a super-linear blowup. BI3 is a 6-hop join chain terminating in an **unbounded
+variable-length path `[:REPLY_OF*0..]`** (recursive CTE) over the 17.4 M-comment reply
+hierarchy; at SF10 the recursive expansion dominates. This is a characterizable
+translation/plan pathology on one query, and it is the *real* version of the
+"scaling boundary" the earlier draft had fabricated as a 70 GB OOM.
+
+Sum of passing-query medians: **263.5 s** (dominated by BI3); **22.8 s excluding BI3**.
+
+Raw JSON: `benchmarks/ldbc_snb/results/sf10_official_20260830_233952.json`
+
+## Per-query scaling (median ms), sorted by blowup
+
+| q | SF1 | SF10 | × |
+|---|---|---|---|
+| BI3 | 1600.0 | 240760.2 | 150.5 |
+| BI6 | 271.5 | 3979.6 | 14.7 |
+| BI1 | 45.5 | 536.2 | 11.8 |
+| BI11 | 185.8 | 1323.7 | 7.1 |
+| BI8 | 922.7 | 6408.7 | 6.9 |
+| BI9 | 392.1 | 1929.1 | 4.9 |
+| BI14 | 470.1 | 2125.7 | 4.5 |
+| IC8 | 145.1 | 591.5 | 4.1 |
+| … | | | median 2.6× |
+| IS1 | 4.4 | 4.5 | 1.0 |
+| IC2 | 207.7 | 188.3 | 0.9 |

--- a/benchmarks/ldbc_snb/results/SF1_SF10_POSTFIX_2026-08-31.md
+++ b/benchmarks/ldbc_snb/results/SF1_SF10_POSTFIX_2026-08-31.md
@@ -1,0 +1,78 @@
+# LDBC SNB Official — Post-Fix Re-Run (SF1 + SF10)
+
+**Date**: 2026-08-31
+**ClickGraph**: 0.6.8-dev @ `5b076f6b` (includes #1101, #1102)
+**ClickHouse**: 26.7.1.1315
+**Host**: single node, 32 cores, 121 GB RAM, Linux 7.0.0
+**Protocol**: 5 measured iterations per query, median (1 warm-up discarded), HTTP `/query`
+**Supersedes**: `SF1_REAL_RUN_2026-08-30.md` (24/41 baseline) — same host, same datasets, same harness.
+
+## What changed since the 24/41 baseline
+
+Two merged fixes to variable-length-path (VLP) endpoint resolution across a
+`WITH`/`UNWIND` barrier:
+
+- **PR #1101** (`5aca1c4a`) — VLP endpoint re-matched across a WITH/UNWIND barrier: the
+  re-bound endpoint variable (e.g. `collect(distinct friend)` → `UNWIND` → re-`MATCH (friend)`)
+  now resolves to the WITH-CTE column instead of the stale `t.end_*` VLP alias.
+- **PR #1102** (`5b076f6b`) — bare-node identity (`WHERE NOT friend = root`) inside a VLP
+  filter now normalizes to the schema node-id column(s), axis-correct for renamed and
+  composite node-ids.
+
+**Effect: IC5 and IC9 now execute end-to-end** (both were Code 47 in the baseline). No
+other query changed status. **24/41 → 26/41**, at *both* scale factors.
+
+## Result: 26 / 41 at SF1 and 26 / 41 at SF10
+
+| Category | SF1 pass | SF1 min/med/max | SF10 pass | SF10 min/med/max |
+|---|---|---|---|---|
+| Interactive Short (IS) | 5/7 | 3.6 / 22.5 / 133.3 ms | 5/7 | 4.0 / 27.8 / 347.4 ms |
+| Interactive Complex (IC) | 9/14 | 43.6 / 130.0 / 235.5 ms | 9/14 | 79.8 / 268.3 / 597.6 ms |
+| Business Intelligence (BI) | 12/20 | 40.8 ms / 366.9 ms / 1.84 s | 12/20 | 197.9 ms / 1.46 s / **241.2 s** |
+| **Total** | **26/41** | | **26/41** | |
+
+**Zero OOM, zero timeout** at both scales. Pass/fail *set* is identical across SF1 and
+SF10 — the 15 non-passing queries are structural, not scale-driven.
+
+Newly passing vs the Aug-30 baseline: **IC5, IC9** (at both SF1 and SF10).
+
+## The 15 remaining failures, categorized
+
+- **Require GDS/APOC procedure libraries (out of scope): 5** — IC14, BI10, BI15, BI19, BI20.
+- **Require `CALL {}` subqueries (unimplemented front-end feature): 2** — BI4, BI16.
+- **Polymorphic schema-mapping gap in the benchmark YAML (`IS_LOCATED_IN` Company→Country unmapped): 2** — IC1, IC11.
+- **Chained undirected OPTIONAL hop (planner limitation): 1** — IS7.
+- **VLP endpoint across a WITH/UNWIND barrier — residual shapes (tracked): 5** — IS2, IC3, IC10, BI12, BI17.
+  These are the harder sub-shapes of the same #1100 family the two merged fixes addressed:
+  IS2/IC10 (property projection out of the VLP / list-comp pattern predicate → #1105/#1106),
+  BI12/IS2 (polymorphic multi-target `REPLY_OF` endpoint → #989), IC3 (deep 6-barrier query,
+  Code 62), BI17 (two VLPs in one scope, #544's out-of-confinement shape).
+
+## Scaling SF1 → SF10 (10× data)
+
+Median latency scaling across the 26 passing queries is **2.54×** for a 10× data increase —
+strongly **sub-linear**. Point lookups are flat (IS1 0.9×, IS4 1.1×, IC2 0.8×). The one real
+scaling boundary is unchanged: **BI3 1.84 s → 241.2 s (≈131×)** — a 6-hop chain ending in an
+unbounded `[:REPLY_OF*0..]` recursive CTE over the 17.4 M-comment reply hierarchy. Not an OOM;
+a characterizable recursive-CTE plan pathology on one query shape.
+
+Sum of passing-query medians at SF10: **264.3 s** (BI3-dominated); **23.1 s excluding BI3**.
+
+## Raw JSON
+
+- SF1: `benchmarks/ldbc_snb/results/sf1_official_20260831_140842.json`
+- SF10: `benchmarks/ldbc_snb/results/sf10_official_20260831_143638.json`
+
+## Reproduce
+
+Same recipe as `SF1_REAL_RUN_2026-08-30.md`. Rebuild the release binary at `5b076f6b` or
+later (`cargo build --release --bin clickgraph`), then:
+
+```bash
+# SF1 (DB ldbc, port 7475)
+CLICKHOUSE_DATABASE=ldbc GRAPH_CONFIG_PATH=benchmarks/ldbc_snb/schemas/ldbc_snb.yaml \
+  RUST_LOG=warn ./target/release/clickgraph --http-port 7475
+python3 run_ldbc_sf1.py     # 41 official queries + .params.json, 5 iters, median
+
+# SF10 (DB ldbc_sf10, port 7476; yaml with database: ldbc_sf10, RUST_LOG=warn mandatory at scale)
+```

--- a/benchmarks/ldbc_snb/results/sf10_official_20260830_233952.json
+++ b/benchmarks/ldbc_snb/results/sf10_official_20260830_233952.json
@@ -1,0 +1,343 @@
+{
+  "benchmark": "LDBC SNB official",
+  "scale_factor": "sf10",
+  "iterations": 5,
+  "timestamp": "2026-08-30T23:39:52",
+  "results": [
+    {
+      "qid": "IS1",
+      "status": "ok",
+      "median_ms": 4.5,
+      "min_ms": 4.3,
+      "max_ms": 6.3,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS2",
+      "status": "error",
+      "median_ms": 6.3,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'message_messageCreationDate_messageId.p7_message_start_id' cannot be resolved from subquery with name message_messageCreationDate_messageId. In scope WITH RECURSIVE vlp_multi_type_message_t1 AS (SELEC",
+      "rows": null
+    },
+    {
+      "qid": "IS3",
+      "status": "ok",
+      "median_ms": 26.8,
+      "min_ms": 24.2,
+      "max_ms": 28.3,
+      "rows": 25,
+      "error": null
+    },
+    {
+      "qid": "IS4",
+      "status": "ok",
+      "median_ms": 3.5,
+      "min_ms": 3.4,
+      "max_ms": 3.9,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS5",
+      "status": "ok",
+      "median_ms": 31.3,
+      "min_ms": 31.0,
+      "max_ms": 33.1,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS6",
+      "status": "ok",
+      "median_ms": 308.3,
+      "min_ms": 292.0,
+      "max_ms": 352.3,
+      "rows": 0,
+      "error": null
+    },
+    {
+      "qid": "IS7",
+      "status": "error",
+      "median_ms": 0.9,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: OPTIONAL MATCH with an undirected hop chained onto another optional hop (e.g. `OPTIONAL MATCH (a)-[:R]-(b) OPTIONAL MATCH (b)-[:R]-(c)`, or `OPTIONAL MATCH (a)-[:R]-(b)-[:R]-(c)`) is not supported: the bidirectional expansion of the undirected hop ",
+      "rows": null
+    },
+    {
+      "qid": "IC1",
+      "status": "error",
+      "median_ms": 1.1,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC2",
+      "status": "ok",
+      "median_ms": 188.3,
+      "min_ms": 184.1,
+      "max_ms": 241.1,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC3",
+      "status": "error",
+      "median_ms": 10.5,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 62. DB::Exception: Syntax error: failed at position 937 (.) (line 21, col 32): .one\nINNER JOIN ldbc_sf10.Place AS country ON country.id = t1.Place2Id\nINNER JOIN ldbc_sf10.Place_isPartOf_Place AS t1 ON t1.Place1Id = city.id\nWHERE (c",
+      "rows": null
+    },
+    {
+      "qid": "IC4",
+      "status": "ok",
+      "median_ms": 187.2,
+      "min_ms": 178.7,
+      "max_ms": 187.6,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC5",
+      "status": "error",
+      "median_ms": 18.1,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression or function identifier `person` in scope SELECT start_node.id AS start_id, end_node.id AS end_id, 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships, [start_node.id, end_node.id] A",
+      "rows": null
+    },
+    {
+      "qid": "IC6",
+      "status": "ok",
+      "median_ms": 612.7,
+      "min_ms": 584.6,
+      "max_ms": 634.1,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC7",
+      "status": "ok",
+      "median_ms": 372.4,
+      "min_ms": 362.3,
+      "max_ms": 397.3,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC8",
+      "status": "ok",
+      "median_ms": 591.5,
+      "min_ms": 577.2,
+      "max_ms": 618.2,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC9",
+      "status": "error",
+      "median_ms": 49.9,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression or function identifier `friend` in scope SELECT start_node.id AS start_id, end_node.id AS end_id, 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships, [start_node.id, end_node.id] A",
+      "rows": null
+    },
+    {
+      "qid": "IC10",
+      "status": "error",
+      "median_ms": 6.9,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression identifier `person.id` in scope  with_birthday_city_friend_person_cte_0 AS birthday_city_friend_person. Maybe you meant: ['personId']. (UNKNOWN_IDENTIFIER) (version 26.7.1.1315 (official build)",
+      "rows": null
+    },
+    {
+      "qid": "IC11",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC12",
+      "status": "ok",
+      "median_ms": 446.6,
+      "min_ms": 436.4,
+      "max_ms": 465.6,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC13",
+      "status": "ok",
+      "median_ms": 80.7,
+      "min_ms": 76.7,
+      "max_ms": 88.2,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IC14",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  apoc.create.uuidBase64(),\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH\\n      (pA:Person)-[knows:KNOWS]-(pB:Person),\\n      (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:",
+      "rows": null
+    },
+    {
+      "qid": "BI1",
+      "status": "ok",
+      "median_ms": 536.2,
+      "min_ms": 531.6,
+      "max_ms": 538.5,
+      "rows": 12,
+      "error": null
+    },
+    {
+      "qid": "BI2",
+      "status": "ok",
+      "median_ms": 203.5,
+      "min_ms": 199.3,
+      "max_ms": 208.0,
+      "rows": 77,
+      "error": null
+    },
+    {
+      "qid": "BI3",
+      "status": "ok",
+      "median_ms": 240760.2,
+      "min_ms": 211488.5,
+      "max_ms": 253740.9,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI4",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH topForums\\n  UNWIND topForums AS topForum1\\n  MATCH (topForum1)-[:CONTAINER_OF]->(post:Post)<-[:REPLY_OF*0..]-(message:Message)-[:HAS_CREATOR]->(person:Person)<-[:HAS_MEMBER]-(topForum2:Forum)\\n  WITH person, mes",
+      "rows": null
+    },
+    {
+      "qid": "BI5",
+      "status": "ok",
+      "median_ms": 358.4,
+      "min_ms": 353.8,
+      "max_ms": 374.5,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI6",
+      "status": "ok",
+      "median_ms": 3979.6,
+      "min_ms": 3868.4,
+      "max_ms": 4170.9,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI7",
+      "status": "ok",
+      "median_ms": 466.0,
+      "min_ms": 456.7,
+      "max_ms": 483.2,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI8",
+      "status": "ok",
+      "median_ms": 6408.7,
+      "min_ms": 6241.6,
+      "max_ms": 6452.7,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI9",
+      "status": "ok",
+      "median_ms": 1929.1,
+      "min_ms": 1858.2,
+      "max_ms": 1933.5,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI10",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL apoc.path.subgraphNodes(startPerson, {\\n\\trelationshipFilter: \\\"KNOWS\\\",\\n    minLevel: 1,\\n    maxLevel: 3\\n})\\nYIELD node\\nWITH nodesCloserThanMinPathDistance, collect(DISTINCT node) AS nodesCloserThanMaxPathDistance\\nWI",
+      "rows": null
+    },
+    {
+      "qid": "BI11",
+      "status": "ok",
+      "median_ms": 1323.7,
+      "min_ms": 1271.1,
+      "max_ms": 1412.1,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "BI12",
+      "status": "error",
+      "median_ms": 22.5,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'end_node.language' cannot be resolved from table with name end_node. In scope SELECT vp.start_id, end_node.id AS end_id, vp.hop_count + 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships,",
+      "rows": null
+    },
+    {
+      "qid": "BI13",
+      "status": "ok",
+      "median_ms": 1730.6,
+      "min_ms": 1684.2,
+      "max_ms": 1769.2,
+      "rows": 16,
+      "error": null
+    },
+    {
+      "qid": "BI14",
+      "status": "ok",
+      "median_ms": 2125.7,
+      "min_ms": 2093.3,
+      "max_ms": 2621.6,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI15",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  'bi15',\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH (pA:Person)-[knows:KNOWS]-(pB:Person)\\n      OPTIONAL MATCH (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:HAS_CREATOR",
+      "rows": null
+    },
+    {
+      "qid": "BI16",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH paramTagX, paramDateX\\n  MATCH (person1:Person)<-[:HAS_CREATOR]-(message1:Message)-[:HAS_TAG]->(tag:Tag {name: paramTagX})\\n  WHERE date(message1.creationDate) = date(paramDateX)\\n  OPTIONAL MATCH (person1)-[:KNO",
+      "rows": null
+    },
+    {
+      "qid": "BI17",
+      "status": "error",
+      "median_ms": 1.2,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: (#544) this MATCH scope contains 2 variable-length path relationships ((message1)-[t2*..]->(post1), (message2)-[t11*..]->(post2)). ClickGraph does not yet support multiple recursive variable-length paths in one MATCH scope (except same-end fan-in) ",
+      "rows": null
+    },
+    {
+      "qid": "BI18",
+      "status": "ok",
+      "median_ms": 856.6,
+      "min_ms": 843.5,
+      "max_ms": 862.7,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI19",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unexpected tokens after query\"), (\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unparsed input",
+      "rows": null
+    },
+    {
+      "qid": "BI20",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"WITH person1.id AS person1Id, totalCost AS totalWeight\\nORDER BY totalWeight ASC\\nWITH collect({person1Id: person1Id, totalWeight: totalWeight}) AS results\\nUNWIND results AS result\\nWITH result.person1Id AS person1Id, result.t",
+      "rows": null
+    }
+  ]
+}

--- a/benchmarks/ldbc_snb/results/sf10_official_20260831_143638.json
+++ b/benchmarks/ldbc_snb/results/sf10_official_20260831_143638.json
@@ -1,0 +1,347 @@
+{
+  "benchmark": "LDBC SNB official",
+  "scale_factor": "sf10",
+  "iterations": 5,
+  "timestamp": "2026-08-31T14:36:38",
+  "results": [
+    {
+      "qid": "IS1",
+      "status": "ok",
+      "median_ms": 4.8,
+      "min_ms": 4.3,
+      "max_ms": 5.7,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS2",
+      "status": "error",
+      "median_ms": 5.7,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'message_messageCreationDate_messageId.p7_message_start_id' cannot be resolved from subquery with name message_messageCreationDate_messageId. In scope WITH RECURSIVE vlp_multi_type_message_t1 AS (SELEC",
+      "rows": null
+    },
+    {
+      "qid": "IS3",
+      "status": "ok",
+      "median_ms": 27.8,
+      "min_ms": 27.3,
+      "max_ms": 28.9,
+      "rows": 25,
+      "error": null
+    },
+    {
+      "qid": "IS4",
+      "status": "ok",
+      "median_ms": 4.0,
+      "min_ms": 3.9,
+      "max_ms": 4.6,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS5",
+      "status": "ok",
+      "median_ms": 32.2,
+      "min_ms": 31.6,
+      "max_ms": 33.5,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS6",
+      "status": "ok",
+      "median_ms": 347.4,
+      "min_ms": 320.8,
+      "max_ms": 356.2,
+      "rows": 0,
+      "error": null
+    },
+    {
+      "qid": "IS7",
+      "status": "error",
+      "median_ms": 1.0,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: OPTIONAL MATCH with an undirected hop chained onto another optional hop (e.g. `OPTIONAL MATCH (a)-[:R]-(b) OPTIONAL MATCH (b)-[:R]-(c)`, or `OPTIONAL MATCH (a)-[:R]-(b)-[:R]-(c)`) is not supported: the bidirectional expansion of the undirected hop ",
+      "rows": null
+    },
+    {
+      "qid": "IC1",
+      "status": "error",
+      "median_ms": 1.0,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC2",
+      "status": "ok",
+      "median_ms": 185.2,
+      "min_ms": 179.9,
+      "max_ms": 198.2,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC3",
+      "status": "error",
+      "median_ms": 13.7,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 62. DB::Exception: Syntax error: failed at position 937 (.) (line 21, col 32): .one\nINNER JOIN ldbc_sf10.Place AS country ON country.id = t1.Place2Id\nINNER JOIN ldbc_sf10.Place_isPartOf_Place AS t1 ON t1.Place1Id = city.id\nWHERE (c",
+      "rows": null
+    },
+    {
+      "qid": "IC4",
+      "status": "ok",
+      "median_ms": 180.6,
+      "min_ms": 180.1,
+      "max_ms": 203.9,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC5",
+      "status": "ok",
+      "median_ms": 268.3,
+      "min_ms": 262.5,
+      "max_ms": 272.7,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC6",
+      "status": "ok",
+      "median_ms": 597.6,
+      "min_ms": 588.0,
+      "max_ms": 615.2,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC7",
+      "status": "ok",
+      "median_ms": 366.5,
+      "min_ms": 358.1,
+      "max_ms": 373.6,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC8",
+      "status": "ok",
+      "median_ms": 587.1,
+      "min_ms": 578.3,
+      "max_ms": 602.1,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC9",
+      "status": "ok",
+      "median_ms": 194.6,
+      "min_ms": 191.9,
+      "max_ms": 197.4,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC10",
+      "status": "error",
+      "median_ms": 12.9,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression identifier `person.id` in scope  with_birthday_city_friend_person_cte_0 AS birthday_city_friend_person. Maybe you meant: ['personId']. (UNKNOWN_IDENTIFIER) (version 26.7.1.1315 (official build)",
+      "rows": null
+    },
+    {
+      "qid": "IC11",
+      "status": "error",
+      "median_ms": 0.9,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC12",
+      "status": "ok",
+      "median_ms": 441.1,
+      "min_ms": 420.0,
+      "max_ms": 454.6,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC13",
+      "status": "ok",
+      "median_ms": 79.8,
+      "min_ms": 77.3,
+      "max_ms": 91.8,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IC14",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  apoc.create.uuidBase64(),\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH\\n      (pA:Person)-[knows:KNOWS]-(pB:Person),\\n      (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:",
+      "rows": null
+    },
+    {
+      "qid": "BI1",
+      "status": "ok",
+      "median_ms": 537.8,
+      "min_ms": 529.4,
+      "max_ms": 561.0,
+      "rows": 12,
+      "error": null
+    },
+    {
+      "qid": "BI2",
+      "status": "ok",
+      "median_ms": 197.9,
+      "min_ms": 186.0,
+      "max_ms": 207.9,
+      "rows": 77,
+      "error": null
+    },
+    {
+      "qid": "BI3",
+      "status": "ok",
+      "median_ms": 241218.7,
+      "min_ms": 229636.2,
+      "max_ms": 250770.3,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI4",
+      "status": "error",
+      "median_ms": 0.8,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH topForums\\n  UNWIND topForums AS topForum1\\n  MATCH (topForum1)-[:CONTAINER_OF]->(post:Post)<-[:REPLY_OF*0..]-(message:Message)-[:HAS_CREATOR]->(person:Person)<-[:HAS_MEMBER]-(topForum2:Forum)\\n  WITH person, mes",
+      "rows": null
+    },
+    {
+      "qid": "BI5",
+      "status": "ok",
+      "median_ms": 354.5,
+      "min_ms": 350.1,
+      "max_ms": 372.6,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI6",
+      "status": "ok",
+      "median_ms": 4017.4,
+      "min_ms": 3947.0,
+      "max_ms": 4075.6,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI7",
+      "status": "ok",
+      "median_ms": 465.6,
+      "min_ms": 459.1,
+      "max_ms": 476.2,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI8",
+      "status": "ok",
+      "median_ms": 6349.4,
+      "min_ms": 6203.5,
+      "max_ms": 6440.7,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI9",
+      "status": "ok",
+      "median_ms": 1832.5,
+      "min_ms": 1830.8,
+      "max_ms": 1900.6,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI10",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL apoc.path.subgraphNodes(startPerson, {\\n\\trelationshipFilter: \\\"KNOWS\\\",\\n    minLevel: 1,\\n    maxLevel: 3\\n})\\nYIELD node\\nWITH nodesCloserThanMinPathDistance, collect(DISTINCT node) AS nodesCloserThanMaxPathDistance\\nWI",
+      "rows": null
+    },
+    {
+      "qid": "BI11",
+      "status": "ok",
+      "median_ms": 1279.3,
+      "min_ms": 1264.5,
+      "max_ms": 1302.5,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "BI12",
+      "status": "error",
+      "median_ms": 23.7,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'end_node.language' cannot be resolved from table with name end_node. In scope SELECT vp.start_id, end_node.id AS end_id, vp.hop_count + 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships,",
+      "rows": null
+    },
+    {
+      "qid": "BI13",
+      "status": "ok",
+      "median_ms": 1638.0,
+      "min_ms": 1633.3,
+      "max_ms": 1668.3,
+      "rows": 16,
+      "error": null
+    },
+    {
+      "qid": "BI14",
+      "status": "ok",
+      "median_ms": 2342.0,
+      "min_ms": 2313.5,
+      "max_ms": 2373.1,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI15",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  'bi15',\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH (pA:Person)-[knows:KNOWS]-(pB:Person)\\n      OPTIONAL MATCH (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:HAS_CREATOR",
+      "rows": null
+    },
+    {
+      "qid": "BI16",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH paramTagX, paramDateX\\n  MATCH (person1:Person)<-[:HAS_CREATOR]-(message1:Message)-[:HAS_TAG]->(tag:Tag {name: paramTagX})\\n  WHERE date(message1.creationDate) = date(paramDateX)\\n  OPTIONAL MATCH (person1)-[:KNO",
+      "rows": null
+    },
+    {
+      "qid": "BI17",
+      "status": "error",
+      "median_ms": 1.0,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: (#544) this MATCH scope contains 2 variable-length path relationships ((message1)-[t2*..]->(post1), (message2)-[t11*..]->(post2)). ClickGraph does not yet support multiple recursive variable-length paths in one MATCH scope (except same-end fan-in) ",
+      "rows": null
+    },
+    {
+      "qid": "BI18",
+      "status": "ok",
+      "median_ms": 780.2,
+      "min_ms": 772.8,
+      "max_ms": 798.8,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI19",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unexpected tokens after query\"), (\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unparsed input",
+      "rows": null
+    },
+    {
+      "qid": "BI20",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"WITH person1.id AS person1Id, totalCost AS totalWeight\\nORDER BY totalWeight ASC\\nWITH collect({person1Id: person1Id, totalWeight: totalWeight}) AS results\\nUNWIND results AS result\\nWITH result.person1Id AS person1Id, result.t",
+      "rows": null
+    }
+  ]
+}

--- a/benchmarks/ldbc_snb/results/sf1_official_20260830_213214.json
+++ b/benchmarks/ldbc_snb/results/sf1_official_20260830_213214.json
@@ -1,0 +1,343 @@
+{
+  "benchmark": "LDBC SNB official",
+  "scale_factor": "sf1",
+  "iterations": 5,
+  "timestamp": "2026-08-30T21:32:14",
+  "results": [
+    {
+      "qid": "IS1",
+      "status": "ok",
+      "median_ms": 4.4,
+      "min_ms": 4.4,
+      "max_ms": 5.8,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS2",
+      "status": "error",
+      "median_ms": 9.2,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'message_messageCreationDate_messageId.p7_message_start_id' cannot be resolved from subquery with name message_messageCreationDate_messageId. In scope WITH RECURSIVE vlp_multi_type_message_t1 AS (SELEC",
+      "rows": null
+    },
+    {
+      "qid": "IS3",
+      "status": "ok",
+      "median_ms": 19.9,
+      "min_ms": 19.4,
+      "max_ms": 24.7,
+      "rows": 18,
+      "error": null
+    },
+    {
+      "qid": "IS4",
+      "status": "ok",
+      "median_ms": 3.6,
+      "min_ms": 3.2,
+      "max_ms": 4.4,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS5",
+      "status": "ok",
+      "median_ms": 24.7,
+      "min_ms": 24.5,
+      "max_ms": 26.5,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS6",
+      "status": "ok",
+      "median_ms": 123.9,
+      "min_ms": 117.3,
+      "max_ms": 136.6,
+      "rows": 0,
+      "error": null
+    },
+    {
+      "qid": "IS7",
+      "status": "error",
+      "median_ms": 1.2,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: OPTIONAL MATCH with an undirected hop chained onto another optional hop (e.g. `OPTIONAL MATCH (a)-[:R]-(b) OPTIONAL MATCH (b)-[:R]-(c)`, or `OPTIONAL MATCH (a)-[:R]-(b)-[:R]-(c)`) is not supported: the bidirectional expansion of the undirected hop ",
+      "rows": null
+    },
+    {
+      "qid": "IC1",
+      "status": "error",
+      "median_ms": 2.0,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC2",
+      "status": "ok",
+      "median_ms": 207.7,
+      "min_ms": 198.3,
+      "max_ms": 244.7,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC3",
+      "status": "error",
+      "median_ms": 19.6,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 62. DB::Exception: Syntax error: failed at position 922 (.) (line 21, col 32): .one\nINNER JOIN ldbc.Place AS country ON country.id = t1.Place2Id\nINNER JOIN ldbc.Place_isPartOf_Place AS t1 ON t1.Place1Id = city.id\nWHERE (country.typ",
+      "rows": null
+    },
+    {
+      "qid": "IC4",
+      "status": "ok",
+      "median_ms": 73.2,
+      "min_ms": 63.7,
+      "max_ms": 109.9,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC5",
+      "status": "error",
+      "median_ms": 9.3,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression or function identifier `person` in scope SELECT start_node.id AS start_id, end_node.id AS end_id, 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships, [start_node.id, end_node.id] A",
+      "rows": null
+    },
+    {
+      "qid": "IC6",
+      "status": "ok",
+      "median_ms": 231.4,
+      "min_ms": 214.8,
+      "max_ms": 235.0,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC7",
+      "status": "ok",
+      "median_ms": 107.4,
+      "min_ms": 104.7,
+      "max_ms": 125.8,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC8",
+      "status": "ok",
+      "median_ms": 145.1,
+      "min_ms": 135.8,
+      "max_ms": 149.3,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC9",
+      "status": "error",
+      "median_ms": 11.5,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression or function identifier `friend` in scope SELECT start_node.id AS start_id, end_node.id AS end_id, 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships, [start_node.id, end_node.id] A",
+      "rows": null
+    },
+    {
+      "qid": "IC10",
+      "status": "error",
+      "median_ms": 7.6,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression identifier `person.id` in scope  with_birthday_city_friend_person_cte_0 AS birthday_city_friend_person. Maybe you meant: ['personId']. (UNKNOWN_IDENTIFIER) (version 26.7.1.1315 (official build)",
+      "rows": null
+    },
+    {
+      "qid": "IC11",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC12",
+      "status": "ok",
+      "median_ms": 228.9,
+      "min_ms": 222.4,
+      "max_ms": 243.3,
+      "rows": 17,
+      "error": null
+    },
+    {
+      "qid": "IC13",
+      "status": "ok",
+      "median_ms": 43.9,
+      "min_ms": 31.0,
+      "max_ms": 49.8,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IC14",
+      "status": "error",
+      "median_ms": 0.4,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  apoc.create.uuidBase64(),\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH\\n      (pA:Person)-[knows:KNOWS]-(pB:Person),\\n      (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:",
+      "rows": null
+    },
+    {
+      "qid": "BI1",
+      "status": "ok",
+      "median_ms": 45.5,
+      "min_ms": 39.7,
+      "max_ms": 88.3,
+      "rows": 12,
+      "error": null
+    },
+    {
+      "qid": "BI2",
+      "status": "ok",
+      "median_ms": 135.2,
+      "min_ms": 129.3,
+      "max_ms": 152.9,
+      "rows": 77,
+      "error": null
+    },
+    {
+      "qid": "BI3",
+      "status": "ok",
+      "median_ms": 1600.0,
+      "min_ms": 1542.4,
+      "max_ms": 1844.3,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI4",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH topForums\\n  UNWIND topForums AS topForum1\\n  MATCH (topForum1)-[:CONTAINER_OF]->(post:Post)<-[:REPLY_OF*0..]-(message:Message)-[:HAS_CREATOR]->(person:Person)<-[:HAS_MEMBER]-(topForum2:Forum)\\n  WITH person, mes",
+      "rows": null
+    },
+    {
+      "qid": "BI5",
+      "status": "ok",
+      "median_ms": 107.8,
+      "min_ms": 102.6,
+      "max_ms": 128.8,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI6",
+      "status": "ok",
+      "median_ms": 271.5,
+      "min_ms": 262.0,
+      "max_ms": 289.2,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI7",
+      "status": "ok",
+      "median_ms": 179.8,
+      "min_ms": 157.2,
+      "max_ms": 183.1,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI8",
+      "status": "ok",
+      "median_ms": 922.7,
+      "min_ms": 896.5,
+      "max_ms": 936.7,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI9",
+      "status": "ok",
+      "median_ms": 392.1,
+      "min_ms": 377.5,
+      "max_ms": 399.4,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI10",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL apoc.path.subgraphNodes(startPerson, {\\n\\trelationshipFilter: \\\"KNOWS\\\",\\n    minLevel: 1,\\n    maxLevel: 3\\n})\\nYIELD node\\nWITH nodesCloserThanMinPathDistance, collect(DISTINCT node) AS nodesCloserThanMaxPathDistance\\nWI",
+      "rows": null
+    },
+    {
+      "qid": "BI11",
+      "status": "ok",
+      "median_ms": 185.8,
+      "min_ms": 175.8,
+      "max_ms": 189.5,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "BI12",
+      "status": "error",
+      "median_ms": 9.2,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'end_node.language' cannot be resolved from table with name end_node. In scope SELECT vp.start_id, end_node.id AS end_id, vp.hop_count + 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships,",
+      "rows": null
+    },
+    {
+      "qid": "BI13",
+      "status": "ok",
+      "median_ms": 763.1,
+      "min_ms": 747.4,
+      "max_ms": 782.1,
+      "rows": 3,
+      "error": null
+    },
+    {
+      "qid": "BI14",
+      "status": "ok",
+      "median_ms": 470.1,
+      "min_ms": 423.4,
+      "max_ms": 494.8,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI15",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  'bi15',\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH (pA:Person)-[knows:KNOWS]-(pB:Person)\\n      OPTIONAL MATCH (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:HAS_CREATOR",
+      "rows": null
+    },
+    {
+      "qid": "BI16",
+      "status": "error",
+      "median_ms": 0.2,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH paramTagX, paramDateX\\n  MATCH (person1:Person)<-[:HAS_CREATOR]-(message1:Message)-[:HAS_TAG]->(tag:Tag {name: paramTagX})\\n  WHERE date(message1.creationDate) = date(paramDateX)\\n  OPTIONAL MATCH (person1)-[:KNO",
+      "rows": null
+    },
+    {
+      "qid": "BI17",
+      "status": "error",
+      "median_ms": 1.0,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: (#544) this MATCH scope contains 2 variable-length path relationships ((message1)-[t2*..]->(post1), (message2)-[t11*..]->(post2)). ClickGraph does not yet support multiple recursive variable-length paths in one MATCH scope (except same-end fan-in) ",
+      "rows": null
+    },
+    {
+      "qid": "BI18",
+      "status": "ok",
+      "median_ms": 283.9,
+      "min_ms": 275.8,
+      "max_ms": 285.6,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI19",
+      "status": "error",
+      "median_ms": 0.6,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unexpected tokens after query\"), (\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unparsed input",
+      "rows": null
+    },
+    {
+      "qid": "BI20",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"WITH person1.id AS person1Id, totalCost AS totalWeight\\nORDER BY totalWeight ASC\\nWITH collect({person1Id: person1Id, totalWeight: totalWeight}) AS results\\nUNWIND results AS result\\nWITH result.person1Id AS person1Id, result.t",
+      "rows": null
+    }
+  ]
+}

--- a/benchmarks/ldbc_snb/results/sf1_official_20260831_140842.json
+++ b/benchmarks/ldbc_snb/results/sf1_official_20260831_140842.json
@@ -1,0 +1,347 @@
+{
+  "benchmark": "LDBC SNB official",
+  "scale_factor": "sf1",
+  "iterations": 5,
+  "timestamp": "2026-08-31T14:08:42",
+  "results": [
+    {
+      "qid": "IS1",
+      "status": "ok",
+      "median_ms": 5.1,
+      "min_ms": 4.6,
+      "max_ms": 5.4,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS2",
+      "status": "error",
+      "median_ms": 6.3,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'message_messageCreationDate_messageId.p7_message_start_id' cannot be resolved from subquery with name message_messageCreationDate_messageId. In scope WITH RECURSIVE vlp_multi_type_message_t1 AS (SELEC",
+      "rows": null
+    },
+    {
+      "qid": "IS3",
+      "status": "ok",
+      "median_ms": 22.5,
+      "min_ms": 21.3,
+      "max_ms": 22.7,
+      "rows": 18,
+      "error": null
+    },
+    {
+      "qid": "IS4",
+      "status": "ok",
+      "median_ms": 3.6,
+      "min_ms": 3.2,
+      "max_ms": 5.4,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS5",
+      "status": "ok",
+      "median_ms": 27.4,
+      "min_ms": 26.9,
+      "max_ms": 28.1,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IS6",
+      "status": "ok",
+      "median_ms": 133.3,
+      "min_ms": 131.5,
+      "max_ms": 134.9,
+      "rows": 0,
+      "error": null
+    },
+    {
+      "qid": "IS7",
+      "status": "error",
+      "median_ms": 1.1,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: OPTIONAL MATCH with an undirected hop chained onto another optional hop (e.g. `OPTIONAL MATCH (a)-[:R]-(b) OPTIONAL MATCH (b)-[:R]-(c)`, or `OPTIONAL MATCH (a)-[:R]-(b)-[:R]-(c)`) is not supported: the bidirectional expansion of the undirected hop ",
+      "rows": null
+    },
+    {
+      "qid": "IC1",
+      "status": "error",
+      "median_ms": 1.4,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC2",
+      "status": "ok",
+      "median_ms": 228.6,
+      "min_ms": 220.1,
+      "max_ms": 233.1,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC3",
+      "status": "error",
+      "median_ms": 19.0,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 62. DB::Exception: Syntax error: failed at position 922 (.) (line 21, col 32): .one\nINNER JOIN ldbc.Place AS country ON country.id = t1.Place2Id\nINNER JOIN ldbc.Place_isPartOf_Place AS t1 ON t1.Place1Id = city.id\nWHERE (country.typ",
+      "rows": null
+    },
+    {
+      "qid": "IC4",
+      "status": "ok",
+      "median_ms": 82.3,
+      "min_ms": 80.4,
+      "max_ms": 84.2,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC5",
+      "status": "ok",
+      "median_ms": 130.0,
+      "min_ms": 124.5,
+      "max_ms": 138.5,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC6",
+      "status": "ok",
+      "median_ms": 234.9,
+      "min_ms": 234.0,
+      "max_ms": 270.6,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "qid": "IC7",
+      "status": "ok",
+      "median_ms": 108.6,
+      "min_ms": 103.9,
+      "max_ms": 114.6,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC8",
+      "status": "ok",
+      "median_ms": 143.2,
+      "min_ms": 140.0,
+      "max_ms": 144.9,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC9",
+      "status": "ok",
+      "median_ms": 74.5,
+      "min_ms": 70.4,
+      "max_ms": 76.4,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "IC10",
+      "status": "error",
+      "median_ms": 8.1,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Unknown expression identifier `person.id` in scope  with_birthday_city_friend_person_cte_0 AS birthday_city_friend_person. Maybe you meant: ['personId']. (UNKNOWN_IDENTIFIER) (version 26.7.1.1315 (official build)",
+      "rows": null
+    },
+    {
+      "qid": "IC11",
+      "status": "error",
+      "median_ms": 0.9,
+      "error": "Planning error: AnalyzerError: Invalid relationship pattern: (Company)-[:IS_LOCATED_IN]->(Country). Schema defines IS_LOCATED_IN as (Comment)-[:IS_LOCATED_IN]->(Country). Please add the missing relationship definition to your schema YAML.",
+      "rows": null
+    },
+    {
+      "qid": "IC12",
+      "status": "ok",
+      "median_ms": 235.5,
+      "min_ms": 224.0,
+      "max_ms": 245.4,
+      "rows": 17,
+      "error": null
+    },
+    {
+      "qid": "IC13",
+      "status": "ok",
+      "median_ms": 43.6,
+      "min_ms": 36.0,
+      "max_ms": 48.1,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "IC14",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  apoc.create.uuidBase64(),\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH\\n      (pA:Person)-[knows:KNOWS]-(pB:Person),\\n      (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:",
+      "rows": null
+    },
+    {
+      "qid": "BI1",
+      "status": "ok",
+      "median_ms": 40.8,
+      "min_ms": 39.0,
+      "max_ms": 48.7,
+      "rows": 12,
+      "error": null
+    },
+    {
+      "qid": "BI2",
+      "status": "ok",
+      "median_ms": 136.3,
+      "min_ms": 135.6,
+      "max_ms": 138.1,
+      "rows": 77,
+      "error": null
+    },
+    {
+      "qid": "BI3",
+      "status": "ok",
+      "median_ms": 1838.6,
+      "min_ms": 1651.9,
+      "max_ms": 1936.2,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI4",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH topForums\\n  UNWIND topForums AS topForum1\\n  MATCH (topForum1)-[:CONTAINER_OF]->(post:Post)<-[:REPLY_OF*0..]-(message:Message)-[:HAS_CREATOR]->(person:Person)<-[:HAS_MEMBER]-(topForum2:Forum)\\n  WITH person, mes",
+      "rows": null
+    },
+    {
+      "qid": "BI5",
+      "status": "ok",
+      "median_ms": 125.8,
+      "min_ms": 125.4,
+      "max_ms": 128.4,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI6",
+      "status": "ok",
+      "median_ms": 802.2,
+      "min_ms": 780.4,
+      "max_ms": 810.0,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI7",
+      "status": "ok",
+      "median_ms": 220.9,
+      "min_ms": 201.2,
+      "max_ms": 222.4,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI8",
+      "status": "ok",
+      "median_ms": 1113.8,
+      "min_ms": 1024.2,
+      "max_ms": 1133.2,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI9",
+      "status": "ok",
+      "median_ms": 427.1,
+      "min_ms": 422.2,
+      "max_ms": 429.4,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI10",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL apoc.path.subgraphNodes(startPerson, {\\n\\trelationshipFilter: \\\"KNOWS\\\",\\n    minLevel: 1,\\n    maxLevel: 3\\n})\\nYIELD node\\nWITH nodesCloserThanMinPathDistance, collect(DISTINCT node) AS nodesCloserThanMaxPathDistance\\nWI",
+      "rows": null
+    },
+    {
+      "qid": "BI11",
+      "status": "ok",
+      "median_ms": 188.0,
+      "min_ms": 179.1,
+      "max_ms": 202.9,
+      "rows": 1,
+      "error": null
+    },
+    {
+      "qid": "BI12",
+      "status": "error",
+      "median_ms": 9.8,
+      "error": "Executor error: I/O error while reading results: bad response: Code: 47. DB::Exception: Identifier 'end_node.language' cannot be resolved from table with name end_node. In scope SELECT vp.start_id, end_node.id AS end_id, vp.hop_count + 1 AS hop_count, CAST([], 'Array(String)') AS path_relationships,",
+      "rows": null
+    },
+    {
+      "qid": "BI13",
+      "status": "ok",
+      "median_ms": 797.7,
+      "min_ms": 782.8,
+      "max_ms": 815.6,
+      "rows": 3,
+      "error": null
+    },
+    {
+      "qid": "BI14",
+      "status": "ok",
+      "median_ms": 481.9,
+      "min_ms": 463.4,
+      "max_ms": 505.2,
+      "rows": 100,
+      "error": null
+    },
+    {
+      "qid": "BI15",
+      "status": "error",
+      "median_ms": 0.5,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL gds.graph.project.cypher(\\n  'bi15',\\n  'MATCH (p:Person) RETURN id(p) AS id',\\n  'MATCH (pA:Person)-[knows:KNOWS]-(pB:Person)\\n      OPTIONAL MATCH (pA)<-[:HAS_CREATOR]-(m1:Message)-[r:REPLY_OF]-(m2:Message)-[:HAS_CREATOR",
+      "rows": null
+    },
+    {
+      "qid": "BI16",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"CALL {\\n  WITH paramTagX, paramDateX\\n  MATCH (person1:Person)<-[:HAS_CREATOR]-(message1:Message)-[:HAS_TAG]->(tag:Tag {name: paramTagX})\\n  WHERE date(message1.creationDate) = date(paramDateX)\\n  OPTIONAL MATCH (person1)-[:KNO",
+      "rows": null
+    },
+    {
+      "qid": "BI17",
+      "status": "error",
+      "median_ms": 0.9,
+      "error": "Planning error: AnalyzerError: Unsupported pattern: (#544) this MATCH scope contains 2 variable-length path relationships ((message1)-[t2*..]->(post1), (message2)-[t11*..]->(post2)). ClickGraph does not yet support multiple recursive variable-length paths in one MATCH scope (except same-end fan-in) ",
+      "rows": null
+    },
+    {
+      "qid": "BI18",
+      "status": "ok",
+      "median_ms": 306.7,
+      "min_ms": 300.2,
+      "max_ms": 320.0,
+      "rows": 20,
+      "error": null
+    },
+    {
+      "qid": "BI19",
+      "status": "error",
+      "median_ms": 0.7,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unexpected tokens after query\"), (\".totalWeight\\nRETURN person1Id, person2Id, totalWeight\\nORDER BY person1Id, person2Id\", \"Unparsed input",
+      "rows": null
+    },
+    {
+      "qid": "BI20",
+      "status": "error",
+      "median_ms": 0.3,
+      "error": "Query syntax error: Parsing Failure: OpenCypherParsingError { errors: [(\"WITH person1.id AS person1Id, totalCost AS totalWeight\\nORDER BY totalWeight ASC\\nWITH collect({person1Id: person1Id, totalWeight: totalWeight}) AS results\\nUNWIND results AS result\\nWITH result.person1Id AS person1Id, result.t",
+      "rows": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Re-ran the full 41-query LDBC SNB official suite at **SF1 and SF10** against the release binary at `5b076f6b` (which includes the two merged VLP-endpoint-across-WITH/UNWIND-barrier fixes, **#1101** and **#1102**).

**Result: 24/41 → 26/41 at both scale factors.** `IC5` and `IC9` — the `collect`/`UNWIND` → re-`MATCH` endpoint-rebind queries — now execute end-to-end. No other query changed status; zero OOM, zero timeout.

## Numbers

| | SF1 | SF10 |
|---|---|---|
| Coverage | **26/41** | **26/41** |
| IS / IC / BI pass | 5 / 9 / 12 | 5 / 9 / 12 |
| Median scaling (10× data) | — | **2.5×** (sub-linear) |
| BI3 boundary | 1.8 s | 241 s (~130×) |

The 15 remaining failures categorize cleanly: 5 GDS/APOC (out of scope), 2 `CALL {}` subquery, 2 polymorphic schema-gap (`IS_LOCATED_IN` Company→Country), 1 chained-undirected-OPTIONAL (IS7), 5 VLP-barrier residue (IS2/IC3/IC10/BI12/BI17 — harder sub-shapes of the #1100 family, routed to #989/#1105/#1106).

## Contents

- `SF1_SF10_POSTFIX_2026-08-31.md` — refreshed writeup superseding the 24/41 Aug-30 baseline
- four raw result JSONs (both scale factors, before + after)
- also commits the Aug-30 baseline writeup + JSONs that were left untracked

The arXiv tech-report draft (`outline.html`, external artifact) has been updated in lockstep: 24→26, "seven→five" residual VLP-barrier shapes, refreshed latency bands, and the Figure 5 SF1→SF10 data array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)