### PR TITLE
fix(vlp): #1141 denorm VLP ORDER BY binds the role-correct physical column

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,29 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness — denormalized undirected-VLP ORDER BY bound the
+  LOGICAL property name (`t.start_city`) instead of the projected PHYSICAL,
+  role-correct column** (branch `fix/1141-denorm-undirected-vlp-order-by`,
+  PR #1144, closes #1141). A denormalized node whose `from_properties`/
+  `to_properties` DISAGREE on a property's physical column reaches the emitter
+  in RAW Cypher form — the #471 guard
+  (`order_by_property_is_ambiguous_denorm_standalone`) deliberately declines to
+  pick one mapping up front. `rewrite_expr_for_vlp` then prefixed that raw name
+  verbatim, emitting a column no arm projects (Code 47, loud). New helper
+  `vlp_denorm_role_column` resolves it PER ENDPOINT through the schema-catalog
+  accessor `NodeSchema::denorm_role_properties` (axis-dispatch rule; ratchet
+  clean), which also gives each undirected arm its OWN role — the #1138 class,
+  for a shape #1139 could not reach (the raw spelling never matched an output
+  alias, so the output-alias chain always fell through to the legacy path). The
+  node_id property was equally broken (`t.start_code`) and resolves the same
+  way. Gated OFF for the multi-type union CTE (`vlp_multi_type_*`), a DIFFERENT
+  generator that names columns by CYPHER property — rewriting those re-dangles
+  a working shape (caught in development by the zeek corpus golden, now pinned
+  by a boundary test). Live: 38 rows == the independent `o.code` id path == a
+  hand-computed two-arm oracle. EXPOSED **#1143 OPEN** (aggregate/GROUP BY on
+  the same shape binds `t.end_origin_city` — end role + FROM-role column;
+  loud, byte-identical on main).
+
 - 2026-09-05: **Correctness (ground-rule-1) — `*0..0` (and the `*0` spelling)
   rendered as a plain ONE-hop join instead of the zero-hop identity** (branch
   `fix/1135-zero-zero-hop`, PR #1142, closes #1135). `exact_hop_count()`

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -2584,7 +2584,11 @@ pub(crate) fn rewrite_expr_for_vlp(
                     // This is accessing start node property
                     // Create Column with the full table.column format to prevent heuristic inference
                     // The FROM clause has the CTE aliased as 't', so use t.start_xxx
-                    let prop_name = derive_cypher_property_name(col_raw);
+                    // #1141: a role-ambiguous denormalized property is projected
+                    // under its PHYSICAL from-role column (`start_origin_city`),
+                    // not the raw Cypher name (`start_city`).
+                    let prop_name = vlp_denorm_role_column(start, col_raw, true)
+                        .unwrap_or_else(|| derive_cypher_property_name(col_raw));
                     return RenderExpr::Column(Column(PropertyValue::Column(format!(
                         "{vlp_alias}.start_{prop_name}"
                     ))));
@@ -2615,7 +2619,10 @@ pub(crate) fn rewrite_expr_for_vlp(
                     }
 
                     // This is accessing end node property
-                    let prop_name = derive_cypher_property_name(col_raw);
+                    // #1141: as in the start arm — resolve a role-ambiguous
+                    // denormalized property to its PHYSICAL to-role column.
+                    let prop_name = vlp_denorm_role_column(end, col_raw, false)
+                        .unwrap_or_else(|| derive_cypher_property_name(col_raw));
                     return RenderExpr::Column(Column(PropertyValue::Column(format!(
                         "{vlp_alias}.end_{prop_name}"
                     ))));
@@ -2836,6 +2843,92 @@ fn is_vlp_path_is_null(expr: &RenderExpr, path_variable: &Option<String>) -> boo
         }
     }
     false
