### PR TITLE
fix(vlp): #1152 rebind whole-node VLP arms via each arm's own CTE metadata

### DIFF
--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3752,6 +3752,21 @@ fn rebind_vlp_arm_select(outer: &RenderPlan, arm: &RenderPlan) -> Option<SelectI
 /// generator emits. When the body yields NOTHING recognizable the set is empty,
 /// which makes every lookup abstain: unable to prove a column exists, the
 /// helper declines rather than guessing.
+///
+/// SAFETY INVARIANT (review L4). The raw-SQL scan deliberately OVER-collects:
+/// it also picks up type names (`CAST(x AS Int64)`), table aliases
+/// (`FROM tbl AS t1`), `ARRAY JOIN ... AS elem`, and text inside string
+/// literals or comments. That is sound here for one reason only — this set is
+/// used solely to INTERSECT `CteColumnMetadata`, whose `cte_column_name` is
+/// always built as `start_<prop>` / `end_<prop>` (see `cte_manager`'s
+/// `add_property_selections`), and no spurious token takes that shape. Widening
+/// the candidate set can therefore never re-admit a fabricated name.
+///
+/// If a future CTE builder ever emits metadata under a DIFFERENTLY shaped
+/// alias, that invariant lapses and this scan must be tightened to real aliases
+/// (parse the select list) before it can be trusted — otherwise H1 reopens:
+/// a metadata-only name would match a spurious token and be emitted as a
+/// column no arm defines, which is loud only until the name happens to exist.
 fn cte_body_output_names(cte: &crate::render_plan::Cte) -> std::collections::HashSet<String> {
     let mut names = std::collections::HashSet::new();
     match &cte.content {

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3713,8 +3713,110 @@ fn rebind_vlp_arm_select(outer: &RenderPlan, arm: &RenderPlan) -> Option<SelectI
         .0
         .iter()
         .find(|c| c.cte_name == from_name && c.vlp_cypher_start_alias.is_some())?;
+
+    // Review H1: `CteColumnMetadata` is what the CTE BUILDER intended to
+    // project, and on the composite-denorm path it disagrees with what the CTE
+    // BODY actually emits — the metadata advertises `start_code`/`start_state`
+    // while the body emits only `start_origin_code`/`start_origin_state`.
+    // Binding straight off the metadata therefore fabricated a name no arm
+    // defines. That is loud today, but only by luck: on a schema where a
+    // logical property maps to a physical column literally named `code`, the
+    // fabricated `start_code` EXISTS and carries the wrong value — loud
+    // becomes silently wrong, the exact hazard this helper exists to avoid.
+    //
+    // So intersect the metadata with the body's real output names and treat
+    // the intersection as the resolvable set. An entry the body does not
+    // emit is not a candidate, which routes the whole item to the ABSTAIN
+    // path (reproducing today's output byte-for-byte) rather than to a
+    // plausible-looking guess.
+    let emitted = cte_body_output_names(cte);
+    let projected: Vec<crate::render_plan::cte_manager::CteColumnMetadata> = cte
+        .columns
+        .iter()
+        .filter(|m| emitted.contains(m.cte_column_name.as_str()))
+        .cloned()
+        .collect();
+
     let vlp_alias = crate::server::query_context::vlp_from_alias();
-    rebind_arm_items_to_cte_columns(&arm.select, &cte.cte_name, &cte.columns, &vlp_alias)
+    rebind_arm_items_to_cte_columns(&arm.select, &cte.cte_name, &projected, &vlp_alias)
+}
+
+/// Review H1: the set of column names a VLP CTE's BODY actually exports.
+///
+/// `CteColumnMetadata` records the builder's intent and can drift from the
+/// rendered body (see `rebind_vlp_arm_select`). This reads the body itself so
+/// the rebind can only ever name a column that exists.
+///
+/// A structured body exposes its select items' aliases directly. A raw-SQL body
+/// is scanned for `AS <name>` / `as "<name>"` — the same spelling every VLP CTE
+/// generator emits. When the body yields NOTHING recognizable the set is empty,
+/// which makes every lookup abstain: unable to prove a column exists, the
+/// helper declines rather than guessing.
+fn cte_body_output_names(cte: &crate::render_plan::Cte) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    match &cte.content {
+        crate::render_plan::CteContent::Structured(inner) => {
+            collect_structured_output_names(inner, &mut names);
+        }
+        crate::render_plan::CteContent::RawSql(sql) => {
+            collect_sql_output_names(sql, &mut names);
+        }
+    }
+    names
+}
+
+/// Aliases exported by a structured CTE body, including its UNION arms (a
+/// recursive VLP CTE is `base UNION ALL recursive`, and both arms must agree,
+/// so either arm's aliases describe the exported shape).
+fn collect_structured_output_names(
+    plan: &RenderPlan,
+    names: &mut std::collections::HashSet<String>,
+) {
+    for item in &plan.select.items {
+        if let Some(alias) = &item.col_alias {
+            names.insert(alias.0.trim_matches('"').to_string());
+        }
+    }
+    if let Some(union) = &plan.union.0 {
+        for arm in &union.input {
+            collect_structured_output_names(arm, names);
+        }
+    }
+}
+
+/// `AS <name>` / `as "<name>"` occurrences in a raw-SQL CTE body.
+fn collect_sql_output_names(sql: &str, names: &mut std::collections::HashSet<String>) {
+    let bytes: Vec<char> = sql.chars().collect();
+    let lower: Vec<char> = sql.to_ascii_lowercase().chars().collect();
+    let mut i = 0usize;
+    while i + 3 < lower.len() {
+        let is_as = lower[i] == 'a'
+            && lower[i + 1] == 's'
+            && (i == 0 || !lower[i - 1].is_alphanumeric() && lower[i - 1] != '_')
+            && lower[i + 2].is_whitespace();
+        if !is_as {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 3;
+        while j < bytes.len() && bytes[j].is_whitespace() {
+            j += 1;
+        }
+        let quoted = j < bytes.len() && bytes[j] == '"';
+        if quoted {
+            j += 1;
+        }
+        let start = j;
+        while j < bytes.len()
+            && (bytes[j].is_alphanumeric() || bytes[j] == '_' || (quoted && bytes[j] == '.'))
+        {
+            j += 1;
+        }
+        if j > start {
+            names.insert(bytes[start..j].iter().collect());
+        }
+        i = j.max(i + 1);
+    }
 }
 
 /// #1140: the PRIMARY direction's `(start_alias, end_alias)` — the roles the

--- a/src/sql_generator/emitters/clickhouse/to_sql_query.rs
+++ b/src/sql_generator/emitters/clickhouse/to_sql_query.rs
@@ -3558,6 +3558,165 @@ struct VlpArmRoles {
     arm_cte: Option<String>,
 }
 
+/// #1152: rebind a UNION arm's SELECT items to the columns its OWN VLP CTE
+/// projects, using that CTE's `CteColumnMetadata`.
+///
+/// `RETURN o` (a whole node) and `RETURN o.city` reach the emitter differently.
+/// The per-property form arrives already resolved to the arm's role-correct CTE
+/// column (`t.end_dest_city`) — `rewrite_expr_for_vlp` did that upstream. The
+/// whole-node form is expanded by `SelectBuilder`'s `n.*` branch, which resolves
+/// each property against the BASE TABLE and, on a denormalized schema, through
+/// the alias->edge-alias remap: `t1.dest_city`. The physical column is already
+/// role-correct for this arm; only the table alias is wrong — `t1` is the edge
+/// table's alias INSIDE the CTE body, invisible in the outer scope (Code 47).
+///
+/// Rather than suppress that remap upstream (attempted in #1153 and withdrawn —
+/// the gate had to fire on VLP-endpoint-ness alone, which also caught the flat
+/// chained render where the remap is load-bearing, and the mixed-access arm
+/// where it produced silently wrong rows), rebind HERE, where the arm's own CTE
+/// metadata is available and says exactly which column carries which
+/// `(alias, property)` pair.
+///
+/// Deliberately conservative — every unresolvable case ABSTAINS, reproducing
+/// today's output byte-for-byte so no shape becomes newly loud and, far more
+/// importantly, no loud shape becomes silently wrong
+/// (the `fallback-to-a-proven-wrong-spelling` hazard that sank #1153):
+///  - arm does not scan a `vlp_*` CTE with role metadata (the flat chained
+///    render of #1155 scans a BASE TABLE, so it never enters here);
+///  - the item is not a plain `<alias>.<column>` property access;
+///  - the referenced column is not one this CTE projects under that item's
+///    output alias contract;
+///  - the lookup is ambiguous (two properties sharing one physical column).
+fn rebind_arm_items_to_cte_columns(
+    select: &SelectItems,
+    arm_cte_name: &str,
+    columns: &[crate::render_plan::cte_manager::CteColumnMetadata],
+    vlp_alias: &str,
+) -> Option<SelectItems> {
+    use crate::graph_catalog::expression_parser::PropertyValue;
+
+    if columns.is_empty() {
+        return None;
+    }
+
+    let mut rebound = false;
+    let mut items: Vec<SelectItem> = Vec::with_capacity(select.items.len());
+
+    for item in &select.items {
+        // The output alias is the contract: `o.city` names the Cypher
+        // (alias, property) pair this position must carry. Without it there is
+        // nothing to key the lookup on.
+        let Some(out) = item.col_alias.as_ref().map(|a| a.0.clone()) else {
+            items.push(item.clone());
+            continue;
+        };
+        let Some((cy_alias, cy_prop)) = out.split_once('.') else {
+            items.push(item.clone());
+            continue;
+        };
+
+        // Only a bare `<alias>.<column>` property access is rebindable. An
+        // expression (`toUpper(...)`), a literal, or an aggregate keeps its
+        // current form — those either already resolve or are separately
+        // tracked, and guessing here is how a loud error becomes wrong rows.
+        let RenderExpr::PropertyAccessExp(pa) = &item.expression else {
+            items.push(item.clone());
+            continue;
+        };
+        // Already bound to the CTE's own FROM alias: upstream resolved it
+        // (the per-property path). Leave it alone.
+        if pa.table_alias.0 == vlp_alias {
+            items.push(item.clone());
+            continue;
+        }
+
+        // Ask this arm's CTE which column carries that (alias, property) pair.
+        let matches: Vec<&crate::render_plan::cte_manager::CteColumnMetadata> = columns
+            .iter()
+            .filter(|m| m.cypher_alias == cy_alias && m.cypher_property == cy_prop)
+            .collect();
+
+        // A node's id property legitimately appears TWICE: once as the CTE's
+        // generic identity column (`start_id`, `is_id_column`) and once as an
+        // ordinary projected property (`start_origin_code`). Both carry the
+        // SAME `db_column`, so this is two spellings of one value, not a real
+        // ambiguity — disambiguate by the column the item already references
+        // (`t1.origin_code` -> the entry whose `db_column` is `origin_code`),
+        // preferring the non-id spelling when both still qualify so the emitted
+        // column matches what the per-property path produces.
+        //
+        // Anything that remains ambiguous AFTER that (two DIFFERENT physical
+        // columns for one pair) abstains: guessing there is exactly the
+        // proven-wrong-spelling hazard.
+        let referenced = pa.column.raw().to_string();
+        let only = match matches.as_slice() {
+            [one] => *one,
+            [] => {
+                items.push(item.clone());
+                continue;
+            }
+            many => {
+                let same_col: Vec<_> = many.iter().filter(|m| m.db_column == referenced).collect();
+                let distinct_targets: std::collections::BTreeSet<&str> =
+                    same_col.iter().map(|m| m.db_column.as_str()).collect();
+                if same_col.is_empty() || distinct_targets.len() != 1 {
+                    items.push(item.clone());
+                    continue;
+                }
+                match same_col.iter().find(|m| !m.is_id_column) {
+                    Some(m) => **m,
+                    None => *same_col[0],
+                }
+            }
+        };
+
+        log::debug!(
+            "🔧 #1152: arm '{}' rebinding {}.{} -> {}.{} (for {})",
+            arm_cte_name,
+            pa.table_alias.0,
+            pa.column.raw(),
+            vlp_alias,
+            only.cte_column_name,
+            out
+        );
+        rebound = true;
+        items.push(SelectItem {
+            expression: RenderExpr::PropertyAccessExp(PropertyAccess {
+                table_alias: TableAlias(vlp_alias.to_string()),
+                column: PropertyValue::Column(only.cte_column_name.clone()),
+            }),
+            col_alias: item.col_alias.clone(),
+        });
+    }
+
+    // Nothing changed => report `None` so the caller keeps the original object
+    // and the emitted SQL is byte-identical.
+    rebound.then_some(SelectItems {
+        items,
+        distinct: select.distinct,
+    })
+}
+
+/// #1152: apply [`rebind_arm_items_to_cte_columns`] to one arm of an undirected
+/// VLP union, resolving that arm's CTE from the OUTER plan (the only place
+/// `ctes` lives — an arm carries just its FROM).
+///
+/// Returns a rebound `SelectItems`, or `None` meaning "emit exactly what you
+/// would have emitted". `None` covers every shape that is not an arm scanning a
+/// role-annotated `vlp_*` CTE — including the flat chained render (#1155),
+/// whose FROM is a base table, so that shape is excluded structurally rather
+/// than by a blacklist.
+fn rebind_vlp_arm_select(outer: &RenderPlan, arm: &RenderPlan) -> Option<SelectItems> {
+    let from_name = arm.from.0.as_ref().map(|f| f.name.as_str())?;
+    let cte = outer
+        .ctes
+        .0
+        .iter()
+        .find(|c| c.cte_name == from_name && c.vlp_cypher_start_alias.is_some())?;
+    let vlp_alias = crate::server::query_context::vlp_from_alias();
+    rebind_arm_items_to_cte_columns(&arm.select, &cte.cte_name, &cte.columns, &vlp_alias)
+}
+
 /// #1140: the PRIMARY direction's `(start_alias, end_alias)` — the roles the
 /// global ORDER BY rewrite resolved against. Read from the outer plan's first
 /// role-carrying VLP CTE, which is the one the primary FROM scans.
@@ -6552,7 +6711,12 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
                     activate_scope_context(&plan.from, &plan.joins);
 
                     let mut first_branch_sql = String::new();
-                    first_branch_sql.push_str(&plan.select.to_sql());
+                    // #1152: the base arm IS the outer plan; rebind its whole-node
+                    // items against the CTE its own FROM scans.
+                    match rebind_vlp_arm_select(&plan, &plan) {
+                        Some(rebound) => first_branch_sql.push_str(&rebound.to_sql()),
+                        None => first_branch_sql.push_str(&plan.select.to_sql()),
+                    }
                     first_branch_sql.push_str(&plan.from.to_sql());
                     first_branch_sql.push_str(&plan.joins.to_sql());
                     // #624: the base arm of a UNION may carry its own UNWIND
@@ -6566,7 +6730,16 @@ pub fn render_plan_to_sql(mut plan: RenderPlan, _max_cte_depth: u32) -> String {
 
                     for union_branch in &union.input {
                         sql.push_str(union_type_str);
-                        sql.push_str(&render_union_branch_sql(union_branch));
+                        // #1152: same rebinding for the sibling arm, against
+                        // ITS OWN CTE (which assigns the opposite roles).
+                        match rebind_vlp_arm_select(&plan, union_branch) {
+                            Some(rebound) => {
+                                let mut arm = union_branch.clone();
+                                arm.select = rebound;
+                                sql.push_str(&render_union_branch_sql(&arm));
+                            }
+                            None => sql.push_str(&render_union_branch_sql(union_branch)),
+                        }
                     }
                 } else if has_aggregation {
                     // For aggregation: use pre-computed inner SELECT that includes

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -3202,3 +3202,175 @@ async fn ldbc_1135_positive_exact_bounds_stay_flat() {
         );
     }
 }
