### PR TITLE
fix(vlp): #1118 project the node schema `filter:` column into the VLP CTE

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -684,6 +684,12 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   golden churn**. Exposed **#1119** (OPEN): a DENORMALIZED endpoint drops its
   schema filter entirely and SILENTLY (6 vs an oracle 3 on a purpose-built
   fixture) — unreachable in every shipped schema, filed rather than half-fixed.
+  Also exposed **#1120** (OPEN): a CLOSED pattern `(a:Country)-[:R*2..3]->(a)`
+  drops its schema filter entirely and silently (5 vs an oracle 3). Both are
+  byte-identical on main and on this branch. NOTE on oracles: the closed-pattern
+  defect is INVISIBLE on LDBC's acyclic `Place` graph (0 == 0 by coincidence) —
+  finding it needed a cyclic fixture in which the filter actually discriminates,
+  reinforcing the `cyclic-oracle-for-edge-uniqueness` lesson.
 
 - 2026-09-04 (backfill): the six PRs merged 2026-08-31..09-04 were NOT logged
   here at merge time, contrary to §1 rule 3. Recorded now, newest first:

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,53 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-04: **Correctness (ground-rule-1) — a node schema `filter:` column was
+  never projected into the VLP CTE, so the end-filter reference went out of
+  scope** (branch `fix/1118-vlp-schema-filter-column-projection`, PR #1120,
+  closes #1118). A node-level YAML `filter:` (`Country.filter: "type =
+  'Country'"`) is combined into the end-filter slot, but #607 defers the end
+  predicate to the OUTER WRAPPER, which can only reference columns the recursive
+  CTE projects. `filter_properties` is built from the query TEXT plus
+  `PropertyRequirements` — a schema filter is a SCHEMA fact invisible to both —
+  so the column was pruned and the wrapper emitted a bare `end_node.type`:
+  ClickHouse **Code 47 on every multi-hop-capable shape**. Reachable in the
+  SHIPPED LDBC schema, whose `City`/`Country`/`Continent`/`University`/`Company`
+  labels are all `filter:`-discriminated views over one physical table. Live
+  matrix on `ldbc` SF1, each verified against a hand-computed edge-distinct
+  oracle: `*1..2` Code 47 → **1343**, `*0..2` Code 47 → **1454**, shortestPath
+  Code 47 → **1343**; `*1..1` (1343) and `*2..2` (0) already passed — they render
+  as flat joins / a base-case-only CTE where `end_node` IS in scope — and the
+  START-side filter (base arm, 111) was always correct. Fix: re-add the schema
+  filter's columns to `filter_properties` AFTER pruning, mirroring how a user
+  WHERE's columns reach the CTE via `extract_properties_from_filter`; the
+  declared property that maps to the column supplies the output alias, falling
+  back to the raw column name for the undeclared case (LDBC's `type`). Gated PER
+  ENDPOINT — a mixed-access pattern has one embedded and one own-table endpoint,
+  so a whole-pattern gate is wrong in both directions. 5 regression tests
+  (`ldbc_1118_*`), full suite green (1738 + 668 + ratchet), clippy clean, **zero
+  golden churn**. Exposed **#1119** (OPEN): a DENORMALIZED endpoint drops its
+  schema filter entirely and SILENTLY (6 vs an oracle 3 on a purpose-built
+  fixture) — unreachable in every shipped schema, filed rather than half-fixed.
+
+- 2026-09-04 (backfill): the six PRs merged 2026-08-31..09-04 were NOT logged
+  here at merge time, contrary to §1 rule 3. Recorded now, newest first:
+  **#1117** `af49fb47` — #1113 follow-up: the count/size pattern-comprehension
+  inner-WHERE renderer returned `""` for an unhandled variant, which POISONED
+  the parent operator (`toLower(x.name) = 'bob'` → `WHERE  = 'bob'`; a `CASE`
+  predicate vanished entirely → live count 4 where the oracle is 2). Now returns
+  `Option<String>`; `None` propagates and all 5 call sites refuse.
+  **#1116** `7e858353` — #1113: an inner WHERE rejected by the #882 allowlist was
+  dropped instead of refused (silent over-count).
+  **#1115** `24c874a0` — #1112: node identity in RETURN position emitted an
+  invalid `a.* = b.*`.
+  **#1114** `af1d3e93` — #1111: a denormalized both-endpoint WHERE predicate was
+  applied on the base case, not the wrapper (cyclic fixture: 14 vs an oracle 9).
+  **#1110** `04240dbf` — #1104: node-identity comparison across mismatched
+  node_id arity now refuses loudly instead of comparing incomparable keys.
+  **#1109** `8cd13f6e` — #1103: a both-endpoint WHERE predicate was applied on
+  the BASE CASE, deleting legal paths (`*1..2` 3728 vs an oracle 3942) and
+  leaking self-paths (`*1..3` 52 vs an oracle 0).
+
 - 2026-08-09: **Correctness (ground-rule-1) — `ORDER BY <expr> DESC` placed
   NULLs last, but Neo4j places them first (and Databricks ASC diverged too)**
   (branch `fix/order-by-null-placement-1065`, PR #1066 `44232ef2`, closes

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -689,7 +689,17 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   byte-identical on main and on this branch. NOTE on oracles: the closed-pattern
   defect is INVISIBLE on LDBC's acyclic `Place` graph (0 == 0 by coincidence) —
   finding it needed a cyclic fixture in which the filter actually discriminates,
-  reinforcing the `cyclic-oracle-for-edge-uniqueness` lesson.
+  reinforcing the `cyclic-oracle-for-edge-uniqueness` lesson. Adversarial review
+  (no CRITICAL/HIGH) additionally found: the first cut projected a column for the
+  START endpoint too, which `prune_vlp_columns` silently deleted again everywhere
+  EXCEPT the undirected mixed VLP, where it survived as dead weight and made the
+  denorm family's SQL differ — so the block is now END-endpoint-only and gated off
+  the denorm/mixed strategies (whose end filter stays in the base arm); and two
+  further PRE-EXISTING defects in `rewrite_end_filter_for_cte`'s textual
+  `str::replace`, filed as **#1122** (a cypher property named after a different
+  physical filter column mis-binds the predicate — SILENT: returns pk 3 where the
+  answer is pk 2, and the COUNTS agree by coincidence) and **#1123** (a filter on a
+  COMPOSITE node_id component is left unrewritten → Code 47, loud).
 
 - 2026-09-04 (backfill): the six PRs merged 2026-08-31..09-04 were NOT logged
   here at merge time, contrary to §1 rule 3. Recorded now, newest first:

--- a/schemas/test/foreign_selfloop_filtered.yaml
+++ b/schemas/test/foreign_selfloop_filtered.yaml
@@ -1,0 +1,39 @@
+# `foreign_selfloop.yaml` plus a node-level `filter:` — the fixture that makes
+# the #1118 embedded-endpoint gate LOAD-BEARING.
+#
+# A denormalized / mixed-access endpoint keeps its end filter in the base and
+# recursive arms (`end_filter_in_base_recursive_case`), where the raw `end_node`
+# alias IS in scope. #1118 projects a schema-filter column ONLY for the families
+# whose end predicate moves to a wrapper — projecting one here would be dead
+# weight that no predicate references, and on the UNDIRECTED shape
+# `prune_vlp_columns` does not strip it, so it would leak into the SQL.
+#
+# NOTE: this schema's filter is NOT applied at all today — that is #1119
+# (silent-wrong: 6 vs an oracle 3 on a populated fixture). This file exists to
+# pin the #1118 scope boundary, NOT to assert that behavior is correct.
+name: foreign_selfloop_filtered_test
+version: "1.0"
+description: "Foreign-embedded self-loop WITH a node schema filter (#1118 scope-boundary fixture; the filter itself is #1119)"
+
+graph_schema:
+  nodes:
+    - label: Person
+      database: testdb
+      table: people_f
+      node_id: pid
+      is_denormalized: true
+      filter: "active = 1"
+      property_mappings:
+        pid: pid
+        name: name
+      from_node_properties:
+        pid: mgr_id
+  edges:
+    - type: REPORTS_TO
+      database: testdb
+      table: reports_f
+      from_node: Person
+      to_node: Person
+      from_id: mgr_id
+      to_id: emp_id
+      property_mappings: {}

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4206,6 +4206,104 @@ pub fn extract_ctes_with_context(
                     props
                 };
 
+                // #1118: a node-level schema `filter:` (YAML `filter: "type =
+                // 'Country'"`) is combined into the start/end filter slots below, but
+                // its COLUMNS were never added to `filter_properties`. For the END node
+                // that is a correctness hole: `end_filter_applied_in_wrapper` (#607)
+                // defers the end predicate to the outer wrapper, which can only see
+                // columns the recursive CTE actually PROJECTS. An unprojected filter
+                // column therefore renders as a bare `end_node.<col>` reference in the
+                // wrapper — out of scope there → ClickHouse Code 47 on every
+                // multi-hop-capable shape (`*1..2`, `*0..N`, shortestPath). This is
+                // reachable in the shipped LDBC schema, whose City/Country/Continent/
+                // University/Company labels are all `filter:`-discriminated views over
+                // one physical `Place`/`Organisation` table.
+                //
+                // The pruner (`PropertyRequirements`) keeps only properties the query
+                // TEXT mentions, and a schema filter is invisible to it — so the column
+                // must be re-added here, after pruning. This mirrors how a user WHERE's
+                // columns reach the CTE via `extract_properties_from_filter`.
+                //
+                // Checked PER ENDPOINT: a MIXED-access pattern has one embedded and one
+                // own-table endpoint, so a whole-pattern gate would be wrong in both
+                // directions. An endpoint read off the edge row (`EmbeddedInEdge`) has
+                // no own-table column to project, so it is skipped and keeps its
+                // pre-#1118 behavior — that family drops the filter SILENTLY (6 vs
+                // an oracle 3 on a purpose-built fixture) and is tracked as #1119.
+                let start_is_own_table = pattern_ctx_for_filters
+                    .as_ref()
+                    .is_none_or(|c| !c.left_node.is_embedded());
+                let end_is_own_table = pattern_ctx_for_filters
+                    .as_ref()
+                    .is_none_or(|c| !c.right_node.is_embedded());
+                let filter_properties = {
+                    let mut props = filter_properties;
+                    for (alias, label, is_own_table) in [
+                        (&start_alias, &start_label, start_is_own_table),
+                        (&end_alias, &end_label, end_is_own_table),
+                    ] {
+                        if label.is_empty() || !is_own_table {
+                            continue;
+                        }
+                        let Some(node_schema) = schema.node_schema_opt(label) else {
+                            continue;
+                        };
+                        let Some(ref schema_filter) = node_schema.filter else {
+                            continue;
+                        };
+                        let id_columns = node_schema.node_id.columns();
+                        for col in schema_filter.get_columns() {
+                            // The id column is projected as `start_id`/`end_id`, not as
+                            // a `<prefix>_<prop>` column; skip it (a filter on the id is
+                            // already handled by the id rewrite).
+                            if id_columns.contains(&col.as_str()) {
+                                continue;
+                            }
+                            // The filter is written against PHYSICAL columns, but the
+                            // generator names its output after the CYPHER property
+                            // (`end_<prop>`), and `rewrite_end_filter_for_cte` rewrites
+                            // `end_node.<column>` to exactly that. Prefer the declared
+                            // property that maps to this column.
+                            let prop_name = match node_schema
+                                .property_mappings
+                                .iter()
+                                .find(|(_, v)| v.raw() == col)
+                            {
+                                Some((name, _)) => name.clone(),
+                                None => {
+                                    // Undeclared filter column — the shipped LDBC shape
+                                    // (`Country.filter: "type = 'Country'"` with `type`
+                                    // absent from property_mappings). Project it under
+                                    // its own column name. Skip when a DIFFERENT declared
+                                    // property already claims that output name, since
+                                    // `end_<name>` would then be ambiguous.
+                                    if node_schema.property_mappings.contains_key(col.as_str()) {
+                                        continue;
+                                    }
+                                    col.clone()
+                                }
+                            };
+                            if props.iter().any(|p: &NodeProperty| {
+                                p.cypher_alias == *alias && p.alias == prop_name
+                            }) {
+                                continue;
+                            }
+                            log::info!(
+                                "🔧 #1118: projecting schema-filter column '{}' for '{}' ({}) into the VLP CTE",
+                                col,
+                                alias,
+                                label
+                            );
+                            props.push(NodeProperty {
+                                cypher_alias: alias.clone(),
+                                column_name: col.clone(),
+                                alias: prop_name,
+                            });
+                        }
+                    }
+                    props
+                };
+
                 // Generate CTE with filters
                 // For shortest path queries, always use recursive CTE (even for exact hops)
                 // because we need proper filtering and shortest path selection logic

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4224,24 +4224,37 @@ pub fn extract_ctes_with_context(
                 // must be re-added here, after pruning. This mirrors how a user WHERE's
                 // columns reach the CTE via `extract_properties_from_filter`.
                 //
-                // Checked PER ENDPOINT: a MIXED-access pattern has one embedded and one
-                // own-table endpoint, so a whole-pattern gate would be wrong in both
-                // directions. An endpoint read off the edge row (`EmbeddedInEdge`) has
-                // no own-table column to project, so it is skipped and keeps its
-                // pre-#1118 behavior — that family drops the filter SILENTLY (6 vs
-                // an oracle 3 on a purpose-built fixture) and is tracked as #1119.
-                let start_is_own_table = pattern_ctx_for_filters
-                    .as_ref()
-                    .is_none_or(|c| !c.left_node.is_embedded());
-                let end_is_own_table = pattern_ctx_for_filters
-                    .as_ref()
-                    .is_none_or(|c| !c.right_node.is_embedded());
+                // END ENDPOINT ONLY. The START filter is emitted in the BASE ARM,
+                // where the raw `start_node` alias IS in scope, so it needs no
+                // projected column — pushing one produces a column no predicate ever
+                // references. Review of the first cut confirmed that: the start-side
+                // push was silently deleted again by `prune_vlp_columns`
+                // (`render_plan/plan_optimizer.rs`) in every shape but the UNDIRECTED
+                // mixed-access VLP, where it survived as dead weight and made that
+                // family's SQL differ for no reason. Restricting to the end endpoint
+                // keeps the change surface exactly the shapes that were broken.
+                //
+                // Restricted further to the families whose end filter actually MOVES
+                // to a wrapper. `end_filter_in_base_recursive_case` keeps the
+                // denormalized family's end predicate in the base/recursive arms,
+                // where the raw `end_node` alias IS in scope — so projecting a column
+                // there is pure dead weight (it survived `prune_vlp_columns` on the
+                // undirected mixed shape and made that family's SQL differ for no
+                // reason). Those families keep their pre-#1118 behavior: they drop the
+                // filter SILENTLY (6 vs an oracle 3 on a purpose-built fixture),
+                // tracked as #1119 — a real defect, but not one a projected-but-
+                // unreferenced column fixes.
+                let end_is_own_table = pattern_ctx_for_filters.as_ref().is_none_or(|c| {
+                    !c.right_node.is_embedded()
+                        && !matches!(
+                            c.join_strategy,
+                            JoinStrategy::SingleTableScan { .. } | JoinStrategy::MixedAccess { .. }
+                        )
+                });
                 let filter_properties = {
                     let mut props = filter_properties;
-                    for (alias, label, is_own_table) in [
-                        (&start_alias, &start_label, start_is_own_table),
-                        (&end_alias, &end_label, end_is_own_table),
-                    ] {
+                    for (alias, label, is_own_table) in [(&end_alias, &end_label, end_is_own_table)]
+                    {
                         if label.is_empty() || !is_own_table {
                             continue;
                         }
@@ -4254,8 +4267,12 @@ pub fn extract_ctes_with_context(
                         let id_columns = node_schema.node_id.columns();
                         for col in schema_filter.get_columns() {
                             // The id column is projected as `start_id`/`end_id`, not as
-                            // a `<prefix>_<prop>` column; skip it (a filter on the id is
-                            // already handled by the id rewrite).
+                            // a `<prefix>_<prop>` column; skip it — a filter on a SINGLE
+                            // id is already handled by the id rewrite
+                            // (`end_node.<id_col>` -> `end_id`). That does NOT hold for a
+                            // COMPOSITE id, whose `end_id` is a pipe-joined concat with no
+                            // per-component target: such a filter is left unrewritten and
+                            // fails loud (Code 47). Pre-existing, tracked as #1123.
                             if id_columns.contains(&col.as_str()) {
                                 continue;
                             }
@@ -4277,6 +4294,14 @@ pub fn extract_ctes_with_context(
                                     // its own column name. Skip when a DIFFERENT declared
                                     // property already claims that output name, since
                                     // `end_<name>` would then be ambiguous.
+                                    //
+                                    // NOTE: skipping keeps THIS code from making things
+                                    // worse; it does NOT make that shape correct.
+                                    // `rewrite_end_filter_for_cte` still rewrites via the
+                                    // cypher-alias spelling and binds the predicate to
+                                    // the OTHER property's column — silent-wrong,
+                                    // pre-existing, tracked as #1122 (its textual
+                                    // `str::replace` needs a structural rewrite).
                                     if node_schema.property_mappings.contains_key(col.as_str()) {
                                         continue;
                                     }

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1746,3 +1746,128 @@ async fn ldbc_pc_count_where_supported_shapes_still_render() {
         );
     }
 }
+
+// --- #1118: node schema `filter:` column must be projected into the VLP CTE ---
+//
+// A node-level YAML `filter:` (`Country.filter: "type = 'Country'"`) is combined
+// into the end-filter slot, but #607 defers the end predicate to the OUTER
+// WRAPPER, which can only see columns the recursive CTE projects. The filter
+// column was never added to the CTE's property list (the pruner only keeps
+// properties the query TEXT mentions, and a schema filter is invisible to it),
+// so the wrapper emitted a bare `end_node.type` — out of scope there.
+//
+// Live before the fix (LDBC SF1, `MATCH (a:Place)-[:IS_PART_OF*1..2]->(c:Country)`):
+//   Code 47: Unknown expression or function identifier `end_node.type`
+// After: 1343 rows, matching a hand-computed edge-distinct oracle.
+//
+// This is reachable in the SHIPPED LDBC schema — City/Country/Continent/
+// University/Company are all `filter:`-discriminated views over one table.
+
+/// The end-node schema filter must resolve against a PROJECTED CTE column
+/// (`end_type`), never a bare `end_node.<col>` the wrapper cannot see.
+#[tokio::test]
+async fn ldbc_1118_end_schema_filter_column_projected_into_vlp_cte() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    for cypher in [
+        "MATCH (a:Place)-[:IS_PART_OF*1..2]->(c:Country) RETURN count(*)",
+        "MATCH (a:Place)-[:IS_PART_OF*0..2]->(c:Country) RETURN count(*)",
+        "MATCH (a:Place)-[:IS_PART_OF*1..3]->(c:Country) RETURN c.name",
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            sql.contains("as end_type") || sql.contains("AS end_type"),
+            "#1118: the schema-filter column must be PROJECTED by the CTE \
+             for `{cypher}`:\n{sql}"
+        );
+        // The wrapper predicate must reference the projected column, not the
+        // out-of-scope node alias.
+        assert!(
+            !sql.contains("end_node.type = 'Country'"),
+            "#1118: the wrapper must not reference the unprojected \
+             `end_node.type` (ClickHouse Code 47) for `{cypher}`:\n{sql}"
+        );
+        assert!(
+            sql.contains("end_type = 'Country'"),
+            "#1118: the end schema filter must survive, rewritten onto the \
+             projected column, for `{cypher}`:\n{sql}"
+        );
+    }
+}
+
+/// shortestPath uses its own `_to_target` wrapper — same defect, same fix.
+#[tokio::test]
+async fn ldbc_1118_shortest_path_end_schema_filter_projected() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH p=shortestPath((a:City)-[:IS_PART_OF*1..3]->(c:Country)) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("as end_type") || sql.contains("AS end_type"),
+        "#1118: shortestPath must project the end schema-filter column:\n{sql}"
+    );
+    // The WRAPPER must read the projected column. `end_node.type` still appears
+    // in the CTE's own projection (`end_node.type as end_type`) — that is the
+    // fix working, not the defect; assert on the wrapper predicate itself.
+    assert!(
+        sql.contains("end_type = 'Country'"),
+        "#1118: the shortestPath wrapper must filter on the projected \
+         `end_type`, not an out-of-scope `end_node.type`:\n{sql}"
+    );
+}
+
+/// The START endpoint's schema filter goes in the BASE ARM, where `start_node`
+/// IS in scope — that path already worked and must stay byte-compatible (the
+/// fix must not move it to a projected column or duplicate it).
+#[tokio::test]
+async fn ldbc_1118_start_schema_filter_stays_in_base_arm() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Country)-[:IS_PART_OF*1..2]->(c:Place) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_node.type = 'Country'"),
+        "#1118: the START schema filter is applied in the base arm, where \
+         `start_node` is in scope — unchanged:\n{sql}"
+    );
+}
+
+/// A single-hop VLP has no wrapper: the base case IS the endpoint, so the end
+/// filter stays on `end_node` there. Guards against "fix everything" overreach.
+#[tokio::test]
+async fn ldbc_1118_single_hop_end_filter_stays_on_end_node() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Place)-[:IS_PART_OF*1..1]->(c:Country) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("'Country'"),
+        "#1118: the single-hop end schema filter must still be applied:\n{sql}"
+    );
+}
+
+/// A DENORMALIZED (edge-embedded) endpoint has no own-table column to project,
+/// so #1118 must skip it rather than emit a column the arm cannot resolve.
+/// That family's dropped schema filter is a SEPARATE, pre-existing defect
+/// (#1119, silent-wrong: 6 vs an oracle 3) — this locks the scope boundary,
+/// not the still-wrong behavior.
+#[tokio::test]
+async fn ldbc_1118_embedded_endpoint_not_projected() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    // `foreign_selfloop.yaml` declares no `filter:`, so nothing is added; the
+    // assertion is that the mixed arm renders unchanged and stays valid.
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO*1..2]->(b:Person) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_own"),
+        "#1118: the mixed-access arm must be unchanged:\n{sql}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1851,6 +1851,31 @@ async fn ldbc_1118_single_hop_end_filter_stays_on_end_node() {
     );
 }
 
