### PR TITLE
fix(vlp): #1152 whole-node RETURN on a denorm undirected VLP binds CTE columns

### DIFF
--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -863,10 +863,36 @@ impl SelectBuilder for LogicalPlan {
                                 }
                             }
 
+                            // #1152: a VLP ENDPOINT is bound by the recursive
+                            // `vlp_*` CTE, not by the edge table. On a
+                            // denormalized schema the alias→edge-alias remap
+                            // below would rewrite `o` to the edge table's alias
+                            // (`t1`), which exists only INSIDE the CTE body —
+                            // the outer scope sees only the CTE (aliased `t`),
+                            // so the emitted `t1.origin_city` is ClickHouse
+                            // Code 47. Leaving the Cypher alias in place routes
+                            // the item through `rewrite_expr_for_vlp`, which
+                            // resolves each arm's own role prefix
+                            // (`t.start_origin_city` / `t.end_dest_city`) — the
+                            // same chain the per-property path already uses
+                            // (#1140/#1141/#1143/#1146).
+                            //
+                            // A non-denormalized endpoint has no remap to skip
+                            // (`mapped_alias` already equals the Cypher alias),
+                            // so this gate is a no-op there. Consumes the same
+                            // `graph_rel_vlp_endpoint_role` discriminator the
+                            // #537 composite-id branch above uses, rather than
+                            // a raw denorm flag (CLAUDE.md rule 7).
+                            let is_vlp_endpoint = self
+                                .graph_rel_vlp_endpoint_role(&prop.table_alias.0)
+                                .is_some();
+
                             // Check if this is a denormalized edge alias mapping
                             // First try plan_ctx (populated during planning), then fall back to
                             // logical plan inspection, then QUERY_CONTEXT
-                            let mapped_alias = if let Some(ctx) = plan_ctx {
+                            let mapped_alias = if is_vlp_endpoint {
+                                prop.table_alias.0.clone()
+                            } else if let Some(ctx) = plan_ctx {
                                 if let Some((edge_alias, _is_from, _label, _type)) =
                                     ctx.get_denormalized_alias_info(&prop.table_alias.0)
                                 {

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -3202,3 +3202,112 @@ async fn ldbc_1135_positive_exact_bounds_stay_flat() {
         );
     }
 }
+
+// --- #1152: whole-node RETURN on a denormalized undirected VLP ---------------
+//
+// `RETURN o` (as opposed to `RETURN o.city`) reaches a DIFFERENT expansion
+// site than the per-property path: the wildcard branch of `SelectBuilder`,
+// which applies the denormalized alias->EDGE-alias remap before the VLP
+// rewriter runs. On a denormalized schema that rewrote the endpoint to the
+// edge table's alias (`t1`) — a name bound only INSIDE the recursive CTE
+// body, so the outer scope's `t1.origin_city` was ClickHouse Code 47 (loud).
+// The remap is correct for an ordinary embedded-denorm node; it is wrong for
+// a VLP ENDPOINT, whose columns live in the `vlp_*` CTE. Skipping it leaves
+// the Cypher alias in place so the item routes through `rewrite_expr_for_vlp`
+// and picks up each arm's own role prefix, exactly as the per-property path
+// already did (#1140/#1141/#1143/#1146).
+
+/// #1152: each undirected arm binds ITS OWN role's projected CTE columns, and
+/// the edge-table alias never escapes the CTE body.
+#[tokio::test]
+async fn ldbc_1152_whole_node_denorm_undirected_vlp_binds_cte_columns() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o",
+    )
+    .await;
+
+    // Split off the outer SELECT: the CTE bodies legitimately reference the
+    // edge alias, so a whole-file assertion would be vacuous.
+    let outer = sql
+        .rsplit_once(") AS __union")
+        .map(|(head, _)| {
+            let idx = head.rfind("SELECT `").unwrap_or(0);
+            head[idx..].to_string()
+        })
+        .unwrap_or_else(|| panic!("expected a two-arm union:\n{sql}"));
+
+    // Match ANY numbered edge alias (`t1.`, `t3.`, ...) — the anon-alias
+    // counter is query-scoped (#1088), so pinning one spelling would make the
+    // test pass by accident on a plan that merely renumbered.
+    let leaked: Vec<&str> = outer
+        .split_whitespace()
+        .filter(|tok| {
+            tok.strip_prefix('t')
+                .and_then(|rest| rest.split_once('.'))
+                .is_some_and(|(n, _)| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "#1152: an edge-table alias escaped into the outer SELECT (bound only \
+         inside the CTE body -> Code 47): {leaked:?}\n{outer}"
+    );
+    // Per arm, not whole-file: main emitted BOTH physical spellings too (off
+    // the edge alias), so a bare `contains` pair would pass on main.
+    let arms: Vec<&str> = outer.split("UNION ALL").collect();
+    assert_eq!(arms.len(), 2, "#1152: expected two arms:\n{outer}");
+    assert!(
+        arms[0].contains("t.start_origin_city") && arms[0].contains("t.start_origin_state"),
+        "#1152: the forward arm must read its FROM-role columns:\n{outer}"
+    );
+    assert!(
+        arms[1].contains("t.end_dest_city") && arms[1].contains("t.end_dest_state"),
+        "#1152: the reversed arm must read its TO-role columns — binding the \
+         forward arm's spelling here would return the WRONG airport's data \
+         while still executing:\n{outer}"
+    );
+}
+
+/// #1152: the gate keys on VLP-endpoint-ness, not on denormalization, so a
+/// non-denormalized undirected VLP must be BYTE-IDENTICAL to its pre-fix form
+/// (it never had an alias remap to skip).
+#[tokio::test]
+async fn ldbc_1152_standard_undirected_vlp_whole_node_unchanged() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql =
+        generate_sql_inline(&schema, "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) RETURN a").await;
+    // The standard schema resolves the whole node through the base-table path
+    // (one alias, no role split) and already worked; pin that it still does.
+    assert!(
+        sql.contains("t.start_name") && sql.contains("t.start_city"),
+        "#1152: a standard VLP endpoint must keep reading its CTE columns:\n{sql}"
+    );
+    assert!(
+        !sql.contains("UNION ALL\nSELECT \n      t1."),
+        "#1152: no edge-alias leak on the standard path:\n{sql}"
+    );
+}
+
+/// #1152: a DIRECTED denorm VLP renders a single CTE and already resolved
+/// correctly — the fix must not perturb it.
+#[tokio::test]
+async fn ldbc_1152_directed_denorm_vlp_whole_node_unchanged() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]->(d:Airport) RETURN o",
+    )
+    .await;
+    assert!(
+        sql.contains("t.start_origin_city"),
+        "#1152: the directed shape must keep its FROM-role CTE columns:\n{sql}"
+    );
+    // The recursive CTE body has its own base/recursive `UNION ALL`; the
+    // point here is that the OUTER select is a single arm (no two-CTE split).
+    assert!(
+        !sql.contains(") AS __union"),
+        "#1152: the directed shape renders ONE outer arm, not a union:\n{sql}"
+    );
+}


