### PR TITLE
fix(pattern-comp): #1113 refuse an unrenderable inner WHERE instead of dropping it

### DIFF
--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -2227,7 +2227,25 @@ pub(crate) fn build_pattern_comprehension_sql(
     // filter is silently dropped (#878).
     let inner_where_sql = match (where_clause, target_var, target_label) {
         (Some(expr), Some(tvar), Some(tlabel)) => {
-            render_target_where_predicate(expr, tvar, tlabel, schema)
+            let rendered = render_target_where_predicate(expr, tvar, tlabel, schema);
+            if rendered.is_none() {
+                // #1113: the target-safe allowlist rejected this predicate — it
+                // references something other than the target var (the
+                // correlation var, a bare node identity like `WHERE a <> x`, an
+                // intermediate node), none of which the single-hop `__tgt`
+                // subquery can resolve.
+                //
+                // For a PROJECTION, falling back is harmless (a different value
+                // shape). For a WHERE PREDICATE it is NOT: "no filter" silently
+                // collects rows the user asked to exclude. Signal the caller to
+                // refuse instead of dropping it.
+                log::warn!(
+                    "#1113: pattern-comprehension inner WHERE is not resolvable against \
+                     the target node alone; refusing rather than dropping it: {expr:?}"
+                );
+                return None;
+            }
+            rendered
         }
         _ => None,
     };

--- a/src/render_plan/plan_builder.rs
+++ b/src/render_plan/plan_builder.rs
@@ -1589,6 +1589,10 @@ impl RenderPlanBuilder for LogicalPlan {
                             render_plan.group_by.0.clear();
 
                             log::info!("✅ Added pattern comp CTE '{}' with LEFT JOIN (GraphJoins context)", pc_cte_name);
+                        } else if let Some(err) = pattern_comprehension_where_unrenderable(pc_meta)
+                        {
+                            // #1113: never let an unrenderable inner WHERE become "no filter".
+                            return Err(err);
                         }
                     }
                 }
@@ -2684,6 +2688,10 @@ impl RenderPlanBuilder for LogicalPlan {
                                 "✅ Added pattern comp CTE '{}' with LEFT JOIN for RETURN context",
                                 pc_cte_name
                             );
+                        } else if let Some(err) = pattern_comprehension_where_unrenderable(pc_meta)
+                        {
+                            // #1113: never let an unrenderable inner WHERE become "no filter".
+                            return Err(err);
                         }
                     }
                 }
@@ -5913,6 +5921,11 @@ impl RenderPlanBuilder for LogicalPlan {
                                     "✅ Added pattern comp CTE '{}' with LEFT JOIN (with_ctx path)",
                                     pc_cte_name
                                 );
+                            } else if let Some(err) =
+                                pattern_comprehension_where_unrenderable(pc_meta)
+                            {
+                                // #1113: never let an unrenderable inner WHERE become "no filter".
+                                return Err(err);
                             }
                         }
                     }
@@ -6824,4 +6837,31 @@ fn find_pattern_comprehensions_in_plan(
         LogicalPlan::GraphNode(gn) => find_pattern_comprehensions_in_plan(&gn.input),
         _ => vec![],
     }
+}
+
+/// #1113: a pattern comprehension whose inner `WHERE` could not be rendered
+/// must NOT silently become an unfiltered comprehension.
+///
+/// `build_pattern_comprehension_sql` returns `None` both when there is no SQL to
+/// build and when the target-safe allowlist rejected the inner predicate (it
+/// references the correlation var, a bare node identity, or an intermediate
+/// node — none resolvable in the single-hop `__tgt` subquery). For a projection
+/// the fallback is harmless; for a WHERE predicate "no filter" collects rows the
+/// user asked to exclude. Call this when the builder returns `None` AND the
+/// comprehension carried a `where_clause`, so the query fails loudly instead.
+fn pattern_comprehension_where_unrenderable(
+    pc_meta: &crate::query_planner::logical_plan::PatternComprehensionMeta,
+) -> Option<RenderBuildError> {
+    let where_clause = pc_meta.where_clause.as_ref()?;
+    Some(RenderBuildError::UnsupportedFeature(format!(
+        "pattern comprehension inner WHERE cannot be evaluated: `{where_clause:?}` \
+         references something other than the comprehension's own target node \
+         `{target}` (e.g. the outer correlation variable, or a bare node identity \
+         like `WHERE a <> {target}`). The comprehension is rendered as a single-hop \
+         subquery joining only the target, so such a predicate cannot be applied \
+         there — and dropping it would silently collect rows you asked to exclude. \
+         Rewrite the filter using only `{target}`'s properties, or lift it into the \
+         enclosing MATCH/WHERE.",
+        target = pc_meta.target_var.as_deref().unwrap_or("<target>")
+    )))
 }

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1568,3 +1568,79 @@ async fn ldbc_1112_bare_node_projection_unaffected() {
         "#1112: a bare whole-node projection must still expand:\n{sql}"
     );
 }
