### PR TITLE
fix(vlp): #1122 colliding schema-filter column binds the real column, not the decoy

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — schema-filter column colliding
+  with a differently-mapped declared property mis-bound the wrapper predicate
+  to the WRONG column** (branch `fix/1122-structural-end-filter-rewrite`,
+  PR #1128, closes #1122). `filter: "kind = 'A'"` + `property_mappings: kind:
+  decoy` → two coupled defects: the #1118 projection SKIPPED the collision
+  (leaving the filter unprojected) and `rewrite_end_filter_for_cte`'s
+  cypher-ALIAS-spelling replace then rewrote `end_node.kind` onto `end_kind`
+  — the declared property's projected column, holding `decoy`'s value. Valid
+  SQL, WRONG ROWS, no error: live pk 3 where the answer is pk 2, with the
+  COUNTS agreeing by coincidence (1 either way — a count-only oracle passes
+  this defect; assert on IDs). Fix: (1) project the collision under a mangled
+  `__sf_<col>` alias bound to the REAL column; (2) DELETE the alias-spelling
+  replace — filters reach the rewrite already property-mapped (verified: a
+  236-combo end-WHERE sweep and the full suite are byte-identical without it),
+  so it had no covered use and was purely the mis-bind vector; an uncovered
+  reliance now fails LOUD, never silently against the wrong column. LDBC
+  matrix re-verified (1343/1454/1343/199). New fixture
+  `schemas/test/decoy_schema_filter.yaml` + 3 tests (targeting one fails on
+  main). Suite green (1738 + 678 + ratchet), clippy clean, zero golden churn.
+
 - 2026-09-05: **Correctness (ground-rule-1) — the type-inference ViewScan
   rebuilds dropped `schema_filter`, silently disarming every downstream
   schema-filter application for inferred-label nodes** (branch

--- a/schemas/test/decoy_schema_filter.yaml
+++ b/schemas/test/decoy_schema_filter.yaml
@@ -1,18 +1,24 @@
 # #1122 fixture: a declared cypher property NAMED after a different physical
 # column that the schema `filter:` references.
 #
-#   filter: "kind = 'A'"      -- physical column `kind`
-#   property_mappings:
-#     kind: decoy             -- cypher `kind` -> physical column `decoy`
+#   P:  filter: "kind = 'A'"   + property_mappings: kind: decoy
+#       (cypher `kind` -> physical `decoy`; filter on the physical `kind`)
+#   Q:  filter: "kind = 'A' AND kind_extra = 'X'" + kind_extra: decoy2
+#       (#1128 review HIGH: `kind` is a strict PREFIX of `kind_extra`)
 #
-# Pre-#1122, the end-filter textual rewrite matched the CYPHER-ALIAS spelling
-# too, so the wrapper predicate bound to `end_kind` — a projected column holding
-# `decoy`'s value: valid SQL, WRONG ROWS, no error (returned pk 3 where the
-# answer is pk 2; counts agreed by coincidence). Post-#1122 the collision is
-# projected under a mangled `__sf_`-prefixed alias bound to the REAL column.
+# Pre-#1122 (P), the end-filter textual rewrite matched the CYPHER-ALIAS
+# spelling too, so the wrapper predicate bound to `end_kind` — a projected
+# column holding `decoy`'s value: valid SQL, WRONG ROWS, no error (returned
+# pk 3 where the answer is pk 2; counts agreed by coincidence).
+#
+# Pre-rework (Q), the plain replace applied shortest-first corrupted
+# `end_node.kind_extra` -> `end_kind_extra` (the decoy projection), with
+# correctness DEPENDENT ON THE YAML PREDICATE ORDER. Fixed by longest-first +
+# word-boundary (`replace_column_token`) + literal-aware
+# (`rewrite_outside_string_literals`) rewrite — the #934 primitives.
 name: decoy_schema_filter_test
 version: "1.0"
-description: "#1122: schema-filter column colliding with a differently-mapped declared property"
+description: "#1122/#1128: schema-filter columns colliding with differently-mapped declared properties"
 
 graph_schema:
   nodes:
@@ -24,12 +30,31 @@ graph_schema:
       property_mappings:
         pk: pk
         kind: decoy
+
+    - label: Q
+      database: d1122
+      table: p2
+      node_id: pk
+      filter: "kind = 'A' AND kind_extra = 'X'"
+      property_mappings:
+        pk: pk
+        kind_extra: decoy2
+
   edges:
     - type: L
       database: d1122
       table: l
       from_node: P
       to_node: P
+      from_id: f
+      to_id: t
+      property_mappings: {}
+
+    - type: L2
+      database: d1122
+      table: l2
+      from_node: Q
+      to_node: Q
       from_id: f
       to_id: t
       property_mappings: {}

--- a/schemas/test/decoy_schema_filter.yaml
+++ b/schemas/test/decoy_schema_filter.yaml
@@ -1,0 +1,35 @@
+# #1122 fixture: a declared cypher property NAMED after a different physical
+# column that the schema `filter:` references.
+#
+#   filter: "kind = 'A'"      -- physical column `kind`
+#   property_mappings:
+#     kind: decoy             -- cypher `kind` -> physical column `decoy`
+#
+# Pre-#1122, the end-filter textual rewrite matched the CYPHER-ALIAS spelling
+# too, so the wrapper predicate bound to `end_kind` — a projected column holding
+# `decoy`'s value: valid SQL, WRONG ROWS, no error (returned pk 3 where the
+# answer is pk 2; counts agreed by coincidence). Post-#1122 the collision is
+# projected under a mangled `__sf_`-prefixed alias bound to the REAL column.
+name: decoy_schema_filter_test
+version: "1.0"
+description: "#1122: schema-filter column colliding with a differently-mapped declared property"
+
+graph_schema:
+  nodes:
+    - label: P
+      database: d1122
+      table: p
+      node_id: pk
+      filter: "kind = 'A'"
+      property_mappings:
+        pk: pk
+        kind: decoy
+  edges:
+    - type: L
+      database: d1122
+      table: l
+      from_node: P
+      to_node: P
+      from_id: f
+      to_id: t
+      property_mappings: {}

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4291,21 +4291,24 @@ pub fn extract_ctes_with_context(
                                     // Undeclared filter column — the shipped LDBC shape
                                     // (`Country.filter: "type = 'Country'"` with `type`
                                     // absent from property_mappings). Project it under
-                                    // its own column name. Skip when a DIFFERENT declared
-                                    // property already claims that output name, since
-                                    // `end_<name>` would then be ambiguous.
+                                    // its own column name — unless a DIFFERENT declared
+                                    // property already claims that output name
+                                    // (`kind: decoy` declared + filter on physical
+                                    // `kind`), where `end_<name>` would be ambiguous.
                                     //
-                                    // NOTE: skipping keeps THIS code from making things
-                                    // worse; it does NOT make that shape correct.
-                                    // `rewrite_end_filter_for_cte` still rewrites via the
-                                    // cypher-alias spelling and binds the predicate to
-                                    // the OTHER property's column — silent-wrong,
-                                    // pre-existing, tracked as #1122 (its textual
-                                    // `str::replace` needs a structural rewrite).
+                                    // #1122: for that collision, project under a MANGLED
+                                    // alias instead of skipping. The skip left the filter
+                                    // unrewritten, and the (now removed) alias-spelling
+                                    // replace then mis-bound it to the declared property's
+                                    // column — wrong rows, no error. The mangled alias is
+                                    // collision-free, and `rewrite_end_filter_for_cte`'s
+                                    // physical-column replace targets `end_<alias>`, so
+                                    // the wrapper predicate binds to the REAL column.
                                     if node_schema.property_mappings.contains_key(col.as_str()) {
-                                        continue;
+                                        format!("__sf_{col}")
+                                    } else {
+                                        col.clone()
                                     }
-                                    col.clone()
                                 }
                             };
                             if props.iter().any(|p: &NodeProperty| {

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4300,12 +4300,26 @@ pub fn extract_ctes_with_context(
                                     // alias instead of skipping. The skip left the filter
                                     // unrewritten, and the (now removed) alias-spelling
                                     // replace then mis-bound it to the declared property's
-                                    // column — wrong rows, no error. The mangled alias is
-                                    // collision-free, and `rewrite_end_filter_for_cte`'s
-                                    // physical-column replace targets `end_<alias>`, so
-                                    // the wrapper predicate binds to the REAL column.
+                                    // column — wrong rows, no error.
+                                    // `rewrite_end_filter_for_cte`'s physical-column
+                                    // replace targets `end_<alias>`, so the wrapper
+                                    // predicate binds to the REAL column.
+                                    //
+                                    // The mangle is only PRACTICALLY collision-free: a
+                                    // declared property literally named `__sf_<col>`
+                                    // would collide again (review of #1128). Escape by
+                                    // doubling the prefix until free — deterministic and
+                                    // schema-independent, so the dedup check below can
+                                    // never silently resurrect the skip.
+                                    let mut mangled = format!("__sf_{col}");
+                                    while node_schema
+                                        .property_mappings
+                                        .contains_key(mangled.as_str())
+                                    {
+                                        mangled = format!("__sf_{mangled}");
+                                    }
                                     if node_schema.property_mappings.contains_key(col.as_str()) {
-                                        format!("__sf_{col}")
+                                        mangled
                                     } else {
                                         col.clone()
                                     }

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -1694,13 +1694,24 @@ impl<'a> VariableLengthCteGenerator<'a> {
     }
 
     fn rewrite_end_filter_for_cte(&self, filter: &str) -> String {
-        let mut rewritten = filter.replace(
-            &format!("{}.{}", self.end_node_alias, self.end_node_id_column),
-            VLP_END_ID_COLUMN,
-        );
-
-        // Replace end_node.{column} with end_{alias} for each projected property.
-        //
+        // Collect every rewrite pair first, then apply LONGEST column name
+        // first with word-boundary + string-literal awareness. Three defects
+        // this ordering/primitive choice closes (review of #1128):
+        //   - PREFIX COLLISION: with columns `kind` and `kind_extra` both in
+        //     the filter, a plain `replace("end_node.kind", …)` applied first
+        //     corrupted `end_node.kind_extra` into `end_kind_extra` — the
+        //     DECLARED property's projection (decoy bind, silent wrong rows,
+        //     order-dependent on the YAML predicate order).
+        //   - The same corruption from the ID replace (`node_id: pk` +
+        //     `filter: "pk_flag = 1"` → `end_id_flag`).
+        //   - Literal corruption: a VALUE like 'end_node.full_name' inside a
+        //     string literal was edited by the replace.
+        // `replace_column_token` / `rewrite_outside_string_literals` are the
+        // #934 primitives already in this file, with their own unit tests.
+        let mut pairs: Vec<(String, String)> = vec![(
+            format!("{}.{}", self.end_node_alias, self.end_node_id_column),
+            VLP_END_ID_COLUMN.to_string(),
+        )];
         // #1122: ONLY the physical-column spelling is matched. Filters reaching
         // this point are already property-mapped (a user WHERE `b.name` arrives
         // as `end_node.full_name`; a schema `filter:` is written in physical
@@ -1714,13 +1725,25 @@ impl<'a> VariableLengthCteGenerator<'a> {
         // identifier), never silently against the wrong column.
         for prop in &self.properties {
             if prop.cypher_alias == self.end_cypher_alias {
-                let pattern_col = format!("{}.{}", self.end_node_alias, prop.column_name);
-                let replacement = format!("end_{}", prop.alias);
-                rewritten = rewritten.replace(&pattern_col, &replacement);
+                pairs.push((
+                    format!("{}.{}", self.end_node_alias, prop.column_name),
+                    format!("end_{}", prop.alias),
+                ));
             }
         }
+        // Longest needle first: a shorter column that is a prefix of a longer
+        // one can then never fire inside it (belt to the token-boundary
+        // suspenders — boundary alone already blocks it, ordering makes the
+        // outcome independent of predicate order in the schema YAML).
+        pairs.sort_by_key(|(needle, _)| std::cmp::Reverse(needle.len()));
 
-        rewritten
+        Self::rewrite_outside_string_literals(filter, |segment| {
+            let mut seg = segment.to_string();
+            for (needle, replacement) in &pairs {
+                seg = Self::replace_column_token(&seg, needle, replacement);
+            }
+            seg
+        })
     }
 
     // Note: extract_simple_equality_filter was removed as dead code (never called)

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -1699,18 +1699,24 @@ impl<'a> VariableLengthCteGenerator<'a> {
             VLP_END_ID_COLUMN,
         );
 
-        // Replace end_node.{property} with end_{property} for each property
-        // Try both ClickHouse column name and Cypher alias since filters can use either
+        // Replace end_node.{column} with end_{alias} for each projected property.
+        //
+        // #1122: ONLY the physical-column spelling is matched. Filters reaching
+        // this point are already property-mapped (a user WHERE `b.name` arrives
+        // as `end_node.full_name`; a schema `filter:` is written in physical
+        // columns), so the historical second pass that ALSO matched the
+        // cypher-alias spelling (`end_node.<alias>`) had no covered use — and it
+        // was the mis-bind vector: with `kind: decoy` declared and a schema
+        // filter on the UNDECLARED physical column `kind`, it rewrote
+        // `end_node.kind` to `end_kind`, a projected column holding `decoy`'s
+        // value — valid SQL, wrong rows, no error (review of #1121). Any
+        // uncovered reliance on the alias spelling now fails LOUD (unknown
+        // identifier), never silently against the wrong column.
         for prop in &self.properties {
             if prop.cypher_alias == self.end_cypher_alias {
-                // Try ClickHouse column name (e.g., end_node.full_name → end_name)
                 let pattern_col = format!("{}.{}", self.end_node_alias, prop.column_name);
                 let replacement = format!("end_{}", prop.alias);
                 rewritten = rewritten.replace(&pattern_col, &replacement);
-
-                // Also try Cypher alias (e.g., end_node.name → end_name)
-                let pattern_alias = format!("{}.{}", self.end_node_alias, prop.alias);
-                rewritten = rewritten.replace(&pattern_alias, &replacement);
             }
         }
 

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2144,3 +2144,47 @@ async fn ldbc_1122_user_where_still_property_mapped() {
          the projected column:\n{sql}"
     );
 }
+
+/// #1128 review (HIGH): prefix-pair collision. `kind` is a strict prefix of
+/// `kind_extra` (which maps to `decoy2`); the shortest-first plain replace
+/// corrupted `end_node.kind_extra` into `end_kind_extra` — the decoy
+/// projection — with correctness dependent on the YAML predicate ORDER.
+/// Live before the rework: pk 3 where the answer is pk 2 in one order,
+/// correct in the other. Now longest-first + word-boundary + literal-aware.
+#[tokio::test]
+async fn ldbc_1122_prefix_pair_filter_binds_real_columns() {
+    let schema = load_schema_from("schemas/test/decoy_schema_filter.yaml");
+    let sql = generate_sql_inline(&schema, "MATCH (a:Q)-[:L2*1..3]->(b:Q) RETURN b.pk").await;
+    assert!(
+        sql.contains("end___sf_kind_extra = 'X'"),
+        "#1128: the longer colliding column must bind its mangled projection \
+         (never the decoy `end_kind_extra`):\n{sql}"
+    );
+    assert!(
+        sql.contains("end_kind = 'A'"),
+        "#1128: the shorter (undeclared, non-colliding) column keeps its \
+         plain projection:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_kind_extra = 'X'") || sql.contains("end___sf_kind_extra = 'X'"),
+        "#1128: `end_node.kind_extra` must never be corrupted into the decoy \
+         `end_kind_extra` projection:\n{sql}"
+    );
+}
+
+/// #1128 review: a string LITERAL that happens to contain `end_node.<col>`
+/// must not be edited by the rewrite (`rewrite_outside_string_literals`).
+#[tokio::test]
+async fn ldbc_1122_literal_value_not_corrupted() {
+    let schema = load_schema_from("benchmarks/social_network/schemas/social_benchmark.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) \
+         WHERE b.name = 'end_node.full_name' RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("end_name = 'end_node.full_name'"),
+        "#1128: the literal VALUE must survive the rewrite verbatim:\n{sql}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2064,3 +2064,83 @@ async fn ldbc_1125_multi_label_inferred_node_gets_no_filter() {
          label's schema filter:\n{sql}"
     );
 }
+
+// --- #1122: schema-filter column colliding with a differently-mapped property -
+//
+// `filter: "kind = 'A'"` (physical column `kind`) + `property_mappings:
+// kind: decoy` (cypher `kind` -> physical `decoy`). Two coupled defects:
+//   1. The #1118 projection SKIPPED the collision (ambiguous `end_kind`),
+//      leaving the filter unprojected.
+//   2. `rewrite_end_filter_for_cte` ALSO matched the cypher-alias spelling
+//      (`end_node.kind`), rewriting the unprojected filter onto `end_kind` —
+//      the DECLARED property's projected column, holding `decoy`'s value.
+// Net: valid SQL, wrong rows, no error — live pk 3 where the answer is pk 2,
+// with the COUNTS agreeing by coincidence (1 either way).
+//
+// Fix: project the collision under a mangled `__sf_<col>` alias bound to the
+// REAL column, and drop the alias-spelling replace (filters reach the rewrite
+// already property-mapped, so it had no covered use — an uncovered reliance
+// now fails LOUD instead of silently against the wrong column).
+
+/// The wrapper predicate must bind to the REAL filter column via the mangled
+/// projection — never to the declared property's (differently-mapped) column.
+#[tokio::test]
+async fn ldbc_1122_colliding_schema_filter_binds_real_column() {
+    let schema = load_schema_from("schemas/test/decoy_schema_filter.yaml");
+    for cypher in [
+        "MATCH (a:P)-[:L*1..3]->(b:P) RETURN b.pk",
+        "MATCH (a:P)-[:L*1..3]->(b:P) RETURN count(*)",
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            sql.contains("end_node.kind as end___sf_kind"),
+            "#1122: the colliding filter column must be projected under the \
+             mangled alias, bound to the REAL `kind` column, for `{cypher}`:\n{sql}"
+        );
+        assert!(
+            sql.contains("end___sf_kind = 'A'"),
+            "#1122: the wrapper predicate must reference the mangled \
+             projection for `{cypher}`:\n{sql}"
+        );
+        // The mis-bind: predicate on the DECLARED property's projection.
+        assert!(
+            !sql.contains("(end_kind = 'A'"),
+            "#1122: the predicate must NOT bind to `end_kind` (that column \
+             holds `decoy`'s value) for `{cypher}`:\n{sql}"
+        );
+    }
+}
+
+/// #1122 boundary: the normal declared-property path (filter column IS the
+/// declared property's physical column) keeps its unmangled alias.
+#[tokio::test]
+async fn ldbc_1122_non_colliding_filter_unmangled() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Place)-[:IS_PART_OF*1..2]->(c:Country) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("end_type = 'Country'") && !sql.contains("__sf_"),
+        "#1122: the non-colliding LDBC shape keeps its plain alias:\n{sql}"
+    );
+}
+
+/// #1122 boundary: a user WHERE spelled with the cypher alias still works —
+/// it reaches the rewrite already property-mapped to the physical column, so
+/// removing the alias-spelling replace loses nothing.
+#[tokio::test]
+async fn ldbc_1122_user_where_still_property_mapped() {
+    let schema = load_schema_from("benchmarks/social_network/schemas/social_benchmark.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WHERE b.name = 'Bob' RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("end_name = 'Bob'"),
+        "#1122: a user WHERE on a renamed property must still rewrite onto \
+         the projected column:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

`filter: "kind = 'A'"` (physical column `kind`) + `property_mappings: kind: decoy` (cypher `kind` → physical `decoy`) → **silent wrong rows** via two coupled defects:

1. The #1118 projection **skipped** the collision (ambiguous `end_kind`), leaving the filter unprojected.
2. `rewrite_end_filter_for_cte` also matched the **cypher-alias spelling**, rewriting `end_node.kind` onto `end_kind` — the declared property's projected column, holding `decoy`'s value.

Live: **pk 3 returned where the answer is pk 2** — and the counts agree by coincidence (1 either way), so a count-only oracle passes this defect. Found by the #1121 adversarial review.

## Fix

- Project the collision under a mangled `__sf_<col>` alias bound to the **real** column; the wrapper predicate rewrites onto it via the normal physical-column replace. Live: pk 2, count 1 — both == oracle.
- **Delete the alias-spelling replace.** Filters reach the rewrite already property-mapped (user WHERE `b.name` arrives as `end_node.full_name`; schema filters are written in physical columns). Verified it had no covered use: a 236-combo end-WHERE sweep across every schema plus the full suite are **byte-identical** without it. It was purely the mis-bind vector; any uncovered reliance now fails **loud**, never silently against the wrong column.

## Verification

- LDBC #1118 matrix re-verified live: 1343 / 1454 / 1343 / user-WHERE 199.
- 236-combo sweep vs main: **0 diffs** outside the target shape.
- New fixture `decoy_schema_filter.yaml` + 3 tests; targeting one fails on main (asserts on returned IDs, not counts — the counts lie here).
- Suite green (1738 + 678 + ratchet), clippy clean, zero golden churn.

Closes #1122