### PR TITLE
fix(vlp): #1138 undirected union ORDER BY key role-maps per arm

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,29 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — undirected-VLP union ORDER BY
+  key bound the START role in BOTH arms → silently mis-sorted rows** (branch
+  `fix/1138-order-col-role`, PR #1139, closes #1138). The synthesized
+  `__order_col_*` key was rewritten ONCE globally against the primary
+  direction; the reversed arm projects role-swapped VALUES (`t.end_bank_id AS
+  "a.bank_id"`) but received the same start-roled KEY — its rows sorted by
+  the WRONG endpoint (live: b1/b2 interleaved with b3 mid-stream).
+  Property-agnostic, pre-existing (found by the #1137 review). Fix:
+  extraction captures each key's OUTPUT ALIAS from the outer plan;
+  `add_order_by_columns_to_select` (which recurses per arm) re-resolves the
+  key through the arm's OWN select item carrying that alias — comparison on
+  the normalized `<alias>.<col>` spelling, since the two pipelines produce
+  different RenderExpr shapes for the same column. Two dead-ends recorded:
+  an exact-expression match fails (the reversed arm's select is
+  role-swapped), and a role-swap-the-key heuristic mis-fires when BOTH
+  endpoints are projected (`t.start_bank_id` legitimately exists in the
+  reversed arm as the OTHER endpoint's value). Live: single-key fully sorted
+  (b1×9,b2×9,b3×2), two-key nested sort correct with each key role-matched
+  per arm. 360-combo sweep: 1 diff (the target family). 2 structural tests,
+  both fail on main (the two-key one was tightened after passing on main —
+  a weak test proves nothing). Suite green (1738 + 692 + ratchet), clippy
+  clean, zero golden churn.
+
 - 2026-09-05: **Correctness — ORDER BY / GROUP BY on a composite id COMPONENT
   collapsed onto the whole pipe-joined `t.start_id`** (branch
   `fix/1136-order-by-composite-component`, PR #1137, closes #1136). The late

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3074,8 +3074,36 @@ fn rewrite_fixed_path_functions(mut plan: RenderPlan) -> RenderPlan {
 fn extract_order_by_columns_for_union(
     order_by: &OrderByItems,
     salvageable_id_aliases: &HashSet<String>,
-) -> Vec<(RenderExpr, String)> {
+    outer_select: &crate::render_plan::SelectItems,
+) -> Vec<(RenderExpr, String, Option<String>)> {
     let mut columns = Vec::new();
+    // #1138: the OUTER plan's select maps each ORDER BY key to its OUTPUT
+    // alias (`t.start_bank_id` -> "a.bank_id"). The undirected union's arms
+    // role-swap their expressions but keep the SAME output aliases, so the
+    // alias — not the rewritten expression — is the ground truth each arm
+    // resolves against.
+    // The key arrives as `Column("t.start_bank_id")` (global ORDER BY
+    // rewrite) while the select items carry `PropertyAccessExp{t,
+    // start_bank_id}` (SELECT rewrite) — compare on the normalized
+    // `<alias>.<column>` spelling, not the enum shape.
+    fn norm_col(e: &RenderExpr) -> Option<String> {
+        use crate::graph_catalog::expression_parser::PropertyValue;
+        match e {
+            RenderExpr::Column(Column(PropertyValue::Column(c))) => Some(c.clone()),
+            RenderExpr::PropertyAccessExp(pa) => {
+                Some(format!("{}.{}", pa.table_alias.0, pa.column.raw()))
+            }
+            _ => None,
+        }
+    }
+    let output_alias_for = |e: &RenderExpr| -> Option<String> {
+        let key = norm_col(e)?;
+        outer_select
+            .items
+            .iter()
+            .find(|it| norm_col(&it.expression).as_deref() == Some(key.as_str()))
+            .and_then(|it| it.col_alias.as_ref().map(|a| a.0.clone()))
+    };
 
     for (idx, item) in order_by.0.iter().enumerate() {
         // #484 review follow-up: an unresolved `id()`/`elementId()` ScalarFnCall
@@ -3110,7 +3138,7 @@ fn extract_order_by_columns_for_union(
             if let Some(alias) = id_order_item_alias(&item.expression) {
                 if salvageable_id_aliases.contains(&alias) {
                     let col_alias = format!("__order_col_{}", idx);
-                    columns.push((item.expression.clone(), col_alias));
+                    columns.push((item.expression.clone(), col_alias, None));
                     continue;
                 }
             }
@@ -3141,7 +3169,8 @@ fn extract_order_by_columns_for_union(
 
         // Generate a unique alias for this ORDER BY column
         let col_alias = format!("__order_col_{}", idx);
-        columns.push((item.expression.clone(), col_alias));
+        let out_alias = output_alias_for(&item.expression);
+        columns.push((item.expression.clone(), col_alias, out_alias));
     }
 
     columns
@@ -3392,7 +3421,7 @@ fn collect_salvageable_id_order_aliases(
 /// ended up with mismatched column counts (ClickHouse Code 53).
 fn add_order_by_columns_to_select(
     mut plan: RenderPlan,
-    order_columns: &[(RenderExpr, String)],
+    order_columns: &[(RenderExpr, String, Option<String>)],
 ) -> RenderPlan {
     use crate::render_plan::render_expr::ColumnAlias;
     use crate::render_plan::SelectItem;
@@ -3401,7 +3430,30 @@ fn add_order_by_columns_to_select(
     // Parse the path tuple to find which aliases are start/end and the rel alias
     let path_context = extract_path_context_from_select(&plan.select);
 
-    for (expr, alias) in order_columns {
+    // #1138: the ORDER BY expression was rewritten ONCE, globally, against the
+    // primary direction (start-role: `t.start_bank_id`), but the undirected
+    // union's arms ROLE-SWAP their SELECT expressions (`t.end_bank_id AS
+    // "a.bank_id"` in the reversed arm) while keeping the SAME output aliases.
+    // Pushing the globally-rewritten key into both arms sorts the reversed
+    // arm's rows by the WRONG endpoint — silently mis-sorted output. The
+    // OUTPUT ALIAS captured from the outer plan at extraction time is the
+    // ground truth: each arm re-resolves the key through its OWN select item
+    // carrying that alias. (An exact-expression heuristic is NOT enough — with
+    // both endpoints projected, `t.start_bank_id` exists in the reversed arm
+    // too, as the OTHER endpoint's value.)
+    let arm_expr_by_alias = |out_alias: &str| -> Option<RenderExpr> {
+        plan.select
+            .items
+            .iter()
+            .find(|it| it.col_alias.as_ref().is_some_and(|a| a.0 == out_alias))
+            .map(|it| it.expression.clone())
+    };
+    let arm_resolutions: Vec<Option<RenderExpr>> = order_columns
+        .iter()
+        .map(|(_, _, out_alias)| out_alias.as_deref().and_then(&arm_expr_by_alias))
+        .collect();
+
+    for (order_idx, (expr, alias, _)) in order_columns.iter().enumerate() {
         let resolved_expr = if let Some(id_alias) = id_order_item_alias(expr) {
             // #546: an `id(alias)` marker survives extraction only after
             // `union_branches_all_salvage_id` verified that EVERY
@@ -3414,6 +3466,11 @@ fn add_order_by_columns_to_select(
                 Some(id_col) => typed_id_order_key_expr(&id_alias, &id_col),
                 None => typed_id_order_dummy_expr(),
             }
+        } else if let Some(arm_expr) = arm_resolutions.get(order_idx).cloned().flatten() {
+            // #1138: per-arm output-alias resolution (doc above). Falls through
+            // to the legacy paths only when the outer plan projected no item
+            // for this key or this arm lacks the alias.
+            arm_expr
         } else if let Some(ref ctx) = path_context {
             resolve_denormalized_order_by_expr(expr, ctx)
         } else {
@@ -5868,7 +5925,11 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
 
         // Extract ORDER BY columns that need to be added to UNION branches
         let order_by_columns = if !plan.order_by.0.is_empty() {
-            extract_order_by_columns_for_union(&plan.order_by, &salvageable_id_aliases)
+            extract_order_by_columns_for_union(
+                &plan.order_by,
+                &salvageable_id_aliases,
+                &plan.select,
+            )
         } else {
             Vec::new()
         };
@@ -6354,7 +6415,7 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
                 // BY key entirely.
                 let order_clauses: Vec<String> = order_by_columns
                     .iter()
-                    .filter_map(|(_, col_alias)| {
+                    .filter_map(|(_, col_alias, _)| {
                         let idx: usize = col_alias.strip_prefix("__order_col_")?.parse().ok()?;
                         let item = plan.order_by.0.get(idx)?;
                         let order_str = match item.order {
@@ -9495,6 +9556,7 @@ mod tests {
         let order_columns = vec![(
             RenderExpr::TableAlias(TableAlias("1".to_string())),
             "__order_col_0".to_string(),
+            None,
         )];
         let out = add_order_by_columns_to_select(direction_a, &order_columns);
 

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2496,3 +2496,57 @@ async fn ldbc_1136_single_id_order_by_unchanged() {
         "#1136: single-column id ORDER BY still collapses to `t.start_id`:\n{sql}"
     );
 }
+
+/// #1138: the undirected two-arm union's synthesized ORDER BY key
+/// (`__order_col_*`) bound the START role in BOTH arms while the projected
+/// value role-swaps — the reversed arm sorted by the wrong endpoint (silently
+/// mis-sorted rows, live-proven). Each arm now re-resolves the key through
+/// its own select item carrying the SAME output alias.
+#[tokio::test]
+async fn ldbc_1138_undirected_union_order_key_role_swaps() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]-(b:Account) \
+         RETURN a.bank_id ORDER BY a.bank_id",
+    )
+    .await;
+    assert_eq!(
+        sql.matches("t.start_bank_id AS \"__order_col_0\"").count(),
+        1,
+        "#1138: the forward arm binds the start role once:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_bank_id AS \"__order_col_0\"").count(),
+        1,
+        "#1138: the reversed arm must bind ITS role (end), not repeat the \
+         start role:\n{sql}"
+    );
+}
+
+/// #1138 boundary: with BOTH endpoints ordered, each arm binds each key to
+/// its own role — start key start-roled in arm 1 / end-roled in arm 2, and
+/// vice versa for the second key.
+#[tokio::test]
+async fn ldbc_1138_two_key_order_role_maps_per_arm() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]-(b:Account) \
+         RETURN a.bank_id, b.bank_id ORDER BY a.bank_id, b.bank_id",
+    )
+    .await;
+    // Key 0 is `a.bank_id`: start-roled in the forward arm, END-roled in the
+    // reversed arm (on main both arms bound start — the defect).
+    assert_eq!(
+        sql.matches("t.end_bank_id AS \"__order_col_0\"").count(),
+        1,
+        "#1138: key 0 must be END-roled in the reversed arm:\n{sql}"
+    );
+    // Key 1 is `b.bank_id`: end-roled forward, START-roled reversed.
+    assert_eq!(
+        sql.matches("t.start_bank_id AS \"__order_col_1\"").count(),
+        1,
+        "#1138: key 1 must be START-roled in the reversed arm:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

The undirected union's synthesized `__order_col_*` key was rewritten once, globally — start-roled in **both** arms — while the reversed arm's projected values role-swap. Its rows sorted by the wrong endpoint: **silently mis-sorted** (live: b1/b2 interleaved with b3). Property-agnostic. Filed from the #1137 review.

## Fix

Extraction captures each key's **output alias** from the outer plan; the per-arm helper re-resolves the key through the arm's own select item carrying that alias (normalized `<alias>.<col>` comparison — the two pipelines produce different `RenderExpr` shapes for the same column).

Two rejected approaches recorded in the commit: exact-expression matching (reversed arm never matches) and role-swapping the key (mis-fires when both endpoints are projected — the start-roled column legitimately exists in the reversed arm as the *other* endpoint's value).

## Verification

- Live: single-key fully sorted (9/9/2 grouped); two-key nested sort with each key role-matched per arm.
- 360-combo sweep: 1 diff (target family). Aggregate path (already correct) unchanged.
- 2 structural tests, **both fail on main** — the two-key test was tightened after initially passing there. Suite green (1738 + 692 + ratchet), clippy clean, zero golden churn.

Closes #1138