+/// A CLOSED pattern `(a:Country)-[:R*2..3]->(a)` drops the schema filter
+/// entirely — pre-existing (#1120, silent-wrong: 5 vs an oracle 3 on a cyclic
+/// fixture where the filter discriminates), byte-identical on main and here.
+/// This locks the SCOPE BOUNDARY: #1118 must not change that shape.
+#[tokio::test]
+async fn ldbc_1118_closed_pattern_unchanged() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Country)-[:IS_PART_OF*2..3]->(a) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("t.start_id = t.end_id"),
+        "#1118: the closed-pattern render must be unchanged:\n{sql}"
+    );
+    // NOT an assertion that dropping the filter is correct — it is #1120. This
+    // pins that #1118 neither fixed nor worsened it.
+    assert!(
+        !sql.contains("'Country'"),
+        "#1118/#1120: the closed pattern's dropped schema filter is unchanged \
+         by #1118 (tracked as #1120):\n{sql}"
+    );
+}
+
 /// A DENORMALIZED (edge-embedded) endpoint has no own-table column to project,
 /// so #1118 must skip it rather than emit a column the arm cannot resolve.
 /// That family's dropped schema filter is a SEPARATE, pre-existing defect

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1818,8 +1818,12 @@ async fn ldbc_1118_shortest_path_end_schema_filter_projected() {
 }
 
 /// The START endpoint's schema filter goes in the BASE ARM, where `start_node`
