### PR TITLE
fix(vlp): #1131 composite component comparison binds components, not whole id

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -670,8 +670,19 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   containing `|`; live-verified 10 == oracle 10; the #1103 golden-locking test
   updated accordingly with the rationale. Single-col LDBC comparison unchanged
   (still `start_id = end_id`). 240-combo sweep: exactly 1 diff (the target
-  shape). 2 tests (targeting one fails on main). Suite green
-  (1738 + 686 + ratchet), clippy clean, zero golden churn.
+  shape). 2 tests (targeting one fails on main). Focused adversarial review
+  (PR #1133, no CRITICAL/HIGH) UPGRADED the identity claim: on a
+  separator-injection fixture ('x|y'+'z' vs 'x'+'y|z', identical concats)
+  main's concat equality DROPPED a `<>` row AND fabricated a phantom `=`
+  "cycle" — the per-component expansion is strictly MORE correct, not merely
+  row-equivalent. Also live-verified: mixed one-operand conjuncts (2==2),
+  `<>` (7==7), ordering `<` (5==5, main 7 via concat lexicographic
+  false-positives); FK-edge/undirected/shortestPath/multi-type/renamed-component
+  all bind correctly. Review re-confirmed **#1132** (zero-hop composite
+  malformed — the zero-hop base arm never got composite-capable id emission)
+  + found LOW: a component physically named `id` collides with the whole-id
+  alias (Code 179, loud, pre-existing). Suite green (1738 + 686 + ratchet),
+  clippy clean, zero golden churn.
 
 - 2026-09-05: **Correctness — a filter on a COMPOSITE node_id COMPONENT was
   left unrewritten in the VLP wrapper → Code 47 (loud)** (branch

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — cross-endpoint COMPOSITE
+  component comparison silently widened to whole-id equality** (branch
+  `fix/1131-composite-component-cross-endpoint`, PR #1133, closes #1131).
+  `WHERE a.bank_id = b.bank_id` on a composite-id VLP was lowered by the #1103
+  path to `start_id = end_id` — the FULL pipe-joined id, i.e. a CYCLE test —
+  silently excluding same-bank different-account paths: live 0 vs an oracle 3.
+  Post-#1130 every component is projected in BOTH arms (grouped order), so the
+  fix maps a component reference to its own `<prefix>_<col>` column (len==1
+  ids keep the collapse). Whole-node identity (`a <> b`) now expands to the
+  per-component AND — row-equivalent to concat equality and safer for values
+  containing `|`; live-verified 10 == oracle 10; the #1103 golden-locking test
+  updated accordingly with the rationale. Single-col LDBC comparison unchanged
+  (still `start_id = end_id`). 240-combo sweep: exactly 1 diff (the target
+  shape). 2 tests (targeting one fails on main). Suite green
+  (1738 + 686 + ratchet), clippy clean, zero golden churn.
+
 - 2026-09-05: **Correctness — a filter on a COMPOSITE node_id COMPONENT was
   left unrewritten in the VLP wrapper → Code 47 (loud)** (branch
   `fix/1123-composite-id-filter-component`, PR #1130, closes #1123). A

--- a/src/render_plan/cte_manager/mod.rs
+++ b/src/render_plan/cte_manager/mod.rs
@@ -1994,10 +1994,20 @@ fn lower_both_endpoint_filter_to_cte_columns(
         id_column_name: &str,
         properties: &[NodeProperty],
     ) -> Result<String, CteError> {
-        // Any column of the node_id maps to the CTE's single id projection —
-        // a composite key is projected pipe-joined into one `start_id`/`end_id`.
-        if id_cols.iter().any(|c| c == column) {
+        // A SINGLE-column node_id maps to the CTE's id projection. A COMPOSITE
+        // key's `start_id`/`end_id` is the pipe-joined concat of ALL components,
+        // so collapsing ONE component onto it changes semantics (#1131: a
+        // same-bank cross-endpoint comparison `a.bank_id = b.bank_id` became
+        // whole-id equality — i.e. a cycle test — silently excluding same-bank
+        // different-account paths, 0 vs an oracle 3). Since #1130 the emitter
+        // always projects each composite component as `<prefix>_<col>` in BOTH
+        // arms (grouped order), so a component reference maps to its own
+        // projected column instead.
+        if id_cols.len() == 1 && id_cols.iter().any(|c| c == column) {
             return Ok(id_column_name.to_string());
+        }
+        if id_cols.len() > 1 && id_cols.iter().any(|c| c == column) {
+            return Ok(format!("{}{}", prefix, column));
         }
         for prop in properties {
             if prop.cypher_alias == cypher_alias

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1160,8 +1160,11 @@ async fn ldbc_1103_unprojected_property_is_a_real_error() {
 /// vs an oracle 3). Post-#1131 each component maps to its own projected
 /// `<prefix>_<col>` column, so whole-node identity expands to the
 /// per-component AND — row-equivalent to concat equality (and safer for values
-/// containing the `|` separator), live-verified 8 == oracle 8 on a populated
-/// fixture.
+/// containing the `|` separator), live-verified 10 == oracle 10 on a populated
+/// fixture. The #1133 review then PROVED the separator case live: with values
+/// 'x|y'+'z' vs 'x'+'y|z' (identical concats), main's concat equality DROPPED
+/// a `<>` row and FABRICATED a phantom `=` "cycle" — the per-component form is
+/// strictly MORE correct, not merely row-equivalent on benign data.
 #[tokio::test]
 async fn ldbc_1103_composite_node_id_collapses_to_single_id_predicate() {
     let schema = load_schema_from("schemas/test/composite_node_ids.yaml");

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -1153,9 +1153,15 @@ async fn ldbc_1103_unprojected_property_is_a_real_error() {
     }
 }
 
-/// #1103: COMPOSITE node_id is projected as ONE pipe-joined `start_id`/`end_id`,
-/// so every key column maps to it — and the per-column expansion collapses to a
-/// single predicate rather than a repeated conjunct.
+/// #1103 (updated by #1131): COMPOSITE node_id identity comparison. Originally
+/// this collapsed every key column onto the ONE pipe-joined `start_id`/`end_id`
+/// — which was also what silently turned a SINGLE-component cross-endpoint
+/// comparison (`a.bank_id = b.bank_id`) into whole-id equality (#1131, 0 rows
+/// vs an oracle 3). Post-#1131 each component maps to its own projected
+/// `<prefix>_<col>` column, so whole-node identity expands to the
+/// per-component AND — row-equivalent to concat equality (and safer for values
+/// containing the `|` separator), live-verified 8 == oracle 8 on a populated
+/// fixture.
 #[tokio::test]
 async fn ldbc_1103_composite_node_id_collapses_to_single_id_predicate() {
     let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
@@ -1167,13 +1173,16 @@ async fn ldbc_1103_composite_node_id_collapses_to_single_id_predicate() {
     )
     .await;
     assert!(
-        sql.contains("WHERE (NOT (end_id = start_id))"),
-        "#1103: composite node_id identity must collapse to the pipe-joined id \
-         columns, deduplicated:\n{sql}"
+        sql.contains(
+            "NOT ((end_bank_id = start_bank_id AND end_account_number = start_account_number))"
+        ),
+        "#1103/#1131: composite node identity expands to the per-component \
+         conjunction over the projected component columns:\n{sql}"
     );
     assert!(
-        !sql.contains("end_id = start_id AND end_id = start_id"),
-        "#1103: the collapsed per-column conjuncts must be deduplicated:\n{sql}"
+        !sql.contains("end_id = start_id"),
+        "#1131: no whole-concat collapse — a component-level predicate must \
+         never be widened to pipe-joined-id equality:\n{sql}"
     );
 }
 
@@ -2290,5 +2299,52 @@ async fn ldbc_1123_composite_component_arm_order_aligned() {
         base_order, rec_order,
         "#1130: base and recursive arms must emit component columns in the \
          SAME positional order (UNION ALL binds by position):\n{sql}"
+    );
+}
+
+// --- #1131: cross-endpoint COMPONENT comparison must not widen to whole-id ---
+//
+// `WHERE a.bank_id = b.bank_id` on a composite-id VLP was lowered by the #1103
+// path to `start_id = end_id` — equality of the FULL pipe-joined id, i.e. a
+// cycle test — silently excluding same-bank different-account paths (live: 0
+// vs an oracle 3). Post-#1130 every component is projected in both arms
+// (grouped order), so a component reference maps to its own
+// `<prefix>_<col>` column. Single-column ids keep the id collapse.
+
+/// A single-component cross-endpoint comparison binds the component columns.
+#[tokio::test]
+async fn ldbc_1131_component_comparison_not_widened_to_whole_id() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]->(b:Account) \
+         WHERE a.bank_id = b.bank_id RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_bank_id = end_bank_id"),
+        "#1131: the component comparison must bind the projected component \
+         columns:\n{sql}"
+    );
+    assert!(
+        !sql.contains("start_id = end_id"),
+        "#1131: never widened to whole-pipe-joined-id equality (a cycle \
+         test):\n{sql}"
+    );
+}
+
+/// #1131 boundary: a SINGLE-column id keeps the id collapse.
+#[tokio::test]
+async fn ldbc_1131_single_id_comparison_still_collapses() {
+    let schema = load_schema_from("benchmarks/ldbc_snb/schemas/ldbc_snb.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Place)-[:IS_PART_OF*1..2]->(c:Place) WHERE a.id = c.id RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_id = end_id"),
+        "#1131: a single-column id comparison still collapses to the id \
+         projection:\n{sql}"
     );
 }


### PR DESCRIPTION
## Problem

`WHERE a.bank_id = b.bank_id` on a composite-id VLP was lowered to `start_id = end_id` — the **full pipe-joined id**, i.e. a cycle test — silently excluding same-bank different-account paths. Live: **0 rows vs oracle 3**. Filed from the #1130 review.

## Fix

Post-#1130 every composite component is projected in both arms (grouped order), so `cte_column_for` maps a component reference to its own `<prefix>_<col>` column; single-column ids keep the collapse.

Whole-node identity (`a <> b`) on a composite now expands to the per-component AND — row-equivalent to concat equality (and safer for values containing `|`), live-verified **10 == oracle 10**. The #1103 test locking the concat collapse is updated with the rationale; the single-column LDBC shape is unchanged (boundary-tested).

## Verification

- Repro: 0 → **3 == oracle**. Identity: **10 == oracle**. Both-components AND: 0 == oracle.
- 240-combo sweep vs main: exactly 1 diff (the target shape).
- 2 tests; targeting one fails on main. Suite green (1738 + 686 + ratchet), clippy clean, zero golden churn.

Closes #1131