### PR TITLE
fix(vlp): #1140 unprojected/expression ORDER BY keys role-swap per arm

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,26 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-05: **Correctness (ground-rule-1) — unprojected / expression ORDER BY
+  keys on the undirected VLP union bound the START role in BOTH arms** (branch
+  `fix/1140-unprojected-order-key-role-map`, PR #1145, closes #1140). #1139
+  fixed only keys resolvable through an OUTPUT ALIAS; a key with no projection
+  to chain through (`RETURN a.bank_id ORDER BY a.balance`) or an EXPRESSION key
+  (`ORDER BY toUpper(a.bank_id)`) fell to the legacy path and sorted the
+  reversed arm by the WRONG endpoint — silently mis-sorted rows. Each arm's own
+  `Cte` already records its role assignment structurally
+  (`vlp_cypher_start_alias`/`vlp_cypher_end_alias`); an arm assigning the
+  OPPOSITE roles now has the key's `start_*`/`end_*` prefixes flipped. TWO
+  first-cut bugs recorded in the commit: (1) reading `plan.ctes` PER ARM never
+  fired — only the OUTER plan carries `ctes` (the reversed arm has zero), so
+  the name→roles map is captured once and threaded through the recursion;
+  (2) returning `Replace(clone)` for non-column nodes stopped `map_render_expr`
+  and left the EXPRESSION shape unfixed — must `Recurse`. Ordered strictly
+  AFTER #1139's chain, so projected keys are untouched; self-loop endpoints
+  (`start == end`) return None. Live (`db_composite_id`): pre-fix the balance
+  column comes back scrambled (…15000, 7800.25, 3100.75); post-fix all 32 rows
+  ascend monotonically with each balance matching its own account.
+
 - 2026-09-05: **Correctness — denormalized undirected-VLP ORDER BY bound the
   LOGICAL property name (`t.start_city`) instead of the projected PHYSICAL,
   role-correct column** (branch `fix/1141-denorm-undirected-vlp-order-by`,

--- a/schemas/test/denorm_decoy_unrelated_label.yaml
+++ b/schemas/test/denorm_decoy_unrelated_label.yaml
@@ -1,0 +1,109 @@
+# #1141/#1140 re-review REGRESSION FIXTURE (decoy).
+#
+# This is `composite_node_ids.yaml` plus ONE unrelated DENORMALIZED label
+# (`Leg`) on a different table AND database, whose from-side role map declares
+# the physical column `account_type`.
+#
+# `Account` is a plain, NON-denormalized node. Before the fix, the undirected
+# VLP role-swap re-resolved an ORDER BY key through a SCHEMA-WIDE scan, so
+# `Leg` reached across labels/tables/databases and rewrote the reversed arm's
+# key to `end_holder_name` — a column that EXISTS and sorts wrongly (loud ->
+# silently mis-sorted; ground rule 1). The swap now reads the ARM'S OWN
+# `CteColumnMetadata`, which is query-bound, so `Leg` cannot reach it.
+#
+# See `ldbc_1141_unrelated_denorm_label_must_not_rewrite_key`.
+
+# Composite node-ID single-graph schema — extracted/adapted from
+# schemas/examples/composite_node_id_test.yaml so the byte-exact golden
+# harness (tests/rust/integration/sql_golden_tests.rs) can load it directly
+# via GraphSchemaConfig::from_yaml_file (the original file's shape — flat
+# top-level `nodes:`/`edges:`, no `graph_schema:` wrapper, `to_id_composite:`
+# instead of `to_id:` — does not deserialize through that entry point: the
+# wrapper is required and `to_id` is a mandatory field on StandardEdgeDefinition).
+# This file keeps the SAME database/tables/data as the example schema (and its
+# companion `scripts/setup/setup_composite_id_data.sh`), so goldens can be
+# live-verified against `db_composite_id` without any new data setup.
+#
+# Composite-ID pattern (`Identifier::Composite`):
+#   Account identified by (bank_id, account_number) — a TWO-column node ID.
+#   Customer identified by customer_id — single column (mixed in the same graph).
+#
+# Graph patterns:
+#   (c:Customer)-[:OWNS]->(a:Account)         — single-to-composite key join
+#   (a1:Account)-[:TRANSFERRED]->(a2:Account) — composite-to-composite key join
+#     (the interesting case: BOTH sides of the join must carry ALL id
+#     components, e.g. `(a1.bank_id, a1.account_number) = (t.from_bank_id,
+#     t.from_account_number)` — a join on only bank_id would be a correctness
+#     bug silently fanning out rows across accounts sharing a bank).
+#
+# Physical tables (db_composite_id, created by scripts/setup/setup_composite_id_data.sh):
+#   accounts(bank_id String, account_number String, holder_name String,
+#            account_type String, balance Float64, opened_date Date)
+#   customers(customer_id UInt64, name String, email String, city String)
+#   account_ownership(customer_id UInt64, bank_id String, account_number String,
+#                      role String, since Date)
+#   transfers(transfer_id UInt64, from_bank_id String, from_account_number String,
+#             to_bank_id String, to_account_number String, amount Float64,
+#             transfer_date Date)
+
+name: composite_node_ids
+
+graph_schema:
+  nodes:
+
+    # Unrelated DENORMALIZED label on a different table entirely.
+    - label: Leg
+      database: db_denormalized
+      table: flights_denorm
+      node_id: account_type
+      property_mappings: {}
+      from_node_properties:
+        account_type: account_type
+      to_node_properties:
+        account_type: holder_name
+    - label: Account
+      database: db_composite_id
+      table: accounts
+      node_id: [bank_id, account_number]
+      property_mappings:
+        bank_id: bank_id
+        account_number: account_number
+        holder_name: holder_name
+        account_type: account_type
+        balance: balance
+        opened_date: opened_date
+
+    - label: Customer
+      database: db_composite_id
+      table: customers
+      node_id: customer_id
+      property_mappings:
+        customer_id: customer_id
+        name: name
+        email: email
+        city: city
+
+  edges:
+    - type: OWNS
+      database: db_composite_id
+      table: account_ownership
+      from_id: customer_id
+      to_id: [bank_id, account_number]
+      from_node: Customer
+      to_node: Account
+      property_mappings:
+        role: role
+        since: since
+
+    - type: TRANSFERRED
+      database: db_composite_id
+      table: transfers
+      from_id: [from_bank_id, from_account_number]
+      to_id: [to_bank_id, to_account_number]
+      from_node: Account
+      to_node: Account
+      edge_id: transfer_id
+      property_mappings:
+        transfer_id: transfer_id
+        amount: amount
+        transfer_date: transfer_date

--- a/schemas/test/denorm_shared_from_column.yaml
+++ b/schemas/test/denorm_shared_from_column.yaml
@@ -1,0 +1,48 @@
+# Denormalized Flights Test Schema
+# Tests: denormalized node properties, string IDs, virtual nodes
+#
+# Airport nodes are "virtual" - their properties come from the flights table
+# via from_node_properties and to_node_properties mappings.
+
+name: flights_denorm_test
+version: "1.0"
+
+graph_schema:
+  nodes:
+    # Airport is a virtual node - all data comes from the flights table
+    - label: Airport
+      database: db_denormalized
+      table: flights_denorm
+      node_id: code  # Logical property name for the ID
+      property_mappings: {}  # Empty - all properties are denormalized
+      
+      # Properties when Airport appears as origin (from_node)
+      from_node_properties:
+        code: origin_code
+        city: origin_city
+        town: origin_city
+        state: origin_state
+      
+      # Properties when Airport appears as destination (to_node)
+      to_node_properties:
+        code: dest_code
+        city: dest_city
+        town: dest_code
+        state: dest_state
+
+  edges:
+    # FLIGHT relationship - connects two Airports
+    - type: FLIGHT
+      database: db_denormalized
+      table: flights_denorm
+      from_id: origin_code
+      to_id: dest_code
+      from_node: Airport
+      to_node: Airport
+      property_mappings:
+        flight_id: flight_id
+        flight_number: flight_number
+        carrier: carrier
+        departure_time: departure_time
+        arrival_time: arrival_time
+        distance: distance

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3627,15 +3627,34 @@ fn swap_vlp_role_prefixes(expr: &RenderExpr, roles: &VlpArmRoles) -> RenderExpr 
     // with the Cypher alias and property it came from. That is query-bound and
     // ordered, so the swap becomes a lookup rather than an inference: find the
     // column being referenced, take its PROPERTY, then find the column this
-    // arm projects for the SAME property under the opposite role. Falls back
-    // to the plain prefix flip only when the arm publishes no such metadata.
+    // arm projects for the SAME property under the opposite role.
+    //
+    // Final-review CRITICAL: when that lookup finds NOTHING, the swap must
+    // ABSTAIN — leave the expression exactly as the global rewrite produced it
+    // — never fall back to a bare prefix flip. That flip is the very spelling
+    // round 1 proved wrong (`end_` + the FROM-role column), and it is reachable
+    // on the shipped denorm schema through any EXPRESSION key
+    // (`ORDER BY toUpper(o.state)`), because the pruner only projects the
+    // opposite-role column for BARE keys (which #1141 resolves in
+    // `rewrite_expr_for_vlp`). Emitting it produced a Code 47 that main does
+    // not have, and a silent mis-sort wherever the flipped name happened to
+    // collide with a real column. Abstaining restores main's behavior for that
+    // shape exactly (still imperfect — tracked separately — but never a
+    // regression, and never a NEW silent wrong).
+    //
+    // The lookup is keyed on the source column's own metadata entry. Two
+    // properties can share one physical column (`city`/`town` both ->
+    // `origin_city`), so an entry found by column name alone is ambiguous:
+    // resolve only when every candidate agrees on the target column.
     let target_cte = roles.arm_cte.as_deref();
     let columns: &[crate::render_plan::cte_manager::CteColumnMetadata] = target_cte
         .and_then(|name| roles.columns_by_cte.get(name))
         .map(|v| v.as_slice())
         .unwrap_or(&[]);
 
-    let reresolve = |rest: &str, to_start: bool| -> String {
+    // `None` = cannot resolve; the caller must then leave the WHOLE expression
+    // untouched rather than emit a half-swapped column.
+    let reresolve = |rest: &str, to_start: bool| -> Option<String> {
         let want = if to_start {
             crate::render_plan::cte_manager::VlpColumnPosition::Start
         } else {
@@ -3643,30 +3662,51 @@ fn swap_vlp_role_prefixes(expr: &RenderExpr, roles: &VlpArmRoles) -> RenderExpr 
         };
         // The column as spelled BEFORE the flip, i.e. under the opposite role.
         let have_prefix = if to_start { "end_" } else { "start_" };
+        let target_prefix = if to_start { "start_" } else { "end_" };
         let spelled = format!("{have_prefix}{rest}");
-        let Some(src_meta) = columns.iter().find(|m| m.cte_column_name == spelled) else {
-            return rest.to_string();
-        };
-        // The same PROPERTY, projected by this arm under the target role.
-        match columns
+
+        // Every property this arm projects under `spelled`. Two properties can
+        // legitimately share one physical column, so collect them all.
+        let props: Vec<&str> = columns
             .iter()
-            .find(|m| m.cypher_property == src_meta.cypher_property && m.vlp_position == Some(want))
-        {
-            Some(dst) => dst
-                .cte_column_name
-                .strip_prefix(if to_start { "start_" } else { "end_" })
-                .unwrap_or(&dst.cte_column_name)
-                .to_string(),
-            None => rest.to_string(),
+            .filter(|m| m.cte_column_name == spelled)
+            .map(|m| m.cypher_property.as_str())
+            .collect();
+        if props.is_empty() {
+            return None;
+        }
+
+        // The target-role column for each candidate property. Resolve only if
+        // they agree — an ambiguous column must abstain, not guess.
+        let mut targets: Vec<String> = props
+            .iter()
+            .filter_map(|prop| {
+                columns
+                    .iter()
+                    .find(|m| m.cypher_property == *prop && m.vlp_position == Some(want))
+            })
+            .map(|dst| {
+                dst.cte_column_name
+                    .strip_prefix(target_prefix)
+                    .unwrap_or(&dst.cte_column_name)
+                    .to_string()
+            })
+            .collect();
+        targets.sort();
+        targets.dedup();
+        match targets.as_slice() {
+            // Every candidate agrees, and none was left unresolved.
+            [only] if targets.len() == props.len() || props.len() > 1 => Some(only.clone()),
+            _ => None,
         }
     };
 
     let flip = |col: &str| -> Option<String> {
         if let Some(rest) = col.strip_prefix(&start_pfx) {
-            Some(format!("{end_pfx}{}", reresolve(rest, false)))
+            reresolve(rest, false).map(|c| format!("{end_pfx}{c}"))
         } else {
-            col.strip_prefix(&end_pfx)
-                .map(|rest| format!("{start_pfx}{}", reresolve(rest, true)))
+            let rest = col.strip_prefix(&end_pfx)?;
+            reresolve(rest, true).map(|c| format!("{start_pfx}{c}"))
         }
     };
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3549,6 +3549,13 @@ struct VlpArmRoles {
     by_cte: std::collections::HashMap<String, (String, String)>,
     /// The roles the global ORDER BY rewrite resolved against.
     primary: (String, String),
+    /// CTE name -> the columns that CTE projects, each tagged with the Cypher
+    /// alias/property it came from. Query-bound truth for the role swap
+    /// (re-review CRITICAL: a schema-wide scan mis-bound unrelated VLPs).
+    columns_by_cte:
+        std::collections::HashMap<String, Vec<crate::render_plan::cte_manager::CteColumnMetadata>>,
+    /// The CTE the arm currently being rewritten scans. Set per arm.
+    arm_cte: Option<String>,
 }
 
 /// #1140: the PRIMARY direction's `(start_alias, end_alias)` — the roles the
@@ -3566,6 +3573,16 @@ fn primary_vlp_roles(plan: &RenderPlan) -> Option<VlpArmRoles> {
         })
         .collect();
 
+    let columns_by_cte: std::collections::HashMap<
+        String,
+        Vec<crate::render_plan::cte_manager::CteColumnMetadata>,
+    > = plan
+        .ctes
+        .0
+        .iter()
+        .map(|c| (c.cte_name.clone(), c.columns.clone()))
+        .collect();
+
     let from = plan.from.0.as_ref()?;
     let (start, end) = by_cte.get(&from.name)?.clone();
     if start == end {
@@ -3574,6 +3591,8 @@ fn primary_vlp_roles(plan: &RenderPlan) -> Option<VlpArmRoles> {
     Some(VlpArmRoles {
         by_cte,
         primary: (start, end),
+        columns_by_cte,
+        arm_cte: None,
     })
 }
 
@@ -3581,7 +3600,7 @@ fn primary_vlp_roles(plan: &RenderPlan) -> Option<VlpArmRoles> {
 /// reference in `expr`, structurally (recursing through every wrapper via
 /// `map_render_expr`, so an EXPRESSION key such as `toUpper(a.bank_id)` is
 /// covered, not just a bare column).
-fn swap_vlp_role_prefixes(expr: &RenderExpr) -> RenderExpr {
+fn swap_vlp_role_prefixes(expr: &RenderExpr, roles: &VlpArmRoles) -> RenderExpr {
     use crate::graph_catalog::expression_parser::PropertyValue;
     use crate::render_plan::render_expr::{map_render_expr, RenderRewrite};
 
@@ -3594,43 +3613,60 @@ fn swap_vlp_role_prefixes(expr: &RenderExpr) -> RenderExpr {
     // `start_origin_state` -> `end_origin_state` keeps the FROM-role column
     // under the `end_` prefix, which either dangles or — worse, once #1141
     // makes such names resolvable — binds a column that exists but holds the
-    // OTHER endpoint's value (silently mis-sorted rows). The role's own column
-    // must be re-resolved: `start_origin_state` -> `end_dest_state`.
-    let reresolve_denorm = |rest: &str, to_from_role: bool| -> String {
-        // `rest` is the physical column of the ORIGINAL role. Find the Cypher
-        // property it maps to on that side, then take the OTHER side's column.
-        let Some(schema) = crate::server::query_context::get_current_schema() else {
+    // OTHER endpoint's value (silently mis-sorted rows).
+    //
+    // Re-review CRITICAL: resolving that through a SCHEMA-WIDE scan let a
+    // denormalized label anywhere in the catalog rewrite an unrelated (even
+    // non-denormalized) VLP's key — proven live: a `Leg` label on a different
+    // table/database rewrote a plain `Account` key to `end_holder_name`, a
+    // real column that sorts wrongly. It was also nondeterministic (`HashMap`
+    // iteration picked between two properties sharing a from-side column).
+    //
+    // Both go away by asking the ARM ITSELF. Every VLP `Cte` carries
+    // `CteColumnMetadata` — the exact set of columns it projects, each tagged
+    // with the Cypher alias and property it came from. That is query-bound and
+    // ordered, so the swap becomes a lookup rather than an inference: find the
+    // column being referenced, take its PROPERTY, then find the column this
+    // arm projects for the SAME property under the opposite role. Falls back
+    // to the plain prefix flip only when the arm publishes no such metadata.
+    let target_cte = roles.arm_cte.as_deref();
+    let columns: &[crate::render_plan::cte_manager::CteColumnMetadata] = target_cte
+        .and_then(|name| roles.columns_by_cte.get(name))
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+
+    let reresolve = |rest: &str, to_start: bool| -> String {
+        let want = if to_start {
+            crate::render_plan::cte_manager::VlpColumnPosition::Start
+        } else {
+            crate::render_plan::cte_manager::VlpColumnPosition::End
+        };
+        // The column as spelled BEFORE the flip, i.e. under the opposite role.
+        let have_prefix = if to_start { "end_" } else { "start_" };
+        let spelled = format!("{have_prefix}{rest}");
+        let Some(src_meta) = columns.iter().find(|m| m.cte_column_name == spelled) else {
             return rest.to_string();
         };
-        for node_schema in schema.all_node_schemas().values() {
-            if node_schema.role_dependent_property_names().is_empty() {
-                continue;
-            }
-            // The original role is the opposite of the one we are moving TO.
-            let (from_map, to_map) = (
-                node_schema.denorm_role_properties(!to_from_role),
-                node_schema.denorm_role_properties(to_from_role),
-            );
-            let (Some(from_map), Some(to_map)) = (from_map, to_map) else {
-                continue;
-            };
-            if let Some((prop, _)) = from_map.iter().find(|(_, col)| col.as_str() == rest) {
-                if let Some(target) = to_map.get(prop) {
-                    return target.clone();
-                }
-            }
+        // The same PROPERTY, projected by this arm under the target role.
+        match columns
+            .iter()
+            .find(|m| m.cypher_property == src_meta.cypher_property && m.vlp_position == Some(want))
+        {
+            Some(dst) => dst
+                .cte_column_name
+                .strip_prefix(if to_start { "start_" } else { "end_" })
+                .unwrap_or(&dst.cte_column_name)
+                .to_string(),
+            None => rest.to_string(),
         }
-        rest.to_string()
     };
 
     let flip = |col: &str| -> Option<String> {
         if let Some(rest) = col.strip_prefix(&start_pfx) {
-            // start -> end: the end role is the TO side (`to_from_role = false`).
-            Some(format!("{end_pfx}{}", reresolve_denorm(rest, false)))
+            Some(format!("{end_pfx}{}", reresolve(rest, false)))
         } else {
             col.strip_prefix(&end_pfx)
-                // end -> start: the start role is the FROM side.
-                .map(|rest| format!("{start_pfx}{}", reresolve_denorm(rest, true)))
+                .map(|rest| format!("{start_pfx}{}", reresolve(rest, true)))
         }
     };
 
@@ -3721,7 +3757,17 @@ fn add_order_by_columns_to_select(
             // arms — silently mis-sorting the reversed one. This arm's own CTE
             // says it assigns the OPPOSITE roles, so flip the key's role
             // prefixes structurally.
-            swap_vlp_role_prefixes(expr)
+            {
+                // Bind the metadata lookup to THIS arm's CTE.
+                let base = primary_roles.expect("guarded by arm_swaps_vlp_roles above");
+                let arm_roles = VlpArmRoles {
+                    by_cte: base.by_cte.clone(),
+                    primary: base.primary.clone(),
+                    columns_by_cte: base.columns_by_cte.clone(),
+                    arm_cte: plan.from.0.as_ref().map(|f| f.name.clone()),
+                };
+                swap_vlp_role_prefixes(expr, &arm_roles)
+            }
         } else if let Some(ref ctx) = path_context {
             resolve_denormalized_order_by_expr(expr, ctx)
         } else {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -2868,12 +2868,6 @@ fn vlp_denorm_role_column(alias: &str, prop_name: &str, role_is_from: bool) -> O
         get_current_schema, get_multi_type_vlp_aliases, get_node_label_for_alias,
     };
 
-    // The multi-type union CTE (`vlp_multi_type_*`, built by a DIFFERENT
-    // generator in `cte_extraction.rs`) names its property columns after the
-    // CYPHER property (`start_ip`), not the physical column the recursive VLP
-    // CTE uses. Its spellings are already correct and role-resolved per arm;
-    // rewriting them here would dangle. Only the recursive/undirected VLP CTE
-    // needs this resolution.
     // The multi-type union CTE (`vlp_multi_type_*`) is built by a DIFFERENT
     // generator (`cte_extraction.rs`) that names its property columns after
     // the CYPHER property (`start_ip`), not after the physical column the
@@ -3595,12 +3589,48 @@ fn swap_vlp_role_prefixes(expr: &RenderExpr) -> RenderExpr {
     let start_pfx = format!("{vlp_alias}.start_");
     let end_pfx = format!("{vlp_alias}.end_");
 
+    // #1141 review (CRITICAL): flipping only the ROLE PREFIX is not enough on a
+    // DENORMALIZED schema whose from/to maps disagree on the physical column.
+    // `start_origin_state` -> `end_origin_state` keeps the FROM-role column
+    // under the `end_` prefix, which either dangles or — worse, once #1141
+    // makes such names resolvable — binds a column that exists but holds the
+    // OTHER endpoint's value (silently mis-sorted rows). The role's own column
+    // must be re-resolved: `start_origin_state` -> `end_dest_state`.
+    let reresolve_denorm = |rest: &str, to_from_role: bool| -> String {
+        // `rest` is the physical column of the ORIGINAL role. Find the Cypher
+        // property it maps to on that side, then take the OTHER side's column.
+        let Some(schema) = crate::server::query_context::get_current_schema() else {
+            return rest.to_string();
+        };
+        for node_schema in schema.all_node_schemas().values() {
+            if node_schema.role_dependent_property_names().is_empty() {
+                continue;
+            }
+            // The original role is the opposite of the one we are moving TO.
+            let (from_map, to_map) = (
+                node_schema.denorm_role_properties(!to_from_role),
+                node_schema.denorm_role_properties(to_from_role),
+            );
+            let (Some(from_map), Some(to_map)) = (from_map, to_map) else {
+                continue;
+            };
+            if let Some((prop, _)) = from_map.iter().find(|(_, col)| col.as_str() == rest) {
+                if let Some(target) = to_map.get(prop) {
+                    return target.clone();
+                }
+            }
+        }
+        rest.to_string()
+    };
+
     let flip = |col: &str| -> Option<String> {
         if let Some(rest) = col.strip_prefix(&start_pfx) {
-            Some(format!("{end_pfx}{rest}"))
+            // start -> end: the end role is the TO side (`to_from_role = false`).
+            Some(format!("{end_pfx}{}", reresolve_denorm(rest, false)))
         } else {
             col.strip_prefix(&end_pfx)
-                .map(|rest| format!("{start_pfx}{rest}"))
+                // end -> start: the start role is the FROM side.
+                .map(|rest| format!("{start_pfx}{}", reresolve_denorm(rest, true)))
         }
     };
 

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3512,9 +3512,125 @@ fn collect_salvageable_id_order_aliases(
 /// the primary direction gained the extra `__order_col_N` columns while the
 /// nested sibling direction did not, so the inner `UNION ALL` between them
 /// ended up with mismatched column counts (ClickHouse Code 53).
+/// #1140: does this arm SWAP the endpoint roles relative to the direction the
+/// ORDER BY key was globally rewritten against?
+///
+/// The undirected union renders two CTEs whose names encode their role
+/// assignment — `vlp_a_b` binds `a`=start / `b`=end, `vlp_b_a` the reverse —
+/// and each `Cte` records that mapping structurally in
+/// `vlp_cypher_start_alias` / `vlp_cypher_end_alias`. The global ORDER BY
+/// rewrite always resolves against the PRIMARY direction, so an arm whose CTE
+/// assigns the opposite roles needs every `start_*`/`end_*` reference in the
+/// key flipped.
+///
+/// #1139 handles keys that are PROJECTED (resolvable through an output alias);
+/// this covers the residue it could not reach — an unprojected key
+/// (`ORDER BY a.balance` while returning `a.bank_id`) and an expression key
+/// (`ORDER BY toUpper(a.bank_id)`), which have no select item to chain
+/// through. Returns `None` when the arm is not a VLP-CTE scan or its CTE
+/// carries no role metadata, leaving the legacy behavior exactly as-is.
+fn arm_swaps_vlp_roles(plan: &RenderPlan, roles: &VlpArmRoles) -> Option<bool> {
+    // Only the OUTER plan carries `ctes`; an arm carries just its FROM, so the
+    // name->roles map is captured once up front and threaded down.
+    let from = plan.from.0.as_ref()?;
+    let (start, end) = roles.by_cte.get(&from.name)?;
+    // A self-loop endpoint (`start == end`) has no distinguishable roles.
+    if start == end {
+        return None;
+    }
+    if *start == roles.primary.0 && *end == roles.primary.1 {
+        Some(false)
+    } else if *start == roles.primary.1 && *end == roles.primary.0 {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+/// #1140: the undirected union's per-arm role assignment, captured from the
+/// OUTER plan (the only place `ctes` lives) so each arm can be classified
+/// after recursion.
+struct VlpArmRoles {
+    /// CTE name -> (cypher start alias, cypher end alias).
+    by_cte: std::collections::HashMap<String, (String, String)>,
+    /// The roles the global ORDER BY rewrite resolved against.
+    primary: (String, String),
+}
+
+/// #1140: the PRIMARY direction's `(start_alias, end_alias)` — the roles the
+/// global ORDER BY rewrite resolved against. Read from the outer plan's first
+/// role-carrying VLP CTE, which is the one the primary FROM scans.
+fn primary_vlp_roles(plan: &RenderPlan) -> Option<VlpArmRoles> {
+    let by_cte: std::collections::HashMap<String, (String, String)> = plan
+        .ctes
+        .0
+        .iter()
+        .filter_map(|c| {
+            let s = c.vlp_cypher_start_alias.clone()?;
+            let e = c.vlp_cypher_end_alias.clone()?;
+            Some((c.cte_name.clone(), (s, e)))
+        })
+        .collect();
+
+    let from = plan.from.0.as_ref()?;
+    let (start, end) = by_cte.get(&from.name)?.clone();
+    if start == end {
+        return None;
+    }
+    Some(VlpArmRoles {
+        by_cte,
+        primary: (start, end),
+    })
+}
+
+/// #1140: flip every `<vlp_alias>.start_*` / `<vlp_alias>.end_*` column
+/// reference in `expr`, structurally (recursing through every wrapper via
+/// `map_render_expr`, so an EXPRESSION key such as `toUpper(a.bank_id)` is
+/// covered, not just a bare column).
+fn swap_vlp_role_prefixes(expr: &RenderExpr) -> RenderExpr {
+    use crate::graph_catalog::expression_parser::PropertyValue;
+    use crate::render_plan::render_expr::{map_render_expr, RenderRewrite};
+
+    let vlp_alias = crate::server::query_context::vlp_from_alias();
+    let start_pfx = format!("{vlp_alias}.start_");
+    let end_pfx = format!("{vlp_alias}.end_");
+
+    let flip = |col: &str| -> Option<String> {
+        if let Some(rest) = col.strip_prefix(&start_pfx) {
+            Some(format!("{end_pfx}{rest}"))
+        } else {
+            col.strip_prefix(&end_pfx)
+                .map(|rest| format!("{start_pfx}{rest}"))
+        }
+    };
+
+    map_render_expr(expr, &mut |node| match node {
+        RenderExpr::Column(Column(PropertyValue::Column(c))) => match flip(c) {
+            Some(swapped) => {
+                RenderRewrite::Replace(RenderExpr::Column(Column(PropertyValue::Column(swapped))))
+            }
+            None => RenderRewrite::Replace(node.clone()),
+        },
+        RenderExpr::PropertyAccessExp(pa) => {
+            let joined = format!("{}.{}", pa.table_alias.0, pa.column.raw());
+            match flip(&joined) {
+                Some(swapped) => RenderRewrite::Replace(RenderExpr::Column(Column(
+                    PropertyValue::Column(swapped),
+                ))),
+                None => RenderRewrite::Replace(node.clone()),
+            }
+        }
+        // Every other node: DESCEND (not `Replace(clone)`, which would stop
+        // the walk and leave an EXPRESSION key such as `toUpper(a.bank_id)`
+        // unswapped inside its wrapper).
+        _ => RenderRewrite::Recurse,
+    })
+}
+
 fn add_order_by_columns_to_select(
     mut plan: RenderPlan,
     order_columns: &[(RenderExpr, String, Option<String>)],
+    primary_roles: Option<&VlpArmRoles>,
 ) -> RenderPlan {
     use crate::render_plan::render_expr::ColumnAlias;
     use crate::render_plan::SelectItem;
@@ -3564,6 +3680,18 @@ fn add_order_by_columns_to_select(
             // to the legacy paths only when the outer plan projected no item
             // for this key or this arm lacks the alias.
             arm_expr
+        } else if primary_roles
+            .and_then(|p| arm_swaps_vlp_roles(&plan, p))
+            .unwrap_or(false)
+        {
+            // #1140: the key is UNPROJECTED (`ORDER BY a.balance` while
+            // returning `a.bank_id`) or an EXPRESSION (`toUpper(a.bank_id)`),
+            // so #1138's output-alias chain has nothing to resolve through and
+            // the globally-rewritten start-role key would be pushed into BOTH
+            // arms — silently mis-sorting the reversed one. This arm's own CTE
+            // says it assigns the OPPOSITE roles, so flip the key's role
+            // prefixes structurally.
+            swap_vlp_role_prefixes(expr)
         } else if let Some(ref ctx) = path_context {
             resolve_denormalized_order_by_expr(expr, ctx)
         } else {
@@ -3604,7 +3732,7 @@ fn add_order_by_columns_to_select(
         union.input = union
             .input
             .into_iter()
-            .map(|branch| add_order_by_columns_to_select(branch, order_columns))
+            .map(|branch| add_order_by_columns_to_select(branch, order_columns, primary_roles))
             .collect();
         plan.union.0 = Some(union);
     }
@@ -6043,7 +6171,16 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
             // to every top-level arm (each arm would gain the columns once
             // via this call's recursion and again via the loop), producing
             // duplicate `__order_col_N` columns / an outer-scope alias clash.
-            modified_plan = add_order_by_columns_to_select(modified_plan, &order_by_columns);
+            // #1140: capture the PRIMARY direction's role assignment before
+            // recursing, so an arm whose own CTE assigns the opposite roles can
+            // flip an unprojected/expression key that #1138's output-alias
+            // chain cannot resolve.
+            let primary_roles = primary_vlp_roles(&modified_plan);
+            modified_plan = add_order_by_columns_to_select(
+                modified_plan,
+                &order_by_columns,
+                primary_roles.as_ref(),
+            );
         }
 
         // Use the modified plan for SQL generation
@@ -9651,7 +9788,7 @@ mod tests {
             "__order_col_0".to_string(),
             None,
         )];
-        let out = add_order_by_columns_to_select(direction_a, &order_columns);
+        let out = add_order_by_columns_to_select(direction_a, &order_columns, None);
 
         assert!(
             out.select

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2695,13 +2695,53 @@ async fn ldbc_1141_multi_type_union_cte_keeps_cypher_spelling() {
          WHERE ip.ip = '192.168.1.10' RETURN target LIMIT 20",
     )
     .await;
-    if sql.contains("vlp_multi_type_") {
-        assert!(
-            !sql.contains("start_id.orig_h"),
-            "#1141: the multi-type union CTE must keep its Cypher-name \
-             spelling (`start_ip`):\n{sql}"
-        );
-    }
+    // Assert the PRECONDITION rather than branching on it: if planning ever
+    // stops routing this shape through the multi-type generator, this test
+    // must fail loudly rather than silently pass while testing nothing.
+    assert!(
+        sql.contains("vlp_multi_type_"),
+        "#1141: precondition — this shape must render through the multi-type \
+         union generator:\n{sql}"
+    );
+    assert!(
+        !sql.contains("start_id.orig_h"),
+        "#1141: the multi-type union CTE must keep its Cypher-name \
+         spelling (`start_ip`):\n{sql}"
+    );
+}
+
+/// #1141 review (CRITICAL): an UNPROJECTED role-ambiguous key. There is no
+/// select item to chain through (#1139) so it falls to #1140's role swap —
+/// which must re-resolve the DENORM COLUMN for the new role, not merely flip
+/// the `start_`/`end_` prefix. Flipping alone yields `end_OriginState`: the
+/// end role paired with the FROM-role column, which once #1141 makes such
+/// names resolvable would bind a column holding the OTHER endpoint's value
+/// (silently mis-sorted rows — a loud->silent regression).
+#[tokio::test]
+async fn ldbc_1141_unprojected_role_ambiguous_key_reresolves_column() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.city ORDER BY o.state",
+    )
+    .await;
+    assert_eq!(
+        sql.matches("t.start_OriginState AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1141: forward arm keeps its from-role column:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_DestState AS \"__order_col_0\"").count(),
+        1,
+        "#1141: the reversed arm must order by the TO-role column \
+         (`end_DestState`), not the from-role column under an `end_` prefix:\n{sql}"
+    );
+    assert!(
+        !sql.contains("end_OriginState") && !sql.contains("start_DestState"),
+        "#1141: no arm may pair a role prefix with the OTHER role's \
+         column:\n{sql}"
+    );
 }
 
 // --- #1135: `*0..0` is the zero-hop identity, not a 1-hop chain --------------

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2813,6 +2813,77 @@ async fn ldbc_1141_role_swap_resolution_is_deterministic() {
     );
 }
 
+/// #1141/#1140 final review (CRITICAL): when the arm publishes no target-role
+/// entry for the key's property, the swap must ABSTAIN — leave the expression
+/// exactly as the global rewrite produced it — never emit a bare prefix flip.
+///
+/// That flip is the spelling round 1 proved wrong (`end_` + the FROM-role
+/// column). It is reachable on the shipped denorm schema through any
+/// EXPRESSION key, because the pruner only projects the opposite-role column
+/// for BARE keys (which #1141 resolves in `rewrite_expr_for_vlp`). Emitting it
+/// caused a Code 47 that main does NOT have.
+///
+/// Abstaining reproduces main's spelling for this shape exactly: still
+/// imperfect (both arms sort by the forward endpoint — tracked separately),
+/// but never a regression and never a NEW silent wrong.
+#[tokio::test]
+async fn ldbc_1141_unresolvable_expression_key_abstains_not_prefix_flip() {
+    let schema = load_schema_from("schemas/test/denormalized_flights.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) \
+         RETURN o.city ORDER BY toUpper(o.state)",
+    )
+    .await;
+    assert!(
+        !sql.contains("end_OriginState"),
+        "#1141 final review: must never emit the FROM-role column under an \
+         `end_` prefix — that column is projected by no arm (Code 47), a \
+         regression versus main:\n{sql}"
+    );
+    // Main's spelling: both arms keep the globally-rewritten key.
+    assert_eq!(
+        sql.matches("upperUTF8(t.start_OriginState) AS \"__order_col_0\"")
+            .count(),
+        2,
+        "#1141 final review: abstain leaves BOTH arms with the global \
+         rewrite:\n{sql}"
+    );
+}
+
+/// #1141/#1140 final review (HIGH): two Cypher properties may share one
+/// from-side physical column (`city` and `town` both -> `origin_city`) while
+/// differing on the to-side (`dest_city` vs `dest_code`). The swap must
+/// resolve the key's OWN property, not whichever entry matches the column
+/// name first.
+#[tokio::test]
+async fn ldbc_1141_shared_from_column_resolves_the_keys_own_property() {
+    let schema = load_schema_from("schemas/test/denorm_shared_from_column.yaml");
+
+    let town = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.state ORDER BY o.town",
+    )
+    .await;
+    assert_eq!(
+        town.matches("t.end_dest_code AS \"__order_col_0\"").count(),
+        1,
+        "#1141: `town` maps to dest_code on the to-side:\n{town}"
+    );
+
+    let city = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.state ORDER BY o.city",
+    )
+    .await;
+    assert_eq!(
+        city.matches("t.end_dest_city AS \"__order_col_0\"").count(),
+        1,
+        "#1141: `city` maps to dest_city — the sibling property sharing the \
+         same from-side column must NOT bleed across:\n{city}"
+    );
+}
+
 // --- #1135: `*0..0` is the zero-hop identity, not a 1-hop chain --------------
 //
 // `exact_hop_count()` returned `Some(0)` and every consumer treats `Some(n)`

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2744,6 +2744,75 @@ async fn ldbc_1141_unprojected_role_ambiguous_key_reresolves_column() {
     );
 }
 
+/// #1141/#1140 re-review (CRITICAL): the role swap must be bound to the ARM's
+/// OWN projected columns. Resolving it through a schema-wide scan let ANY
+/// denormalized label in the catalog rewrite an unrelated — here entirely
+/// NON-denormalized — VLP's ORDER BY key into a real column holding the other
+/// endpoint's value (loud -> silently mis-sorted; ground rule 1).
+///
+/// The fixture is the plain composite `Account` graph plus one unrelated
+/// denormalized `Leg` label on a different table AND database.
+#[tokio::test]
+async fn ldbc_1141_unrelated_denorm_label_must_not_rewrite_key() {
+    let schema = load_schema_from("schemas/test/denorm_decoy_unrelated_label.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]-(b:Account) \
+         RETURN a.bank_id ORDER BY a.account_type",
+    )
+    .await;
+    // Scoped to the ORDER BY KEY: `holder_name` legitimately appears as a
+    // projected CTE column (the schema declares it); what must never happen is
+    // the unrelated label's column becoming this query's sort key.
+    assert!(
+        !sql.contains("holder_name AS \"__order_col_"),
+        "#1141 re-review: an unrelated denormalized label must not reach \
+         across into this query's ORDER BY key:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.start_account_type AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1141 re-review: forward arm:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_account_type AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1141 re-review: the reversed arm flips only the ROLE — this node has \
+         no role-specific maps, so the column name is unchanged:\n{sql}"
+    );
+}
+
+/// #1141/#1140 re-review (HIGH): SQL generation must be deterministic. The
+/// previous resolution iterated a `HashMap`, so when two Cypher properties
+/// share a from-side physical column but differ on the to-side, the answer
+/// varied run to run (observed 6/6 split over 12 runs). Reading the arm's
+/// ordered `CteColumnMetadata` makes it a lookup, not a guess.
+#[tokio::test]
+async fn ldbc_1141_role_swap_resolution_is_deterministic() {
+    let schema = load_schema_from("schemas/test/denorm_shared_from_column.yaml");
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..8 {
+        let sql = generate_sql_inline(
+            &schema,
+            "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.state ORDER BY o.city",
+        )
+        .await;
+        let key = sql
+            .split_whitespace()
+            .find(|w| w.starts_with("t.end_"))
+            .unwrap_or("<none>")
+            .to_string();
+        seen.insert(key);
+    }
+    assert_eq!(
+        seen.len(),
+        1,
+        "#1141 re-review: role-swap resolution must be deterministic, saw {seen:?}"
+    );
+}
+
 // --- #1135: `*0..0` is the zero-hop identity, not a 1-hop chain --------------
 //
 // `exact_hop_count()` returned `Some(0)` and every consumer treats `Some(n)`

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -2551,6 +2551,66 @@ async fn ldbc_1138_two_key_order_role_maps_per_arm() {
     );
 }
 
+// --- #1140: unprojected / expression ORDER BY keys on the undirected union ---
+//
+// #1139 fixed the role binding for keys that are PROJECTED (resolvable through
+// an output alias). A key with no projection to chain through fell to the
+// legacy path and bound the START role in BOTH arms — silently mis-sorted
+// rows on the reversed arm. Each arm's own CTE records its role assignment
+// (`vlp_a_b` = a-start/b-end, `vlp_b_a` the reverse), so an arm that swaps
+// roles relative to the primary direction flips the key's role prefixes.
+
+/// #1140 shape A: the ORDER BY key is not projected (`RETURN a.bank_id
+/// ORDER BY a.balance`).
+#[tokio::test]
+async fn ldbc_1140_unprojected_order_key_role_swaps_per_arm() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]-(b:Account) \
+         RETURN a.bank_id ORDER BY a.balance",
+    )
+    .await;
+    assert_eq!(
+        sql.matches("t.start_balance AS \"__order_col_0\"").count(),
+        1,
+        "#1140: the forward arm keeps the start role:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("t.end_balance AS \"__order_col_0\"").count(),
+        1,
+        "#1140: the reversed arm must order by ITS endpoint (end role), not \
+         repeat the start role:\n{sql}"
+    );
+}
+
+/// #1140 shape B: an EXPRESSION key (`ORDER BY toUpper(a.bank_id)`). The swap
+/// must reach INSIDE the function wrapper, which is why the rewriter descends
+/// structurally instead of cloning non-column nodes.
+#[tokio::test]
+async fn ldbc_1140_expression_order_key_role_swaps_inside_wrapper() {
+    let schema = load_schema_from("schemas/test/composite_node_ids.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Account)-[:TRANSFERRED*1..2]-(b:Account) \
+         RETURN a.bank_id ORDER BY toUpper(a.bank_id)",
+    )
+    .await;
+    assert_eq!(
+        sql.matches("upperUTF8(t.start_bank_id) AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1140: forward arm:\n{sql}"
+    );
+    assert_eq!(
+        sql.matches("upperUTF8(t.end_bank_id) AS \"__order_col_0\"")
+            .count(),
+        1,
+        "#1140: the reversed arm must swap the role INSIDE the function \
+         wrapper:\n{sql}"
+    );
+}
+
 // --- #1141: role-ambiguous denorm property in a VLP ORDER BY -----------------
 //
 // A denormalized node whose from/to maps DISAGREE on a property's physical


### PR DESCRIPTION
Fixes #1140. (Supersedes #1145, which GitHub auto-closed when its base branch — the now-merged #1144 — was deleted. Same commits, rebased onto main; all review history is on #1145.)

## Summary

#1139 fixed the undirected union's ORDER BY role binding for keys that are **projected** (resolvable through an output alias). A key with **no projection to chain through** fell to the legacy path and bound the **start role in both arms**, so the reversed arm sorted by the wrong endpoint — **silently mis-sorted rows**:

```cypher
RETURN a.bank_id ORDER BY a.balance          -- key not projected
RETURN a.bank_id ORDER BY toUpper(a.bank_id) -- expression key
```

Each arm's own `Cte` already records its role assignment structurally, so an arm assigning the opposite roles has the key's role prefixes flipped. Ordered strictly after #1139's chain, so projected keys are untouched.

## Three review rounds, three CRITICALs — all fixed

This PR carries the fixes for all three, since each was found in the machinery this branch introduces.

1. **Prefix flipped, column not re-resolved** — on a denorm schema `start_OriginState` → `end_OriginState` pairs the end role with the *from*-role column. Because #1141 made such names resolvable, that bound a real column holding the other endpoint's value: a loud Code 47 became **silently mis-sorted rows**.

2. **Schema-wide re-resolution mis-bound unrelated queries** — the fix for (1) scanned every node schema with no label binding, so a denormalized label on a *different table and database* rewrote a plain non-denormalized query's sort key to `end_holder_name`. Plus a HIGH: `HashMap` iteration made SQL generation **nondeterministic** (6/6 split over 12 runs).

3. **The correct lookup still fell back to (1)'s spelling** — reachable on the shipped denorm schema through any **expression** key, because the pruner only projects the opposite-role column for *bare* keys. Live: main returned 38 rows, this branch returned **Code 47** — a regression I introduced.

**Final design**: resolve through the arm's own `CteColumnMetadata` — query-bound, ordered, unambiguous — and **abstain** when the lookup misses, leaving the expression exactly as the global rewrite produced it. Abstaining reproduces main byte-for-byte: never a regression, never a new silent wrong.

## Live sweep vs main (`db_denormalized`)

| query | main | this branch |
|---|---|---|
| `RETURN o.city ORDER BY o.city` | Code 47 | **38 rows** |
| `RETURN o.city ORDER BY o.state` | Code 47 | **38 rows** |
| `RETURN o.code ORDER BY o.code` | Code 47 | **38 rows** |
| `ORDER BY toUpper(o.state)` | 38 rows | 38 rows (unchanged) |
| `ORDER BY d.state` | Code 47 | Code 47 (#1146) |
| `RETURN o.city, count(*)` | Code 47 | Code 47 (#1143) |

Composite (`db_composite_id`): pre-fix the balance column returns scrambled; post-fix all 32 rows ascend monotonically with each balance matching its own account. Counts alone would agree here — both arms return the same row count — so every check asserts projected **values** row-for-row.

## Tests

10 regression tests across #1140/#1141. Each behavior test was verified to **fail on the specific commit that introduced its defect** and pass here, in isolated worktrees. Two committed fixtures (`denorm_decoy_unrelated_label.yaml`, `denorm_shared_from_column.yaml`).

Suite: 1738 unit + 704 integration, ratchet clean, clippy clean.

## Residue filed, not folded in

**#1143** (aggregate/GROUP BY), **#1146** (other-endpoint key never projected), **#1147** (schema `filter:` drops endpoint properties) — all loud, all byte-identical on main.

Refs #1140, #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)