### PR TITLE
fix(vlp): #1135 *0..0 is the zero-hop identity, not a one-hop chain

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — `*0..0` (and the `*0` spelling)
+  rendered as a plain ONE-hop join instead of the zero-hop identity** (branch
+  `fix/1135-zero-zero-hop`, PR #1142, closes #1135). `exact_hop_count()`
+  returned `Some(0)` and every consumer treats `Some(n)` as an n-edge flat
+  r1..rN chain — which has no zero-length form: live, `*0..0` returned the
+  1-hop pairs where the answer is one identity row per node. Silent-wrong on
+  ALL id shapes. Fixed at the SINGLE SOURCE OF TRUTH: `exact_hop_count()`
+  returns None for (0,0), routing via `is_range()` to the recursive CTE whose
+  zero-hop seed with `max_hops == Some(0)` (no recursive arm) is exactly this
+  shape — the generator already handled it. (A first cut flipped only the
+  from_builder gate; the sibling flat-join walkers disagreed → invalid SQL —
+  the walkers-must-agree hazard, avoided by fixing the shared predicate
+  instead.) Live: identity rows == oracle; *1..1/*2..2/*0..1/undirected/WHERE
+  boundaries all correct; 240-combo sweep = exactly the `*0..0` shape (+
+  thread-id noise in a pre-existing panic). TWO CORPUS GOLDENS HAD FROZEN THE
+  BUG (`test_zero_length_path`, `test_zero_length`): their own source Python
+  tests assert `a.name == b.name` and row_count 1 — the #933-class stale-golden
+  trap; regenerated with justification. 2 tests (targeting one fails on main).
+  Suite green (1738 + 694 + ratchet), clippy clean.
+
 - 2026-09-05: **Correctness (ground-rule-1) — undirected-VLP union ORDER BY
   key bound the START role in BOTH arms → silently mis-sorted rows** (branch
   `fix/1138-order-col-role`, PR #1139, closes #1138). The synthesized

--- a/src/query_planner/logical_plan/mod.rs
+++ b/src/query_planner/logical_plan/mod.rs
@@ -1087,6 +1087,16 @@ impl VariableLengthSpec {
     /// Returns Some(n) if min == max == n, None otherwise
     pub fn exact_hop_count(&self) -> Option<u32> {
         match (self.min_hops, self.max_hops) {
+            // #1135: `*0..0` is NOT a fixed-length traversal — it is the
+            // zero-hop identity (a = b, no edge). Every consumer of this
+            // function treats `Some(n)` as an n-edge flat chain (r1..rN
+            // self-joins), which has no zero-length form: the flat path
+            // silently rendered `*0..0` as ONE hop (returned the 1-hop pairs
+            // where the answer is the identity rows). Returning None routes it
+            // through `is_range()` to the recursive CTE, whose zero-hop seed
+            // with `max_hops == Some(0)` (no recursive arm) is exactly this
+            // shape — the generator already handles it.
+            (Some(0), Some(0)) => None,
             (Some(min), Some(max)) if min == max => Some(min),
             _ => None,
         }

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathEdgeCases_test_zero_length_path.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathEdgeCases_test_zero_length_path.clickhouse.sql
@@ -1,8 +1,17 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        start_node.user_id as end_id,
+        0 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id] as path_nodes,
+        start_node.name as start_name,
+        start_node.name as end_name
+    FROM test_integration.users AS start_node
+    WHERE start_node.name = 'Alice'
+)
 SELECT 
-      a.name AS "a.name", 
-      b.name AS "b.name", 
-      0 AS "path_length"
-FROM test_integration.users AS a
-INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id
-INNER JOIN test_integration.users AS b ON b.user_id = t0.followed_id
-WHERE a.name = 'Alice'
+      t.start_name AS "a.name", 
+      t.end_name AS "b.name", 
+      t.hop_count AS "path_length"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathEdgeCases_test_zero_length_path.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_path_variables__TestPathEdgeCases_test_zero_length_path.databricks.sql
@@ -1,8 +1,17 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        start_node.user_id as end_id,
+        0 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id) as path_nodes,
+        start_node.name as start_name,
+        start_node.name as end_name
+    FROM test_integration.users AS start_node
+    WHERE start_node.name = 'Alice'
+)
 SELECT 
-      a.name AS `a.name`, 
-      b.name AS `b.name`, 
-      0 AS `path_length`
-FROM test_integration.users AS a
-INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id
-INNER JOIN test_integration.users AS b ON b.user_id = t0.followed_id
-WHERE a.name = 'Alice'
+      t.start_name AS `a.name`, 
+      t.end_name AS `b.name`, 
+      t.hop_count AS `path_length`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthEdgeCases_test_zero_length.clickhouse.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthEdgeCases_test_zero_length.clickhouse.sql
@@ -1,7 +1,16 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        start_node.user_id as end_id,
+        0 as hop_count,
+        CAST([] AS Array(String)) as path_relationships,
+        [start_node.user_id] as path_nodes,
+        start_node.name as start_name,
+        start_node.name as end_name
+    FROM test_integration.users AS start_node
+    WHERE start_node.name = 'Alice'
+)
 SELECT 
-      a.name AS "a.name", 
-      b.name AS "b.name"
-FROM test_integration.users AS a
-INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id
-INNER JOIN test_integration.users AS b ON b.user_id = t0.followed_id
-WHERE a.name = 'Alice'
+      t.start_name AS "a.name", 
+      t.end_name AS "b.name"
+FROM vlp_a_b AS t

--- a/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthEdgeCases_test_zero_length.databricks.sql
+++ b/tests/rust/integration/golden/corpus/test_fixtures/test_variable_length_paths__TestVariableLengthEdgeCases_test_zero_length.databricks.sql
@@ -1,7 +1,16 @@
+WITH RECURSIVE vlp_a_b AS (
+    SELECT 
+        start_node.user_id as start_id,
+        start_node.user_id as end_id,
+        0 as hop_count,
+        CAST(array() AS ARRAY<STRING>) as path_relationships,
+        array(start_node.user_id) as path_nodes,
+        start_node.name as start_name,
+        start_node.name as end_name
+    FROM test_integration.users AS start_node
+    WHERE start_node.name = 'Alice'
+)
 SELECT 
-      a.name AS `a.name`, 
-      b.name AS `b.name`
-FROM test_integration.users AS a
-INNER JOIN test_integration.follows AS t0 ON t0.follower_id = a.user_id
-INNER JOIN test_integration.users AS b ON b.user_id = t0.followed_id
-WHERE a.name = 'Alice'
+      t.start_name AS `a.name`, 
+      t.end_name AS `b.name`
+FROM vlp_a_b AS t

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2550,3 +2550,65 @@ async fn ldbc_1138_two_key_order_role_maps_per_arm() {
         "#1138: key 1 must be START-roled in the reversed arm:\n{sql}"
     );
 }
+
+// --- #1135: `*0..0` is the zero-hop identity, not a 1-hop chain --------------
+//
+// `exact_hop_count()` returned `Some(0)` and every consumer treats `Some(n)`
+// as an n-edge flat r1..rN chain — which has no zero-length form, so `*0..0`
+// (and the `*0` spelling) silently rendered as ONE hop: live, the 1-hop
+// pairs where the answer is the identity rows (a = b, one per node). Fixed
+// at the single source of truth: `exact_hop_count()` returns None for
+// (0, 0), routing through `is_range()` to the recursive CTE, whose zero-hop
+// seed with `max_hops == Some(0)` (no recursive arm) is exactly this shape.
+//
+// Two corpus goldens had FROZEN the wrong 1-hop SQL — their own source
+// Python tests assert `a.name == b.name` (identity) and row_count 1, so the
+// goldens contradicted the tests that generated them (the #933-class stale
+// golden trap). Regenerated.
+
+/// `*0..0` renders the zero-hop seed with no edge join and no recursion.
+#[tokio::test]
+async fn ldbc_1135_zero_zero_hop_is_identity() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:User)-[:FOLLOWS*0..0]->(b:User) RETURN a.user_id, b.user_id",
+    )
+    .await;
+    assert!(
+        sql.contains("0 as hop_count"),
+        "#1135: *0..0 must render the zero-hop identity seed:\n{sql}"
+    );
+    assert!(
+        !sql.contains("user_follows") && !sql.contains("JOIN"),
+        "#1135: no edge join — a zero-hop path traverses no edge:\n{sql}"
+    );
+}
+
+/// #1135 boundary: `*1..1` and `*2..2` keep the flat chained-join path.
+#[tokio::test]
+async fn ldbc_1135_positive_exact_bounds_stay_flat() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    for (cypher, expect_joins) in [
+        (
+            "MATCH (a:User)-[:FOLLOWS*1..1]->(b:User) RETURN a.user_id, b.user_id",
+            1,
+        ),
+        (
+            "MATCH (a:User)-[:FOLLOWS*2..2]->(b:User) RETURN a.user_id, b.user_id",
+            2,
+        ),
+    ] {
+        let sql = generate_sql_inline(&schema, cypher).await;
+        assert!(
+            !sql.contains("WITH RECURSIVE"),
+            "#1135: positive exact bounds keep the flat join path \
+             (`{cypher}`):\n{sql}"
+        );
+        assert_eq!(
+            sql.matches("user_follows").count(),
+            expect_joins,
+            "#1135: expected {expect_joins} edge join(s) for `{cypher}`:\n{sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`exact_hop_count()` returned `Some(0)` for `*0..0`/`*0`, and every consumer treats `Some(n)` as an n-edge flat chain — no zero-length form exists, so the shape silently rendered as **one hop**: live, the 1-hop pairs where the answer is one identity row per node. All id shapes. Found by the #1134 review (also seen by #1133's).

## Fix

One line at the single source of truth: `exact_hop_count()` returns `None` for `(0,0)` → routes via `is_range()` to the recursive CTE, whose zero-hop seed with `max_hops == Some(0)` is exactly this semantics (already handled; #1132 made it composite-capable).

**Why not gate the flat path**: a first cut flipped only the `from_builder` gate — the sibling flat-join walkers each consult `exact_hop_count().is_some()` independently and disagreed, emitting a FROM referencing a CTE nobody built. Fixing the shared predicate makes all walkers agree by construction.

## Golden note

Two corpus goldens had **frozen the bug** — locked the wrong 1-hop SQL while their own source Python tests assert `a.name == b.name` and `row_count 1` (the #933-class stale-golden trap). Regenerated; the golden diff *is* the fix.

## Verification

- Live: identity rows == oracle; `*1..1`/`*2..2`/`*0..1`/undirected/WHERE boundaries all correct.
- 240-combo sweep: every DIFF is the `*0..0` shape. 2 tests; targeting one fails on main. Suite green (1738 + 694 + ratchet), clippy clean.

Closes #1135