### PR TITLE
fix(vlp): #1132 zero-hop composite base arm uses composite-aware id emission

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,22 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness — zero-hop (`*0..N`) composite VLP emitted a
+  malformed base arm (Code 44, loud)** (branch `fix/1132-zero-hop-composite`,
+  PR #1134, closes #1132). `generate_zero_hop_base_case` interpolated the RAW
+  comma-separated composite column string (`start_node.bank_id, account_number
+  as start_id` — alias on the SECOND column, concat never built). Fix: route
+  the seed id through the composite-aware `emit_id_expr` (#604/#713 pattern:
+  thread the column vector, don't stringify), emit the per-component columns
+  in the #1130 GROUPED order so UNION ALL binds correctly, and skip components
+  in the props loop (a first cut double-projected → Code 44; caught by the
+  full-projection probe per the pruning-can-mask lesson). Live: count 15 ==
+  oracle AND the full 4-column 15-row matrix row-for-row identical to a hand
+  enumeration. 240-combo `*0..2` sweep: 3 diffs = the fix on 2 composite
+  schemas + a thread-id in a pre-existing panic message (byte-equal
+  otherwise). 2 tests (targeting one fails on main). Suite green
+  (1738 + 687 + ratchet), clippy clean, zero golden churn.
+
 - 2026-09-05: **Correctness (ground-rule-1) — cross-endpoint COMPOSITE
   component comparison silently widened to whole-id equality** (branch
   `fix/1131-composite-component-cross-endpoint`, PR #1133, closes #1131).

--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -670,8 +670,21 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
   oracle AND the full 4-column 15-row matrix row-for-row identical to a hand
   enumeration. 240-combo `*0..2` sweep: 3 diffs = the fix on 2 composite
   schemas + a thread-id in a pre-existing panic message (byte-equal
-  otherwise). 2 tests (targeting one fails on main). Suite green
-  (1738 + 687 + ratchet), clippy clean, zero golden churn.
+  otherwise). Focused review (PR #1134) passed all 6 directed attacks (3-arm
+  alignment incl. pruned subsets; filters; closed; cross-type refusal;
+  nodes(p)/#1077 arrays; LDBC 1454 unchanged) but found a **HIGH the fix
+  newly exposed**: the undirected two-CTE split gave BOTH arms `min_hops: 0`,
+  so the direction-independent zero-hop identity rows were seeded twice —
+  silently DOUBLED (30 vs oracle 25), loud→silent via #1132 making the shape
+  render at all (the loud-fix-exposes-silent-bug class). Fixed in-PR: the
+  swapped Incoming arm's min bumped to 1, seed lives in the forward arm only
+  (25 == oracle; single-walk single-id and LDBC shapes byte-identical/4431
+  unchanged; the hop-2 mixed-direction UNDERCOUNT 20-vs-22 is PRE-EXISTING
+  #583/#887-family, byte-identical on main). Review also re-confirmed
+  pre-existing: ORDER BY on a composite component maps to whole `t.start_id`;
+  `*0..0` renders as a plain 1-hop join (semantics bug, all id shapes).
+  3 tests (targeting ones fail on main). Suite green (1738 + 688 + ratchet),
+  clippy clean, zero golden churn.
 
 - 2026-09-05: **Correctness (ground-rule-1) — cross-endpoint COMPOSITE
   component comparison silently widened to whole-id equality** (branch

--- a/src/query_planner/analyzer/bidirectional_union.rs
+++ b/src/query_planner/analyzer/bidirectional_union.rs
@@ -2182,6 +2182,25 @@ fn apply_direction_combination_inner(
                     )
                 };
 
+            // #1132 review: a zero-hop (`*0..N`) row is DIRECTION-INDEPENDENT
+            // (the identity a = b, no edge traversed), so it must be seeded in
+            // exactly ONE arm of the two-CTE undirected split. Both arms kept
+            // `min_hops: 0` and the outer UNION ALL retained both copies —
+            // every zero-hop row silently DOUBLED (30 vs an oracle 25 on the
+            // composite fixture; reachable once #1132 made composite `*0..N`
+            // render at all). Keep the seed on the forward arm; the swapped
+            // Incoming arm starts at 1 hop.
+            let arm_variable_length = if is_incoming_swap {
+                graph_rel.variable_length.clone().map(|mut spec| {
+                    if spec.effective_min_hops() == 0 {
+                        spec.min_hops = Some(1);
+                    }
+                    spec
+                })
+            } else {
+                graph_rel.variable_length.clone()
+            };
+
             // Create new GraphRel with the determined direction
             Arc::new(LogicalPlan::GraphRel(GraphRel {
                 left: final_left,
@@ -2192,7 +2211,7 @@ fn apply_direction_combination_inner(
                 left_connection: new_left_connection,
                 right_connection: new_right_connection,
                 is_rel_anchor: graph_rel.is_rel_anchor,
-                variable_length: graph_rel.variable_length.clone(),
+                variable_length: arm_variable_length,
                 shortest_path_mode: graph_rel.shortest_path_mode.clone(),
                 path_variable: graph_rel.path_variable.clone(),
                 where_predicate: graph_rel.where_predicate.clone(),

--- a/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
+++ b/src/sql_generator/emitters/clickhouse/variable_length_cte.rs
@@ -2712,26 +2712,22 @@ impl<'a> VariableLengthCteGenerator<'a> {
             std::collections::HashSet::new() // Not needed when tables are same
         };
 
+        // #1132: the id must go through the composite-aware `emit_id_expr` —
+        // interpolating the raw comma-separated column string produced
+        // `start_node.bank_id, acct_no as start_id` (two columns, alias on the
+        // second; the pipe-joined concat never built) → Code 44 on every
+        // composite `*0..N`. Single-column ids emit byte-identically to the
+        // old string form.
+        let start_id_identifier = Identifier::from_comma_separated(&self.start_node_id_column);
+        let start_id_expr = emit_id_expr(&self.start_node_alias, &start_id_identifier);
         let mut select_items = vec![
-            format!(
-                "{}.{} as start_id",
-                self.start_node_alias, self.start_node_id_column
-            ),
-            format!(
-                "{}.{} as end_id",
-                self.start_node_alias,
-                self.start_node_id_column // Same node for self-loop
-            ),
+            format!("{start_id_expr} as start_id"),
+            // Same node for self-loop
+            format!("{start_id_expr} as end_id"),
             "0 as hop_count".to_string(), // Zero hops
             format!("{empty_str_arr} as path_relationships"), // Minimal placeholder when path data not needed
             // Add path_nodes for UNWIND nodes(p) support - for zero hop, just the start node
-            format!(
-                "{} as path_nodes",
-                arr(&format!(
-                    "{}.{}",
-                    self.start_node_alias, self.start_node_id_column
-                ))
-            ),
+            format!("{} as path_nodes", arr(&start_id_expr)),
         ];
 
         // #1077: zero-hop parallel per-node property arrays — the path visits
@@ -2768,6 +2764,37 @@ impl<'a> VariableLengthCteGenerator<'a> {
             ));
         }
 
+        // #1132: the non-zero arms project each composite component as
+        // `start_<col>`/`end_<col>` (grouped — #1130). The zero-hop arm must
+        // emit the SAME columns in the SAME order or UNION ALL misbinds by
+        // position. At hop 0 start == end, so both groups read the start node.
+        if let Identifier::Composite(cols) = &start_id_identifier {
+            for col in cols.iter() {
+                select_items.push(format!(
+                    "{}.{} as start_{}",
+                    self.start_node_alias,
+                    crate::clickhouse_query_generator::quote_identifier(col),
+                    col
+                ));
+            }
+            for col in cols.iter() {
+                select_items.push(format!(
+                    "{}.{} as end_{}",
+                    self.start_node_alias,
+                    crate::clickhouse_query_generator::quote_identifier(col),
+                    col
+                ));
+            }
+        }
+
+        // Composite components already projected above — the props loop must
+        // not emit them again (Code 44 column-already-exists). Mirrors the
+        // non-zero arms, whose props loops skip id components too.
+        let is_id_component = |col: &str| -> bool {
+            matches!(&start_id_identifier, Identifier::Composite(cols)
+                if cols.iter().any(|c| c == col))
+        };
+
         // Add properties for start node (which is also the end node)
         for prop in &self.properties {
             if prop.cypher_alias == self.start_cypher_alias {
@@ -2775,6 +2802,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
                 // But keep it if it's a different property that happens to be the ID column
                 // (e.g., "node_id" as a separate property in some schemas)
                 if prop.column_name == self.start_node_id_column && prop.alias == "id" {
+                    continue;
+                }
+                if is_id_component(&prop.column_name) {
                     continue;
                 }
 
@@ -2787,6 +2817,9 @@ impl<'a> VariableLengthCteGenerator<'a> {
             if prop.cypher_alias == self.end_cypher_alias {
                 // Skip ID column when it's the actual id property (already added as end_id)
                 if prop.column_name == self.end_node_id_column && prop.alias == "id" {
+                    continue;
+                }
+                if is_id_component(&prop.column_name) {
                     continue;
                 }
 

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2417,3 +2417,26 @@ async fn ldbc_1132_zero_hop_single_id_unchanged() {
         "#1132: single-column zero-hop id emission unchanged:\n{sql}"
     );
 }
+
+/// #1132 review (HIGH): the undirected two-CTE split gave BOTH directional
+/// arms `min_hops: 0`, so the direction-independent zero-hop identity rows
+/// were seeded TWICE and the outer UNION ALL kept both copies — every
+/// zero-hop row silently doubled (30 vs an oracle 25 on the composite
+/// fixture), newly reachable once #1132 made composite `*0..N` render at all.
+/// The seed now lives in the FORWARD arm only; the swapped Incoming arm
+/// starts at 1 hop.
+#[tokio::test]
+async fn ldbc_1132_undirected_split_seeds_zero_hop_once() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*0..2]-(b:Account) RETURN count(*)",
+    )
+    .await;
+    assert_eq!(
+        sql.matches("0 as hop_count").count(),
+        1,
+        "#1132: the two-CTE undirected split must seed the zero-hop identity \
+         row in exactly ONE arm:\n{sql}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2351,3 +2351,69 @@ async fn ldbc_1131_single_id_comparison_still_collapses() {
          projection:\n{sql}"
     );
 }
+
+// --- #1132: zero-hop (*0..N) composite VLP base arm ---------------------------
+//
+// `generate_zero_hop_base_case` interpolated the RAW comma-separated composite
+// column string: `start_node.bank_id, account_number as start_id` — two
+// columns with the alias on the second; the pipe-joined concat never built —
+// Code 44 on every composite `*0..N` (loud, both channels). The zero-hop arm
+// also never projected the per-component columns the non-zero arms carry
+// (#1130 grouped order), so UNION ALL would misbind by position once the id
+// emission was fixed. Fix: route through `emit_id_expr` + emit the grouped
+// component columns + skip them in the props loop (Code 44 double-projection).
+// Live: count 15 == oracle AND the full 4-column 15-row matrix row-for-row
+// identical to a hand enumeration.
+
+/// Zero-hop composite: pipe-joined id, grouped component columns, no
+/// double-projection.
+#[tokio::test]
+async fn ldbc_1132_zero_hop_composite_id_emission() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*0..2]->(b:Account) \
+         RETURN a.bank_id, a.account_number, b.bank_id, b.account_number",
+    )
+    .await;
+    assert!(
+        sql.contains(
+            "concat(toString(start_node.bank_id), '|', toString(start_node.account_number)) as start_id"
+        ),
+        "#1132: the zero-hop seed id must be the composite-aware concat:\n{sql}"
+    );
+    assert!(
+        !sql.contains(", account_number as start_id"),
+        "#1132: never the raw comma-joined column string:\n{sql}"
+    );
+    // Grouped component columns present exactly once each in the zero-hop arm.
+    let zero_arm = sql.split("UNION ALL").next().unwrap_or("");
+    for col in [
+        "as start_bank_id",
+        "as start_account_number",
+        "as end_bank_id",
+        "as end_account_number",
+    ] {
+        assert_eq!(
+            zero_arm.matches(col).count(),
+            1,
+            "#1132: `{col}` must appear exactly once in the zero-hop arm:\n{sql}"
+        );
+    }
+}
+
+/// #1132 boundary: single-column-id zero-hop is byte-compatible (the id
+/// emission path is identical for `Identifier::Single`).
+#[tokio::test]
+async fn ldbc_1132_zero_hop_single_id_unchanged() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*0..2]->(b:User) RETURN count(*)",
+    )
+    .await;
+    assert!(
+        sql.contains("start_node.user_id as start_id"),
+        "#1132: single-column zero-hop id emission unchanged:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

`generate_zero_hop_base_case` interpolated the **raw comma-separated** composite column string: `start_node.bank_id, account_number as start_id` — alias on the second column, concat never built → Code 44 on every composite `*0..N`. Filed from the #1130 review; re-confirmed by the #1133 review.

## Fix

1. Seed id through the composite-aware `emit_id_expr` (#604/#713 pattern). Single-column ids byte-identical (boundary-tested).
2. Per-component columns emitted in the #1130 **grouped** order — the non-zero arms project them, so the zero-hop arm must match or UNION ALL misbinds by position.
3. Components skipped in the props loop — the first cut double-projected (Code 44), caught by running the **full 4-column projection** instead of `count(*)`, per the pruning-can-mask lesson.

## Verification

- Live: count **15 == oracle**, and the full 15-row 4-column matrix row-for-row identical to a hand enumeration.
- 240-combo `*0..2` sweep: 3 diffs = the fix on 2 composite schemas + a thread-id in a pre-existing panic message.
- 2 tests; targeting one fails on main. Suite green (1738 + 687 + ratchet), clippy clean, zero golden churn.

Closes #1132