+
+// --- #1152: whole-node RETURN on a denormalized undirected VLP ---------------
+//
+// `RETURN o` (as opposed to `RETURN o.city`) reaches a DIFFERENT expansion site
+// than the per-property path: `SelectBuilder`'s `n.*` wildcard branch, which
+// resolves each property against the BASE TABLE and, on a denormalized schema,
+// through the alias->edge-alias remap -> `t1.origin_city`. The physical column
+// is already role-correct for the arm; only the alias is wrong (`t1` is bound
+// only INSIDE the CTE body), so the outer scope saw Code 47.
+//
+// A first attempt (PR #1153, closed) suppressed that remap upstream in
+// `SelectBuilder`. It had to gate on VLP-endpoint-ness alone, which ALSO caught
+// the flat chained render (where the remap is load-bearing -> new loud
+// regression, #1155) and the mixed-access arm (where it produced silently wrong
+// rows, #1154). The discriminator does not exist at that layer.
+//
+// This resolves one layer down instead, in the emitter, where each arm's own
+// `CteColumnMetadata` says exactly which column carries which
+// `(cypher_alias, cypher_property)` pair — the same query-bound truth the
+// per-arm ORDER BY machinery of #1140/#1143 already consumes. Everything
+// unresolvable ABSTAINS, reproducing today's output byte-for-byte.
+
+/// #1152: each undirected arm binds ITS OWN role's projected CTE columns, and
+/// the edge-table alias never escapes the CTE body.
+#[tokio::test]
+async fn ldbc_1152_whole_node_denorm_undirected_vlp_binds_cte_columns() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o",
+    )
+    .await;
+
+    // Only the OUTER select matters: the CTE bodies legitimately reference the
+    // edge alias, so a whole-file assertion would be vacuous.
+    let outer = sql
+        .rsplit_once(") AS __union")
+        .map(|(head, _)| {
+            let idx = head.rfind("SELECT `").unwrap_or(0);
+            head[idx..].to_string()
+        })
+        .unwrap_or_else(|| panic!("expected a two-arm union:\n{sql}"));
+
+    // Match ANY numbered edge alias (`t1.`, `t3.`, ...): the anon-alias counter
+    // is query-scoped (#1088), so pinning one spelling would let a mere
+    // renumbering pass.
+    let leaked: Vec<&str> = outer
+        .split_whitespace()
+        .filter(|tok| {
+            tok.strip_prefix('t')
+                .and_then(|rest| rest.split_once('.'))
+                .is_some_and(|(n, _)| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "#1152: an edge-table alias escaped into the outer SELECT (bound only \
+         inside the CTE body -> Code 47): {leaked:?}\n{outer}"
+    );
+
+    // PER ARM, not whole-file: main emitted both physical spellings too (off
+    // the edge alias), so a bare `contains` pair would pass on main.
+    let arms: Vec<&str> = outer.split("UNION ALL").collect();
+    assert_eq!(arms.len(), 2, "#1152: expected two arms:\n{outer}");
+    assert!(
+        arms[0].contains("t.start_origin_city")
+            && arms[0].contains("t.start_origin_code")
+            && arms[0].contains("t.start_origin_state"),
+        "#1152: the forward arm must read its FROM-role columns:\n{outer}"
+    );
+    assert!(
+        arms[1].contains("t.end_dest_city")
+            && arms[1].contains("t.end_dest_code")
+            && arms[1].contains("t.end_dest_state"),
+        "#1152: the reversed arm must read its TO-role columns — binding the \
+         forward arm's spelling here would return the WRONG airport's data \
+         while still executing:\n{outer}"
+    );
+}
+
+/// #1152: the flat CHAINED render (#1155) has NO VLP CTE, so the rebind is
+/// inert there by construction. This is the shape PR #1153's upstream gate
+/// regressed (22 rows -> Code 47); pin that it keeps the edge-alias spelling.
+#[tokio::test]
+async fn ldbc_1152_flat_chained_render_keeps_edge_alias() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport)-[:FLIGHT]->(e:Airport) RETURN o",
+    )
+    .await;
+    assert!(
+        !sql.contains("vlp_"),
+        "#1152/#1155: this shape renders FLAT — if it ever grows a VLP CTE, \
+         this test's premise (and the rebind's inertness here) must be \
+         re-derived:\n{sql}"
+    );
+    // The edge alias is correct here: it IS the FROM. Removing it (as #1153
+    // did) makes the reference dangle. Assert STRUCTURALLY: whatever numbered
+    // alias the FROM binds, the projection must use that same alias — the
+    // anon-alias counter is query-scoped (#1088) and shared across
+    // concurrently-running tests, so a hardcoded `t1` is order-dependent.
+    let from_alias = sql
+        .split("flights_denorm AS ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or_else(|| panic!("#1152: expected an aliased base-table FROM:\n{sql}"));
+    assert!(
+        sql.contains(&format!("{from_alias}.origin_city")),
+        "#1152: the flat render must keep resolving through the edge alias \
+         (`{from_alias}`), which is bound by its own FROM:\n{sql}"
+    );
+}
+
+/// #1152: the mixed-access arm (#1154) must ABSTAIN — it stays exactly as loud
+/// as main. Making it resolvable without fixing #1154's NULL projection would
+/// turn a loud error into silently wrong rows (PR #1153 did exactly that).
+#[tokio::test]
+async fn ldbc_1152_mixed_access_arm_abstains() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO*1..2]-(b:Person) RETURN a, b",
+    )
+    .await;
+    // `mgr_id` is NOT a column any arm projects, so this stays Code 47 at
+    // execution — the pre-existing, ground-rule-1-safe behavior.
+    assert!(
+        sql.contains("t.mgr_id"),
+        "#1152: the mixed-access arm must abstain and reproduce main's \
+         spelling; resolving it here surfaces #1154's NULL projection as \
+         silently wrong rows:\n{sql}"
+    );
+    assert!(
+        sql.contains("NULL AS \"b.pid\"") || sql.contains("NULL AS `b.pid`"),
+        "#1152: #1154's NULL projection is expected to still be present \
+         (tracked separately) — if it is gone, this test's premise changed:\n{sql}"
+    );
+}
+
+/// #1152: a standard (non-denormalized) undirected VLP endpoint already
+/// resolved to its CTE columns; the rebind must leave it exactly as it was.
+#[tokio::test]
+async fn ldbc_1152_standard_undirected_vlp_whole_node_unchanged() {
+    let schema = load_schema_from("schemas/dev/social_standard.yaml");
+    let sql =
+        generate_sql_inline(&schema, "MATCH (a:User)-[:FOLLOWS*1..2]-(b:User) RETURN a").await;
+    assert!(
+        sql.contains("t.start_name") && sql.contains("t.start_city"),
+        "#1152: a standard VLP endpoint must keep reading its CTE columns:\n{sql}"
+    );
+}
+
+/// #1152: a DIRECTED denorm VLP renders a single arm and already resolved
+/// correctly.
+#[tokio::test]
+async fn ldbc_1152_directed_denorm_vlp_whole_node_unchanged() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]->(d:Airport) RETURN o",
+    )
+    .await;
+    assert!(
+        sql.contains("t.start_origin_city"),
+        "#1152: the directed shape must keep its FROM-role CTE columns:\n{sql}"
+    );
+    assert!(
+        !sql.contains(") AS __union"),
+        "#1152: the directed shape renders ONE outer arm, not a union:\n{sql}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -3374,3 +3374,110 @@ async fn ldbc_1152_directed_denorm_vlp_whole_node_unchanged() {
         "#1152: the directed shape renders ONE outer arm, not a union:\n{sql}"
     );
 }
