### PR TITLE
fix(pattern-comp): #1113 follow-up — count-form inner WHERE returns Option, never ""

### DIFF
--- a/src/render_plan/pattern_comprehension_sql.rs
+++ b/src/render_plan/pattern_comprehension_sql.rs
@@ -330,14 +330,19 @@ fn generate_pattern_comprehension_correlated_subquery(
 
     // Handle WHERE clause from pattern comprehension
     if let Some(ref where_expr) = pc_meta.where_clause {
-        if let Some(where_sql) = render_pc_where_clause(
+        match render_pc_where_clause(
             where_expr,
             &pc_meta.pattern_hops,
             &edge_tables,
             schema,
             &mut join_clauses,
         ) {
-            where_conditions.push(where_sql);
+            Some(where_sql) => where_conditions.push(where_sql),
+            // #1113 follow-up: unrenderable ⇒ refuse the whole comprehension
+            // rather than emit it UNFILTERED (which would silently count rows
+            // the user asked to exclude). The caller turns `None` into a loud
+            // render error naming the predicate.
+            None => return None,
         }
     }
 
@@ -501,14 +506,19 @@ pub(crate) fn generate_pattern_comprehension_cte(
 
     // Handle WHERE clause from pattern comprehension
     if let Some(ref where_expr) = pc_meta.where_clause {
-        if let Some(where_sql) = render_pc_where_clause(
+        match render_pc_where_clause(
             where_expr,
             &pc_meta.pattern_hops,
             &edge_tables,
             schema,
             &mut join_clauses,
         ) {
-            where_conditions.push(where_sql);
+            Some(where_sql) => where_conditions.push(where_sql),
+            // #1113 follow-up: unrenderable ⇒ refuse the whole comprehension
+            // rather than emit it UNFILTERED (which would silently count rows
+            // the user asked to exclude). The caller turns `None` into a loud
+            // render error naming the predicate.
+            None => return None,
         }
     }
 
@@ -700,7 +710,7 @@ fn generate_pc_cte_with_either(
 
         // WHERE clause
         if let Some(ref where_expr) = pc_meta.where_clause {
-            if let Some(where_sql) = render_pc_where_clause(
+            match render_pc_where_clause(
                 where_expr,
                 &pc_meta.pattern_hops,
                 &edge_tables
@@ -710,7 +720,9 @@ fn generate_pc_cte_with_either(
                 schema,
                 &mut join_clauses,
             ) {
-                where_conditions.push(where_sql);
+                // #1113 follow-up: unrenderable ⇒ refuse, never emit unfiltered.
+                None => return None,
+                Some(where_sql) => where_conditions.push(where_sql),
             }
         }
 
@@ -966,14 +978,19 @@ fn generate_list_comp_array_count(
 
     // Handle additional WHERE clause from pattern
     if let Some(ref where_expr) = pc_meta.where_clause {
-        if let Some(where_sql) = render_pc_where_clause(
+        match render_pc_where_clause(
             where_expr,
             &pc_meta.pattern_hops,
             &edge_tables,
             schema,
             &mut join_clauses,
         ) {
-            where_conditions.push(where_sql);
+            Some(where_sql) => where_conditions.push(where_sql),
+            // #1113 follow-up: unrenderable ⇒ refuse the whole comprehension
+            // rather than emit it UNFILTERED (which would silently count rows
+            // the user asked to exclude). The caller turns `None` into a loud
+            // render error naming the predicate.
+            None => return None,
         }
     }
 
@@ -1386,7 +1403,7 @@ fn generate_pc_correlated_subquery_with_either(
 
         // WHERE clause from pattern comprehension
         if let Some(ref where_expr) = pc_meta.where_clause {
-            if let Some(where_sql) = render_pc_where_clause(
+            match render_pc_where_clause(
                 where_expr,
                 &pc_meta.pattern_hops,
                 &edge_tables
@@ -1396,7 +1413,9 @@ fn generate_pc_correlated_subquery_with_either(
                 schema,
                 &mut join_clauses,
             ) {
-                where_conditions.push(where_sql);
+                // #1113 follow-up: unrenderable ⇒ refuse, never emit unfiltered.
+                None => return None,
+                Some(where_sql) => where_conditions.push(where_sql),
             }
         }
 
@@ -1810,7 +1829,7 @@ fn render_pc_where_clause(
         schema,
         join_clauses,
         &mut node_joins_added,
-    );
+    )?;
 
     if sql.is_empty() {
         None
@@ -1832,7 +1851,7 @@ fn render_logical_expr_to_sql(
     schema: &GraphSchema,
     join_clauses: &mut Vec<String>,
     node_joins_added: &mut HashSet<String>,
-) -> String {
+) -> Option<String> {
     use crate::query_planner::logical_expr::LogicalExpr;
 
     match expr {
@@ -1879,10 +1898,10 @@ fn render_logical_expr_to_sql(
                     prop_name
                 };
 
-                format!("{}.{}", sql_alias, db_col)
+                Some(format!("{}.{}", sql_alias, db_col))
             } else {
                 // Not a pattern node - might be an outer reference, use raw
-                format!("{}.{}", alias, prop_name)
+                Some(format!("{}.{}", alias, prop_name))
             }
         }
         LogicalExpr::OperatorApplicationExp(op) => {
@@ -1928,7 +1947,7 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
+                )?;
                 let right = render_logical_expr_to_sql(
                     &op.operands[1],
                     node_alias_map,
@@ -1937,8 +1956,8 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
-                return match op.operator {
+                )?;
+                return Some(match op.operator {
                     Op::StartsWith => {
                         crate::clickhouse_query_generator::starts_with_predicate(&left, &right)
                     }
@@ -1953,7 +1972,7 @@ fn render_logical_expr_to_sql(
                         crate::clickhouse_query_generator::regex_match_predicate(&left, &right)
                     }
                     _ => unreachable!(),
-                };
+                });
             }
 
             // Unary postfix operators (IS NULL, IS NOT NULL)
@@ -1966,8 +1985,8 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
-                return format!("{}{}", operand, op_str);
+                )?;
+                return Some(format!("{}{}", operand, op_str));
             }
 
             // Unary prefix operator (NOT)
@@ -1980,8 +1999,8 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
-                return format!("{}{}", op_str, operand);
+                )?;
+                return Some(format!("{}{}", op_str, operand));
             }
 
             if op.operands.len() == 2 {
@@ -1993,7 +2012,7 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
+                )?;
                 let right = render_logical_expr_to_sql(
                     &op.operands[1],
                     node_alias_map,
@@ -2002,13 +2021,13 @@ fn render_logical_expr_to_sql(
                     schema,
                     join_clauses,
                     node_joins_added,
-                );
+                )?;
                 // Exponentiation has no infix form on ClickHouse/Spark; route
                 // through the dialect mapper's `POWER(base, exp)` (Rule #7).
                 if op.operator == Op::Exponentiation {
-                    return current_function_mapper().power(&left, &right);
+                    return Some(current_function_mapper().power(&left, &right));
                 }
-                format!("{}{}{}", left, op_str, right)
+                Some(format!("{}{}{}", left, op_str, right))
             } else {
                 let rendered: Vec<String> = op
                     .operands
@@ -2024,11 +2043,11 @@ fn render_logical_expr_to_sql(
                             node_joins_added,
                         )
                     })
-                    .collect();
-                rendered.join(op_str)
+                    .collect::<Option<Vec<String>>>()?;
+                Some(rendered.join(op_str))
             }
         }
-        LogicalExpr::Literal(lit) => match lit {
+        LogicalExpr::Literal(lit) => Some(match lit {
             crate::query_planner::logical_expr::Literal::Integer(i) => i.to_string(),
             crate::query_planner::logical_expr::Literal::Float(f) => f.to_string(),
             crate::query_planner::logical_expr::Literal::String(s) => {
@@ -2042,14 +2061,23 @@ fn render_logical_expr_to_sql(
                 }
             }
             _ => "NULL".to_string(),
-        },
-        LogicalExpr::Parameter(p) => format!("${}", p),
+        }),
+        LogicalExpr::Parameter(p) => Some(format!("${}", p)),
+        // #1113 follow-up: an unhandled variant returns `None`, NOT an empty
+        // string. This renderer only covers PropertyAccess / OperatorApplication
+        // / Literal / Parameter — a ScalarFnCall, CASE, list literal, etc. lands
+        // here. Returning `""` poisoned the PARENT operator, which joined
+        // operands blindly: `toLower(x.name) = 'bob'` became `WHERE  = 'bob'`
+        // and `x.user_id IN [1,2,3]` became `WHERE x.user_id IN ` — malformed
+        // SQL — while a top-level CASE produced no WHERE at all (silent wrong).
+        // `None` propagates through every operand via `?`, so the caller learns
+        // the predicate is unrenderable instead of emitting garbage.
         _ => {
             log::warn!(
                 "⚠️ Unhandled LogicalExpr variant in PC WHERE clause: {:?}",
                 expr
             );
-            String::new()
+            None
         }
     }
 }

--- a/src/render_plan/with_to_cte/mod.rs
+++ b/src/render_plan/with_to_cte/mod.rs
@@ -4747,7 +4747,7 @@ fn apply_pattern_comprehensions(
     schema: &GraphSchema,
     plan_ctx: Option<&PlanCtx>,
     cte_schemas: &crate::render_plan::CteSchemas,
-) {
+) -> RenderPlanBuilderResult<()> {
     use super::CteContent;
     if !pattern_comprehensions.is_empty() {
         // Check if any PC has full pattern info for correlated subquery approach
@@ -4883,11 +4883,24 @@ fn apply_pattern_comprehensions(
 
                         pc_cte_names.push((*pc_idx, pc_cte_name));
                     }
+                } else if pc_meta.where_clause.is_some() {
+                    // #1113 follow-up: the PC CTE builder returns `None` when its inner
+                    // WHERE could not be rendered. Dropping the comprehension there
+                    // silently removes the whole computed column (and, before this,
+                    // emitted it UNFILTERED). Refuse loudly instead.
+                    return Err(RenderBuildError::UnsupportedFeature(format!(
+                        "pattern comprehension inner WHERE cannot be rendered for the \
+                         count/size form: `{:?}`. This path supports property comparisons \
+                         on the pattern's own nodes; function calls, CASE expressions and \
+                         list literals are not yet lowered here. Rewrite the filter as a \
+                         plain property comparison, or lift it into the enclosing MATCH.",
+                        pc_meta.where_clause
+                    )));
                 } else {
                     log::warn!(
-                                "⚠️ Could not generate PC CTE for pattern comprehension #{} — falling back to 0",
-                                pc_idx
-                            );
+                        "⚠️ Could not generate PC CTE for pattern comprehension #{} — falling back to 0",
+                        pc_idx
+                    );
                 }
             }
 