+}
+
+/// #1141: the VLP CTE column suffix for a ROLE-AMBIGUOUS denormalized
+/// property, for the endpoint bound to `role_is_from`.
+///
+/// A denormalized node whose `from_properties`/`to_properties` disagree on a
+/// property's physical column (`Airport.city` → `origin_city` from-side,
+/// `dest_city` to-side) reaches the emitter in its RAW Cypher form: the #471
+/// guard (`order_by_property_is_ambiguous_denorm_standalone`) deliberately
+/// declines to pick one mapping up front, precisely because no single choice
+/// is right for both roles. The VLP CTE, however, names each projected
+/// property column after the PHYSICAL column it resolved per role
+/// (`start_origin_city` / `end_dest_city`), so prefixing the raw Cypher name
+/// yields `t.start_city` — a column no arm projects (ClickHouse Code 47).
+///
+/// Resolve it here, per endpoint, through the canonical schema-catalog
+/// accessor (`denorm_role_properties`, axis-dispatch rule / CLAUDE.md §7)
+/// rather than a raw `from_properties`/`to_properties` read. Returns `None`
+/// for every non-denormalized or role-UNambiguous property, leaving the
+/// historical `derive_cypher_property_name` spelling completely untouched.
+fn vlp_denorm_role_column(alias: &str, prop_name: &str, role_is_from: bool) -> Option<String> {
+    use crate::server::query_context::{
+        get_current_schema, get_multi_type_vlp_aliases, get_node_label_for_alias,
+    };
+
+    // The multi-type union CTE (`vlp_multi_type_*`, built by a DIFFERENT
+    // generator in `cte_extraction.rs`) names its property columns after the
+    // CYPHER property (`start_ip`), not the physical column the recursive VLP
+    // CTE uses. Its spellings are already correct and role-resolved per arm;
+    // rewriting them here would dangle. Only the recursive/undirected VLP CTE
+    // needs this resolution.
+    // The multi-type union CTE (`vlp_multi_type_*`) is built by a DIFFERENT
+    // generator (`cte_extraction.rs`) that names its property columns after
+    // the CYPHER property (`start_ip`), not after the physical column the
+    // recursive VLP CTE uses (`start_id.orig_h`). Its spellings are already
+    // correct, so rewriting them here would dangle. The registry is keyed by
+    // the RELATIONSHIP alias, so presence of ANY entry is the signal that this
+    // scope renders through that generator.
+    if !get_multi_type_vlp_aliases().is_empty() {
+        return None;
+    }
+
+    let schema = get_current_schema()?;
+
+    // The render-time alias->label map is not populated on every VLP path
+    // (it is rebuilt per SQL branch), so fall back to resolving by label when
+    // it is available and otherwise scanning the schema's denormalized nodes.
+    // A role-AMBIGUOUS property name is unambiguous within a schema: only a
+    // denormalized node declares role-specific maps that DISAGREE, and the
+    // candidate set below is filtered to exactly those. When two distinct
+    // denormalized labels would disagree about the same property name, bail
+    // (`None`) rather than guess — the historical spelling is preserved and
+    // the shape stays exactly as loud/quiet as it is today.
+    let candidates: Vec<&crate::graph_catalog::graph_schema::NodeSchema> =
+        match get_node_label_for_alias(alias).and_then(|l| schema.node_schema_opt(&l)) {
+            Some(ns) => vec![ns],
+            None => schema
+                .all_node_schemas()
+                .values()
+                .filter(|ns| ns.role_dependent_property_names().contains(prop_name))
+                .collect(),
+        };
+
+    let node_schema = match candidates.as_slice() {
+        [only] => *only,
+        // Zero candidates: not a role-dependent property (the overwhelmingly
+        // common case). More than one: genuinely ambiguous across labels.
+        _ => return None,
+    };
+
+    // Only a genuinely role-DEPENDENT property needs this: when both roles
+    // map to the same physical column the historical spelling is already
+    // correct, and rewriting it would be churn with no behavior change.
+    if !node_schema
+        .role_dependent_property_names()
+        .contains(prop_name)
+    {
+        return None;
+    }
+
+    let resolved = node_schema
+        .denorm_role_properties(role_is_from)?
+        .get(prop_name)
+        .cloned()?;
+
+    Some(resolved)
 }
 
 /// Derive Cypher property name from database column name

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2551,6 +2551,99 @@ async fn ldbc_1138_two_key_order_role_maps_per_arm() {
     );
 }
 
+// --- #1141: role-ambiguous denorm property in a VLP ORDER BY -----------------
+//
+// A denormalized node whose from/to maps DISAGREE on a property's physical
+// column (`Airport.city` -> `OriginCityName` from-side, `DestCityName`
+// to-side) reaches the emitter in its raw Cypher form: the #471 guard
+// deliberately declines to pick one mapping up front. The VLP CTE names each
+// projected property column after the PHYSICAL column it resolved per role,
+// so prefixing the raw Cypher name emitted `t.start_city` — a column no arm
+// projects (ClickHouse Code 47, loud). Resolved per endpoint through
+// `denorm_role_properties`, which also gives each undirected arm its OWN
+// role (the #1138 class of defect, here for a shape #1139 could not reach
+// because the raw spelling never matched an output alias).
+
+/// #1141: the ORDER BY helper column binds the PHYSICAL, role-correct column
+/// in each arm — not the raw Cypher property name.
+#[tokio::test]
+async fn ldbc_1141_denorm_vlp_order_by_binds_physical_role_column() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.city ORDER BY o.city",
+    )
+    .await;
+    assert!(
+        !sql.contains("start_city") && !sql.contains("end_city"),
+        "#1141: the raw Cypher property name must not be prefixed onto a CTE \
+         column (no arm projects `start_city`/`end_city`):\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.start_OriginCityName AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1141: the forward arm orders by its own (from-role) column:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_DestCityName AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1141: the reversed arm must order by ITS role's column, not repeat \
+         the forward arm's:\n{sql}"
+    );
+}
+
+/// #1141: the node_id property is role-ambiguous too (`code` ->
+/// `Origin`/`Dest`) and was equally broken — both arms emitted the dangling
+/// `t.start_code`. It resolves through the same path, and the reversed arm
+/// gets its OWN role.
+#[tokio::test]
+async fn ldbc_1141_denorm_id_property_order_by_binds_role_column() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.code ORDER BY o.code",
+    )
+    .await;
+    assert!(
+        !sql.contains("start_code") && !sql.contains("end_code"),
+        "#1141: no arm projects `start_code`/`end_code`:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.start_Origin AS \"__order_col_0\"").count(),
+        1,
+        "#1141: forward arm orders by its from-role id column:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_Dest AS \"__order_col_0\"").count(),
+        1,
+        "#1141: reversed arm orders by its to-role id column:\n{sql}"
+    );
+}
+
+/// #1141 boundary: the MULTI-TYPE union CTE (`vlp_multi_type_*`) is built by a
+/// different generator that names property columns after the CYPHER property
+/// (`start_ip`), so this resolution must NOT touch it — doing so re-dangles a
+/// working shape (caught by the zeek corpus golden during development).
+#[tokio::test]
+async fn ldbc_1141_multi_type_union_cte_keeps_cypher_spelling() {
+    let schema = load_schema_from("schemas/examples/zeek_merged.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (ip:IP)-[:DNS_REQUESTED|CONNECTED_TO]->(target) \
+         WHERE ip.ip = '192.168.1.10' RETURN target LIMIT 20",
+    )
+    .await;
+    if sql.contains("vlp_multi_type_") {
+        assert!(
+            !sql.contains("start_id.orig_h"),
+            "#1141: the multi-type union CTE must keep its Cypher-name \
+             spelling (`start_ip`):\n{sql}"
+        );
+    }
+}
+
 // --- #1135: `*0..0` is the zero-hop identity, not a 1-hop chain --------------
 //
 // `exact_hop_count()` returned `Some(0)` and every consumer treats `Some(n)`


