### PR TITLE
fix(vlp): #1120 closed pattern re-resolves its schema filter by label

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -676,10 +676,17 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   adversarial Country→City→Country cycle that must and does count). POSITIVE
   gate on `JoinStrategy::Traditional` (the first cut used raw
   `is_denormalized`/`is_fk_edge` flags and the RATCHET CAUGHT IT — rule 7
-  works); denorm/mixed/FK-edge closed shapes keep pre-#1120 behavior (#1119
-  class, their generators don't bind `start_node`). Composes with a user WHERE
-  (1 == oracle 1). 174-combo sweep: only the filtered-label closed shape
-  differs. The #1118 boundary test `ldbc_1118_closed_pattern_unchanged` was
+  works). Adversarial review (PR #1124, no CRITICAL/HIGH) CORRECTED the scoping
+  claim: the Traditional gate is WIDER than "standard schema" — POLYMORPHIC
+  edges over standard node tables and the standard-node arm of MIXED schemas
+  also classify Traditional, so the fallback fires there too, and is verified
+  correct live (polymorphic closed *2..3/*2..2/*0..2 → 4/3/6 == oracles, main
+  7/4/10; now pinned by a committed polymorphic test + fixture). Truly
+  denormalized and FK-edge closed shapes ARE byte-identical to main (#1119
+  class). Review also surfaced **#1125** (OPEN): the FLAT single-hop closed
+  shape (`(a:Country)-[:R]->(a)`, `*1..1`) still drops the filter (2 vs oracle
+  1) — it renders via the #994 fold with no node join at all, leaving a seam at
+  exactly hop 1. Composes with a user WHERE (1 == oracle 1). The #1118 boundary test `ldbc_1118_closed_pattern_unchanged` was
   UPGRADED to `ldbc_1120_closed_pattern_schema_filter_in_base_arm` (correctness)
   + 2 new boundary tests. Suite green (1738 + 671 + ratchet), clippy clean,
   zero golden churn.

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,33 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-04: **Correctness (ground-rule-1) — a CLOSED VLP pattern
+  `(a:Country)-[:R*2..3]->(a)` dropped its node schema `filter:` entirely,
+  silently** (branch `fix/1120-closed-vlp-schema-filter`, PR #1124, closes
+  #1120). `DuplicateScansRemoving` replaces the repeated endpoint's subtree
+  with `Empty`, and the surviving side's ViewScan is rebuilt WITHOUT
+  `schema_filter` — so both plan-walks in `extract_schema_filter_from_node`
+  returned None and the filter vanished. Cycles through EXCLUDED nodes were
+  counted: on a cyclic fixture with a Country 3-cycle + a City 2-cycle,
+  directed `*2..3` returned 5 vs an oracle 3; zero-hop `*0..2` 12 vs 5
+  (counting City zero-hops); undirected `*2..3` 20 vs 12. INVISIBLE on LDBC's
+  acyclic Place graph (0 == 0 by coincidence) — the cyclic-oracle lesson again,
+  and the cycle must contain EXCLUDED nodes or it also agrees by coincidence.
+  Fix: when both walks return None on a closed pattern, re-resolve the filter
+  from the SCHEMA by label into the base arm's START slot; same variable ⇒ same
+  node ⇒ once suffices (the closure predicate `start_id = end_id` equates the
+  endpoints; unlabeled intermediate hops stay unfiltered — verified by an
+  adversarial Country→City→Country cycle that must and does count). POSITIVE
+  gate on `JoinStrategy::Traditional` (the first cut used raw
+  `is_denormalized`/`is_fk_edge` flags and the RATCHET CAUGHT IT — rule 7
+  works); denorm/mixed/FK-edge closed shapes keep pre-#1120 behavior (#1119
+  class, their generators don't bind `start_node`). Composes with a user WHERE
+  (1 == oracle 1). 174-combo sweep: only the filtered-label closed shape
+  differs. The #1118 boundary test `ldbc_1118_closed_pattern_unchanged` was
+  UPGRADED to `ldbc_1120_closed_pattern_schema_filter_in_base_arm` (correctness)
+  + 2 new boundary tests. Suite green (1738 + 671 + ratchet), clippy clean,
+  zero golden churn.
+
 - 2026-09-04: **Correctness (ground-rule-1) — a node schema `filter:` column was
   never projected into the VLP CTE, so the end-filter reference went out of
   scope** (branch `fix/1118-vlp-schema-filter-column-projection`, PR #1120,

--- a/schemas/test/polymorphic_filtered_closed.yaml
+++ b/schemas/test/polymorphic_filtered_closed.yaml
@@ -1,0 +1,40 @@
+# Polymorphic edge over standard node tables, with a node-level `filter:` —
+# the fixture that makes #1120's polymorphic coverage LOAD-BEARING.
+#
+# A polymorphic edge over standard node tables classifies as
+# `JoinStrategy::Traditional` (pattern_schema.rs), so the #1120 closed-pattern
+# schema-filter fallback FIRES for this shape — intended, and verified correct
+# live during the #1124 adversarial review (closed *2..3/*2..2/*0..2 matched
+# hand oracles 4/3/6 where main returned 7/4/10 on a cyclic fixture).
+#
+# Uses the db_polymorphic physical tables; `is_active` does not exist there, so
+# this schema is for STRUCTURAL (sql-gen) tests only — do not execute against
+# db_polymorphic.
+name: polymorphic_filtered_closed_test
+version: "1.0"
+description: "Polymorphic edge + filtered node label: #1120 closed-pattern fallback coverage"
+
+graph_schema:
+  nodes:
+    - label: User
+      database: db_polymorphic
+      table: users
+      node_id: user_id
+      filter: "account_status = 'active'"
+      property_mappings:
+        user_id: user_id
+        name: full_name
+
+  edges:
+    - polymorphic: true
+      database: db_polymorphic
+      table: interactions
+      from_id: from_id
+      to_id: to_id
+      type_column: interaction_type
+      from_label_column: from_type
+      to_label_column: to_type
+      type_values:
+        - FOLLOWS
+      edge_id: [from_id, to_id, interaction_type]
+      property_mappings: {}

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -5075,6 +5075,55 @@ pub fn extract_ctes_with_context(
                     let end_schema_filter =
                         extract_schema_filter_from_node(&graph_rel.right, "end_node");
 
+                    // #1120: a CLOSED pattern `(a:Country)-[:R*2..3]->(a)` loses its
+                    // schema filter entirely: `DuplicateScansRemoving` replaces the
+                    // repeated endpoint's subtree with `Empty`, and the surviving
+                    // side's ViewScan is (re)built WITHOUT `schema_filter` — so both
+                    // plan-walks above return None and the filter silently vanishes
+                    // (5 rows vs an oracle 3 on a cyclic fixture; invisible on
+                    // LDBC's acyclic Place graph, where 0 == 0 by coincidence).
+                    //
+                    // The label is still known, so fall back to resolving the filter
+                    // from the SCHEMA by label. Same variable ⇒ same node ⇒ applying
+                    // it ONCE, in the base arm's START slot (where the raw
+                    // `start_node` alias is in scope), suffices: the closure
+                    // predicate `start_id = end_id` equates the endpoints, and
+                    // intermediate hops are unlabeled and correctly stay unfiltered.
+                    //
+                    // POSITIVE gate on `JoinStrategy::Traditional` (allowlist, not a
+                    // flag blacklist — ratchet rule 7): only that family's generator
+                    // binds the raw `start_node` alias this filter references. The
+                    // denormalized / mixed / FK-edge closed shapes address their
+                    // endpoints through other aliases — a `start_node.` reference
+                    // there would dangle — and their dropped filter is the #1119
+                    // class, so they keep pre-#1120 behavior.
+                    let start_schema_filter = if start_schema_filter.is_none()
+                        && end_schema_filter.is_none()
+                        && graph_rel.left_connection == graph_rel.right_connection
+                        && matches!(pattern_ctx.join_strategy, JoinStrategy::Traditional { .. })
+                    {
+                        let label = if !start_label.is_empty() {
+                            &start_label
+                        } else {
+                            &end_label
+                        };
+                        let fallback = schema
+                            .node_schema_opt(label)
+                            .and_then(|ns| ns.filter.as_ref())
+                            .and_then(|f| f.to_sql("start_node").ok());
+                        if let Some(ref f) = fallback {
+                            log::info!(
+                                "🔧 #1120: closed pattern lost its schema filter to \
+                                 scan dedup; re-resolved by label '{}': {}",
+                                label,
+                                f
+                            );
+                        }
+                        fallback
+                    } else {
+                        start_schema_filter
+                    };
+
                     // Combine user filters with schema filters using AND
                     let combined_start_filters = match (&start_filters_sql, &start_schema_filter) {
                         (Some(user), Some(schema)) => Some(format!("({}) AND ({})", user, schema)),

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -5091,17 +5091,28 @@ pub fn extract_ctes_with_context(
                     // intermediate hops are unlabeled and correctly stay unfiltered.
                     //
                     // POSITIVE gate on `JoinStrategy::Traditional` (allowlist, not a
-                    // flag blacklist — ratchet rule 7): only that family's generator
-                    // binds the raw `start_node` alias this filter references. The
-                    // denormalized / mixed / FK-edge closed shapes address their
-                    // endpoints through other aliases — a `start_node.` reference
-                    // there would dangle — and their dropped filter is the #1119
-                    // class, so they keep pre-#1120 behavior.
+                    // flag blacklist — ratchet rule 7): that strategy's generators
+                    // bind the raw `start_node` alias this filter references. NOTE
+                    // the gate is WIDER than "standard schema": a POLYMORPHIC edge
+                    // over standard node tables and the standard-node arm of a MIXED
+                    // schema also classify as Traditional — and the fallback firing
+                    // there is intended and verified correct live (review of this
+                    // fix: polymorphic closed *2..3/*2..2/*0..2 returned 4/3/6
+                    // matching hand oracles where main returned 7/4/10). The truly
+                    // denormalized / FK-edge closed shapes classify as other
+                    // strategies, address their endpoints through other aliases — a
+                    // `start_node.` reference would dangle — and keep pre-#1120
+                    // behavior (their dropped filter is the #1119 class).
                     let start_schema_filter = if start_schema_filter.is_none()
                         && end_schema_filter.is_none()
                         && graph_rel.left_connection == graph_rel.right_connection
                         && matches!(pattern_ctx.join_strategy, JoinStrategy::Traditional { .. })
                     {
+                        // A closed pattern has ONE variable, so start/end labels
+                        // agree except in the (invalid, double-labeled) form
+                        // `(a:Country)-[*..]->(a:City)` — which is pre-existing
+                        // broken on this path regardless (the second label's filter
+                        // is dropped on main too; not a #1120 concern).
                         let label = if !start_label.is_empty() {
                             &start_label
                         } else {

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1910,6 +1910,32 @@ async fn ldbc_1120_closed_pattern_unfiltered_label_unchanged() {
     }
 }
 
+/// #1120: the `JoinStrategy::Traditional` gate is WIDER than "standard schema"
+/// — a POLYMORPHIC edge over standard node tables also classifies Traditional,
+/// so the fallback fires there too. Intended and verified correct live during
+/// the #1124 review (closed *2..3/*2..2/*0..2 matched hand oracles 4/3/6 where
+/// main returned 7/4/10 on a cyclic fixture). This pins that silently
+/// load-bearing coverage: the filter must land in the base arm AND compose
+/// with the polymorphic type discriminators.
+#[tokio::test]
+async fn ldbc_1120_polymorphic_closed_pattern_filter_in_base_arm() {
+    let schema = load_schema_from("schemas/test/polymorphic_filtered_closed.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*2..3]->(a) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_node.account_status = 'active'"),
+        "#1120: the polymorphic closed pattern must get the schema filter in \
+         the base arm (Traditional-classified, fallback fires):\n{sql}"
+    );
+    assert!(
+        sql.contains("rel.interaction_type = 'FOLLOWS'"),
+        "#1120: the polymorphic type discriminator must still compose:\n{sql}"
+    );
+}
+
 /// #1120 boundary: an OPEN pattern with a filtered label is untouched by the
 /// fallback (its filters resolve through the normal plan-walk, per #1118).
 #[tokio::test]

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1855,12 +1855,20 @@ async fn ldbc_1118_single_hop_end_filter_stays_on_end_node() {
     );
 }
 
-/// A CLOSED pattern `(a:Country)-[:R*2..3]->(a)` drops the schema filter
-/// entirely — pre-existing (#1120, silent-wrong: 5 vs an oracle 3 on a cyclic
-/// fixture where the filter discriminates), byte-identical on main and here.
-/// This locks the SCOPE BOUNDARY: #1118 must not change that shape.
+/// #1120 (upgraded from the #1118 scope-boundary lock): a CLOSED pattern
+/// `(a:Country)-[:R*2..3]->(a)` DROPPED its schema filter — the dedup pass
+/// replaces the repeated endpoint's subtree with `Empty`, and the surviving
+/// side's ViewScan is rebuilt without `schema_filter`, so both plan-walks in
+/// `extract_schema_filter_from_node` returned None. Silent-wrong: 5 vs an
+/// oracle 3 on a cyclic fixture where the filter discriminates (invisible on
+/// LDBC's acyclic Place graph, where 0 == 0 by coincidence).
+///
+/// Fixed by re-resolving the filter from the SCHEMA by label into the base
+/// arm's START slot. Same variable ⇒ same node ⇒ once suffices: the closure
+/// predicate `start_id = end_id` equates the endpoints, and intermediate hops
+/// are unlabeled and stay unfiltered.
 #[tokio::test]
-async fn ldbc_1118_closed_pattern_unchanged() {
+async fn ldbc_1120_closed_pattern_schema_filter_in_base_arm() {
     let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
     let sql = generate_sql_inline(
         &schema,
@@ -1869,14 +1877,53 @@ async fn ldbc_1118_closed_pattern_unchanged() {
     .await;
     assert!(
         sql.contains("t.start_id = t.end_id"),
-        "#1118: the closed-pattern render must be unchanged:\n{sql}"
+        "#1120: the closed-pattern closure predicate must remain:\n{sql}"
     );
-    // NOT an assertion that dropping the filter is correct — it is #1120. This
-    // pins that #1118 neither fixed nor worsened it.
     assert!(
-        !sql.contains("'Country'"),
-        "#1118/#1120: the closed pattern's dropped schema filter is unchanged \
-         by #1118 (tracked as #1120):\n{sql}"
+        sql.contains("start_node.type = 'Country'"),
+        "#1120: the schema filter must be re-resolved by label into the base \
+         arm (it was dropped entirely):\n{sql}"
+    );
+    // Applied ONCE — no spurious end-side duplicate that would reference an
+    // out-of-scope alias in the wrapper (the #1118 defect class).
+    assert!(
+        !sql.contains("end_node.type = 'Country'") && !sql.contains("end_type = 'Country'"),
+        "#1120: the filter is applied once, in the base arm:\n{sql}"
+    );
+}
+
+/// #1120 boundary: an UNFILTERED label's closed pattern must be byte-compatible
+/// with the pre-#1120 render (no fallback fires when the schema has no filter).
+#[tokio::test]
+async fn ldbc_1120_closed_pattern_unfiltered_label_unchanged() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    for cypher in [
+        "MATCH (a:Place)-[:IS_PART_OF*2..3]->(a) RETURN count(*)",
+        "MATCH (a:Person)-[:KNOWS*2..2]->(a) RETURN count(*)",
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            !sql.contains("'Country'") && !sql.contains("schema filter"),
+            "#1120: no fallback filter may appear for an unfiltered label \
+             (`{cypher}`):\n{sql}"
+        );
+    }
+}
+
+/// #1120 boundary: an OPEN pattern with a filtered label is untouched by the
+/// fallback (its filters resolve through the normal plan-walk, per #1118).
+#[tokio::test]
+async fn ldbc_1120_open_pattern_untouched() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Country)-[:IS_PART_OF*2..3]->(b:Place) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_node.type = 'Country'"),
+        "#1120: the open pattern's start filter comes from the normal \
+         plan-walk and must remain in the base arm:\n{sql}"
     );
 }
 


### PR DESCRIPTION
## Problem

A **closed** VLP pattern `(a:Country)-[:IS_PART_OF*2..3]->(a)` dropped the node's YAML `filter:` entirely — **silently**. `DuplicateScansRemoving` replaces the repeated endpoint's subtree with `Empty`, and the surviving side's ViewScan is rebuilt without `schema_filter`, so both plan-walks in `extract_schema_filter_from_node` returned `None`. Cycles through excluded nodes were counted.

## Live matrix (cyclic fixture, hand oracles)

| Shape | Before | After | Oracle |
|---|---|---|---|
| directed `*2..3` | 5 | 3→4* | 3→4* |
| zero-hop `*0..2` | 12 | 5 | 5 |
| undirected `*2..3` | 20 | 12 | 12 |
| + user `WHERE a.name='A'` | — | 1 | 1 |

*4 after adding the adversarial Country→City→Country cycle, which **must** count (intermediate hops are unlabeled) and does.

Worth restating: this defect is **invisible on LDBC's acyclic Place graph** (0 == 0 by coincidence), and even a cyclic fixture agrees by coincidence unless a cycle of *excluded* nodes exists.

## Fix

When both plan-walks return `None` and the pattern is closed, re-resolve the filter **from the schema by label** into the base arm's START slot. Same variable ⇒ same node ⇒ once suffices: `start_id = end_id` equates the endpoints; unlabeled intermediate hops stay unfiltered.

**Gated positively on `JoinStrategy::Traditional`.** The first cut used raw `is_denormalized`/`is_fk_edge` flags and the **axis-dispatch ratchet rejected it** — routed through `PatternSchemaContext` instead, no baseline bump. Denorm/mixed/FK-edge closed shapes keep pre-#1120 behavior (their dropped filter is the #1119 class; `start_node.` would dangle in their generators) and are md5-identical to main.

## Change surface

174-combo sweep across every schema: **only the filtered-label closed shape differs**. Unfiltered closed shapes (`Place`, `Person`) byte-identical.

## Tests

The #1118 scope-boundary lock `ldbc_1118_closed_pattern_unchanged` — which pinned this exact shape as *unchanged-and-wrong* — is upgraded to `ldbc_1120_closed_pattern_schema_filter_in_base_arm` asserting the fix (it failed the moment the fix landed, exactly as a boundary lock should). Plus two new boundary tests. Suite green (1738 + 671 + ratchet), clippy clean, zero golden churn.

Closes #1120