### PR TITLE
fix(render): #1112 resolve node identity in RETURN position (was invalid `a.* = b.*`)

### DIFF
--- a/src/render_plan/filter_builder.rs
+++ b/src/render_plan/filter_builder.rs
@@ -1634,9 +1634,29 @@ fn check_one_node_identity(expr: &RenderExpr, plan: &LogicalPlan) -> FilterBuild
 
     if let RenderExpr::OperatorApplicationExp(op) = expr {
         if matches!(op.operator, Operator::Equal | Operator::NotEqual) && op.operands.len() == 2 {
-            if let (RenderExpr::TableAlias(l), RenderExpr::TableAlias(r)) =
-                (&op.operands[0], &op.operands[1])
-            {
+            // #1112: a bare node reference has TWO spellings — `TableAlias("a")`
+            // in predicate position, and a whole-node `PropertyAccess("a", "*")`
+            // in projection position (the planner lowers `RETURN a = b` that
+            // way). Accept both, or a mismatched-arity comparison in RETURN
+            // position truncates silently exactly as the WHERE form used to.
+            fn bare_node_alias(e: &RenderExpr) -> Option<&str> {
+                match e {
+                    RenderExpr::TableAlias(t) => Some(t.0.as_str()),
+                    RenderExpr::PropertyAccessExp(p) if p.column.raw() == "*" => {
+                        Some(p.table_alias.0.as_str())
+                    }
+                    _ => None,
+                }
+            }
+            if let (Some(l), Some(r)) = (
+                bare_node_alias(&op.operands[0]),
+                bare_node_alias(&op.operands[1]),
+            ) {
+                let (l, r) = (
+                    crate::render_plan::render_expr::TableAlias(l.to_string()),
+                    crate::render_plan::render_expr::TableAlias(r.to_string()),
+                );
+                let (l, r) = (&l, &r);
                 // Resolve each alias's node_id arity. When either side is
                 // unresolvable, stay silent: the emitter has its own fallback
                 // and this guard must not turn an unrelated shape into an error.

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -1987,6 +1987,18 @@ impl SelectBuilder for LogicalPlan {
             LogicalPlan::Remove(r) => r.input.extract_select_items(plan_ctx)?,
         };
 
+        // #1112/#1104: a node-identity comparison in PROJECTION position must
+        // obey the same arity rule as in WHERE position. #1104 hooked
+        // `extract_filters` and the post-WITH render sites, none of which a
+        // SELECT item passes through — so a mismatched-arity `RETURN c = a`
+        // would silently truncate exactly the way the WHERE form used to.
+        for item in &select_items {
+            crate::render_plan::filter_builder::reject_mismatched_arity_node_identity(
+                &item.expression,
+                self,
+            )?;
+        }
+
         Ok(select_items)
     }
 }

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -8141,12 +8141,35 @@ impl RenderExpr {
                 // column, which usually does not exist and fails at execution
                 // (ClickHouse "cannot be resolved" / Databricks UNRESOLVED_COLUMN).
                 // ClickHouse doesn't understand bare table aliases as values.
+                //
+                // #1112: the same comparison in RETURN/projection position does
+                // NOT arrive as two `TableAlias` operands — the planner lowers a
+                // bare node variable there to a whole-node `PropertyAccess(alias,
+                // "*")`. That form reached the generic emitter and rendered
+                // `a.* = b.*`, which is not valid SQL. Accept BOTH spellings of
+                // "a bare node reference" so WHERE- and RETURN-position identity
+                // resolve identically.
                 if matches!(op.operator, Operator::Equal | Operator::NotEqual)
                     && op.operands.len() == 2
                 {
-                    if let (RenderExpr::TableAlias(l), RenderExpr::TableAlias(r)) =
-                        (&op.operands[0], &op.operands[1])
-                    {
+                    // A bare node reference: `TableAlias("a")` (predicate
+                    // position) or `PropertyAccess("a", "*")` (projection
+                    // position). Returns the alias.
+                    fn bare_node_alias(e: &RenderExpr) -> Option<&str> {
+                        match e {
+                            RenderExpr::TableAlias(t) => Some(t.0.as_str()),
+                            RenderExpr::PropertyAccessExp(p) if p.column.raw() == "*" => {
+                                Some(p.table_alias.0.as_str())
+                            }
+                            _ => None,
+                        }
+                    }
+                    if let (Some(la), Some(ra)) = (
+                        bare_node_alias(&op.operands[0]),
+                        bare_node_alias(&op.operands[1]),
+                    ) {
+                        let (l, r) = (TableAlias(la.to_string()), TableAlias(ra.to_string()));
+                        let (l, r) = (&l, &r);
                         use crate::server::query_context::{
                             get_current_schema, get_node_label_for_alias,
                         };

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1475,3 +1475,96 @@ async fn ldbc_1111_denorm_without_both_endpoint_unwrapped() {
         "#1111: a start-only filter must still be applied:\n{sql}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1112 — node identity in RETURN / projection position
+//
+// `a = b` between bare node variables compares node IDENTITY. In WHERE position
+// it resolves to the schema's node_id column(s) (#1076/#1104). In projection
+// position it reached neither seam and rendered `a.* = b.*` — invalid SQL.
+//
+// Root cause: the planner lowers a bare node variable in RETURN to a whole-node
+// `PropertyAccess(alias, "*")`, NOT a `TableAlias`, so the identity handler's
+// two-`TableAlias` match never fired. Both seams now accept both spellings.
+// ---------------------------------------------------------------------------
+
+/// #1112: `RETURN a = b` must compare the node_id columns, not `a.* = b.*`.
+#[tokio::test]
+async fn ldbc_1112_return_position_identity_resolves_node_id() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a = b AS same",
+    )
+    .await;
+    assert!(
+        sql.contains("a.user_id = b.user_id"),
+        "#1112: RETURN-position identity must resolve to the node_id column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("a.* = b.*"),
+        "#1112: must not emit the invalid whole-node comparison:\n{sql}"
+    );
+}
+
+/// #1112: the same inside a projection-position CASE (the emitter must reach it
+/// through the wrapper, not only at the top level).
+#[tokio::test]
+async fn ldbc_1112_return_position_identity_inside_case() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN CASE WHEN a = b THEN 1 ELSE 0 END AS x",
+    )
+    .await;
+    assert!(
+        sql.contains("CASE WHEN a.user_id = b.user_id"),
+        "#1112: identity inside a projection CASE must resolve:\n{sql}"
+    );
+}
+
+/// #1112: COMPOSITE node_ids expand to the full per-column AND chain here too —
+/// a hardcoded `.id` or a first-column-only comparison would be wrong.
+#[tokio::test]
+async fn ldbc_1112_return_position_identity_composite() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a1:Account)-[:TRANSFERRED]->(a2:Account) RETURN a1 = a2 AS same",
+    )
+    .await;
+    assert!(
+        sql.contains("a1.bank_id = a2.bank_id")
+            && sql.contains("a1.account_number = a2.account_number"),
+        "#1112: composite node_id must compare BOTH key columns:\n{sql}"
+    );
+}
+
+/// #1112 + #1104 parity: a mismatched-arity identity in RETURN position must
+/// refuse exactly like the WHERE-position form, not truncate silently.
+#[tokio::test]
+async fn ldbc_1112_return_position_mismatched_arity_refuses() {
+    let schema = load_schema_from("schemas/examples/composite_node_id_test.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (c:Customer)-[:OWNS]->(a:Account) RETURN c = a AS same",
+    )
+    .await
+    .expect_err("#1112: mismatched arity in RETURN position must refuse");
+    assert!(
+        err.contains("node_id column counts differ"),
+        "#1112: RETURN position must reuse the #1104 arity refusal:\n{err}"
+    );
+}
+
+/// #1112 SCOPE: a bare `RETURN a` (whole-node projection, no comparison) must
+/// still expand to its columns — the new match keys on the comparison operator.
+#[tokio::test]
+async fn ldbc_1112_bare_node_projection_unaffected() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(&schema, "MATCH (a:User) RETURN a LIMIT 1").await;
+    assert!(
+        sql.contains("a.city") && sql.contains("a.user_id"),
+        "#1112: a bare whole-node projection must still expand:\n{sql}"
+    );
+}


### PR DESCRIPTION
See commit message and #1112 for full detail.

Verified: `cargo test` green, clippy clean, live-verified where a populated fixture exists.

Closes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)