+
+/// #1152 review H1: the rebind may only name a column the CTE BODY actually
+/// emits, not merely one its `CteColumnMetadata` advertises.
+///
+/// On the composite-denorm path the two disagree: the metadata claims
+/// `start_code`/`start_state` while the body emits only
+/// `start_origin_code`/`start_origin_state`. Binding straight off the metadata
+/// fabricated a name no arm defines. That is loud here only by luck — on a
+/// schema where a logical property maps to a physical column literally named
+/// `code`, the fabricated `start_code` EXISTS and carries the wrong value, so
+/// loud would become silently wrong. The body/metadata intersection makes the
+/// item abstain instead.
+///
+/// This also pins the `[]`-no-candidates ABSTAIN arm that the whole safety
+/// argument rests on (review M1): a mutation replacing it with a guess must be
+/// caught here.
+#[tokio::test]
+async fn ldbc_1152_rebind_never_names_a_column_the_body_lacks() {
+    let schema = load_schema_from("schemas/dev/flights_denorm_mixed_sources.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:AirportComposite)-[:COMPOSITE_FLIGHT*1..2]-(b:AirportComposite) RETURN a",
+    )
+    .await;
+
+    let outer = sql
+        .rsplit_once(") AS __union")
+        .map(|(head, _)| {
+            let idx = head.rfind("SELECT `").unwrap_or(0);
+            head[idx..].to_string()
+        })
+        .unwrap_or_else(|| panic!("expected a two-arm union:\n{sql}"));
+
+    // Collect every column the outer SELECT reads off the VLP CTE alias, and
+    // require each to be a name some CTE body actually exports. Asserting the
+    // GENERAL property (rather than the two names that happen to be wrong
+    // today) is what makes this survive changes to the metadata builder.
+    let exported: std::collections::HashSet<String> = sql
+        .split(" as ")
+        .skip(1)
+        .chain(sql.split(" AS ").skip(1))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(|n| n.trim_matches(|c| c == '"' || c == ',').to_string())
+        .collect();
+
+    for tok in outer.split(|c: char| c.is_whitespace() || c == ',') {
+        let Some(col) = tok.strip_prefix("t.") else {
+            continue;
+        };
+        let col = col.trim_matches('"');
+        if col.is_empty() {
+            continue;
+        }
+        assert!(
+            exported.contains(col),
+            "#1152 H1: outer SELECT reads `t.{col}`, which no CTE body \
+             exports — the rebind must ABSTAIN rather than name a column \
+             that only exists in `CteColumnMetadata`:\n{sql}"
+        );
+    }
+
+    // Concretely: these two were fabricated before the intersection.
+    assert!(
+        !outer.contains("t.start_code") && !outer.contains("t.end_code"),
+        "#1152 H1: `start_code`/`end_code` are metadata-only names on this \
+         schema; the body emits `start_origin_code`/`end_dest_code`:\n{outer}"
+    );
+}
+
+/// #1152 review M1: pin the `[]`-no-candidates ABSTAIN arm directly.
+///
+/// `RETURN o.city, o` projects the same property twice; the duplicate carries a
+/// disambiguated output alias (`o.city_2`) that no `CteColumnMetadata` entry
+/// matches, so the lookup finds ZERO candidates and must abstain. Replacing
+/// that arm with any same-alias fallback binds `t.end_id` there — a CITY column
+/// holding an airport CODE, executing happily and silently wrong.
+///
+/// The other tests all pass under that mutation (it only affects this
+/// duplicate-projection shape), so without this the guard the whole safety
+/// argument rests on would be untested.
+#[tokio::test]
+async fn ldbc_1152_no_candidate_lookup_abstains_rather_than_guessing() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT*1..2]-(d:Airport) RETURN o.city, o",
+    )
+    .await;
+
+    let dup = sql
+        .lines()
+        .find(|l| l.contains("\"o.city_2\""))
+        .unwrap_or_else(|| panic!("#1152 M1: expected a disambiguated duplicate:\n{sql}"));
+
+    assert!(
+        !dup.contains("end_id") && !dup.contains("start_id"),
+        "#1152 M1: the unmatched duplicate must ABSTAIN, not fall back to the \
+         arm's id column — that binds an airport CODE under a CITY alias and \
+         executes silently wrong:\n{dup}"
+    );
+    // Abstaining means keeping the pre-existing edge-alias spelling, which
+    // stays loud exactly as on main (ground rule 1).
+    assert!(
+        dup.contains("dest_city") || dup.contains("origin_city"),
+        "#1152 M1: abstaining reproduces main's spelling for this item:\n{dup}"
+    );
+}