+
+// #1113 — pattern-comprehension inner WHERE must never be silently dropped
+//
+// `[(a)-[:FOLLOWS]->(x) WHERE <pred> | x.name]` renders as a single-hop
+// subquery joining only the target node as `__tgt`. A predicate that references
+// anything else — the outer correlation var, or a bare node identity — is
+// rejected by the target-safe allowlist (#882) and `build_pattern_comprehension_sql`
+// returns `None`. For a PROJECTION that fallback is harmless; for a WHERE it
+// silently produced an UNFILTERED comprehension, collecting rows the user asked
+// to exclude. It now refuses loudly.
+// ---------------------------------------------------------------------------
+
+/// #1113: bare-node identity inside a pattern comprehension must refuse.
+#[tokio::test]
+async fn ldbc_1113_pc_inner_where_bare_identity_refuses() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User) RETURN [(a)-[:FOLLOWS]->(x:User) WHERE a <> x | x.name] AS fs",
+    )
+    .await
+    .expect_err("#1113: an unrenderable inner WHERE must refuse, not drop");
+    assert!(
+        err.contains("pattern comprehension inner WHERE cannot be evaluated"),
+        "#1113: the refusal must name the unrenderable inner WHERE:\n{err}"
+    );
+}
+
+/// #1113: a CORRELATED property reference (outer var on one side) is equally
+/// unresolvable in the single-hop subquery and must refuse.
+#[tokio::test]
+async fn ldbc_1113_pc_inner_where_correlated_property_refuses() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User) RETURN [(a)-[:FOLLOWS]->(x:User) WHERE a.user_id <> x.user_id | x.name] AS fs",
+    )
+    .await
+    .expect_err("#1113: a correlated inner WHERE must refuse, not drop");
+    assert!(
+        err.contains("pattern comprehension inner WHERE cannot be evaluated"),
+        "#1113: the refusal must name the unrenderable inner WHERE:\n{err}"
+    );
+}
+
+/// #1113 SCOPE: a TARGET-ONLY predicate is resolvable and must keep rendering
+/// exactly as before — the refusal fires only where the filter was being lost.
+#[tokio::test]
+async fn ldbc_1113_pc_inner_where_target_only_still_applied() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User) RETURN [(a)-[:FOLLOWS]->(x:User) WHERE x.user_id > 3 | x.name] AS fs",
+    )
+    .await;
+    assert!(
+        sql.contains("WHERE __tgt.user_id > 3"),
+        "#1113: a target-only inner WHERE must still be applied:\n{sql}"
+    );
+}
+
+/// #1113 SCOPE: a comprehension with NO inner WHERE is untouched (the refusal
+/// keys on `where_clause` being present, not on the builder returning None).
+#[tokio::test]
+async fn ldbc_1113_pc_without_inner_where_unaffected() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User) RETURN [(a)-[:FOLLOWS]->(x:User) | x.name] AS fs",
+    )
+    .await;
+    assert!(
+        sql.contains("groupArray"),
+        "#1113: a comprehension with no inner WHERE must render normally:\n{sql}"
+    );
+}


### PR DESCRIPTION
See commit message and #1113 for full detail.

Verified: `cargo test` green, clippy clean, live-verified where a populated fixture exists.

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)