### PR DESCRIPTION
## Problem

`RETURN o` (a **whole node**) on a denormalized undirected VLP emitted the edge-table alias in the OUTER select instead of the CTE's projected columns → ClickHouse **Code 47**, loud, on every such shape.

```
Code: 47. Unknown expression identifier `t1.origin_city` in scope
SELECT t1.origin_city AS `o.city`, ... FROM vlp_o_d AS t
```

`t1` is the edge table's alias **inside** the CTE body; the outer scope only has the CTE, aliased `t`.

## Root cause

`RETURN o` and `RETURN o.city` reach **different expansion sites**.

- **Per-property** (`o.city`) goes through `rewrite_expr_for_vlp`, which resolves each arm's own role prefix. This is the chain fixed across #1140/#1141/#1143/#1146.
- **Whole-node** (`o`) is rewritten by the analyzer to `o.*` and lands in `SelectBuilder`'s wildcard branch, which applies the denormalized alias→**edge-alias** remap *first*. That remap is correct for an ordinary embedded-denorm node, but a VLP endpoint's columns live in the recursive `vlp_*` CTE, so the resulting reference dangles.

Traced by instrumenting both sites and diffing the working (directed) against the broken (undirected) shape:

```
UNDIRECTED (broken):  out=o.city expr=t1.origin_city   <- wildcard branch, edge alias
DIRECTED   (works):   out=o.city expr=o.origin_city    <- base-table branch, Cypher alias
```

## Fix

Skip the remap when the alias is a VLP endpoint, leaving the Cypher alias in place so the item routes through the already-correct per-arm chain. Gated on `graph_rel_vlp_endpoint_role` — the same discriminator the #537 composite-id branch directly above already uses — not a raw denorm flag (CLAUDE.md rule 7). Ratchet unchanged. A non-denormalized endpoint has no remap to skip, so the gate is a no-op there.

## Verification — values, not row counts

An undirected VLP renders two arms bound by position, so a count or single-column check is blind to an arm swap. Everything below compares values.

**Independent SQL oracle** (hand-built two-arm edge-distinct walk enumeration, not another ClickGraph path):

| | ATL | DEN | JFK | LAX | ORD | PHX | SFO |
|---|---|---|---|---|---|---|---|
| oracle | 7 | 4 | 7 | 10 | 6 | 2 | 2 |
| `RETURN o` | 7 | 4 | 7 | 10 | 6 | 2 | 2 |

- 38 rows, Code 47 on main.
- **Pairwise**: `RETURN o, d` matches the oracle's (o,d) pair tally exactly — this is what actually pins per-arm role assignment; a swap preserves both the row count and the single-column tally.
- Every row self-consistent against ground truth (an Atlanta row shows GA, not CA).
- Multiset-identical to the independently-correct per-property path.

**Second denorm schema, cyclic fixture** (zeek, dotted column names, 3-node cycle — the shape required to expose edge-uniqueness defects): Code 47 → 12 rows, tallies matching a hand oracle.

**Corpus sweep**: 408 generated VLP whole-node shapes across every repo YAML, SQL diffed against clean main in an isolated target dir. Exactly **34 shapes change, all denorm+undirected whole-node**; each binds a column the CTE actually projects where main bound one it never did. The other **374 are byte-identical**.

All five schema variations exercised live (standard, polymorphic, FK-edge, composite, denormalized).

## Tests

Three added; full suite green (1738 unit + 715 integration + 7 + 29, zero failures).

The behavior test asserts **per arm** — a whole-file `contains` passes on main, which emits both physical spellings off the edge alias — and matches any numbered edge alias rather than one spelling, since the anon-alias counter is query-scoped (#1088). Verified to **fail on main** and pass here. Two guard tests pin the unchanged standard-undirected and directed-denorm shapes.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
