### PR TITLE
fix(vlp): #1103 both-endpoint WHERE predicate applied on wrapper, not base case

### DIFF
--- a/schemas/test/prefix_collision_vlp.yaml
+++ b/schemas/test/prefix_collision_vlp.yaml
@@ -1,0 +1,28 @@
+# #1103 regression fixture: property names that COLLIDE BY PREFIX with the
+# node_id column and with each other. A textual `str::replace` rewrite of
+# rendered SQL turns `end_node.codeName` into `end_idName` (node_id `code` →
+# `end_id`, leaving `Name`), which is a DIFFERENT REAL COLUMN here — valid SQL,
+# wrong answer, no error. Only a structural (AST) rewrite survives this schema.
+name: prefix_collision_vlp
+version: "1.0"
+
+graph_schema:
+  nodes:
+    - label: Item
+      database: pt
+      table: items
+      node_id: code
+      property_mappings:
+        code: code
+        codeName: codeName
+        idName: other_col
+
+  edges:
+    - type: LINK
+      database: pt
+      table: links
+      from_id: src
+      to_id: dst
+      from_node: Item
+      to_node: Item
+      property_mappings: {}

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -556,6 +556,9 @@ pub fn generate_vlp_cte_via_manager(
     start_filters_sql: Option<String>,
     end_filters_sql: Option<String>,
     rel_filters_sql: Option<String>,
+    // #1103: pre-rendered SQL for a predicate naming BOTH VLP endpoints.
+    // Applied on the post-recursion wrapper, never in base/recursive arms.
+    both_endpoint_filters_sql: Option<String>,
     path_variable: Option<String>,
     shortest_path_mode: Option<crate::query_planner::logical_plan::ShortestPathMode>,
     relationship_types: Option<Vec<String>>,
@@ -604,9 +607,11 @@ pub fn generate_vlp_cte_via_manager(
         end_node_filters: None,
         relationship_filters: None,
         path_function_filters: None,
+        both_endpoint_filters: None,
         start_sql: start_filters_sql,
         end_sql: end_filters_sql,
         relationship_sql: rel_filters_sql,
+        both_endpoint_sql: both_endpoint_filters_sql,
     };
 
     // Create CteManager and generate VLP CTE
@@ -3560,6 +3565,15 @@ pub fn extract_ctes_with_context(
                         let mut mapped_end = categorized.end_node_filters.clone();
                         let mut mapped_rel = categorized.relationship_filters.clone();
                         let mut mapped_path = categorized.path_function_filters.clone();
+                        // #1103: a both-endpoint predicate names BOTH aliases, so it
+                        // needs BOTH role mappings applied. `apply_property_mapping_*`
+                        // resolves each PropertyAccess by its own table_alias (via
+                        // `get_node_label_for_alias`), so the two passes touch disjoint
+                        // leaves; the second is a no-op on leaves already rewritten by
+                        // the first (a mapped column arrives as
+                        // `PropertyValue::Column` and re-mapping is idempotent for the
+                        // From/To role that owns it).
+                        let mut mapped_both = categorized.both_endpoint_filters.clone();
 
                         if let Some(ref mut expr) = mapped_start {
                             apply_property_mapping_to_expr_with_context(
@@ -3570,6 +3584,20 @@ pub fn extract_ctes_with_context(
                             );
                         }
                         if let Some(ref mut expr) = mapped_end {
+                            apply_property_mapping_to_expr_with_context(
+                                expr,
+                                &LogicalPlan::GraphRel(graph_rel.clone()),
+                                rel_type,
+                                Some(crate::render_plan::cte_generation::NodeRole::To),
+                            );
+                        }
+                        if let Some(ref mut expr) = mapped_both {
+                            apply_property_mapping_to_expr_with_context(
+                                expr,
+                                &LogicalPlan::GraphRel(graph_rel.clone()),
+                                rel_type,
+                                Some(crate::render_plan::cte_generation::NodeRole::From),
+                            );
                             apply_property_mapping_to_expr_with_context(
                                 expr,
                                 &LogicalPlan::GraphRel(graph_rel.clone()),
@@ -3671,6 +3699,37 @@ pub fn extract_ctes_with_context(
                                 render_expr_to_sql_string(expr, &alias_mapping)
                             }
                         });
+                        // #1103: a both-endpoint predicate names both node aliases, so
+                        // it always uses the NODE alias mapping (start→start_node,
+                        // end→end_node) — never the rel mapping, which would collapse
+                        // both sides onto one alias and destroy the comparison.
+                        let both_endpoint_sql = mapped_both
+                            .as_ref()
+                            .map(|expr| render_expr_to_sql_string(expr, &alias_mapping));
+
+                        // #1103 SCOPE: the fully-denormalized pattern is intercepted
+                        // upstream by `DenormalizedCteStrategy`, which has no wrapper
+                        // path for a both-endpoint predicate — its CTE columns are
+                        // role-prefixed physical names (`start_Origin`/`end_Dest`), so
+                        // the rewrite needs from/to-column role resolution the standard
+                        // rewrite does not do. Rather than drop the predicate (silently
+                        // wrong) or half-rewrite it (Code 47), route it back into the
+                        // start slot — byte-identical to the pre-#1103 behavior for this
+                        // family. The denormalized half of #1103 is tracked separately.
+                        let is_fully_denormalized = matches!(
+                            pattern_ctx_for_mapping.as_ref().map(|c| &c.join_strategy),
+                            Some(JoinStrategy::SingleTableScan { .. })
+                        );
+                        let (both_endpoint_sql, start_sql) = if is_fully_denormalized {
+                            let folded = match (start_sql, both_endpoint_sql) {
+                                (Some(st), Some(be)) => Some(format!("{} AND {}", st, be)),
+                                (Some(st), None) => Some(st),
+                                (None, be) => be,
+                            };
+                            (None, folded)
+                        } else {
+                            (both_endpoint_sql, start_sql)
+                        };
                         // ✅ Relationship filters always use rel_alias_mapping
                         let rel_sql_rendered = mapped_rel
                             .as_ref()
@@ -3684,9 +3743,11 @@ pub fn extract_ctes_with_context(
                             end_node_filters: mapped_end,
                             relationship_filters: mapped_rel,
                             path_function_filters: mapped_path,
+                            both_endpoint_filters: mapped_both,
                             start_sql: start_sql.clone(),
                             end_sql: end_sql.clone(),
                             relationship_sql: rel_sql_rendered.clone(),
+                            both_endpoint_sql: both_endpoint_sql.clone(),
                         };
 
                         // Note: End node filters are placed INSIDE the CTE (via end_sql above).
@@ -3884,7 +3945,7 @@ pub fn extract_ctes_with_context(
 
                     let mut props = Vec::new();
 
-                    if let Some(categorized) = categorized_filters_opt {
+                    if let Some(ref categorized) = categorized_filters_opt {
                         // Extract from start filters
                         if let Some(ref filter_expr) = categorized.start_node_filters {
                             let start_props = extract_properties_from_filter(
@@ -3900,6 +3961,26 @@ pub fn extract_ctes_with_context(
                             let end_props =
                                 extract_properties_from_filter(filter_expr, &end_alias, &end_label);
                             props.extend(end_props);
+                        }
+
+                        // #1103: a both-endpoint predicate names BOTH aliases, so
+                        // extract for each. Its properties must be projected into the
+                        // CTE — the wrapper reads them as `start_*`/`end_*`. This also
+                        // preserves the pre-#1103 LOUD failure for a property that does
+                        // not exist on a denormalized node: extraction produces the
+                        // NodeProperty whose `map_denormalized_property` lookup rejects
+                        // it, rather than silently rendering an unresolvable column.
+                        if let Some(ref filter_expr) = categorized.both_endpoint_filters {
+                            props.extend(extract_properties_from_filter(
+                                filter_expr,
+                                &start_alias,
+                                &start_label,
+                            ));
+                            props.extend(extract_properties_from_filter(
+                                filter_expr,
+                                &end_alias,
+                                &end_label,
+                            ));
                         }
                     }
 
@@ -4618,6 +4699,24 @@ pub fn extract_ctes_with_context(
                         //    from WITH clause output). These belong in the outer query.
                         // 2. Filters involving both start and end aliases (OR) are kept in
                         //    start_filters with end_node. alias replacement done per branch.
+                        // #1103 SCOPE: multi-type VLP expands to FLAT per-branch JOIN
+                        // chains (one branch per concrete hop-count/type combination) —
+                        // there is no recursive CTE and no "intermediate hop" to
+                        // mis-prune, so each branch's WHERE already sees that branch's
+                        // TRUE endpoint pair. Base placement is correct here; fold the
+                        // both-endpoint predicate back into the start slot so this
+                        // family's output is byte-identical to pre-#1103. (The per-branch
+                        // `end_node.` alias substitution below is exactly what makes it
+                        // work.)
+                        let mt_both_endpoint: Option<String> = categorized_filters_opt
+                            .as_ref()
+                            .and_then(|c| c.both_endpoint_sql.clone());
+                        let start_filters_sql: Option<String> =
+                            match (start_filters_sql.clone(), mt_both_endpoint) {
+                                (Some(st), Some(be)) => Some(format!("{} AND {}", st, be)),
+                                (Some(st), None) => Some(st),
+                                (None, be) => be,
+                            };
                         let mt_start_filters = start_filters_sql.as_ref().map(|f| {
                             // Strip outer wrapping parens to get clean predicates
                             let inner = f.trim();
@@ -4871,6 +4970,14 @@ pub fn extract_ctes_with_context(
                         (None, Some(schema)) => Some(schema.clone()),
                         (None, None) => None,
                     };
+
+                    // #1103: both-endpoint predicate, pre-rendered against the node
+                    // alias mapping during categorization. No schema-filter combining
+                    // applies (schema filters are per-node, already folded into the
+                    // start/end slots above).
+                    let both_endpoint_filters_sql = categorized_filters_opt
+                        .as_ref()
+                        .and_then(|c| c.both_endpoint_sql.clone());
 
                     if start_schema_filter.is_some() || end_schema_filter.is_some() {
                         log::info!(
@@ -5201,6 +5308,7 @@ pub fn extract_ctes_with_context(
                         combined_start_filters,
                         combined_end_filters,
                         rel_filters_sql,
+                        both_endpoint_filters_sql,
                         graph_rel.path_variable.clone(),
                         graph_rel.shortest_path_mode.clone(),
                         graph_rel.labels.clone(),

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -556,9 +556,11 @@ pub fn generate_vlp_cte_via_manager(
     start_filters_sql: Option<String>,
     end_filters_sql: Option<String>,
     rel_filters_sql: Option<String>,
-    // #1103: pre-rendered SQL for a predicate naming BOTH VLP endpoints.
-    // Applied on the post-recursion wrapper, never in base/recursive arms.
-    both_endpoint_filters_sql: Option<String>,
+    // #1103: predicate naming BOTH VLP endpoints, as a RenderExpr — NOT
+    // pre-rendered SQL. `CteManager` lowers it structurally onto the path CTE's
+    // own `start_*`/`end_*` columns; a textual rewrite of rendered SQL would
+    // corrupt prefix-colliding property names and string literals.
+    both_endpoint_filters_expr: Option<RenderExpr>,
     path_variable: Option<String>,
     shortest_path_mode: Option<crate::query_planner::logical_plan::ShortestPathMode>,
     relationship_types: Option<Vec<String>>,
@@ -607,11 +609,11 @@ pub fn generate_vlp_cte_via_manager(
         end_node_filters: None,
         relationship_filters: None,
         path_function_filters: None,
-        both_endpoint_filters: None,
+        both_endpoint_filters: both_endpoint_filters_expr,
         start_sql: start_filters_sql,
         end_sql: end_filters_sql,
         relationship_sql: rel_filters_sql,
-        both_endpoint_sql: both_endpoint_filters_sql,
+        both_endpoint_sql: None,
     };
 
     // Create CteManager and generate VLP CTE
@@ -4975,9 +4977,9 @@ pub fn extract_ctes_with_context(
                     // alias mapping during categorization. No schema-filter combining
                     // applies (schema filters are per-node, already folded into the
                     // start/end slots above).
-                    let both_endpoint_filters_sql = categorized_filters_opt
+                    let both_endpoint_filters_expr = categorized_filters_opt
                         .as_ref()
-                        .and_then(|c| c.both_endpoint_sql.clone());
+                        .and_then(|c| c.both_endpoint_filters.clone());
 
                     if start_schema_filter.is_some() || end_schema_filter.is_some() {
                         log::info!(
@@ -5308,7 +5310,7 @@ pub fn extract_ctes_with_context(
                         combined_start_filters,
                         combined_end_filters,
                         rel_filters_sql,
-                        both_endpoint_filters_sql,
+                        both_endpoint_filters_expr,
                         graph_rel.path_variable.clone(),
                         graph_rel.shortest_path_mode.clone(),
                         graph_rel.labels.clone(),

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1692,12 +1692,47 @@ impl VariableLengthCteStrategy {
             generator.set_weight_cte(weight_config.clone());
         }
 
-        // #1103: a WHERE predicate naming BOTH endpoints. Set post-construction
-        // (like `needs_path_relationships` below) rather than widening the
-        // already-25-argument constructors. Honored by every family that reaches
-        // this generator; the fully-denormalized pattern returned earlier via
-        // `DenormalizedCteStrategy` and never gets here.
-        generator.both_endpoint_filters = filters.both_endpoint_sql.clone();
+        // #1103: a WHERE predicate naming BOTH endpoints, lowered onto the
+        // recursive CTE's own `start_*`/`end_*` output columns.
+        //
+        // This is done STRUCTURALLY on the RenderExpr (not by string-replacing
+        // the rendered SQL): substring rewriting of `end_node.<prop>` corrupts
+        // any property name that has another property's name — or the node_id
+        // column's name — as a prefix (`code` vs `codeName` → `end_idName`),
+        // and it also rewrites alias-looking text inside string literals. Both
+        // produce valid SQL against the WRONG column, which is silent.
+        //
+        // Set post-construction (like `needs_path_relationships` below) rather
+        // than widening the already-25-argument constructors.
+        if let Some(expr) = &filters.both_endpoint_filters {
+            // A COMPOSITE node_id is projected as ONE pipe-joined `start_id`/
+            // `end_id` column, so every column of the key maps to that single
+            // CTE column. Resolve the full key from the schema rather than the
+            // strategy's single `*_id_col` (which is only the first column).
+            let key_cols = |label: Option<&String>, fallback: &str| -> Vec<String> {
+                label
+                    .and_then(|l| schema.node_schema_opt(l))
+                    .map(|ns| {
+                        ns.node_id
+                            .id
+                            .columns()
+                            .iter()
+                            .map(|c| c.to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_else(|| vec![fallback.to_string()])
+            };
+            let start_key = key_cols(context.start_node_label.as_ref(), &self.start_id_col);
+            let end_key = key_cols(context.end_node_label.as_ref(), &self.end_id_col);
+            generator.both_endpoint_filters = Some(lower_both_endpoint_filter_to_cte_columns(
+                expr,
+                &self.pattern_ctx.left_node_alias,
+                &self.pattern_ctx.right_node_alias,
+                &start_key,
+                &end_key,
+                properties,
+            )?);
+        }
 
         // Skip path_relationships growth when relationships(path) isn't used
         generator.needs_path_relationships = context.needs_path_relationships;
@@ -1714,6 +1749,26 @@ impl VariableLengthCteStrategy {
         // is safe: the parallel `path_<prop>` arrays are emitted only by the
         // standard base/recursive/zero-hop arms.
         generator.path_node_properties = context.path_node_properties.clone();
+
+        // #1103: every flag that selects a generator shape is now set, so ask
+        // whether this shape routes AROUND the wrapper that applies a
+        // both-endpoint predicate. Three generators (BFS shortest path,
+        // weighted-BFS reconstruction, heterogeneous polymorphic) return before
+        // that wrapper is built and would drop the predicate SILENTLY. Refuse
+        // loudly instead — a wrong answer with no error is the one outcome that
+        // must never ship.
+        if generator.has_both_endpoint_filter() {
+            if let Some(shape) = generator.bypasses_both_endpoint_wrapper() {
+                return Err(CteError::InvalidStrategy(format!(
+                    "variable-length path: a WHERE predicate referencing BOTH path \
+                     endpoints is not supported for {shape}. This path shape does not \
+                     build the post-recursion wrapper the predicate must be applied on, \
+                     and applying it earlier would filter intermediate hops rather than \
+                     the final endpoint pair. Filter on one endpoint, or drop the \
+                     shortestPath/polymorphic form of this pattern."
+                )));
+            }
+        }
 
         // Generate the CTE using the comprehensive generator
         let cte = generator.generate_cte();
@@ -1778,6 +1833,171 @@ impl VariableLengthCteStrategy {
         }
         Ok(())
     }
+}
+
+/// #1103: lower a both-endpoint WHERE predicate onto the recursive CTE's own
+/// projected columns.
+///
+/// The predicate is written against the Cypher endpoint aliases; in the
+/// post-recursion wrapper only the CTE's projections exist. Each
+/// `PropertyAccess` is therefore retargeted structurally:
+///   * the endpoint's node_id column → `start_id` / `end_id`
+///   * any other property           → `start_<alias>` / `end_<alias>`
+///     (only if that property is actually projected into the CTE)
+///
+/// Structural, not textual. A `str::replace` over rendered SQL — the shape this
+/// replaced — silently corrupts a property whose name is a PREFIX of another
+/// (node_id `code` turns `end_node.codeName` into `end_idName`, a different
+/// real column) and rewrites alias-looking text inside string literals. Both
+/// yield valid SQL reading the WRONG column: no error, wrong answer.
+///
+/// Fails with a `CteError` — a real error the caller propagates — when a
+/// referenced property is not projected into the CTE. The predicate must never
+/// be silently dropped or pointed at a column that does not exist.
+#[allow(clippy::too_many_arguments)]
+fn lower_both_endpoint_filter_to_cte_columns(
+    expr: &crate::render_plan::render_expr::RenderExpr,
+    start_cypher_alias: &str,
+    end_cypher_alias: &str,
+    start_id_cols: &[String],
+    end_id_cols: &[String],
+    properties: &[NodeProperty],
+) -> Result<String, CteError> {
+    use crate::query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN};
+    use crate::render_plan::render_expr::RenderExpr;
+
+    // Resolve one endpoint property to its CTE column name, or explain why not.
+    // `column` may arrive as either the Cypher property name or the already
+    // schema-mapped DB column, so both are accepted (mirroring how the CTE
+    // projection is built from `NodeProperty { column_name, alias }`).
+    fn cte_column_for(
+        alias: &str,
+        column: &str,
+        cypher_alias: &str,
+        id_cols: &[String],
+        prefix: &str,
+        id_column_name: &str,
+        properties: &[NodeProperty],
+    ) -> Result<String, CteError> {
+        // Any column of the node_id maps to the CTE's single id projection —
+        // a composite key is projected pipe-joined into one `start_id`/`end_id`.
+        if id_cols.iter().any(|c| c == column) {
+            return Ok(id_column_name.to_string());
+        }
+        for prop in properties {
+            if prop.cypher_alias == cypher_alias
+                && (prop.column_name == column || prop.alias == column)
+            {
+                return Ok(format!("{}{}", prefix, prop.alias));
+            }
+        }
+        Err(CteError::SchemaValidationError(format!(
+            "variable-length path: WHERE predicate references both endpoints via \
+             `{alias}.{column}`, but that property is not projected into the path \
+             CTE, so it cannot be evaluated on the final endpoint pair. Return or \
+             otherwise reference `{alias}.{column}` in the query, or filter on the \
+             endpoint id instead."
+        )))
+    }
+
+    // Rewrite in place over a clone; every PropertyAccess on either endpoint is
+    // retargeted, and anything else (literals included) is left untouched.
+    fn rewrite(
+        e: &RenderExpr,
+        start_cypher_alias: &str,
+        end_cypher_alias: &str,
+        start_id_cols: &[String],
+        end_id_cols: &[String],
+        properties: &[NodeProperty],
+    ) -> Result<RenderExpr, CteError> {
+        match e {
+            RenderExpr::PropertyAccessExp(prop) => {
+                let alias = prop.table_alias.0.as_str();
+                let column = prop.column.raw();
+                let cte_col = if alias == start_cypher_alias {
+                    cte_column_for(
+                        alias,
+                        column,
+                        start_cypher_alias,
+                        start_id_cols,
+                        "start_",
+                        VLP_START_ID_COLUMN,
+                        properties,
+                    )?
+                } else if alias == end_cypher_alias {
+                    cte_column_for(
+                        alias,
+                        column,
+                        end_cypher_alias,
+                        end_id_cols,
+                        "end_",
+                        VLP_END_ID_COLUMN,
+                        properties,
+                    )?
+                } else {
+                    // Not an endpoint reference — categorization guarantees the
+                    // predicate names both endpoints, so a third alias here means
+                    // a correlated reference the wrapper cannot resolve.
+                    return Err(CteError::SchemaValidationError(format!(
+                        "variable-length path: both-endpoint WHERE predicate also \
+                         references `{alias}.{column}`, which is outside the path \
+                         pattern and cannot be evaluated on the path CTE."
+                    )));
+                };
+                // Emit as a BARE column of the wrapper's own scope: the wrapper
+                // is `SELECT * FROM <inner> WHERE …`, so its projections are
+                // unqualified. A PropertyAccess with an empty table_alias would
+                // render a leading dot (`.end_id`), so use Column directly.
+                Ok(RenderExpr::Column(crate::render_plan::render_expr::Column(
+                    crate::graph_catalog::expression_parser::PropertyValue::Column(cte_col),
+                )))
+            }
+            RenderExpr::OperatorApplicationExp(op) => {
+                let mut new_op = op.clone();
+                new_op.operands = op
+                    .operands
+                    .iter()
+                    .map(|o| {
+                        rewrite(
+                            o,
+                            start_cypher_alias,
+                            end_cypher_alias,
+                            start_id_cols,
+                            end_id_cols,
+                            properties,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                // A COMPOSITE node_id collapses every key column onto the same
+                // pipe-joined `start_id`/`end_id`, so an identity comparison
+                // expanded per-column upstream (#1102) becomes N copies of one
+                // predicate. Keep one — `A AND A` is `A`, and the duplicate is
+                // only noise in the emitted SQL. Order-preserving.
+                if matches!(
+                    new_op.operator,
+                    crate::render_plan::render_expr::Operator::And
+                ) {
+                    let mut seen = std::collections::HashSet::new();
+                    new_op.operands.retain(|o| seen.insert(format!("{o:?}")));
+                    if new_op.operands.len() == 1 {
+                        return Ok(new_op.operands.remove(0));
+                    }
+                }
+                Ok(RenderExpr::OperatorApplicationExp(new_op))
+            }
+            other => Ok(other.clone()),
+        }
+    }
+
+    let lowered = rewrite(
+        expr,
+        start_cypher_alias,
+        end_cypher_alias,
+        start_id_cols,
+        end_id_cols,
+        properties,
+    )?;
+    Ok(crate::render_plan::cte_extraction::render_expr_to_sql_string(&lowered, &[]))
 }
 
 #[cfg(test)]

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1692,6 +1692,13 @@ impl VariableLengthCteStrategy {
             generator.set_weight_cte(weight_config.clone());
         }
 
+        // #1103: a WHERE predicate naming BOTH endpoints. Set post-construction
+        // (like `needs_path_relationships` below) rather than widening the
+        // already-25-argument constructors. Honored by every family that reaches
+        // this generator; the fully-denormalized pattern returned earlier via
+        // `DenormalizedCteStrategy` and never gets here.
+        generator.both_endpoint_filters = filters.both_endpoint_sql.clone();
+
         // Skip path_relationships growth when relationships(path) isn't used
         generator.needs_path_relationships = context.needs_path_relationships;
         // Lightweight BFS mode for shortestPath + length(path)-only queries
@@ -1833,9 +1840,11 @@ mod tests {
             end_node_filters: None,
             relationship_filters: None,
             path_function_filters: None,
+            both_endpoint_filters: None,
             start_sql: None,
             end_sql: None,
             relationship_sql: None,
+            both_endpoint_sql: None,
         }
     }
 
@@ -2145,9 +2154,11 @@ mod tests {
             end_node_filters: None,
             relationship_filters: None,
             path_function_filters: None,
+            both_endpoint_filters: None,
             start_sql: None,
             end_sql: None,
             relationship_sql: None,
+            both_endpoint_sql: None,
         };
 
         // Generate SQL

--- a/src/render_plan/filter_pipeline.rs
+++ b/src/render_plan/filter_pipeline.rs
@@ -20,12 +20,23 @@ pub struct CategorizedFilters {
     pub end_node_filters: Option<RenderExpr>,
     pub relationship_filters: Option<RenderExpr>,
     pub path_function_filters: Option<RenderExpr>,
+    /// #1103: predicates referencing BOTH VLP endpoints (e.g. `friend <> root`,
+    /// `friend.id <> root.id`). These are neither start-only nor end-only: they
+    /// constrain the (start, FINAL endpoint) pair of a whole path, so they must
+    /// be applied on the post-recursion wrapper — never in the base case (which
+    /// sees only hop-1 rows) and never per-hop on the recursive arm (whose
+    /// `end_node` is an INTERMEDIATE node, and which Cypher's TRAIL semantics
+    /// allow to revisit any node). Kept separate from `start_node_filters` so
+    /// the base case cannot pick them up.
+    pub both_endpoint_filters: Option<RenderExpr>,
 
     // Pre-rendered SQL strings (for backward compatibility during CteManager transition)
     // These take precedence over RenderExpr when present
     pub start_sql: Option<String>,
     pub end_sql: Option<String>,
     pub relationship_sql: Option<String>,
+    /// Pre-rendered SQL for [`Self::both_endpoint_filters`] (#1103).
+    pub both_endpoint_sql: Option<String>,
 }
 
 /// Categorize filters based on which nodes/relationships they reference
@@ -67,9 +78,11 @@ pub fn categorize_filters(
         end_node_filters: None,
         relationship_filters: None,
         path_function_filters: None,
+        both_endpoint_filters: None,
         start_sql: None,
         end_sql: None,
         relationship_sql: None,
+        both_endpoint_sql: None,
     };
 
     if filter_expr.is_none() {
@@ -194,6 +207,7 @@ pub fn categorize_filters(
     let mut end_filters = Vec::new();
     let mut rel_filters = Vec::new();
     let mut path_fn_filters = Vec::new();
+    let mut both_endpoint_filters = Vec::new();
 
     for predicate in predicates {
         let refs_start = references_alias(&predicate, start_cypher_alias, "start_node");
@@ -255,12 +269,26 @@ pub fn categorize_filters(
                 rel_alias
             );
             rel_filters.push(predicate);
-        } else if refs_start && refs_end {
-            // Filter references both nodes - can't categorize simply
-            // For now, treat as start filter (will be in base case)
-            crate::debug_println!("DEBUG: Going to start_filters (refs both)");
-            start_filters.push(predicate);
+        } else if refs_start && refs_end && start_cypher_alias != end_cypher_alias {
+            // #1103: references BOTH endpoints. This is a whole-path predicate
+            // on the (start, FINAL endpoint) pair — it belongs in neither the
+            // base case nor the per-hop recursive arm. Routing it to
+            // `start_filters` (the pre-#1103 behavior) put it in the base case
+            // only, which was wrong in both directions: it pruned valid paths
+            // whose INTERMEDIATE hop-1 node failed the predicate, and it let
+            // paths whose FINAL endpoint fails the predicate survive past hop 1.
+            // Its own category defers it to the post-recursion wrapper.
+            crate::debug_println!("DEBUG: Going to both_endpoint_filters (refs both)");
+            log::debug!("  -> both_endpoint_filters (references start AND end)");
+            both_endpoint_filters.push(predicate);
         } else if refs_start {
+            // NOTE (#1103): a CLOSED pattern `(a)-[*]->(a)` has
+            // start_cypher_alias == end_cypher_alias, so `refs_start` and
+            // `refs_end` are the SAME test on ONE variable — not a two-endpoint
+            // comparison. The guard above excludes it so `a.prop = v` keeps its
+            // pre-#1103 start-filter placement (base case), which is correct:
+            // the closed pattern's endpoint identity is enforced structurally,
+            // not by this predicate.
             crate::debug_println!("DEBUG: Going to start_filters");
             start_filters.push(predicate);
         } else if refs_end {
@@ -331,6 +359,7 @@ pub fn categorize_filters(
         }))
     }
 
+    result.both_endpoint_filters = combine_with_and(both_endpoint_filters);
     result.start_node_filters = combine_with_and(start_filters);
     result.end_node_filters = combine_with_and(end_filters);
     result.relationship_filters = combine_with_and(rel_filters);

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -510,6 +510,16 @@ pub struct VariableLengthCteGenerator<'a> {
     pub start_node_filters: Option<String>, // WHERE clause for start node (e.g., "start_node.full_name = 'Alice'")
     pub end_node_filters: Option<String>, // WHERE clause for end node (e.g., "end_full_name = 'Bob'")
     pub relationship_filters: Option<String>, // WHERE clause for relationship (e.g., "rel.weight > 0.5")
+    /// #1103: WHERE predicate referencing BOTH endpoints (e.g.
+    /// `"end_node.id != start_node.id"`). A whole-path predicate on the
+    /// (start, FINAL endpoint) pair — applied ONLY in the post-recursion
+    /// wrapper, rewritten to the CTE's `start_*`/`end_*` output columns.
+    /// Never in the base case (which sees only hop-1 rows) and never per-hop on
+    /// the recursive arm: Cypher's TRAIL semantics let a path revisit any node,
+    /// so an intermediate hop failing the predicate must not prune the path.
+    /// Default `None`; only the standard/mixed/FK-edge generator honors it —
+    /// denormalized VLP is intercepted by `DenormalizedCteStrategy` upstream.
+    pub both_endpoint_filters: Option<String>,
     pub path_variable: Option<String>, // Path variable name from MATCH clause (e.g., "p" in "MATCH p = ...")
     pub relationship_types: Option<Vec<String>>, // Relationship type labels (e.g., ["FOLLOWS", "FRIENDS_WITH"])
     pub edge_id: Option<Identifier>, // Edge ID columns for relationship uniqueness (None = use from_id, to_id)
@@ -756,6 +766,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
             start_node_filters,
             end_node_filters,
             relationship_filters,
+            // #1103: set post-construction by the CteManager (mirrors
+            // `needs_path_relationships` / `use_bfs_mode`).
+            both_endpoint_filters: None,
             path_variable,
             relationship_types,
             edge_id,
@@ -832,6 +845,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
             start_node_filters,
             end_node_filters,
             relationship_filters,
+            // #1103: set post-construction by the CteManager (mirrors
+            // `needs_path_relationships` / `use_bfs_mode`).
+            both_endpoint_filters: None,
             path_variable,
             relationship_types,
             edge_id,
@@ -1638,6 +1654,79 @@ impl<'a> VariableLengthCteGenerator<'a> {
         !self.end_filter_applied_in_wrapper()
     }
 
+    /// #1103: is there a both-endpoint predicate to apply on the wrapper?
+    ///
+    /// Honored for every family that reaches this generator (standard, mixed
+    /// access, FK-edge, polymorphic) — including shortestPath, whose own
+    /// `_to_target`/ROW_NUMBER wrapper is layered on top and must see the
+    /// predicate applied to the FINAL endpoint pair. The fully-denormalized
+    /// pattern never reaches here (`DenormalizedCteStrategy` intercepts it
+    /// upstream in `cte_manager`), so this is a no-op there.
+    fn has_both_endpoint_filter(&self) -> bool {
+        self.both_endpoint_filters.is_some()
+    }
+
+    /// #1103: rewrite a both-endpoint predicate onto the recursive CTE's own
+    /// output columns.
+    ///
+    /// The predicate arrives written against the base-case JOIN aliases
+    /// (`start_node.x`, `end_node.y`). In the wrapper only the CTE's projected
+    /// columns exist, so BOTH sides must be rewritten:
+    ///   `start_node.<id_col>` → `start_id`, `end_node.<id_col>` → `end_id`,
+    ///   `start_node.<prop>`   → `start_<prop>`, `end_node.<prop>` → `end_<prop>`.
+    /// Non-id properties are only available when projected — see
+    /// [`Self::both_endpoint_filter_columns_available`], which refuses loudly
+    /// rather than emitting a reference to a column the CTE does not select.
+    fn rewrite_both_endpoint_filter_for_cte(&self, filter: &str) -> String {
+        use crate::query_planner::join_context::VLP_START_ID_COLUMN;
+        let mut rewritten = filter.replace(
+            &format!("{}.{}", self.start_node_alias, self.start_node_id_column),
+            VLP_START_ID_COLUMN,
+        );
+        rewritten = rewritten.replace(
+            &format!("{}.{}", self.end_node_alias, self.end_node_id_column),
+            VLP_END_ID_COLUMN,
+        );
+        for prop in &self.properties {
+            if prop.cypher_alias == self.start_cypher_alias {
+                let replacement = format!("start_{}", prop.alias);
+                rewritten = rewritten.replace(
+                    &format!("{}.{}", self.start_node_alias, prop.column_name),
+                    &replacement,
+                );
+                rewritten = rewritten.replace(
+                    &format!("{}.{}", self.start_node_alias, prop.alias),
+                    &replacement,
+                );
+            }
+            if prop.cypher_alias == self.end_cypher_alias {
+                let replacement = format!("end_{}", prop.alias);
+                rewritten = rewritten.replace(
+                    &format!("{}.{}", self.end_node_alias, prop.column_name),
+                    &replacement,
+                );
+                rewritten = rewritten.replace(
+                    &format!("{}.{}", self.end_node_alias, prop.alias),
+                    &replacement,
+                );
+            }
+        }
+        rewritten
+    }
+
+    /// #1103: did [`Self::rewrite_both_endpoint_filter_for_cte`] fully resolve
+    /// the predicate onto CTE columns?
+    ///
+    /// A leftover `start_node.` / `end_node.` qualifier means some referenced
+    /// property is NOT projected into the CTE (property pruning kept only what
+    /// the rest of the query needs). Emitting it anyway would be a Code-47
+    /// unknown-identifier at best and a wrong-column read at worst, so the
+    /// caller refuses loudly instead.
+    fn both_endpoint_filter_columns_available(&self, rewritten: &str) -> bool {
+        !rewritten.contains(&format!("{}.", self.start_node_alias))
+            && !rewritten.contains(&format!("{}.", self.end_node_alias))
+    }
+
     fn rewrite_end_filter_for_cte(&self, filter: &str) -> String {
         let mut rewritten = filter.replace(
             &format!("{}.{}", self.end_node_alias, self.end_node_id_column),
@@ -2041,7 +2130,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
         let needs_inner_cte = self.shortest_path_mode.is_some()
             || min_hops > 1
             || denorm_needs_end_filter_wrapper
-            || self.end_filter_applied_in_wrapper();
+            || self.end_filter_applied_in_wrapper()
+            // #1103: a both-endpoint predicate is always wrapper-applied, so it
+            // always forces a wrapper — even for a pure single-hop VLP, where
+            // the wrapper is a trivial pass-through filter.
+            || self.has_both_endpoint_filter();
         let recursive_cte_name = if needs_inner_cte {
             format!("{}_inner", self.cte_name)
         } else {
@@ -2135,6 +2228,38 @@ impl<'a> VariableLengthCteGenerator<'a> {
         } else {
             "hop_count"
         };
+        // #1103: the both-endpoint predicate, rewritten onto the recursive CTE's
+        // own `start_*`/`end_*` output columns. Every arm below applies it on a
+        // layer that reads FINISHED paths — after the recursion has run
+        // unfiltered, and (for shortestPath) BEFORE the shortest-path pick, so
+        // ranking never selects a path the predicate excludes.
+        //
+        // If the rewrite leaves a `start_node.` / `end_node.` qualifier the
+        // referenced property was pruned out of the CTE projection; emitting it
+        // would reference a nonexistent column, so refuse loudly instead of
+        // silently dropping or mis-resolving the predicate.
+        let both_endpoint_pred: Option<String> = match &self.both_endpoint_filters {
+            None => None,
+            Some(raw) => {
+                let rewritten = self.rewrite_both_endpoint_filter_for_cte(raw);
+                if self.both_endpoint_filter_columns_available(&rewritten) {
+                    Some(rewritten)
+                } else {
+                    return format!(
+                        "-- ERROR: ClickGraph cannot render this variable-length path (#1103).\n                         -- A WHERE predicate references BOTH path endpoints, but a property it\n                         -- uses is not projected into the path CTE, so it cannot be applied to\n                         -- the final endpoint pair: {}\n                         SELECT 1 WHERE 0",
+                        rewritten.replace('\n', " ")
+                    );
+                }
+            }
+        };
+        /// Helper: AND an optional extra predicate onto an existing WHERE body.
+        fn and_opt(base: &str, extra: Option<&String>) -> String {
+            match extra {
+                Some(e) => format!("({}) AND ({})", base, e),
+                None => base.to_string(),
+            }
+        }
+
         let sql = match (&self.shortest_path_mode, &self.end_node_filters) {
             (Some(ShortestPathMode::Shortest), Some(end_filters)) => {
                 // Rewrite end filter for use in intermediate CTE
@@ -2154,6 +2279,11 @@ impl<'a> VariableLengthCteGenerator<'a> {
                     filter_with_bounds =
                         format!("({}) AND hop_count <= {}", filter_with_bounds, max);
                 }
+                // #1103: applied on `_to_target`, i.e. BEFORE the ROW_NUMBER
+                // shortest pick — otherwise ranking could choose a path the
+                // predicate excludes and then discard it, yielding no row where
+                // a longer qualifying path exists.
+                filter_with_bounds = and_opt(&filter_with_bounds, both_endpoint_pred.as_ref());
 
                 // CORRECT ORDER: Filter to target FIRST (with min/max_hops), then find shortest path from EACH start node
                 // This ensures we get the shortest path TO THE TARGET within hop bounds from each source
@@ -2182,6 +2312,8 @@ impl<'a> VariableLengthCteGenerator<'a> {
                     filter_with_bounds =
                         format!("({}) AND hop_count <= {}", filter_with_bounds, max);
                 }
+                // #1103: applied before the shortest pick — see the Shortest arm.
+                filter_with_bounds = and_opt(&filter_with_bounds, both_endpoint_pred.as_ref());
 
                 // CORRECT ORDER: Filter to target FIRST (with min/max_hops), then find shortest path from EACH start node
                 format!(
@@ -2195,21 +2327,49 @@ impl<'a> VariableLengthCteGenerator<'a> {
             (Some(ShortestPathMode::Shortest), None) => {
                 // 2-tier: inner → select shortest path to EACH end node (no target filter)
                 // Use window function to get the shortest path to each distinct end_id
-                format!(
-                    "{name}_inner AS (\n{body}\n),\n{name} AS (\n    SELECT * FROM (\n        SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY {order_col} ASC) as rn\n        FROM {name}_inner\n    ) WHERE rn = 1\n)",
-                    name = self.cte_name,
-                    body = query_body,
-                    order_col = order_by_column,
-                )
+                //
+                // #1103: with a both-endpoint predicate there is no `_to_target`
+                // layer to carry it, so insert one — the predicate MUST narrow the
+                // candidate set BEFORE the ROW_NUMBER pick, or ranking could select
+                // an excluded path and drop the qualifying longer one.
+                match &both_endpoint_pred {
+                    Some(pred) => format!(
+                        "{name}_inner AS (\n{body}\n),\n{name}_to_target AS (\n    SELECT * FROM {name}_inner WHERE {pred}\n),\n{name} AS (\n    SELECT * FROM (\n        SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY {order_col} ASC) as rn\n        FROM {name}_to_target\n    ) WHERE rn = 1\n)",
+                        name = self.cte_name,
+                        body = query_body,
+                        pred = pred,
+                        order_col = order_by_column,
+                    ),
+                    None => format!(
+                        "{name}_inner AS (\n{body}\n),\n{name} AS (\n    SELECT * FROM (\n        SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY {order_col} ASC) as rn\n        FROM {name}_inner\n    ) WHERE rn = 1\n)",
+                        name = self.cte_name,
+                        body = query_body,
+                        order_col = order_by_column,
+                    ),
+                }
             }
             (Some(ShortestPathMode::AllShortest), None) => {
                 // 2-tier: inner → select all shortest (no target filter)
-                format!(
-                    "{name}_inner AS (\n{body}\n),\n{name} AS (\n    SELECT * FROM {name}_inner WHERE {order_col} = (SELECT MIN({order_col}) FROM {name}_inner)\n)",
-                    name = self.cte_name,
-                    body = query_body,
-                    order_col = order_by_column,
-                )
+                //
+                // #1103: the predicate must constrain BOTH the rows kept and the
+                // MIN() subquery that defines "shortest" — otherwise the minimum
+                // is computed over paths the predicate excludes and the arm can
+                // return nothing where a qualifying longer path exists.
+                match &both_endpoint_pred {
+                    Some(pred) => format!(
+                        "{name}_inner AS (\n{body}\n),\n{name}_to_target AS (\n    SELECT * FROM {name}_inner WHERE {pred}\n),\n{name} AS (\n    SELECT * FROM {name}_to_target WHERE {order_col} = (SELECT MIN({order_col}) FROM {name}_to_target)\n)",
+                        name = self.cte_name,
+                        body = query_body,
+                        pred = pred,
+                        order_col = order_by_column,
+                    ),
+                    None => format!(
+                        "{name}_inner AS (\n{body}\n),\n{name} AS (\n    SELECT * FROM {name}_inner WHERE {order_col} = (SELECT MIN({order_col}) FROM {name}_inner)\n)",
+                        name = self.cte_name,
+                        body = query_body,
+                        order_col = order_by_column,
+                    ),
+                }
             }
             (None, Some(end_filters)) => {
                 // For denormalized VLP, end filters are NOT applied in base/recursive cases
@@ -2242,7 +2402,12 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
                     format!(
                         "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE ({}){}\n)",
-                        self.cte_name, query_body, self.cte_name, self.cte_name, rewritten_filter, min_hops_filter
+                        self.cte_name,
+                        query_body,
+                        self.cte_name,
+                        self.cte_name,
+                        and_opt(&rewritten_filter, both_endpoint_pred.as_ref()),
+                        min_hops_filter
                     )
                 } else {
                     // Standard VLP.
@@ -2260,14 +2425,32 @@ impl<'a> VariableLengthCteGenerator<'a> {
                         };
                         format!(
                             "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE ({}){}\n)",
-                            self.cte_name, query_body, self.cte_name, self.cte_name, rewritten_filter, min_hops_clause
+                            self.cte_name,
+                            query_body,
+                            self.cte_name,
+                            self.cte_name,
+                            and_opt(&rewritten_filter, both_endpoint_pred.as_ref()),
+                            min_hops_clause
                         )
-                    } else if min_hops > 1 {
-                        // No wrapper carries the end filter (pure single-hop): the
-                        // filter is already in the base case. Only bound min-hops.
+                    } else if min_hops > 1 || both_endpoint_pred.is_some() {
+                        // No wrapper carries the end filter (pure single-hop): that
+                        // filter is already in the base case. The wrapper here only
+                        // bounds min-hops and (#1103) applies the both-endpoint
+                        // predicate, which is never base-case-applied.
+                        let mut conds = Vec::new();
+                        if min_hops > 1 {
+                            conds.push(format!("hop_count >= {}", min_hops));
+                        }
+                        if let Some(pred) = &both_endpoint_pred {
+                            conds.push(format!("({})", pred));
+                        }
                         format!(
-                            "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE hop_count >= {}\n)",
-                            self.cte_name, query_body, self.cte_name, self.cte_name, min_hops
+                            "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE {}\n)",
+                            self.cte_name,
+                            query_body,
+                            self.cte_name,
+                            self.cte_name,
+                            conds.join(" AND ")
                         )
                     } else {
                         format!("{} AS (\n{}\n)", self.cte_name, query_body)
@@ -2279,10 +2462,24 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 // Base case starts at hop 1 to allow recursion, but we need to filter
                 // results to respect min_hops (e.g., *2.. should only return hop_count >= 2)
                 // max_hops is already enforced by recursion termination condition
-                if min_hops > 1 {
+                //
+                // #1103: a both-endpoint predicate is applied here too — this is
+                // the only layer that sees a FINISHED path's (start, end) pair.
+                if min_hops > 1 || both_endpoint_pred.is_some() {
+                    let mut conds = Vec::new();
+                    if min_hops > 1 {
+                        conds.push(format!("hop_count >= {}", min_hops));
+                    }
+                    if let Some(pred) = &both_endpoint_pred {
+                        conds.push(format!("({})", pred));
+                    }
                     format!(
-                        "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE hop_count >= {}\n)",
-                        self.cte_name, query_body, self.cte_name, self.cte_name, min_hops
+                        "{}_inner AS (\n{}\n),\n{} AS (\n    SELECT * FROM {}_inner WHERE {}\n)",
+                        self.cte_name,
+                        query_body,
+                        self.cte_name,
+                        self.cte_name,
+                        conds.join(" AND ")
                     )
                 } else {
                     // No filtering needed (min_hops <= 1)

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -1656,75 +1656,41 @@ impl<'a> VariableLengthCteGenerator<'a> {
 
     /// #1103: is there a both-endpoint predicate to apply on the wrapper?
     ///
-    /// Honored for every family that reaches this generator (standard, mixed
-    /// access, FK-edge, polymorphic) — including shortestPath, whose own
-    /// `_to_target`/ROW_NUMBER wrapper is layered on top and must see the
-    /// predicate applied to the FINAL endpoint pair. The fully-denormalized
-    /// pattern never reaches here (`DenormalizedCteStrategy` intercepts it
-    /// upstream in `cte_manager`), so this is a no-op there.
-    fn has_both_endpoint_filter(&self) -> bool {
+    /// Honored by the wrapper built in [`Self::generate_recursive_sql`] —
+    /// standard, mixed access, FK-edge, polymorphic, and shortestPath (whose
+    /// `_to_target`/ROW_NUMBER layer is built there too and must see the
+    /// predicate applied to the FINAL endpoint pair).
+    ///
+    /// NOT reached by three generators that `generate_recursive_sql` delegates
+    /// to before the wrapper is built — BFS shortestPath, weighted-BFS
+    /// reconstruction, and heterogeneous-polymorphic paths — nor by the
+    /// fully-denormalized pattern (`DenormalizedCteStrategy`) or multi-type VLP
+    /// (flat join expansion), both intercepted upstream. `CteManager` refuses
+    /// LOUDLY before constructing any of those with a both-endpoint predicate
+    /// set, so a bypass can never silently drop it; see
+    /// `both_endpoint_filter_unsupported_here` in `cte_manager`.
+    pub(crate) fn has_both_endpoint_filter(&self) -> bool {
         self.both_endpoint_filters.is_some()
     }
 
-    /// #1103: rewrite a both-endpoint predicate onto the recursive CTE's own
-    /// output columns.
-    ///
-    /// The predicate arrives written against the base-case JOIN aliases
-    /// (`start_node.x`, `end_node.y`). In the wrapper only the CTE's projected
-    /// columns exist, so BOTH sides must be rewritten:
-    ///   `start_node.<id_col>` → `start_id`, `end_node.<id_col>` → `end_id`,
-    ///   `start_node.<prop>`   → `start_<prop>`, `end_node.<prop>` → `end_<prop>`.
-    /// Non-id properties are only available when projected — see
-    /// [`Self::both_endpoint_filter_columns_available`], which refuses loudly
-    /// rather than emitting a reference to a column the CTE does not select.
-    fn rewrite_both_endpoint_filter_for_cte(&self, filter: &str) -> String {
-        use crate::query_planner::join_context::VLP_START_ID_COLUMN;
-        let mut rewritten = filter.replace(
-            &format!("{}.{}", self.start_node_alias, self.start_node_id_column),
-            VLP_START_ID_COLUMN,
-        );
-        rewritten = rewritten.replace(
-            &format!("{}.{}", self.end_node_alias, self.end_node_id_column),
-            VLP_END_ID_COLUMN,
-        );
-        for prop in &self.properties {
-            if prop.cypher_alias == self.start_cypher_alias {
-                let replacement = format!("start_{}", prop.alias);
-                rewritten = rewritten.replace(
-                    &format!("{}.{}", self.start_node_alias, prop.column_name),
-                    &replacement,
-                );
-                rewritten = rewritten.replace(
-                    &format!("{}.{}", self.start_node_alias, prop.alias),
-                    &replacement,
-                );
-            }
-            if prop.cypher_alias == self.end_cypher_alias {
-                let replacement = format!("end_{}", prop.alias);
-                rewritten = rewritten.replace(
-                    &format!("{}.{}", self.end_node_alias, prop.column_name),
-                    &replacement,
-                );
-                rewritten = rewritten.replace(
-                    &format!("{}.{}", self.end_node_alias, prop.alias),
-                    &replacement,
-                );
-            }
+    /// #1103: does this generator's shape route AROUND the wrapper that applies
+    /// a both-endpoint predicate? Used by `CteManager` to refuse loudly rather
+    /// than let the predicate vanish. Mirrors the early returns at the top of
+    /// [`Self::generate_recursive_sql`] exactly.
+    pub(crate) fn bypasses_both_endpoint_wrapper(&self) -> Option<&'static str> {
+        if self.use_bfs_mode {
+            return Some("BFS shortest-path mode (length(path)-only optimization)");
         }
-        rewritten
-    }
-
-    /// #1103: did [`Self::rewrite_both_endpoint_filter_for_cte`] fully resolve
-    /// the predicate onto CTE columns?
-    ///
-    /// A leftover `start_node.` / `end_node.` qualifier means some referenced
-    /// property is NOT projected into the CTE (property pruning kept only what
-    /// the rest of the query needs). Emitting it anyway would be a Code-47
-    /// unknown-identifier at best and a wrong-column read at worst, so the
-    /// caller refuses loudly instead.
-    fn both_endpoint_filter_columns_available(&self, rewritten: &str) -> bool {
-        !rewritten.contains(&format!("{}.", self.start_node_alias))
-            && !rewritten.contains(&format!("{}.", self.end_node_alias))
+        if self.weight_cte.is_some()
+            && self.shortest_path_mode.is_some()
+            && self.end_node_filters.is_some()
+        {
+            return Some("weighted shortest path with a target filter");
+        }
+        if self.is_heterogeneous_polymorphic_path() {
+            return Some("heterogeneous polymorphic path (two-CTE structure)");
+        }
+        None
     }
 
     fn rewrite_end_filter_for_cte(&self, filter: &str) -> String {
@@ -2238,20 +2204,13 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // referenced property was pruned out of the CTE projection; emitting it
         // would reference a nonexistent column, so refuse loudly instead of
         // silently dropping or mis-resolving the predicate.
-        let both_endpoint_pred: Option<String> = match &self.both_endpoint_filters {
-            None => None,
-            Some(raw) => {
-                let rewritten = self.rewrite_both_endpoint_filter_for_cte(raw);
-                if self.both_endpoint_filter_columns_available(&rewritten) {
-                    Some(rewritten)
-                } else {
-                    return format!(
-                        "-- ERROR: ClickGraph cannot render this variable-length path (#1103).\n                         -- A WHERE predicate references BOTH path endpoints, but a property it\n                         -- uses is not projected into the path CTE, so it cannot be applied to\n                         -- the final endpoint pair: {}\n                         SELECT 1 WHERE 0",
-                        rewritten.replace('\n', " ")
-                    );
-                }
-            }
-        };
+        // Already lowered onto this CTE's own `start_*`/`end_*` columns by
+        // `cte_manager::lower_both_endpoint_filter_to_cte_columns`, which owns
+        // the structural rewrite AND the loud failure for an unprojected
+        // property (it has a real `Result` channel; `generate_sql` returns a
+        // bare `String` and must never fabricate an "error" that is itself
+        // valid SQL returning zero rows).
+        let both_endpoint_pred: Option<String> = self.both_endpoint_filters.clone();
         /// Helper: AND an optional extra predicate onto an existing WHERE body.
         fn and_opt(base: &str, extra: Option<&String>) -> String {
             match extra {

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_0.clickhouse.sql
@@ -4,28 +4,34 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         ['FOLLOWS'] as path_relationships,
-        [start_node.user_id, end_node.user_id] as path_nodes
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        start_node.email_address as start_email_address,
+        end_node.email_address as end_email_address
     FROM test_integration.users_test AS start_node
     JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
-    WHERE start_node.email_address != end_node.email_address
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         arrayConcat(vp.path_relationships, ['FOLLOWS']) as path_relationships,
-        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        vp.start_email_address as start_email_address,
+        end_node.email_address as end_email_address
     FROM vlp_a_b_inner vp
     JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
     WHERE vp.hop_count < 5
       AND NOT has(vp.path_nodes, end_node.user_id)
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_email_address != end_email_address
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_0.databricks.sql
@@ -4,28 +4,34 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         array('FOLLOWS') as path_relationships,
-        array(start_node.user_id, end_node.user_id) as path_nodes
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        start_node.email_address as start_email_address,
+        end_node.email_address as end_email_address
     FROM test_integration.users_test AS start_node
     JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
-    WHERE start_node.email_address != end_node.email_address
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         concat(vp.path_relationships, array('FOLLOWS')) as path_relationships,
-        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        vp.start_email_address as start_email_address,
+        end_node.email_address as end_email_address
     FROM vlp_a_b_inner vp
     JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
     WHERE vp.hop_count < 5
       AND NOT array_contains(vp.path_nodes, end_node.user_id)
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_email_address != end_email_address
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_1.clickhouse.sql
@@ -4,28 +4,34 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         ['FOLLOWS'] as path_relationships,
-        [start_node.user_id, end_node.user_id] as path_nodes
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        start_node.country as start_country,
+        end_node.country as end_country
     FROM test_integration.users_test AS start_node
     JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
-    WHERE start_node.country != end_node.country
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         arrayConcat(vp.path_relationships, ['FOLLOWS']) as path_relationships,
-        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        vp.start_country as start_country,
+        end_node.country as end_country
     FROM vlp_a_b_inner vp
     JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
     WHERE vp.hop_count < 5
       AND NOT has(vp.path_nodes, end_node.user_id)
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_country != end_country
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_integration/test_pattern_matrix__TestStandardSchema_test_shortest_path_1.databricks.sql
@@ -4,28 +4,34 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         array('FOLLOWS') as path_relationships,
-        array(start_node.user_id, end_node.user_id) as path_nodes
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        start_node.country as start_country,
+        end_node.country as end_country
     FROM test_integration.users_test AS start_node
     JOIN test_integration.user_follows_test AS rel ON start_node.user_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
-    WHERE start_node.country != end_node.country
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         concat(vp.path_relationships, array('FOLLOWS')) as path_relationships,
-        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        vp.start_country as start_country,
+        end_node.country as end_country
     FROM vlp_a_b_inner vp
     JOIN test_integration.user_follows_test AS rel ON vp.end_id = rel.follower_id
     JOIN test_integration.users_test AS end_node ON rel.followed_id = end_node.user_id
     WHERE vp.hop_count < 5
       AND NOT array_contains(vp.path_nodes, end_node.user_id)
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_country != end_country
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_0.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_0.clickhouse.sql
@@ -4,18 +4,22 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         ['LIKES'] as path_relationships,
-        [start_node.user_id, end_node.user_id] as path_nodes
+        [start_node.user_id, end_node.user_id] as path_nodes,
+        start_node.full_name as start_full_name,
+        end_node.full_name as end_full_name
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.full_name != end_node.full_name
+    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         arrayConcat(vp.path_relationships, ['LIKES']) as path_relationships,
-        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes
+        arrayConcat(vp.path_nodes, [end_node.user_id]) as path_nodes,
+        vp.start_full_name as start_full_name,
+        end_node.full_name as end_full_name
     FROM vlp_a_b_inner vp
     JOIN brahmand.interactions AS rel ON vp.end_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
@@ -23,10 +27,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT has(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_full_name != end_full_name
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_0.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_0.databricks.sql
@@ -4,18 +4,22 @@ WITH RECURSIVE vlp_a_b_inner AS (
         end_node.user_id as end_id,
         1 as hop_count,
         array('LIKES') as path_relationships,
-        array(start_node.user_id, end_node.user_id) as path_nodes
+        array(start_node.user_id, end_node.user_id) as path_nodes,
+        start_node.full_name as start_full_name,
+        end_node.full_name as end_full_name
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.full_name != end_node.full_name
+    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
         end_node.user_id as end_id,
         vp.hop_count + 1 as hop_count,
         concat(vp.path_relationships, array('LIKES')) as path_relationships,
-        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes
+        concat(vp.path_nodes, array(end_node.user_id)) as path_nodes,
+        vp.start_full_name as start_full_name,
+        end_node.full_name as end_full_name
     FROM vlp_a_b_inner vp
     JOIN brahmand.interactions AS rel ON vp.end_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
@@ -23,10 +27,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT array_contains(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_full_name != end_full_name
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_1.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_1.clickhouse.sql
@@ -8,7 +8,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.user_id != end_node.user_id
+    WHERE rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -23,10 +23,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT has(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_id != end_id
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_1.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_1.databricks.sql
@@ -8,7 +8,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.user_id != end_node.user_id
+    WHERE rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -23,10 +23,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT array_contains(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'AUTHORED' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_id != end_id
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_2.clickhouse.sql
@@ -8,7 +8,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.user_id != end_node.user_id
+    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -23,10 +23,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT has(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_id != end_id
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/social_polymorphic/test_pattern_matrix__TestPolymorphicSchema_test_shortest_path_2.databricks.sql
@@ -8,7 +8,7 @@ WITH RECURSIVE vlp_a_b_inner AS (
     FROM brahmand.users_bench AS start_node
     JOIN brahmand.interactions AS rel ON start_node.user_id = rel.from_id
     JOIN brahmand.users_bench AS end_node ON rel.to_id = end_node.user_id
-    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User' AND start_node.user_id != end_node.user_id
+    WHERE rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
     UNION ALL
     SELECT
         vp.start_id,
@@ -23,10 +23,13 @@ WITH RECURSIVE vlp_a_b_inner AS (
       AND NOT array_contains(vp.path_nodes, end_node.user_id)
       AND rel.interaction_type = 'LIKES' AND rel.from_type = 'User' AND rel.to_type = 'User'
 ),
+vlp_a_b_to_target AS (
+    SELECT * FROM vlp_a_b_inner WHERE start_id != end_id
+),
 vlp_a_b AS (
     SELECT * FROM (
         SELECT *, ROW_NUMBER() OVER (PARTITION BY end_id ORDER BY hop_count ASC) as rn
-        FROM vlp_a_b_inner
+        FROM vlp_a_b_to_target
     ) WHERE rn = 1
 )
 SELECT 

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1056,3 +1056,142 @@ async fn ldbc_1103_closed_pattern_keeps_base_case_placement() {
          case (it is not a two-endpoint comparison):\n{sql}"
     );
 }
+
+/// Like [`generate_sql_inline`] but surfaces a render error instead of
+/// panicking — for asserting LOUD refusals.
+async fn try_render_inline(schema: &GraphSchema, cypher: &str) -> Result<String, String> {
+    let schema = schema.clone();
+    let cypher = cypher.to_string();
+    let ctx = QueryContext::new(Some("default".to_string()));
+    with_query_context(ctx, async {
+        set_current_schema(Arc::new(schema.clone()));
+        let cleaned = strip_comments(&cypher);
+        let (_rem, statement) = clickgraph::open_cypher_parser::parse_cypher_statement(&cleaned)
+            .unwrap_or_else(|e| panic!("parse: {e:?}"));
+        let (logical_plan, plan_ctx) =
+            evaluate_read_statement(statement, &schema, None, None, None)
+                .unwrap_or_else(|e| panic!("plan: {e:?}"));
+        match logical_plan_to_render_plan_with_ctx(logical_plan, &schema, Some(&plan_ctx)) {
+            Ok(rp) => Ok(rp.to_sql()),
+            Err(e) => Err(format!("{e:?}")),
+        }
+    })
+    .await
+}
+
+// --- #1103 review hardening -------------------------------------------------
+// The first cut of this fix rewrote the predicate by `str::replace` over
+// already-rendered SQL. Adversarial review found that corrupts any property
+// whose name is a PREFIX-collision with the node_id column or another property,
+// and rewrites alias-looking text inside string literals — valid SQL, wrong
+// column, no error. The rewrite is now structural (on the RenderExpr, in
+// `cte_manager::lower_both_endpoint_filter_to_cte_columns`). These tests pin
+// exactly the shapes a textual rewrite gets wrong.
+
+/// #1103: node_id `code` is a PREFIX of property `codeName`; a textual rewrite
+/// produced `end_idName`, which is a different REAL column on this fixture.
+#[tokio::test]
+async fn ldbc_1103_prefix_collision_property_not_corrupted() {
+    let schema = load_schema_from("schemas/test/prefix_collision_vlp.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Item)-[:LINK*1..3]->(b:Item)
+         WHERE a.code = 'X' AND b.codeName <> a.codeName
+         RETURN b.idName",
+    )
+    .await;
+    assert!(
+        sql.contains("(end_codeName != start_codeName)"),
+        "#1103: prefix-colliding property must resolve to its OWN column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_idName !=") && !sql.contains("!= start_idName"),
+        "#1103: must not corrupt `codeName` into the unrelated `idName` column:\n{sql}"
+    );
+}
+
+/// #1103: a string literal that happens to contain alias-looking text must be
+/// left byte-intact — a textual rewrite mangled it into a column reference.
+#[tokio::test]
+async fn ldbc_1103_string_literal_not_rewritten() {
+    let schema = load_schema_from("schemas/test/prefix_collision_vlp.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Item)-[:LINK*1..3]->(b:Item)
+         WHERE a.code = 'X' AND (b.codeName <> a.codeName OR b.idName = 'end_node.codeName')
+         RETURN b.idName",
+    )
+    .await;
+    assert!(
+        sql.contains("'end_node.codeName'"),
+        "#1103: the string literal must survive the rewrite unchanged:\n{sql}"
+    );
+}
+
+/// #1103: an unprojected property must fail with a REAL error. The first cut
+/// returned a `-- ERROR …\nSELECT 1 WHERE 0` *string*, which is valid SQL that
+/// executes and returns zero rows — a silent wrong answer wearing an error's
+/// clothes.
+#[tokio::test]
+async fn ldbc_1103_unprojected_property_is_a_real_error() {
+    let schema = load_schema_from("schemas/test/prefix_collision_vlp.yaml");
+    // `other_col`/`idName` is projected only when referenced; compare on a
+    // property the CTE does not carry.
+    let result = try_render_inline(
+        &schema,
+        "MATCH (a:Item)-[:LINK*1..3]->(b:Item) WHERE a.code = 'X' AND b.codeName <> a.codeName
+         RETURN b.code",
+    )
+    .await;
+    // Either it resolves (property projected) or it errors — but it must NEVER
+    // emit the fake-error sentinel that silently returns no rows.
+    if let Ok(sql) = &result {
+        assert!(
+            !sql.contains("SELECT 1 WHERE 0"),
+            "#1103: must not emit a fake-error SQL sentinel:\n{sql}"
+        );
+    }
+}
+
+/// #1103: COMPOSITE node_id is projected as ONE pipe-joined `start_id`/`end_id`,
+/// so every key column maps to it — and the per-column expansion collapses to a
+/// single predicate rather than a repeated conjunct.
+#[tokio::test]
+async fn ldbc_1103_composite_node_id_collapses_to_single_id_predicate() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a1:Account)-[:TRANSFERRED*1..2]->(a2:Account)
+         WHERE a2 <> a1
+         RETURN a2.account_type LIMIT 5",
+    )
+    .await;
+    assert!(
+        sql.contains("WHERE (NOT (end_id = start_id))"),
+        "#1103: composite node_id identity must collapse to the pipe-joined id \
+         columns, deduplicated:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_id = start_id AND end_id = start_id"),
+        "#1103: the collapsed per-column conjuncts must be deduplicated:\n{sql}"
+    );
+}
+
+/// #1103: three generator shapes return before the wrapper is built and would
+/// DROP the predicate silently. They must refuse loudly instead.
+#[tokio::test]
+async fn ldbc_1103_heterogeneous_polymorphic_refuses_loudly() {
+    let schema = load_schema_from("schemas/dev/social_polymorphic.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User)-[:LIKES*1..2]->(b:Post)
+         WHERE a.user_id = 1 AND b.content <> a.name
+         RETURN b.post_id",
+    )
+    .await
+    .expect_err("#1103: a path shape that cannot apply the predicate must refuse");
+    assert!(
+        err.contains("referencing BOTH path endpoints is not supported"),
+        "#1103: the refusal must name the unsupported both-endpoint case:\n{err}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -822,14 +822,25 @@ async fn ldbc_1100_bare_node_identity_in_vlp_filter() {
          RETURN friend.id LIMIT 5",
     )
     .await;
+    // #1100's invariant is that the bare aliases normalize to the endpoints'
+    // REAL node_id columns. #1103 then moved the placement: a both-endpoint
+    // predicate is applied on the post-recursion wrapper, where those columns
+    // are the CTE's own `start_id`/`end_id` projections of the same node_ids.
     assert!(
-        sql.contains("end_node.id = start_node.id") || sql.contains("start_node.id = end_node.id"),
-        "#1100: bare-node identity `friend <> root` must normalize to the VLP \
-         endpoint node_id columns:\n{sql}"
+        sql.contains("end_id = start_id") || sql.contains("start_id = end_id"),
+        "#1100/#1103: bare-node identity `friend <> root` must normalize to the \
+         VLP endpoint node_id columns, applied on the wrapper:\n{sql}"
     );
     assert!(
         !sql.contains("friend != root") && !sql.contains("friend = root"),
         "#1100: bare alias names must NOT survive into the VLP CTE body:\n{sql}"
+    );
+    // #1103: it must NOT be applied in the base case — that both prunes valid
+    // paths through a failing intermediate and leaks self-paths past hop 1.
+    assert!(
+        !sql.contains("end_node.id = start_node.id")
+            && !sql.contains("start_node.id = end_node.id"),
+        "#1103: a both-endpoint predicate must not be applied in the base case:\n{sql}"
     );
 }
 
@@ -846,9 +857,10 @@ async fn ldbc_1100_bare_node_identity_nested_in_and() {
          RETURN friend.id LIMIT 5",
     )
     .await;
+    // #1103: normalized to the endpoints' node_ids, applied on the wrapper.
     assert!(
-        sql.contains("end_node.id = start_node.id") || sql.contains("start_node.id = end_node.id"),
-        "#1100: `=` node identity nested in AND must normalize:\n{sql}"
+        sql.contains("end_id = start_id") || sql.contains("start_id = end_id"),
+        "#1100/#1103: `=` node identity nested in AND must normalize:\n{sql}"
     );
     // The sibling property filter must survive (applied on the endpoint).
     assert!(
@@ -879,10 +891,13 @@ async fn ldbc_1100_bare_node_identity_renamed_node_id() {
          RETURN friend.user_id LIMIT 5",
     )
     .await;
+    // #1103: the wrapper projects the renamed node_id as `start_id`/`end_id`;
+    // what #1100 guards is that a REAL id column (not a hardcoded `.id`) was
+    // resolved — verified here by the absence of any `.id` reference.
     assert!(
-        sql.contains("end_node.user_id = start_node.user_id")
-            || sql.contains("start_node.user_id = end_node.user_id"),
-        "#1100: renamed node_id must compare `user_id`, not `.id`:\n{sql}"
+        sql.contains("end_id = start_id") || sql.contains("start_id = end_id"),
+        "#1100/#1103: renamed node_id identity must normalize to the endpoint \
+         id columns on the wrapper:\n{sql}"
     );
     assert!(
         !sql.contains("node.id = ") && !sql.contains(".id !="),
@@ -916,5 +931,128 @@ async fn ldbc_1100_bare_node_identity_composite_node_id() {
     assert!(
         !sql.contains(".id = ") && !sql.contains(".id !="),
         "#1100: must NOT collapse a composite node_id to `.id`:\n{sql}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #1103 — both-endpoint WHERE predicate on a VLP
+//
+// A predicate naming BOTH VLP endpoints (`friend <> root`, or its property
+// form) constrains the (start, FINAL endpoint) pair of a whole path. Before
+// #1103 `categorize_filters` routed it to `start_filters`, which the VLP CTE
+// applies in the BASE CASE only. That was wrong in both directions:
+//
+//   * dropped rows — the base case's `end_node` is the hop-1 node, an
+//     INTERMEDIATE node of any longer path. Filtering there deletes valid paths
+//     whose final endpoint satisfies the predicate (verified live on LDBC SF1:
+//     `*1..2` returned 3728 rows where the hand-computed oracle is 3942).
+//   * leaked rows — nothing re-applied it after hop 1, so at `*1..N` (N>=3) on a
+//     cyclic graph, paths returning to the start survived (52 self-paths).
+//
+// The fix routes it to its own `both_endpoint_filters` category, applied on the
+// post-recursion wrapper. Cypher uses TRAIL semantics (relationships cannot
+// repeat, NODES MAY), so it must NOT be applied per-hop on the recursive arm:
+// a path may legally revisit the start node and end elsewhere.
+// ---------------------------------------------------------------------------
+
+/// #1103: the bare-node form must be applied on the WRAPPER, not the base case.
+#[tokio::test]
+async fn ldbc_1103_both_endpoint_filter_applied_in_wrapper() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..3]-(friend:Person)
+         WHERE friend <> root
+         RETURN friend.id",
+    )
+    .await;
+    assert!(
+        sql.contains("_inner WHERE (NOT (end_id = start_id))")
+            || sql.contains("_inner WHERE (NOT (start_id = end_id))"),
+        "#1103: both-endpoint identity must be applied on the post-recursion \
+         wrapper against the CTE's own start_id/end_id:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_node.id = start_node.id")
+            && !sql.contains("start_node.id = end_node.id"),
+        "#1103: must NOT be applied in the base case (prunes intermediate hops \
+         AND leaks self-paths past hop 1):\n{sql}"
+    );
+}
+
+/// #1103: the PROPERTY form takes the identical path (same categorization
+/// seam), and its properties must be projected so the wrapper can read them.
+#[tokio::test]
+async fn ldbc_1103_both_endpoint_property_form_in_wrapper() {
+    let schema = load_ldbc_schema();
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (root:Person {id: 14})-[:KNOWS*1..3]-(friend:Person)
+         WHERE friend.firstName <> root.firstName
+         RETURN friend.id",
+    )
+    .await;
+    assert!(
+        sql.contains("start_node.firstName as start_firstName"),
+        "#1103: the start-side property must be projected into the CTE so the \
+         wrapper can compare it:\n{sql}"
+    );
+    assert!(
+        sql.contains("_inner WHERE (end_firstName != start_firstName)")
+            || sql.contains("_inner WHERE (start_firstName != end_firstName)"),
+        "#1103: property form must be applied on the wrapper:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_node.firstName != start_node.firstName"),
+        "#1103: property form must NOT remain in the base case:\n{sql}"
+    );
+}
+
+/// #1103: for shortestPath the predicate must narrow candidates BEFORE the
+/// shortest pick. Applying it after ranking would let ROW_NUMBER select an
+/// excluded path and then discard it, returning no row where a longer
+/// qualifying path exists.
+#[tokio::test]
+async fn ldbc_1103_both_endpoint_filter_precedes_shortest_pick() {
+    let schema = load_schema_from("benchmarks/social_network/schemas/social_benchmark.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH p = shortestPath((a:User)-[:FOLLOWS*1..5]->(b:User))
+         WHERE a.email <> b.email
+         RETURN length(p)",
+    )
+    .await;
+    let to_target = sql
+        .find("_to_target AS (")
+        .unwrap_or_else(|| panic!("#1103: expected a _to_target layer:\n{sql}"));
+    let row_number = sql
+        .find("ROW_NUMBER()")
+        .unwrap_or_else(|| panic!("#1103: expected a ROW_NUMBER pick:\n{sql}"));
+    assert!(
+        to_target < row_number,
+        "#1103: the both-endpoint filter layer must precede the shortest pick:\n{sql}"
+    );
+    assert!(
+        sql.contains("start_email_address != end_email_address")
+            || sql.contains("end_email_address != start_email_address"),
+        "#1103: shortestPath both-endpoint filter must compare CTE columns:\n{sql}"
+    );
+}
+
+/// #1103 SCOPE — a CLOSED pattern `(a)-[*]->(a)` binds ONE variable, so
+/// `refs_start` and `refs_end` are the same test and `a.prop = v` is a plain
+/// start filter. It must keep its pre-#1103 base-case placement.
+#[tokio::test]
+async fn ldbc_1103_closed_pattern_keeps_base_case_placement() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(a) WHERE a.user_id = 1 RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("WHERE start_node.user_id = 1"),
+        "#1103: a closed pattern's single-variable filter stays in the base \
+         case (it is not a two-endpoint comparison):\n{sql}"
     );
 }


### PR DESCRIPTION
## Problem

A WHERE predicate naming **both** VLP endpoints (`friend <> root`, or its property form) was routed by `categorize_filters` to `start_filters`, which the VLP CTE generator applies in the **base case only**. Silently wrong in *both* directions:

- **dropped rows** — the base case's `end_node` is the hop-1 node, an *intermediate* node of any longer path. Filtering there deletes valid paths whose **final** endpoint satisfies the predicate. Live on LDBC SF1, `*1..2` returned **3728** rows against a hand-computed oracle of **3942**.
- **leaked rows** — nothing re-applied it after hop 1, so at `*1..N` (N≥3) on a cyclic graph, paths returning to the start survived (**52** self-paths).

## Oracle correction

Issue #1103 proposed applying the predicate on **every arm**. That is wrong. Neo4j uses **TRAIL** semantics — relationships cannot repeat, **nodes may** — so a per-hop filter would prune legal paths that revisit the start and end elsewhere (**832** such paths exist at `*4..4` from Person 14). The predicate constrains the *(start, final endpoint)* pair of a whole path, so it belongs on the post-recursion wrapper — mirroring the #607 end-filter deferral.

## Fix

A dedicated `both_endpoint_filters` category (kept out of `start_filters` so the base case cannot pick it up), rewritten onto the CTE's own `start_*`/`end_*` columns and applied on the wrapper. For shortestPath it lands on a `_to_target` layer **before** the ROW_NUMBER/MIN pick — otherwise ranking could select an excluded path and discard it, returning nothing where a longer qualifying path exists. Both-endpoint properties are now extracted so they get projected; an unprojected reference **refuses loudly** rather than emitting an unresolvable column.

### Scope guards (byte-identical to pre-#1103 for these families)

| Family | Why excluded |
|---|---|
| closed pattern `(a)-[*]->(a)` | one variable — `refs_start`/`refs_end` are the same test, not a comparison |
| fully denormalized | no wrapper path; role-prefixed physical columns need from/to resolution (tracked separately) |
| multi-type VLP | flat per-branch JOIN chains, no recursion — each branch already sees its true endpoint pair |

## Live verification (LDBC SF1, Person 14)

- `*1..3` self-leak **52 → 0**
- `*1..2` property form **3728 → 3942** (matches oracle)
- `*4..4` **24,943,220** — exact oracle match, incl. the 832 TRAIL-legal root-revisiting paths
- partition check at `*1..3`: 251,689 (`<>`) + 52 (`=`) = 251,741 (total) ✓

## Tests

`cargo test` green (1738 + 632 + ratchet). Goldens: 10 files / 82 lines, all shortestPath both-endpoint — the filter moving to a `_to_target` wrapper. Previously-loud denorm errors verified still loud. 4 regression tests added; #1100 tests updated for the new placement (their node_id-normalization invariant is unchanged).

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)