### PR DESCRIPTION
## Problem

`RETURN o` (a whole node) on a denormalized undirected VLP emitted the edge-table alias in the outer SELECT → ClickHouse **Code 47**, loud.

```
Code: 47. Unknown expression identifier `t1.origin_city` in scope
SELECT t1.origin_city AS `o.city`, ... FROM vlp_o_d AS t
```

## Root cause

`RETURN o` and `RETURN o.city` reach different expansion sites. The per-property form arrives already resolved to the arm's role-correct CTE column. The whole-node form is expanded by `SelectBuilder`'s `n.*` branch against the base table, through the denorm alias→edge-alias remap. The physical column it picks (`dest_city` on the reversed arm) is **already role-correct** — only the alias is wrong, and `t1` is bound only *inside* the CTE body.

## Why not the obvious fix

PR #1153 suppressed that remap upstream and was **closed unmerged**. It could only gate on VLP-endpoint-ness, which also caught:
- the **flat chained render** (#1155), where the remap is load-bearing → new loud regression;
- the **mixed-access arm** (#1154), where it produced **silently wrong rows**.

I probed all three at that site. They present identically (`role=Some(...) ctx_vlp=None`) — the discriminator does not exist there.

## This fix

Resolve one layer down, in the emitter, where each arm's own `CteColumnMetadata` says exactly which column carries which `(cypher_alias, cypher_property)` pair — the same query-bound truth the per-arm ORDER BY machinery of #1140/#1143 already consumes:

```
CTE vlp_o_d: start_origin_city[o.city]  end_dest_city[d.city]  ...
CTE vlp_d_o: start_origin_city[d.city]  end_dest_city[o.city]  ...
```

No upstream gate, so the over-broad-gate failure class doesn't apply. Everything unresolvable **abstains**, reproducing today's output byte-for-byte — including non-VLP-CTE arms, so **#1155 is excluded structurally rather than by a blacklist**.

One subtlety: a node's id property appears twice (generic `start_id` and projected `start_origin_code`) with the *same* `db_column` — two spellings of one value, disambiguated by the column the item already references. Anything resolving to two *different* physical columns abstains.

## Verification — values, not row counts

| | tally |
|---|---|
| independent SQL oracle | ATL 7 · DEN 4 · JFK 7 · LAX 10 · ORD 6 · PHX 2 · SFO 2 |
| `RETURN o` | identical |

- **Pairwise**: `RETURN o, d` matches the oracle's (o,d) tally exactly — an arm swap preserves row count *and* single-column tallies, so this is what pins per-arm roles.
- Every row self-consistent (Atlanta shows GA, not CA).
- **#1155** flat chained: unchanged, still 22 rows (#1153 broke this).
- **#1154** mixed-access: abstains, byte-identical to main, still loud — no loud→silent (#1153 turned this into wrong rows).

**Corpus sweep, widened** to the families the previous generator could not emit — chained, post-`WITH`, OPTIONAL, aggregate, ORDER BY, zero-hop, relationship-variable:

- **2112 shapes**, diffed against clean main in an isolated target dir
- **72 change, 2040 byte-identical**
- 60 remove a dangling edge-alias reference; 12 are `RETURN a, r` where node columns are fixed and edge columns untouched
- **zero shapes gain an edge-alias reference**; chained / post-WITH / OPTIONAL / aggregate: **zero changes**

## Tests

Five added, **each verified against the mutation it must catch** — the step #1153 skipped, where all three of its tests passed with the gate forced open. Disabling the rebind fails the behavior test; the guards pin the two abstains plus the unchanged standard and directed shapes.

The flat-chained guard derives the alias from the FROM rather than hardcoding `t1` — the anon-alias counter is query-scoped (#1088) and shared across concurrent tests, so a literal spelling was order-dependent (caught in development).

Full suite green: 1738 unit + 717 integration + 7 + 29, **zero golden changes**. Ratchet green, baseline unchanged.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
