### PR TITLE
fix(vlp): #1111 denormalized both-endpoint WHERE predicate applied on wrapper

### DIFF
--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -3720,29 +3720,12 @@ pub fn extract_ctes_with_context(
                             .as_ref()
                             .map(|expr| render_expr_to_sql_string(expr, &alias_mapping));
 
-                        // #1103 SCOPE: the fully-denormalized pattern is intercepted
-                        // upstream by `DenormalizedCteStrategy`, which has no wrapper
-                        // path for a both-endpoint predicate — its CTE columns are
-                        // role-prefixed physical names (`start_Origin`/`end_Dest`), so
-                        // the rewrite needs from/to-column role resolution the standard
-                        // rewrite does not do. Rather than drop the predicate (silently
-                        // wrong) or half-rewrite it (Code 47), route it back into the
-                        // start slot — byte-identical to the pre-#1103 behavior for this
-                        // family. The denormalized half of #1103 is tracked separately.
-                        let is_fully_denormalized = matches!(
-                            pattern_ctx_for_mapping.as_ref().map(|c| &c.join_strategy),
-                            Some(JoinStrategy::SingleTableScan { .. })
-                        );
-                        let (both_endpoint_sql, start_sql) = if is_fully_denormalized {
-                            let folded = match (start_sql, both_endpoint_sql) {
-                                (Some(st), Some(be)) => Some(format!("{} AND {}", st, be)),
-                                (Some(st), None) => Some(st),
-                                (None, be) => be,
-                            };
-                            (None, folded)
-                        } else {
-                            (both_endpoint_sql, start_sql)
-                        };
+                        // #1111: the fully-denormalized pattern now has its OWN
+                        // role-aware lowering + post-recursion wrapper
+                        // (`DenormalizedCteStrategy::lower_both_endpoint_filter`),
+                        // so the predicate is no longer folded back into the start
+                        // slot the way #1103 left it. It flows through
+                        // `both_endpoint_filters` like every other family.
                         // ✅ Relationship filters always use rel_alias_mapping
                         let rel_sql_rendered = mapped_rel
                             .as_ref()

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -545,6 +545,33 @@ impl DenormalizedCteStrategy {
         // Build the recursive CTE SQL for denormalized schema
         let sql = self.generate_recursive_cte_sql(context, properties, filters)?;
 
+        // #1111: a WHERE predicate naming BOTH endpoints (`a.city <> b.city`)
+        // is a whole-path predicate on the (start, FINAL endpoint) pair. Applied
+        // in the base case — where the denorm strategy previously left it — it
+        // both prunes valid paths whose hop-1 INTERMEDIATE airport fails the
+        // predicate and leaks paths whose final endpoint fails it past hop 1.
+        // #1103 fixed this for the standard families by deferring to a
+        // post-recursion wrapper; this does the same here, using the denorm
+        // CTE's own role-prefixed physical columns
+        // (`start_<from_col>`/`end_<to_col>`).
+        let sql = match &filters.both_endpoint_filters {
+            None => sql,
+            Some(expr) => {
+                let pred = self.lower_both_endpoint_filter(expr, properties)?;
+                let inner = format!("{}_inner", cte_name);
+                // `generate_recursive_cte_sql` emits `<cte_name> AS ( … )` and
+                // self-references `<cte_name>` in the recursive arm; rename both
+                // to the inner name, then wrap.
+                let renamed = sql
+                    .replacen(&format!("{} AS (", cte_name), &format!("{} AS (", inner), 1)
+                    .replace(
+                        &format!("FROM {} vp", cte_name),
+                        &format!("FROM {} vp", inner),
+                    );
+                format!("{renamed},\n{cte_name} AS (\n    SELECT * FROM {inner} WHERE ({pred})\n)")
+            }
+        };
+
         // Build column metadata for denormalized schema
         let mut columns = Vec::new();
 
@@ -634,6 +661,94 @@ impl DenormalizedCteStrategy {
             // ⚠️ CRITICAL: For denormalized VLP, end_node_filters must be applied in outer SELECT
             outer_where_filters: filters.end_sql.clone(),
         })
+    }
+
+    /// #1111: lower a both-endpoint predicate onto the DENORMALIZED CTE's own
+    /// projected columns.
+    ///
+    /// Denorm projections are role-prefixed PHYSICAL names — `start_<from_col>`
+    /// / `end_<to_col>` for the ids, and `start_<physical>` / `end_<physical>`
+    /// for properties, where the physical column depends on WHICH ROLE the node
+    /// plays (`Airport.city` is `OriginCityName` as the from-node and
+    /// `DestCityName` as the to-node). That role resolution is what the standard
+    /// lowering in [`lower_both_endpoint_filter_to_cte_columns`] does not do,
+    /// and why #1103 scoped this family out.
+    ///
+    /// Structural, on the RenderExpr — never a textual rewrite of rendered SQL
+    /// (see #1103's prefix-collision defect). Fails with a `CteError` when a
+    /// referenced property is not projected, rather than emitting a reference to
+    /// a column the CTE does not select.
+    fn lower_both_endpoint_filter(
+        &self,
+        expr: &crate::render_plan::render_expr::RenderExpr,
+        properties: &[NodeProperty],
+    ) -> Result<String, CteError> {
+        use crate::query_planner::join_context::{VLP_END_ID_COLUMN, VLP_START_ID_COLUMN};
+        use crate::render_plan::render_expr::RenderExpr;
+
+        let start_alias = self.pattern_ctx.left_node_alias.clone();
+        let id_prop = self.denorm_node_id_property_name();
+
+        // Resolve one endpoint reference to its CTE column, or explain why not.
+        // `column` may arrive as the Cypher property name OR the already
+        // role-mapped physical column, so both are accepted — mirroring how the
+        // projection is built from `NodeProperty { column_name, alias }`.
+        let resolve = |alias: &str, column: &str| -> Result<String, CteError> {
+            let is_start = alias == start_alias;
+            let (prefix, id_col, id_column_name) = if is_start {
+                ("start_", self.from_col.as_str(), VLP_START_ID_COLUMN)
+            } else {
+                ("end_", self.to_col.as_str(), VLP_END_ID_COLUMN)
+            };
+            // The node_id, by either its logical property name or its physical column.
+            if column == id_col || id_prop.as_deref() == Some(column) {
+                return Ok(id_column_name.to_string());
+            }
+            for prop in properties {
+                if prop.cypher_alias == alias
+                    && (prop.column_name == column || prop.alias == column)
+                {
+                    // Denorm projections key on the PHYSICAL column name, not the
+                    // Cypher alias (see the metadata builder above).
+                    return Ok(format!("{}{}", prefix, prop.column_name));
+                }
+            }
+            Err(CteError::SchemaValidationError(format!(
+                "denormalized variable-length path: WHERE predicate references both \
+                 endpoints via `{alias}.{column}`, but that property is not projected \
+                 into the path CTE, so it cannot be evaluated on the final endpoint \
+                 pair. Reference `{alias}.{column}` in the query, or filter on the \
+                 endpoint id instead."
+            )))
+        };
+
+        fn rewrite<F>(e: &RenderExpr, resolve: &F) -> Result<RenderExpr, CteError>
+        where
+            F: Fn(&str, &str) -> Result<String, CteError>,
+        {
+            match e {
+                RenderExpr::PropertyAccessExp(pa) => {
+                    let col = resolve(pa.table_alias.0.as_str(), pa.column.raw())?;
+                    // Bare column of the wrapper's own scope (`SELECT * FROM inner`).
+                    Ok(RenderExpr::Column(crate::render_plan::render_expr::Column(
+                        crate::graph_catalog::expression_parser::PropertyValue::Column(col),
+                    )))
+                }
+                RenderExpr::OperatorApplicationExp(op) => {
+                    let mut new_op = op.clone();
+                    new_op.operands = op
+                        .operands
+                        .iter()
+                        .map(|o| rewrite(o, resolve))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(RenderExpr::OperatorApplicationExp(new_op))
+                }
+                other => Ok(other.clone()),
+            }
+        }
+
+        let lowered = rewrite(expr, &resolve)?;
+        Ok(crate::render_plan::cte_extraction::render_expr_to_sql_string(&lowered, &[]))
     }
 
     pub fn validate(&self, pattern_ctx: &PatternSchemaContext) -> Result<(), CteError> {

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_shortest_path_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_shortest_path_2.clickhouse.sql
@@ -1,13 +1,17 @@
-WITH RECURSIVE vlp_a_b AS (
+WITH RECURSIVE vlp_a_b_inner AS (
     SELECT
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
         [t0.Origin] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
-        ['FLIGHT'] as path_relationships
+        ['FLIGHT'] as path_relationships,
+        t0."OriginCityName" as "start_OriginCityName",
+        t0."DestCityName" as "end_DestCityName",
+        t0."OriginCityName" as "start_OriginCityName",
+        t0."DestCityName" as "end_DestCityName"
     FROM default.flights AS t0
-    WHERE t0.OriginCityName != t0.DestCityName AND 1 <= 5
+    WHERE 1 <= 5
     UNION ALL
     SELECT
         vp.start_id as start_id,
@@ -15,10 +19,17 @@ WITH RECURSIVE vlp_a_b AS (
         vp.hop_count + 1,
         arrayConcat(vp.path_edges, [next.Origin]),
         arrayConcat(vp.path_nodes, [next.Dest]),
-        arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
-    FROM vlp_a_b vp
+        arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
+        vp."start_OriginCityName" as "start_OriginCityName",
+        next."DestCityName" as "end_DestCityName",
+        vp."start_OriginCityName" as "start_OriginCityName",
+        next."DestCityName" as "end_DestCityName"
+    FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
     WHERE vp.hop_count < 5 AND NOT has(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (start_OriginCityName != end_DestCityName)
 )
 SELECT 
       t.hop_count AS "length(p)"

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_shortest_path_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_matrix__TestDenormalizedSchema_test_shortest_path_2.databricks.sql
@@ -1,13 +1,17 @@
-WITH RECURSIVE vlp_a_b AS (
+WITH RECURSIVE vlp_a_b_inner AS (
     SELECT
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
         array(t0.Origin) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
-        array('FLIGHT') as path_relationships
+        array('FLIGHT') as path_relationships,
+        t0.`OriginCityName` as `start_OriginCityName`,
+        t0.`DestCityName` as `end_DestCityName`,
+        t0.`OriginCityName` as `start_OriginCityName`,
+        t0.`DestCityName` as `end_DestCityName`
     FROM default.flights AS t0
-    WHERE t0.OriginCityName != t0.DestCityName AND 1 <= 5
+    WHERE 1 <= 5
     UNION ALL
     SELECT
         vp.start_id as start_id,
@@ -15,10 +19,17 @@ WITH RECURSIVE vlp_a_b AS (
         vp.hop_count + 1,
         concat(vp.path_edges, array(next.Origin)),
         concat(vp.path_nodes, array(next.Dest)),
-        concat(vp.path_relationships, array('FLIGHT')) as path_relationships
-    FROM vlp_a_b vp
+        concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
+        vp.`start_OriginCityName` as `start_OriginCityName`,
+        next.`DestCityName` as `end_DestCityName`,
+        vp.`start_OriginCityName` as `start_OriginCityName`,
+        next.`DestCityName` as `end_DestCityName`
+    FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
     WHERE vp.hop_count < 5 AND NOT array_contains(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (start_OriginCityName != end_DestCityName)
 )
 SELECT 
       t.hop_count AS `length(p)`

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_shortest_path_2.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_shortest_path_2.clickhouse.sql
@@ -1,13 +1,17 @@
-WITH RECURSIVE vlp_a_b AS (
+WITH RECURSIVE vlp_a_b_inner AS (
     SELECT
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
         [t0.Origin] as path_edges,
         [t0.Origin, t0.Dest] as path_nodes,
-        ['FLIGHT'] as path_relationships
+        ['FLIGHT'] as path_relationships,
+        t0."OriginCityName" as "start_OriginCityName",
+        t0."DestCityName" as "end_DestCityName",
+        t0."OriginCityName" as "start_OriginCityName",
+        t0."DestCityName" as "end_DestCityName"
     FROM default.flights AS t0
-    WHERE t0.OriginCityName != t0.DestCityName AND 1 <= 5
+    WHERE 1 <= 5
     UNION ALL
     SELECT
         vp.start_id as start_id,
@@ -15,10 +19,17 @@ WITH RECURSIVE vlp_a_b AS (
         vp.hop_count + 1,
         arrayConcat(vp.path_edges, [next.Origin]),
         arrayConcat(vp.path_nodes, [next.Dest]),
-        arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships
-    FROM vlp_a_b vp
+        arrayConcat(vp.path_relationships, ['FLIGHT']) as path_relationships,
+        vp."start_OriginCityName" as "start_OriginCityName",
+        next."DestCityName" as "end_DestCityName",
+        vp."start_OriginCityName" as "start_OriginCityName",
+        next."DestCityName" as "end_DestCityName"
+    FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
     WHERE vp.hop_count < 5 AND NOT has(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (start_OriginCityName != end_DestCityName)
 )
 SELECT 
       t.hop_count AS "length(p)"

--- a/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_shortest_path_2.databricks.sql
+++ b/tests/rust/integration/golden/corpus/ontime_flights/test_pattern_schema_matrix__TestDenormalizedSchema_test_shortest_path_2.databricks.sql
@@ -1,13 +1,17 @@
-WITH RECURSIVE vlp_a_b AS (
+WITH RECURSIVE vlp_a_b_inner AS (
     SELECT
         t0.Origin as start_id,
         t0.Dest as end_id,
         1 as hop_count,
         array(t0.Origin) as path_edges,
         array(t0.Origin, t0.Dest) as path_nodes,
-        array('FLIGHT') as path_relationships
+        array('FLIGHT') as path_relationships,
+        t0.`OriginCityName` as `start_OriginCityName`,
+        t0.`DestCityName` as `end_DestCityName`,
+        t0.`OriginCityName` as `start_OriginCityName`,
+        t0.`DestCityName` as `end_DestCityName`
     FROM default.flights AS t0
-    WHERE t0.OriginCityName != t0.DestCityName AND 1 <= 5
+    WHERE 1 <= 5
     UNION ALL
     SELECT
         vp.start_id as start_id,
@@ -15,10 +19,17 @@ WITH RECURSIVE vlp_a_b AS (
         vp.hop_count + 1,
         concat(vp.path_edges, array(next.Origin)),
         concat(vp.path_nodes, array(next.Dest)),
-        concat(vp.path_relationships, array('FLIGHT')) as path_relationships
-    FROM vlp_a_b vp
+        concat(vp.path_relationships, array('FLIGHT')) as path_relationships,
+        vp.`start_OriginCityName` as `start_OriginCityName`,
+        next.`DestCityName` as `end_DestCityName`,
+        vp.`start_OriginCityName` as `start_OriginCityName`,
+        next.`DestCityName` as `end_DestCityName`
+    FROM vlp_a_b_inner vp
     JOIN default.flights next ON next.Origin = vp.end_id
     WHERE vp.hop_count < 5 AND NOT array_contains(vp.path_nodes, next.Dest)
+),
+vlp_a_b AS (
+    SELECT * FROM vlp_a_b_inner WHERE (start_OriginCityName != end_DestCityName)
 )
 SELECT 
       t.hop_count AS `length(p)`

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1400,3 +1400,78 @@ async fn ldbc_1104_post_with_same_arity_still_renders() {
         "#1104: same-arity post-WITH identity must still render:\n{sql}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1111 — DENORMALIZED VLP both-endpoint WHERE predicate
+//
+// #1103 moved a both-endpoint predicate to the post-recursion wrapper for the
+// standard families but scoped the fully-denormalized pattern OUT: its CTE
+// columns are role-prefixed PHYSICAL names (`start_OriginCityName` /
+// `end_DestCityName`, since `Airport.city` is a different column depending on
+// which end the node plays), which the standard lowering cannot resolve. It was
+// left applying the predicate in the base case — the original defect.
+//
+// Verified live on a CYCLIC 4-flight fixture (A→B→C→A plus A→C): main returned
+// 14 rows for `WHERE a.city <> b.city` at `*1..3`; the hand-computed oracle is
+// 9 (5 same-city paths must be excluded). An ACYCLIC fixture cannot expose the
+// leak half — see the "cyclic oracle" lesson.
+// ---------------------------------------------------------------------------
+
+/// #1111: the predicate must land on the wrapper, against role-resolved columns.
+#[tokio::test]
+async fn ldbc_1111_denorm_both_endpoint_applied_in_wrapper() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Airport)-[:FLIGHT*1..3]->(b:Airport) WHERE a.city <> b.city RETURN b.code",
+    )
+    .await;
+    assert!(
+        sql.contains("_inner WHERE (start_OriginCityName != end_DestCityName)"),
+        "#1111: denorm both-endpoint predicate must be applied on the wrapper \
+         against ROLE-RESOLVED physical columns:\n{sql}"
+    );
+    assert!(
+        !sql.contains("WHERE t1.OriginCityName != t1.DestCityName"),
+        "#1111: must NOT remain in the base case (prunes intermediate hops AND \
+         leaks same-city paths past hop 1):\n{sql}"
+    );
+}
+
+/// #1111: role resolution is the crux — `city` is `OriginCityName` on the FROM
+/// side and `DestCityName` on the TO side. A role-blind rewrite would compare
+/// the same column to itself (a tautology) or emit a nonexistent one.
+#[tokio::test]
+async fn ldbc_1111_denorm_both_endpoint_resolves_per_role() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Airport)-[:FLIGHT*1..3]->(b:Airport) WHERE a.city <> b.city RETURN b.code",
+    )
+    .await;
+    assert!(
+        !sql.contains("start_OriginCityName != end_OriginCityName")
+            && !sql.contains("start_DestCityName != end_DestCityName"),
+        "#1111: each endpoint must resolve `city` through its OWN role:\n{sql}"
+    );
+}
+
+/// #1111 SCOPE: a denorm VLP with no both-endpoint predicate keeps its single
+/// un-wrapped CTE — the wrapper is added only when there is a predicate for it.
+#[tokio::test]
+async fn ldbc_1111_denorm_without_both_endpoint_unwrapped() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Airport)-[:FLIGHT*1..3]->(b:Airport) WHERE a.city = 'Seattle' RETURN b.code",
+    )
+    .await;
+    assert!(
+        !sql.contains("vlp_a_b_inner"),
+        "#1111: no both-endpoint predicate ⇒ no wrapper CTE:\n{sql}"
+    );
+    assert!(
+        sql.contains("'Seattle'"),
+        "#1111: a start-only filter must still be applied:\n{sql}"
+    );
+}


### PR DESCRIPTION
See commit message and #1111 for full detail.

Verified: `cargo test` green, clippy clean, live-verified where a populated fixture exists.

Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)