### PR TITLE
fix(vlp): #1136 ORDER BY on a composite id component binds the component

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,25 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness — ORDER BY / GROUP BY on a composite id COMPONENT
+  collapsed onto the whole pipe-joined `t.start_id`** (branch
+  `fix/1136-order-by-composite-component`, PR #1137, closes #1136). The late
+  SELECT/ORDER BY rewriter (`rewrite_expr_for_vlp`, to_sql_query.rs) uses an
+  `ends_with("_id")` HEURISTIC to detect id references — `a.bank_id` matched
+  and was widened to the whole concat: silently wrong ordering
+  (concat-LEXICOGRAPHIC), Code 215 under aggregation, Code 47 in union forms.
+  Same class as #1131, different seam (outer projection vs both-endpoint
+  WHERE). Fix: a NEW task-local registration
+  (`register_vlp_composite_id_components`, query_context.rs, reset in
+  `clear_all_render_contexts`) recorded at VLP CTE generation; the rewriter's
+  id heuristic consults it FIRST and binds the projected `<prefix>_<col>`
+  (#1130's both-arm projection makes that column exist). Live: ORDER BY rows
+  correctly grouped b1×5,b2×5 == oracle; the aggregate form (was Code 215)
+  returns b1:5,b2:5 == oracle. Single-column ids never register → heuristic
+  path byte-identical (boundary-tested). 240-combo ORDER BY sweep: exactly 1
+  diff (the target shape). 2 tests (targeting one fails on main). Suite green
+  (1738 + 690 + ratchet), clippy clean, zero golden churn.
+
 - 2026-09-05: **Correctness — zero-hop (`*0..N`) composite VLP emitted a
   malformed base arm (Code 44, loud)** (branch `fix/1132-zero-hop-composite`,
   PR #1134, closes #1132). `generate_zero_hop_base_case` interpolated the RAW

--- a/src/render_plan/cte_extraction.rs
+++ b/src/render_plan/cte_extraction.rs
@@ -5515,6 +5515,28 @@ pub fn extract_ctes_with_context(
                         );
                     }
 
+                    // #1136: register composite id COMPONENT columns per endpoint
+                    // so the late SELECT/ORDER BY rewriter binds `a.bank_id` to
+                    // the projected `start_bank_id` instead of collapsing it onto
+                    // the whole pipe-joined `start_id`.
+                    for (ep_alias, ep_label) in
+                        [(&start_alias, &start_label), (&end_alias, &end_label)]
+                    {
+                        if ep_label.is_empty() {
+                            continue;
+                        }
+                        if let Some(ns) = schema.node_schema_opt(ep_label) {
+                            let cols = ns.node_id.columns();
+                            if cols.len() > 1 {
+                                let owned: Vec<String> =
+                                    cols.iter().map(|c| c.to_string()).collect();
+                                crate::server::query_context::register_vlp_composite_id_components(
+                                    ep_alias, &owned,
+                                );
+                            }
+                        }
+                    }
+
                     // Generate VLP CTE via unified CteManager API
                     let var_len_cte = generate_vlp_cte_via_manager(
                         &pattern_ctx,

--- a/src/server/query_context.rs
+++ b/src/server/query_context.rs
@@ -151,6 +151,17 @@ pub struct QueryContext {
     /// the ~100 string-protocol sites. Reset per query in `clear_all_render_contexts`.
     pub vlp_from_alias: Option<String>,
 
+    /// #1136: composite node_id COMPONENT columns per VLP endpoint cypher alias.
+    /// The late SELECT/ORDER BY/GROUP BY rewriter (`rewrite_expr_for_vlp`)
+    /// collapses anything id-shaped (`ends_with("_id")` heuristic) onto the
+    /// whole `start_id`/`end_id` — for a composite id that widens a COMPONENT
+    /// reference (`a.bank_id`) to the pipe-joined concat (wrong ordering /
+    /// Code 215 / Code 47). Since #1130 every component is projected as
+    /// `<prefix>_<col>` in every arm, so the rewriter checks this map FIRST
+    /// and binds the component column. Reset per query in
+    /// `clear_all_render_contexts`.
+    pub vlp_composite_id_components: HashMap<String, HashSet<String>>,
+
     /// #544: number of VLPs the analyzer admitted as a chained-forward multi-VLP
     /// path `(a)-[*]->(b)-[*]->(c)...` in the current scope. `None` when the
     /// scope is not a chained multi-VLP. The render phase reads this to VERIFY it
@@ -824,6 +835,33 @@ pub fn vlp_from_alias() -> String {
         .unwrap_or_else(|| crate::query_planner::join_context::VLP_CTE_FROM_ALIAS.to_string())
 }
 
+/// #1136: register a VLP endpoint's composite node_id COMPONENT columns, so the
+/// late SELECT/ORDER BY rewriter maps a component reference to its projected
+/// `<prefix>_<col>` column instead of collapsing it onto the whole pipe-joined
+/// `start_id`/`end_id`. Called from VLP CTE generation for composite endpoints.
+pub fn register_vlp_composite_id_components(cypher_alias: &str, components: &[String]) {
+    let _ = QUERY_CONTEXT.try_with(|ctx| {
+        ctx.borrow_mut().vlp_composite_id_components.insert(
+            cypher_alias.to_string(),
+            components.iter().cloned().collect(),
+        );
+    });
+}
+
+/// #1136: is `column` a composite node_id COMPONENT of the VLP endpoint bound to
+/// `cypher_alias`? False for single-column ids (never registered) and for
+/// non-endpoint aliases.
+pub fn is_vlp_composite_id_component(cypher_alias: &str, column: &str) -> bool {
+    QUERY_CONTEXT
+        .try_with(|ctx| {
+            ctx.borrow()
+                .vlp_composite_id_components
+                .get(cypher_alias)
+                .is_some_and(|cols| cols.contains(column))
+        })
+        .unwrap_or(false)
+}
+
 /// #544: record that the current scope is a chained-forward multi-VLP path of
 /// `count` VLPs. Called from the analyzer's `pre_register_vlp_endpoints` gate.
 pub fn register_expected_chained_vlp_count(count: usize) {
@@ -1244,6 +1282,8 @@ pub fn clear_all_render_contexts() {
         // #1088: reset the query-scoped VLP FROM alias so the next query starts
         // from the default `"t"` and re-registers its own value if it collides.
         ctx.vlp_from_alias = None;
+        // #1136: reset composite id component registrations.
+        ctx.vlp_composite_id_components.clear();
     });
 }
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -2560,6 +2560,15 @@ pub(crate) fn rewrite_expr_for_vlp(
 
                     // Check if this is the ID column (contains "id" or matches known ID column patterns)
                     let col_raw = prop.column.raw();
+                    // #1136: a COMPOSITE id COMPONENT must NOT collapse onto the
+                    // whole pipe-joined `start_id` (wrong ordering; Code 215/47
+                    // in aggregate/union forms). The component is projected as
+                    // `start_<col>` in every arm since #1130 — bind that.
+                    if crate::server::query_context::is_vlp_composite_id_component(start, col_raw) {
+                        return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{vlp_alias}.start_{col_raw}"
+                        ))));
+                    }
                     if col_raw == "id"
                         || col_raw.starts_with("id.")
                         || col_raw.ends_with("_id")