-/// IS in scope — that path already worked and must stay byte-compatible (the
-/// fix must not move it to a projected column or duplicate it).
+/// IS in scope — that path already worked and must stay byte-compatible.
+///
+/// This is why #1118 projects a column for the END endpoint ONLY. The first cut
+/// pushed one for both; review showed the start-side column was then silently
+/// deleted again by `prune_vlp_columns` (`render_plan/plan_optimizer.rs`) in
+/// every shape but the undirected mixed VLP, where it survived as dead weight.
 #[tokio::test]
 async fn ldbc_1118_start_schema_filter_stays_in_base_arm() {
     let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
@@ -1876,23 +1880,38 @@ async fn ldbc_1118_closed_pattern_unchanged() {
     );
 }
 
-/// A DENORMALIZED (edge-embedded) endpoint has no own-table column to project,
-/// so #1118 must skip it rather than emit a column the arm cannot resolve.
+/// A DENORMALIZED / MIXED-access endpoint keeps its end filter in the base and
+/// recursive arms (`end_filter_in_base_recursive_case`), where the raw
+/// `end_node` alias IS in scope — so #1118 must NOT project a column there: it
+/// would be dead weight no predicate references. Review of the first cut caught
+/// exactly that, on the UNDIRECTED mixed shape where `prune_vlp_columns` did not
+/// strip it and that family's SQL changed for no reason.
+///
 /// That family's dropped schema filter is a SEPARATE, pre-existing defect