@@ -5178,6 +5191,8 @@ fn apply_pattern_comprehensions(
             }
         }
     }
+
+    Ok(())
 }
 
 /// Build the CTE's column metadata from its rendered SELECT items (a STEP of the
@@ -9134,7 +9149,7 @@ pub(crate) fn build_chained_with_match_cte_plan(
                 schema,
                 plan_ctx,
                 &cte_schemas,
-            );
+            )?;
 
             // NOTE: Previously had intermediate_reverse_mapping block here (~180 lines)
             // that built reverse mapping from CTE columns and rewrote CTE body expressions.

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1644,3 +1644,105 @@ async fn ldbc_1113_pc_without_inner_where_unaffected() {
         "#1113: a comprehension with no inner WHERE must render normally:\n{sql}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1113 follow-up — the count/size pattern-comprehension WHERE renderer
+//
+// `render_logical_expr_to_sql` (the limited renderer serving the count/size
+// correlated path) handles only PropertyAccess / OperatorApplication / Literal
+// / Parameter. Its catch-all returned an EMPTY STRING, which the parent
+// operator arm then joined blindly. Three distinct failure modes resulted:
+//
+//   toLower(x.name) = 'bob'   ->  WHERE  = 'bob'          (malformed SQL)
+//   x.user_id IN [1,2,3]      ->  WHERE x.user_id IN      (malformed SQL)
+//   CASE WHEN ... END         ->  no WHERE at all         (SILENT WRONG)
+//
+// Live proof of the silent case on a 5-follow fixture: `main` returned a count
+// of 4 where the correct answer is 2 — the filter simply vanished.
+//
+// The renderer now returns `Option<String>`; `None` propagates through every
+// operand via `?` instead of poisoning the parent, and the callers refuse
+// loudly rather than emitting an unfiltered comprehension.
+// ---------------------------------------------------------------------------
+
+/// Follow-up: a function call in the count-form inner WHERE must refuse, not
+/// emit `WHERE  = 'bob'`.
+#[tokio::test]
+async fn ldbc_pc_count_where_function_call_refuses() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User) WITH a, size([(a)-[:FOLLOWS]->(x:User) WHERE toLower(x.name) = 'bob' | x]) AS n
+         RETURN a.name, n",
+    )
+    .await
+    .expect_err("an unrenderable count-form inner WHERE must refuse");
+    assert!(
+        err.contains("cannot be rendered for the count/size form"),
+        "the refusal must name the count/size form:\n{err}"
+    );
+}
+
+/// Follow-up: an `IN` list must refuse rather than emit a truncated `IN `.
+#[tokio::test]
+async fn ldbc_pc_count_where_in_list_refuses() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User) WITH a, size([(a)-[:FOLLOWS]->(x:User) WHERE x.user_id IN [1,2,3] | x]) AS n
+         RETURN a.name, n",
+    )
+    .await
+    .expect_err("an IN-list count-form inner WHERE must refuse");
+    assert!(
+        err.contains("cannot be rendered for the count/size form"),
+        "the refusal must name the count/size form:\n{err}"
+    );
+}
+
+/// Follow-up: the SILENT case — a CASE expression produced no WHERE at all, so
+/// the comprehension counted rows the user excluded (live: 4 vs the correct 2).
+#[tokio::test]
+async fn ldbc_pc_count_where_case_refuses_instead_of_dropping() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let err = try_render_inline(
+        &schema,
+        "MATCH (a:User)
+         WITH a, size([(a)-[:FOLLOWS]->(x:User) WHERE CASE WHEN x.user_id > 3 THEN true ELSE false END | x]) AS n
+         RETURN a.name, n",
+    )
+    .await
+    .expect_err("a CASE inner WHERE must refuse, not silently drop the filter");
+    assert!(
+        err.contains("cannot be rendered for the count/size form"),
+        "the refusal must name the count/size form:\n{err}"
+    );
+}
+
+/// Follow-up SCOPE: every shape the renderer DOES handle must keep rendering —
+/// plain comparisons, AND-chains, NOT, STARTS WITH, and IS NOT NULL. The
+/// `Option` conversion must not narrow existing coverage.
+#[tokio::test]
+async fn ldbc_pc_count_where_supported_shapes_still_render() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    for (pred, expect) in [
+        ("x.user_id > 3", "__n0e.user_id > 3"),
+        ("x.user_id > 3 AND x.city = 'NYC'", "__n0e.user_id > 3"),
+        ("NOT (x.user_id = 5)", "NOT __n0e.user_id = 5"),
+        ("x.name STARTS WITH 'A'", "startsWith(__n0e.full_name, 'A')"),
+        ("x.user_id IS NOT NULL", "__n0e.user_id IS NOT NULL"),
+    ] {
+        let sql = generate_sql_inline(
+            &schema,
+            &format!(
+                "MATCH (a:User) WITH a, size([(a)-[:FOLLOWS]->(x:User) WHERE {pred} | x]) AS n \
+                 RETURN a.name, n"
+            ),
+        )
+        .await;
+        assert!(
+            sql.contains(expect),
+            "count-form inner WHERE `{pred}` must still render `{expect}`:\n{sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`render_logical_expr_to_sql` — the limited renderer serving the **count/size** pattern-comprehension path — handles only PropertyAccess / OperatorApplication / Literal / Parameter. Its catch-all returned an **empty string**, which the parent operator arm then joined blindly:

| Predicate | Emitted | Effect |
|---|---|---|
| `toLower(x.name) = 'bob'` | `WHERE  = 'bob'` | malformed SQL |
| `x.user_id IN [1,2,3]` | `WHERE x.user_id IN ` | malformed SQL |
| `CASE WHEN … END` | *no WHERE at all* | **silent wrong** |

The first two fail at ClickHouse with a syntax error — bad UX, not dangerous. The CASE form is the real defect: the filter vanishes. On a 5-follow fixture, **`main` returned a count of 4 where the correct answer is 2**.

## Distinct seam from #1113

Worth being precise: #1113 fixed `render_target_expr`'s deliberate allowlist gate on the *property-projection* path. This is the *count/size* path's own **parallel renderer**, which never caught up with the #882 work that made the other path comprehensive. Same bug class, different code.

## Fix

The renderer returns `Option<String>`; `None` propagates through every operand via `?` instead of poisoning the parent, and all five `render_pc_where_clause` call sites refuse rather than emitting an unfiltered comprehension. `apply_pattern_comprehensions` becomes fallible so the refusal reaches the user — its pre-existing *"falling back to 0"* warning branch (the silent fallback that would otherwise have swallowed this) is kept only for the no-WHERE case.

## Scope — verified by shape matrix

`x.user_id > 3`, AND-chains, `NOT (…)`, `STARTS WITH`, `IS NOT NULL` all still render byte-identically. Only genuinely unhandled variants refuse.

> An early probe of mine reported NOT / STARTS WITH as dropped — that was a bad grep (they emit `WHERE NOT …` / `WHERE startsWith(…)`, which my pattern missed). Re-checked with a correct detector.

## Verification

`cargo test` green (1738 + 663 + ratchet), clippy clean, **zero golden churn** — no corpus query relied on the dropped or malformed filter. 4 tests: three refusal shapes plus a five-shape non-regression sweep.

Follow-up to #1113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)