@@ -2586,6 +2595,13 @@ pub(crate) fn rewrite_expr_for_vlp(
                 if &prop.table_alias.0 == end {
                     // Check if this is the ID column
                     let col_raw = prop.column.raw();
+                    // #1136: composite id components bind their projected column
+                    // (see the start arm above).
+                    if crate::server::query_context::is_vlp_composite_id_component(end, col_raw) {
+                        return RenderExpr::Column(Column(PropertyValue::Column(format!(
+                            "{vlp_alias}.end_{col_raw}"
+                        ))));
+                    }
                     if col_raw == "id"
                         || col_raw.starts_with("id.")
                         || col_raw.ends_with("_id")

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2440,3 +2440,59 @@ async fn ldbc_1132_undirected_split_seeds_zero_hop_once() {
          row in exactly ONE arm:\n{sql}"
     );
 }
+// --- #1136: ORDER BY / GROUP BY on a composite id COMPONENT ------------------
+//
+// The late SELECT/ORDER BY rewriter's id heuristic (`ends_with("_id")`)
+// collapsed a COMPONENT reference (`a.bank_id`) onto the whole pipe-joined
+// `t.start_id` — wrong ordering silently (concat lexicographic), Code 215
+// under aggregation, Code 47 in union forms. Components are projected as
+// `<prefix>_<col>` in every arm since #1130; a task-local registration
+// (`register_vlp_composite_id_components`) now lets the rewriter bind them.
+
+/// ORDER BY and the aggregate GROUP BY form must bind the component column.
+#[tokio::test]
+async fn ldbc_1136_order_by_component_binds_component_column() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]->(b:Account) \
+         RETURN a.bank_id ORDER BY a.bank_id",
+    )
+    .await;
+    assert!(
+        sql.contains("ORDER BY t.start_bank_id"),
+        "#1136: ORDER BY must bind the projected component column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("ORDER BY t.start_id"),
+        "#1136: never the whole pipe-joined id (concat-lexicographic \
+         ordering):\n{sql}"
+    );
+    let agg = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]->(b:Account) \
+         RETURN a.bank_id, count(*) ORDER BY a.bank_id",
+    )
+    .await;
+    assert!(
+        agg.contains("GROUP BY t.start_bank_id") && agg.contains("ORDER BY t.start_bank_id"),
+        "#1136: the aggregate form (was Code 215) groups and orders by the \
+         component:\n{agg}"
+    );
+}
+
+/// #1136 boundary: a single-column id keeps the whole-id collapse.
+#[tokio::test]
+async fn ldbc_1136_single_id_order_by_unchanged() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*1..2]->(b:User) \
+         RETURN a.user_id ORDER BY a.user_id",
+    )
+    .await;
+    assert!(
+        sql.contains("ORDER BY t.start_id"),
+        "#1136: single-column id ORDER BY still collapses to `t.start_id`:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

The late rewriter's `ends_with("_id")` id heuristic widened a composite **component** reference (`a.bank_id`) onto the whole pipe-joined `t.start_id`: silently wrong ordering (concat-lexicographic), Code 215 under aggregation, Code 47 in union forms. Same class as #1131, different seam. Filed from the #1134 review.

## Fix

New task-local `register_vlp_composite_id_components` (mirrors the `vlp_from_alias` pattern; reset in `clear_all_render_contexts`), recorded at VLP CTE generation. The rewriter consults it before the heuristic and binds the projected `<prefix>_<col>` (#1130 projects it in every arm). Threading schema data through the rewriter's 28 call sites was the alternative.

## Verification

- Live: `ORDER BY t.start_bank_id`, rows b1×5/b2×5 == oracle; aggregate form (was Code 215) → b1:5, b2:5 == oracle.
- Single-column ids never register — byte-identical (boundary-tested).
- 240-combo sweep: exactly 1 diff (the target shape). 2 tests; targeting one fails on main. Suite green (1738 + 690 + ratchet), clippy clean, zero golden churn.

Closes #1136