-/// (#1119, silent-wrong: 6 vs an oracle 3) — this locks the scope boundary,
-/// not the still-wrong behavior.
+/// (#1119, silent-wrong: 6 vs an oracle 3) — this locks the scope boundary, not
+/// the still-wrong behavior.
+///
+/// The fixture DECLARES a `filter:`, so the gate is load-bearing: delete it and
+/// this test fails. (An unfiltered fixture would pass either way.)
 #[tokio::test]
 async fn ldbc_1118_embedded_endpoint_not_projected() {
-    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
-    // `foreign_selfloop.yaml` declares no `filter:`, so nothing is added; the
-    // assertion is that the mixed arm renders unchanged and stays valid.
-    let sql = generate_sql_inline(
-        &schema,
+    let schema = load_schema_from("schemas/test/foreign_selfloop_filtered.yaml");
+    for cypher in [
         "MATCH (a:Person)-[:REPORTS_TO*1..2]->(b:Person) RETURN count(*)",
-    )
-    .await;
-    assert!(
-        sql.contains("start_own"),
-        "#1118: the mixed-access arm must be unchanged:\n{sql}"
-    );
+        // The undirected shape is the one where the pruner does NOT strip an
+        // unreferenced projected column, so a leak here is visible.
+        "MATCH (a:Person)-[:REPORTS_TO*1..2]-(b:Person) RETURN count(*)",
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            !sql.contains("end_active") && !sql.contains("start_active"),
+            "#1118: a denormalized/mixed endpoint must NOT get a projected \
+             schema-filter column (dead weight; the filter stays in the base \
+             arm) for `{cypher}`:\n{sql}"
+        );
+        assert!(
+            sql.contains("start_own"),
+            "#1118: the mixed-access arm must otherwise be unchanged:\n{sql}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

A node-level YAML `filter:` (`Country.filter: "type = 'Country'"`) is correctly combined into the VLP end-filter slot, but `end_filter_applied_in_wrapper` (#607) defers the end predicate to the **outer wrapper**, which can only reference columns the recursive CTE actually projects.

`filter_properties` is built from the properties the query **text** mentions plus `PropertyRequirements`. A schema filter is a *schema* fact, invisible to both — so its column was pruned away and the wrapper emitted a bare `end_node.type`, out of scope there:

```sql
vlp_a_c AS ( SELECT * FROM vlp_a_c_inner WHERE ((end_node.type = 'Country')) )
-- Code: 47. Unknown expression or function identifier 'end_node.type'
```

Reachable in the **shipped LDBC schema** — `City`/`Country`/`Continent`/`University`/`Company` are all `filter:`-discriminated views over one physical table.

## Live matrix (`ldbc` SF1), each against a hand-computed edge-distinct oracle

| Shape | Before | After | Oracle |
|---|---|---|---|
| `*1..2` | **Code 47** | 1343 | 1343 |
| `*0..2` | **Code 47** | 1454 | 1454 |
| `shortestPath *1..3` | **Code 47** | 1343 | 1343 |
| `*1..1` | 1343 | 1343 | 1343 |
| `*2..2` | 0 | 0 | 0 |
| start-side filter (control) | 111 | 111 | 111 |

`*1..1` and `*2..2` escaped because they render as flat joins / a base-case-only CTE where `end_node` IS in scope. The START-side filter is applied in the base arm, where `start_node` is in scope, and was always correct.

Also re-verified on a **cyclic** fixture (9 vs oracle 9) — an acyclic graph can agree with a broken predicate by coincidence.

## Fix

Re-add the schema filter's columns to `filter_properties` **after** pruning, mirroring how a user `WHERE`'s columns reach the CTE via `extract_properties_from_filter`. The declared property that maps to the column supplies the output alias (`end_<prop>`, which `rewrite_end_filter_for_cte` already targets); an undeclared column — LDBC's `type`, absent from `Country`'s `property_mappings` — is projected under its own name, skipped when a different declared property would claim that output name.

Gated **per endpoint**: a mixed-access pattern has one embedded and one own-table endpoint, so a whole-pattern gate would be wrong in both directions.

## Change surface

SQL is **byte-identical to main** for every shape except the broken ones (md5-compared): `*1..1`, start-filtered, unfiltered labels, and closed patterns all unchanged.

## Out of scope — two silent-wrong defects found and filed, not half-fixed

- **#1119** — a DENORMALIZED/edge-embedded endpoint drops its schema filter entirely, *silently* (6 vs an oracle 3 on a purpose-built fixture). Unreachable in every shipped schema.
- **#1120** — a CLOSED pattern `(a:Country)-[:R*2..3]->(a)` drops it too (5 vs an oracle 3). **Invisible on LDBC's acyclic `Place` graph** — finding it needed a cyclic fixture in which the filter actually discriminates.

Both are byte-identical on main and here; the tests pin the boundary, not the behavior.

## Verification

- 6 regression tests (`ldbc_1118_*`). The two targeting the defect **fail on main** and pass here; the other four are deliberate scope-boundary locks.
- `cargo test` green (1738 + 669 + ratchet), `cargo fmt --check` clean, clippy **0 warnings**, **zero golden churn**.
- Backfills the merge log for PRs #1109/#1110/#1114/#1115/#1116/#1117, merged without the §1 rule-3 PRIORITIES.md update.

Closes #1118