### PR TITLE
fix(vlp): #1123 composite node_id component filter projects the component

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -670,7 +670,21 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   ids keep the skip (rewrite onto `end_id`, locked by a boundary test). Live
   on a populated composite fixture: Code 47 → **2 == oracle** (both
   channels). 240-combo sweep vs main: exactly 1 diff (the target shape).
-  2 tests (targeting one fails on main). Suite green (1738 + 682 + ratchet),
+  2 tests (targeting one fails on main). Adversarial review (PR #1130) found a
+  **CRITICAL** in the first cut and BLOCKED the merge: the recursive arm
+  emitted composite components INTERLEAVED per column while the base arm
+  groups them — UNION ALL binds by POSITION (#908 class), so every hop>=2 row
+  swapped `start_account_number`↔`end_bank_id`, silently scrambling
+  RETURN-position component reads (PRE-EXISTING on main: hop>=2 was always
+  wrong, no WHERE needed) and making the new wrapper end-filter read scrambled
+  data (loud→WRONG: 2 rows vs oracle 4; a filter on a NONEXISTENT bank
+  returned 3 phantom rows; my count(*) validation passed only because pruning
+  happened to align the arms — correctness depended on which columns the
+  query RETURNed). Fixed in-PR by aligning the recursive block to the base
+  arm's grouped order (+ keying start pass-throughs on the START composite,
+  not end's): all reviewer repros now == oracle, and main's pre-existing
+  RETURN-position scramble is fixed too (10/10 rows correct). Structural
+  arm-order test added (fails on main). Suite green (1738 + 683 + ratchet),
   clippy clean, zero golden churn.
 
 - 2026-09-05: **Correctness (ground-rule-1) — schema-filter column colliding

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness — a filter on a COMPOSITE node_id COMPONENT was
+  left unrewritten in the VLP wrapper → Code 47 (loud)** (branch
+  `fix/1123-composite-id-filter-component`, PR #1130, closes #1123). A
+  composite id's `end_id` is a pipe-joined concat with no per-component
+  target, so BOTH channels — a schema `filter: "bank_id = 7"` AND a user
+  `WHERE b.bank_id = 'x'` — emitted a bare `end_node.bank_id` in the wrapper.
+  Fix: composite id components FALL THROUGH the id-skips (the #1118
+  schema-filter block and the regular VLP property builder, both sides) and
+  are projected as ordinary `<prefix>_<col>` columns; the #1128
+  boundary-aware rewrite binds the wrapper predicate to them. Single-column
+  ids keep the skip (rewrite onto `end_id`, locked by a boundary test). Live
+  on a populated composite fixture: Code 47 → **2 == oracle** (both
+  channels). 240-combo sweep vs main: exactly 1 diff (the target shape).
+  2 tests (targeting one fails on main). Suite green (1738 + 682 + ratchet),
+  clippy clean, zero golden churn.
+
 - 2026-09-05: **Correctness (ground-rule-1) — schema-filter column colliding
   with a differently-mapped declared property mis-bound the wrapper predicate
   to the WRONG column** (branch `fix/1122-structural-end-filter-rewrite`,

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -4078,7 +4078,13 @@ pub fn extract_ctes_with_context(
                                 start_node_schema.property_mappings.iter().collect();
                             sorted_props.sort_by_key(|(k, _)| k.as_str());
                             for (prop_name, prop_value) in sorted_props {
-                                if start_id_columns.contains(&prop_value.raw()) {
+                                // A SINGLE id is projected as `start_id` and its
+                                // references rewrite onto it. A COMPOSITE id's
+                                // components have no per-component target (#1123),
+                                // so they fall through to ordinary projection.
+                                if start_id_columns.len() == 1
+                                    && start_id_columns.contains(&prop_value.raw())
+                                {
                                     continue;
                                 }
                                 // Prune: skip if requirements exist and this property isn't needed
@@ -4124,7 +4130,11 @@ pub fn extract_ctes_with_context(
                                 end_node_schema.property_mappings.iter().collect();
                             sorted_props.sort_by_key(|(k, _)| k.as_str());
                             for (prop_name, prop_value) in sorted_props {
-                                if end_id_columns.contains(&prop_value.raw()) {
+                                // Composite id components fall through (#1123) — see
+                                // the start-side comment.
+                                if end_id_columns.len() == 1
+                                    && end_id_columns.contains(&prop_value.raw())
+                                {
                                     continue;
                                 }
                                 // Check both Cypher property name and DB column name
@@ -4266,14 +4276,17 @@ pub fn extract_ctes_with_context(
                         };
                         let id_columns = node_schema.node_id.columns();
                         for col in schema_filter.get_columns() {
-                            // The id column is projected as `start_id`/`end_id`, not as
-                            // a `<prefix>_<prop>` column; skip it — a filter on a SINGLE
-                            // id is already handled by the id rewrite
-                            // (`end_node.<id_col>` -> `end_id`). That does NOT hold for a
-                            // COMPOSITE id, whose `end_id` is a pipe-joined concat with no
-                            // per-component target: such a filter is left unrewritten and
-                            // fails loud (Code 47). Pre-existing, tracked as #1123.
-                            if id_columns.contains(&col.as_str()) {
+                            // A SINGLE id column is projected as `start_id`/`end_id`
+                            // and its filter is handled by the id rewrite
+                            // (`end_node.<id_col>` -> `end_id`) — skip it. A COMPOSITE
+                            // id's `end_id` is a pipe-joined concat with NO
+                            // per-component target, so a filter on one component was
+                            // left unrewritten -> Code 47 (#1123). Fall THROUGH for
+                            // the composite case: the component is then projected as
+                            // an ordinary `<prefix>_<col>` column (mangled if a
+                            // declared property collides) and the boundary-aware
+                            // rewrite binds the wrapper predicate to it.
+                            if id_columns.len() == 1 && id_columns.contains(&col.as_str()) {
                                 continue;
                             }
                             // The filter is written against PHYSICAL columns, but the

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -3211,7 +3211,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
         let ac = fmap.array_concat();
         let empty_str_arr = fmap.empty_string_array_cast();
 
-        // Parse end node ID identifier
+        // Parse endpoint ID identifiers (start needed for the composite
+        // pass-through block below — #1130 review).
+        let start_id_identifier = parse_id_cols(&self.start_node_id_column);
         let end_id_identifier = parse_id_cols(&self.end_node_id_column);
         let end_id_expr_str = emit_id_expr(&self.end_node_alias, &end_id_identifier);
 
@@ -3263,13 +3265,27 @@ impl<'a> VariableLengthCteGenerator<'a> {
             ));
         }
 
-        // For composite IDs, add individual ID component columns
-        // Pass through start ID components from vp, add end ID components from joined node
-        if let Identifier::Composite(cols) = &end_id_identifier {
+        // For composite IDs, add individual ID component columns.
+        //
+        // #1130 review (CRITICAL): the arm ORDER must MATCH the base arm —
+        // grouped (all `start_*`, then all `end_*`), never interleaved per
+        // column. A recursive CTE's UNION ALL binds by POSITION (#908 class):
+        // the old interleaved emission swapped `start_account_number` with
+        // `end_bank_id` on every hop>=2 row, silently scrambling both
+        // RETURN-position component reads (pre-existing on main) and the
+        // wrapper end-filter (#1123) that binds to these columns. Also keyed
+        // on the CORRECT side's identifier: the start pass-throughs iterate
+        // the START composite (the old code iterated end's cols for both,
+        // wrong whenever the two composites differ).
+        if let Identifier::Composite(cols) = &start_id_identifier {
             for col in cols.iter() {
                 // Start ID components pass through from vp
                 select_items.push(format!("vp.start_{} as start_{}", col, col));
-                // End ID components come from newly joined node
+            }
+        }
+        if let Identifier::Composite(cols) = &end_id_identifier {
+            for col in cols.iter() {
+                // End ID components come from the newly joined node
                 select_items.push(format!(
                     "{}.{} as end_{}",
                     self.end_node_alias,

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2244,3 +2244,51 @@ async fn ldbc_1123_single_id_filter_still_uses_end_id() {
         "#1123: no redundant projected column for a single-column id:\n{sql}"
     );
 }
+
+/// #1130 review (CRITICAL): the recursive arm emitted composite id components
+/// INTERLEAVED per column (`vp.start_<c>, end_node.<c>` pairs) while the base
+/// arm groups them (all `start_*`, then all `end_*`). UNION ALL binds by
+/// POSITION, so every hop>=2 row swapped `start_account_number` with
+/// `end_bank_id` — silently scrambling RETURN-position component reads
+/// (pre-existing on main) and the #1123 wrapper end-filter (loud on main,
+/// WRONG on the unfixed branch: 2 rows where the oracle is 4, and a filter on
+/// a nonexistent bank returned phantom rows). Structural lock: the ordered
+/// `as start_*`/`as end_*` sequences must be IDENTICAL across arms.
+#[tokio::test]
+async fn ldbc_1123_composite_component_arm_order_aligned() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[r*1..2]->(b:Account) \
+         RETURN a.bank_id, a.account_number, b.bank_id, b.account_number",
+    )
+    .await;
+    let union_pos = sql
+        .to_uppercase()
+        .find("UNION ALL")
+        .unwrap_or_else(|| panic!("expected a recursive UNION ALL:\n{sql}"));
+    let (base_arm, recursive_arm) = sql.split_at(union_pos);
+    let component_aliases = |arm: &str| -> Vec<String> {
+        arm.split(" as ")
+            .skip(1)
+            .filter_map(|tail| tail.split([',', '\n', ' ']).next())
+            .filter(|tok| {
+                (tok.starts_with("start_") || tok.starts_with("end_"))
+                    && *tok != "start_id"
+                    && *tok != "end_id"
+            })
+            .map(|s| s.to_string())
+            .collect()
+    };
+    let base_order = component_aliases(base_arm);
+    let rec_order = component_aliases(recursive_arm);
+    assert!(
+        !base_order.is_empty(),
+        "expected composite component columns in the base arm:\n{sql}"
+    );
+    assert_eq!(
+        base_order, rec_order,
+        "#1130: base and recursive arms must emit component columns in the \
+         SAME positional order (UNION ALL binds by position):\n{sql}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2188,3 +2188,59 @@ async fn ldbc_1122_literal_value_not_corrupted() {
         "#1128: the literal VALUE must survive the rewrite verbatim:\n{sql}"
     );
 }
+
+// --- #1123: filter on a COMPOSITE node_id component --------------------------
+//
+// A composite id's `end_id` is a pipe-joined concat with no per-component
+// target, so the id rewrite could not handle `end_node.bank_id` and BOTH
+// channels — a schema `filter: "bank_id = 7"` and a user `WHERE b.bank_id`
+// — left the reference unrewritten in the wrapper -> Code 47.
+// Fix: composite id components FALL THROUGH the id-skips (the #1118 block and
+// the regular VLP property builder) and are projected as ordinary
+// `<prefix>_<col>` columns; the boundary-aware rewrite binds the wrapper
+// predicate to them. Live: Code 47 -> 2 == oracle on a populated fixture.
+// Single-column ids keep the skip: they're already handled by the id rewrite.
+
+/// Both channels — schema filter and user WHERE — on a composite component
+/// must project the component and bind the wrapper predicate to it.
+#[tokio::test]
+async fn ldbc_1123_composite_component_filter_projected() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[r*1..2]->(b:Account) WHERE b.bank_id = 'x' RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("end_node.bank_id as end_bank_id"),
+        "#1123: the composite id component must be projected:\n{sql}"
+    );
+    assert!(
+        sql.contains("end_bank_id = 'x'"),
+        "#1123: the wrapper predicate must bind to the projected component:\n{sql}"
+    );
+    assert!(
+        !sql.contains("WHERE (end_node.bank_id"),
+        "#1123: no bare out-of-scope `end_node.bank_id` in the wrapper:\n{sql}"
+    );
+}
+
+/// #1123 boundary: a SINGLE-column id keeps the skip — its filter rewrites
+/// onto `end_id`, with no extra projected column.
+#[tokio::test]
+async fn ldbc_1123_single_id_filter_still_uses_end_id() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) WHERE b.user_id = 5 RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("end_id = 5"),
+        "#1123: a single-column id filter must still rewrite onto `end_id`:\n{sql}"
+    );
+    assert!(
+        !sql.contains("as end_user_id"),
+        "#1123: no redundant projected column for a single-column id:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

A composite id's `end_id` is a pipe-joined concat with no per-component target, so a filter referencing one component — **both** a schema `filter: "bank_id = 7"` and a user `WHERE b.bank_id = 'x'` — emitted a bare `end_node.bank_id` in the wrapper → ClickHouse Code 47 (loud). Filed from the #1121 review; the user-WHERE channel found while fixing.

## Fix

Composite id components **fall through** the id-skips (the #1118 schema-filter block and the regular VLP property builder, both sides) and are projected as ordinary `<prefix>_<col>` columns; the #1128 boundary-aware rewrite binds the wrapper predicate to them. Single-column ids keep the skip (rewrite onto `end_id`; a boundary test locks that no redundant column appears).

## Verification

- Live on a populated composite fixture: Code 47 → **2 == oracle** (user WHERE) and **b == oracle** (schema filter).
- 240-combo sweep vs main: **exactly 1 diff** — the target shape.
- 2 tests; targeting one fails on main. Suite green (1738 + 682 + ratchet), clippy clean, zero golden churn.

Closes #1123