### PR DESCRIPTION
## Summary

Fixes #1141 — on a **denormalized** schema's undirected VLP, `ORDER BY o.city` resolved to the **logical** property name (`t.start_city`) while the VLP CTE projects the **physical** column (`start_OriginCityName`) → ClickHouse **Code 47**, loud, on every such shape.

## Root cause

A denormalized node whose `from_properties`/`to_properties` **disagree** on a property's physical column (`Airport.city` → `OriginCityName` from-side, `DestCityName` to-side) reaches the emitter in its **raw Cypher form**: the #471 guard (`order_by_property_is_ambiguous_denorm_standalone`) deliberately declines to pick one mapping up front, precisely because no single choice is right for both roles.

`rewrite_expr_for_vlp` then prefixed that raw name verbatim — `start_` + `city` — a column no arm projects.

## Fix

New helper `vlp_denorm_role_column(alias, prop, role_is_from)` called from **both** PropertyAccess arms of `rewrite_expr_for_vlp`, resolving through the canonical schema-catalog accessor `NodeSchema::denorm_role_properties` (axis-dispatch rule / CLAUDE.md §7 — **ratchet clean**, no raw `from_properties`/`to_properties` read).

Because resolution is **per endpoint**, each undirected arm also gets its **own role** — the #1138 class of defect, for a shape #1139 could not reach (the raw spelling never matched an output alias, so the output-alias chain always fell through to the legacy path).

Before / after (reversed arm):
```sql
-- before: both arms, dangling
t.start_city AS "__order_col_0"
-- after: each arm, its own role's physical column
t.start_OriginCityName AS "__order_col_0"   -- forward
t.end_DestCityName     AS "__order_col_0"   -- reversed
```

The **node_id** property is role-ambiguous too (`code` → `Origin`/`Dest`) and was equally broken (`t.start_code` dangling in both arms); it resolves through the same path.

### Boundary: the multi-type union CTE

Gated **off** when the multi-type VLP registry is non-empty. `vlp_multi_type_*` is built by a **different** generator that names property columns after the **Cypher** property (`start_ip`), so rewriting those re-dangles a working shape. Caught during development by the zeek corpus golden; now pinned by a boundary test.

## Verification

**Live** (`db_denormalized`, 8-edge fixture) — the repro executes and sorts, returning **38 rows**:

| city | rows |
|---|---|
| Atlanta | 7 |
| Chicago | 6 |
| Denver | 4 |
| Los Angeles | 10 |
| New York | 7 |
| Phoenix | 2 |
| San Francisco | 2 |

Cross-checked two independent ways: identical to the **`o.code` id path** (which never touched this code) and to a **hand-computed two-arm oracle**. (A first oracle model said 48 — it wrongly assumed one symmetric edge set, where the engine renders two directional arms. The engine was right.)

**Tests**: 3 regression tests. The two behavior tests **fail on main** and pass here (verified in an isolated main worktree with its own `CARGO_TARGET_DIR`); the boundary test passes on both, as intended.

Full suite green: 1738 unit + 697 integration, **ratchet clean**, clippy clean.

## Residue found (filed, not folded in)

**#1143** — the **aggregate / GROUP BY** projection on the same shape binds `t.end_origin_city` (end role + **from**-role column). Loud (Code 47), **byte-identical on main**, denorm-specific (a standard schema renders this shape as a single CTE). The non-aggregate `RETURN o.city` path is correct.

Refs #1141, #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
