### PR TITLE
fix(denorm): #1154 mixed-access whole-node must resolve BOTH endpoints

### DIFF
--- a/docs/design/PRIORITIES.md
+++ b/docs/design/PRIORITIES.md
@@ -657,6 +657,57 @@ after P-2 merges), 1× P-5 S1. Re-balance here, in writing, not ad hoc.
 
 ## 4. Merge log (newest first — append on merge)
 
+- 2026-09-06: **Correctness — mixed-access whole-node RETURN silently dropped
+  an endpoint** (branch `fix/1154-mixed-access-whole-node-endpoint`, PR #1159,
+  closes #1154 fixed-hop half). On a MIXED-access edge
+  (`classify_edge_table_pattern` -> `Mixed`) whole-node expansion sourced its
+  property set from the structural plan-walk, which returns the EDGE's embedded
+  map — incomplete for BOTH roles at once: the embedded role loses its
+  non-embedded properties (`a.name`), the own-table role has no entry at all
+  and the endpoint VANISHES from the projection. Directed, `RETURN a, b`
+  returned ONE column for two nodes; undirected, `normalize_branch` NULL-padded
+  the missing side into right-count/wrong-value rows. Two corrections to the
+  issue as filed, both verified: NOT VLP-specific (a plain single hop fails
+  identically) and the undirected half is NOT latent (silently wrong on main
+  today). AUTHORITY is the node's `property_mappings`, NOT the edge access
+  strategy — on a mixed edge both roles' strategies are partial, which IS the
+  defect; a first cut keyed on the strategy fixed only the own-table role
+  (measured). Wired at BOTH whole-node sites (`TableAlias` branch and the `n.*`
+  wildcard branch, where undirected UNION arms land). Load-bearing gate,
+  established by MUTATION on the corpus: the pattern must have bound SOME
+  endpoint node table. Of four guards, one was DEAD across all 2400 shapes and
+  was REMOVED rather than shipped unexercised; another is kept with an explicit
+  comment that it is intent, not a filter. Review round 1 found a **CRITICAL**:
+  the gate reads the outermost plan (`GraphJoins` is the root, above the
+  Projection the builder sees) and disjoined across UNION branches, so a
+  COLLAPSED arm passed on its SIBLING's evidence and emitted the dangling
+  columns the gate exists to prevent. Fixed by consulting only branches owning
+  the alias's relationship and requiring EVERY one to bind — "every", not
+  "exactly one": the undirected split reuses the SAME rel alias in both arms,
+  and an "exactly one owner" rule silently restored the NULL padding while all
+  single-clause tests passed. Round 2 found two more, both mine: a **HIGH**
+  regression (across a WITH barrier the second pattern's endpoint join is
+  spelled with the EDGE-side id column -> Code 47 where main returned rows;
+  the corruption happens in a render-stage rewrite AFTER the gate, so it cannot
+  be detected there — abstain across a barrier, filed **#1160**) and a
+  **MEDIUM** over-abstain (any `ORDER BY`/`LIMIT`/`SKIP` above a Union root hid
+  it from the branch lookup, silently switching the fix OFF for the very
+  undirected shape at issue). Final verification, two corpora vs clean main in
+  isolated target dirs: 2400 two-node shapes (109 changed) + 2940 multi-clause
+  shapes (68 changed), all confined to the three mixed-access schemas; live
+  **22 ERROR->OK, 95 OK->OK, 0 OK->ERROR**. Every fixed-hop shape matches an
+  independent per-property oracle row-for-row, undirected per-arm roles
+  included (#908 class). 11 regression tests, each verified to FAIL when the
+  gate it pins is removed; one is labelled in-code as a BEHAVIOR pin only,
+  because no fixture produces a mixed-verdict cartesian. Filed alongside:
+  **#1157** (VLP whole-node still truncates — CTE-column path, different
+  mechanism), **#1158** (chained mixed-access renders `JOIN ON 1 = 1`, rows
+  where the shared middle variable holds TWO values; comma form has the mirror
+  defect), **#1160**. Process lesson reinforced twice more: my sweep generators
+  emit ONE query clause and no clause modifiers, and all three review findings
+  lived in exactly that gap — a gate too LOOSE (CRITICAL) and a gate too TIGHT
+  (MEDIUM) are indistinguishable from "tests pass" without mutation.
+
 - 2026-09-05: **Correctness — whole-node `RETURN o` on a denormalized
   undirected VLP emitted the edge-table alias** (branch
   `fix/1152-whole-node-cte-metadata`, PR #1156, closes #1152). `RETURN o` and

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -2898,6 +2898,19 @@ impl LogicalPlan {
     ) -> Option<bool> {
         use crate::query_planner::logical_plan::LogicalPlan;
         match root {
+            // Descend through single-input wrappers. `pattern_binds_an_endpoint_table`
+            // now stops dead at a `Union`/`CartesianProduct` (it must, or a
+            // branch borrows a sibling's joins), so an `ORDER BY` / `LIMIT` /
+            // `SKIP` sitting above the root would hide the `Union` beneath it,
+            // this lookup would return `None`, and the fallback would abstain.
+            // That silently disabled the fix the moment a sort or limit was
+            // added to the very undirected shape this issue is about
+            // (follow-up review, MEDIUM).
+            LogicalPlan::OrderBy(o) => Self::union_branches_all_bind(&o.input, rel, endpoints),
+            LogicalPlan::Limit(l) => Self::union_branches_all_bind(&l.input, rel, endpoints),
+            LogicalPlan::Skip(sk) => Self::union_branches_all_bind(&sk.input, rel, endpoints),
+            LogicalPlan::Projection(p) => Self::union_branches_all_bind(&p.input, rel, endpoints),
+            LogicalPlan::GraphJoins(gj) => Self::union_branches_all_bind(&gj.input, rel, endpoints),
             LogicalPlan::Union(u) => {
                 let owning: Vec<&std::sync::Arc<LogicalPlan>> = u
                     .inputs
@@ -3065,6 +3078,27 @@ impl LogicalPlan {
             .map(|gr| vec![gr.left_connection.clone(), gr.right_connection.clone()])
             .unwrap_or_else(|| vec![alias.to_string()]);
         let root = crate::render_plan::cte_extraction::render_root_plan();
+
+        // #1160: after a WITH barrier the planner binds a second pattern's
+        // own-table endpoint through the EDGE-side id column — it renders
+        // `people AS d ON d.mgr_id = t2.emp_id`, and `people` has no `mgr_id`.
+        // The corruption happens in a render-stage rewrite, AFTER this gate
+        // runs (at analyzer level the join is still the correct `d.pid =
+        // t2.emp_id`), so it cannot be detected by inspecting the join here.
+        //
+        // Main hides that defect by dropping the endpoint from the projection
+        // entirely; projecting it correctly makes the broken join reachable and
+        // turns a silent truncation into a Code 47. Losing a column and gaining
+        // an error are both wrong, and this fix is not the place to repair the
+        // join — so abstain across a barrier and reproduce main until #1160
+        // lands. Verified: 20 shapes across the three mixed-access schemas.
+        if root
+            .as_deref()
+            .is_some_and(crate::render_plan::plan_predicates::has_with_clause_in_tree)
+        {
+            return None;
+        }
+
         let binds = match (root.as_deref(), rel_alias.as_deref()) {
             (Some(r), Some(rel)) => Self::union_branches_all_bind(r, rel, &endpoints)
                 .unwrap_or_else(|| r.pattern_binds_an_endpoint_table(&endpoints)),

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -2838,6 +2838,13 @@ impl LogicalPlan {
                     .any(|j| endpoints.iter().any(|e| e == &j.table_alias))
                     || gj.input.pattern_binds_an_endpoint_table(endpoints)
             }
+            // A UNION branch or a cartesian side is rendered SEPARATELY, and
+            // its joins say nothing about the branch being rendered now. See
+            // `join_scope_for` — this predicate is only ever applied to a
+            // single scope, so these two arms must NOT disjoin across
+            // siblings. Recursing into a sibling would let a collapsed arm
+            // pass on its neighbour's evidence and emit dangling columns.
+            LogicalPlan::Union(_) | LogicalPlan::CartesianProduct(_) => false,
             LogicalPlan::GraphRel(gr) => {
                 gr.left.pattern_binds_an_endpoint_table(endpoints)
                     || gr.center.pattern_binds_an_endpoint_table(endpoints)
@@ -2853,15 +2860,72 @@ impl LogicalPlan {
             LogicalPlan::Unwind(u) => u.input.pattern_binds_an_endpoint_table(endpoints),
             LogicalPlan::WithClause(w) => w.input.pattern_binds_an_endpoint_table(endpoints),
             LogicalPlan::Cte(c) => c.input.pattern_binds_an_endpoint_table(endpoints),
-            LogicalPlan::CartesianProduct(cp) => {
-                cp.left.pattern_binds_an_endpoint_table(endpoints)
-                    || cp.right.pattern_binds_an_endpoint_table(endpoints)
-            }
-            LogicalPlan::Union(u) => u
-                .inputs
-                .iter()
-                .any(|b| b.pattern_binds_an_endpoint_table(endpoints)),
             _ => false,
+        }
+    }
+
+    /// #1154: the plan subtree whose join list governs the alias currently
+    /// being rendered.
+    ///
+    /// `GraphJoins` sits ABOVE the Projection this builder is invoked on, so
+    /// the arm's own joins are not reachable from `self` and the outermost
+    /// plan recorded by `scoped_render_root_plan` must be consulted. But that
+    /// root may be a `Union` (Cypher `UNION`, or the undirected two-arm split)
+    /// or a `CartesianProduct` (two independent `MATCH` clauses), whose
+    /// branches are rendered SEPARATELY and hold unrelated joins.
+    ///
+    /// Only the branches that actually contain this alias's relationship are
+    /// consulted, and EVERY one of them must satisfy the gate.
+    ///
+    /// "Every", not "any", is the whole point. A Cypher `UNION` can pair a
+    /// collapsed arm with a non-collapsed one; disjoining lets the collapsed
+    /// arm pass on its sibling's evidence and emit exactly the dangling
+    /// columns the gate exists to prevent (adversarial review, CRITICAL).
+    ///
+    /// "Every owning branch", not "exactly one", because the undirected
+    /// two-arm split reuses the SAME rel alias in both arms with swapped
+    /// connections — a legitimate multi-owner case that must still resolve.
+    /// Requiring all owners keeps that working while staying conservative:
+    /// if any arm that binds this relationship lacks an endpoint table, we
+    /// abstain for all of them and reproduce main.
+    ///
+    /// Returns `None` when no branch owns the relationship, which the caller
+    /// turns into an abstain.
+    fn union_branches_all_bind(
+        root: &LogicalPlan,
+        rel: &str,
+        endpoints: &[String],
+    ) -> Option<bool> {
+        use crate::query_planner::logical_plan::LogicalPlan;
+        match root {
+            LogicalPlan::Union(u) => {
+                let owning: Vec<&std::sync::Arc<LogicalPlan>> = u
+                    .inputs
+                    .iter()
+                    .filter(|b| b.find_graph_rel_by_rel_alias(rel).is_some())
+                    .collect();
+                if owning.is_empty() {
+                    return None;
+                }
+                Some(owning.iter().all(|b| {
+                    Self::union_branches_all_bind(b, rel, endpoints)
+                        .unwrap_or_else(|| b.pattern_binds_an_endpoint_table(endpoints))
+                }))
+            }
+            LogicalPlan::CartesianProduct(cp) => {
+                let sides: Vec<&std::sync::Arc<LogicalPlan>> = [&cp.left, &cp.right]
+                    .into_iter()
+                    .filter(|b| b.find_graph_rel_by_rel_alias(rel).is_some())
+                    .collect();
+                if sides.is_empty() {
+                    return None;
+                }
+                Some(sides.iter().all(|b| {
+                    Self::union_branches_all_bind(b, rel, endpoints)
+                        .unwrap_or_else(|| b.pattern_binds_an_endpoint_table(endpoints))
+                }))
+            }
+            _ => None,
         }
     }
 
@@ -3001,8 +3065,13 @@ impl LogicalPlan {
             .map(|gr| vec![gr.left_connection.clone(), gr.right_connection.clone()])
             .unwrap_or_else(|| vec![alias.to_string()]);
         let root = crate::render_plan::cte_extraction::render_root_plan();
-        let join_source: &LogicalPlan = root.as_deref().unwrap_or(self);
-        if !join_source.pattern_binds_an_endpoint_table(&endpoints) {
+        let binds = match (root.as_deref(), rel_alias.as_deref()) {
+            (Some(r), Some(rel)) => Self::union_branches_all_bind(r, rel, &endpoints)
+                .unwrap_or_else(|| r.pattern_binds_an_endpoint_table(&endpoints)),
+            (Some(r), None) => r.pattern_binds_an_endpoint_table(&endpoints),
+            (None, _) => self.pattern_binds_an_endpoint_table(&endpoints),
+        };
+        if !binds {
             return None;
         }
 

--- a/src/render_plan/select_builder.rs
+++ b/src/render_plan/select_builder.rs
@@ -908,6 +908,22 @@ impl SelectBuilder for LogicalPlan {
                                 &mapped_alias
                             };
 
+                            // #1154: same mixed-access defect as the TableAlias
+                            // branch below — an undirected pattern's UNION arms
+                            // arrive here as `n.*` instead. Without this the
+                            // arms project only the edge-side subset (or
+                            // nothing), and `normalize_branch` NULL-pads the
+                            // missing side into right-count/wrong-value rows.
+                            if let Some(items) = self.mixed_access_whole_node_items(
+                                &prop.table_alias.0,
+                                property_lookup_alias,
+                                &mapped_alias,
+                                plan_ctx,
+                            ) {
+                                select_items.extend(items);
+                                continue;
+                            }
+
                             let (properties, table_alias_for_render) =
                                 match self.get_properties_with_table_alias(property_lookup_alias) {
                                     Ok((props, _)) => {
@@ -2740,6 +2756,35 @@ impl LogicalPlan {
             &actual_table_alias
         };
 
+        // #1154: a MIXED-access edge's embedded property map is a strict SUBSET
+        // of the endpoint's real property set — or, for the own-table role,
+        // EMPTY. The structural plan-walk below returns exactly that map, so a
+        // whole-node `RETURN a` silently projected only the embedded columns
+        // (losing `a.name`) and a whole-node `RETURN b` projected NOTHING AT
+        // ALL (the column vanished from the result with no error; under an
+        // undirected UNION the missing side was then NULL-padded by
+        // `normalize_branch`, yielding right-count/wrong-value rows).
+        //
+        // The per-property path never had this bug: it resolves each property
+        // individually and falls through to the #1006 own-table join request
+        // when the embedded map lacks it. Whole-node expansion is the one
+        // caller that asks for the WHOLE SET at once, so it must consult the
+        // same authority the #1006 path ultimately relies on — the schema —
+        // rather than the edge's partial map.
+        //
+        // Per the axis-dispatch rule this goes through `PlanCtx`'s
+        // `NodeAccessStrategy` (built from `PatternSchemaContext`), never a raw
+        // denorm flag. Gated to the case that is actually broken: the strategy
+        // must disagree with the structural walk about which properties exist.
+        // When they agree — every standard, fully-denormalized, FK-edge and
+        // polymorphic shape — this is inert and the output is byte-identical.
+        if let Some(items) =
+            self.mixed_access_whole_node_items(alias, lookup_alias, &actual_table_alias, plan_ctx)
+        {
+            select_items.extend(items);
+            return;
+        }
+
         // Use plan_ctx-aware method to handle coupled edges
         match self.get_properties_with_plan_ctx(lookup_alias, plan_ctx) {
             Ok((properties, resolved_table_alias)) if !properties.is_empty() => {
@@ -2768,6 +2813,324 @@ impl LogicalPlan {
                 log::debug!("⚠️ No properties found for base table entity '{}'", alias);
             }
         }
+    }
+
+    /// #1154: did the planner bind ANY endpoint node table for this pattern?
+    ///
+    /// A mixed-access pattern normally emits a join for its own-table endpoint
+    /// (`b` in `foreign_selfloop`). When the `SingleTableScan` collapse fires
+    /// the join list holds only the edge alias, and nothing will bind an
+    /// endpoint's own table — so own-table columns emitted for EITHER endpoint
+    /// would dangle.
+    ///
+    /// The test is deliberately "some endpoint is joined", not "THIS alias is
+    /// joined": the embedded endpoint's own-table join is injected LAZILY by
+    /// `inject_own_table_joins` in response to the very request this function's
+    /// caller registers, so it is legitimately absent at check time. The
+    /// collapse is a whole-pattern decision, so one endpoint's presence is a
+    /// sound proxy for "the collapse did not fire".
+    fn pattern_binds_an_endpoint_table(&self, endpoints: &[String]) -> bool {
+        use crate::query_planner::logical_plan::LogicalPlan;
+        match self {
+            LogicalPlan::GraphJoins(gj) => {
+                gj.joins
+                    .iter()
+                    .any(|j| endpoints.iter().any(|e| e == &j.table_alias))
+                    || gj.input.pattern_binds_an_endpoint_table(endpoints)
+            }
+            LogicalPlan::GraphRel(gr) => {
+                gr.left.pattern_binds_an_endpoint_table(endpoints)
+                    || gr.center.pattern_binds_an_endpoint_table(endpoints)
+                    || gr.right.pattern_binds_an_endpoint_table(endpoints)
+            }
+            LogicalPlan::GraphNode(gn) => gn.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Projection(p) => p.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Filter(f) => f.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::GroupBy(g) => g.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::OrderBy(o) => o.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Limit(l) => l.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Skip(sk) => sk.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Unwind(u) => u.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::WithClause(w) => w.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::Cte(c) => c.input.pattern_binds_an_endpoint_table(endpoints),
+            LogicalPlan::CartesianProduct(cp) => {
+                cp.left.pattern_binds_an_endpoint_table(endpoints)
+                    || cp.right.pattern_binds_an_endpoint_table(endpoints)
+            }
+            LogicalPlan::Union(u) => u
+                .inputs
+                .iter()
+                .any(|b| b.pattern_binds_an_endpoint_table(endpoints)),
+            _ => false,
+        }
+    }
+
+    /// #1154: whole-node property set for a MIXED-access (foreign-embedded)
+    /// endpoint, or `None` to leave the caller's pre-#1154 behavior untouched.
+    ///
+    /// # Why this exists
+    ///
+    /// `classify_edge_table_pattern` returns `Mixed` when one endpoint of an
+    /// edge is `EmbeddedInEdge` and the other is `OwnTable`. On such an edge
+    /// the embedded property map — the only thing the structural plan-walk
+    /// `get_properties_with_table_alias` knows about — is INCOMPLETE for both
+    /// roles at once:
+    ///
+    /// * the embedded role's map holds only the columns physically present on
+    ///   the EDGE table (`foreign_selfloop`: `a` embeds `pid → mgr_id`, so
+    ///   `name` is absent);
+    /// * the own-table role has NO entry on the edge at all, so the walk
+    ///   returns an empty vector and the caller emits nothing.
+    ///
+    /// The node's real property set lives on its own table either way. This
+    /// resolves it through the schema (via `PlanCtx`'s `NodeAccessStrategy`,
+    /// per the axis-dispatch rule) and registers the same #1006 own-table join
+    /// requests the per-property path registers, so `join_builder`'s
+    /// `inject_own_table_joins` supplies the LEFT JOIN those columns need.
+    ///
+    /// # Which authority decides "what properties does this node have"
+    ///
+    /// The node's own `property_mappings`, NOT the edge access strategy. This
+    /// is the crux: on a mixed-access edge BOTH roles' strategies are partial
+    /// — the embedded role sees only the edge-side subset (`pid`, not `name`),
+    /// and the own-table role has no entry on the edge at all. Keying the gate
+    /// on the strategy therefore fixes only the own-table role and leaves the
+    /// embedded role's `name` silently missing (measured: it did exactly that).
+    /// The node schema is the only source that knows the full set for both.
+    ///
+    /// The strategy is still consulted for the one thing it alone knows —
+    /// whether the node is `Virtual` (polymorphic `$any`, no fixed label) —
+    /// and only when it is available: a UNION arm's cloned `PlanCtx` carries
+    /// no pattern contexts, which is precisely the undirected case this must
+    /// serve.
+    ///
+    /// # Abstain contract
+    ///
+    /// Returning `None` MUST reproduce main's output exactly. Every guard
+    /// abstains rather than guesses:
+    ///
+    /// * no `PlanCtx`, or a `Virtual` strategy;
+    /// * the node schema declares no property the structural walk lacks — we
+    ///   would be acting without new information. (This also covers a
+    ///   same-table denormalized node, whose map is `{}` by design.);
+    /// * the alias is a `__denorm_scan_` anchor (#582/#590), whose properties
+    ///   resolve through the anchor CTE, not a lazy own-table join;
+    /// * **the planner bound no endpoint node table for this pattern** — the
+    ///   `SingleTableScan` collapse fired, so own-table columns would dangle.
+    ///   Measured by mutation on a 2400-shape schema corpus, this is the
+    ///   load-bearing gate: it is the only one whose removal changes output,
+    ///   and it alone excludes every fully-denormalized and collapsed shape;
+    /// * a composite node id — `inject_own_table_joins` bails on those, so
+    ///   emitting columns it will not join would be a Code 47 of our own
+    ///   making;
+    /// * the node label cannot be resolved, or the schema has no such node;
+    /// * nothing in the set actually needed the own table (the caller's
+    ///   existing path already covers the alias).
+    ///
+    /// # Scope
+    ///
+    /// Fixed-hop patterns only. A VLP endpoint's properties come from CTE
+    /// columns (`t.start_name`), not an own-table join, so this mechanism does
+    /// not apply and VLP whole-node output is byte-identical to before —
+    /// including where it is still truncated. Extending the repair there is a
+    /// separate change against a different resolution path.
+    ///
+    /// A partial answer is never returned: if ANY property in the set fails to
+    /// resolve against the own table we abstain wholesale, because projecting
+    /// a subset is precisely the silent-truncation defect being fixed here.
+    fn mixed_access_whole_node_items(
+        &self,
+        alias: &str,
+        lookup_alias: &str,
+        actual_table_alias: &str,
+        plan_ctx: Option<&crate::query_planner::plan_ctx::PlanCtx>,
+    ) -> Option<Vec<SelectItem>> {
+        use crate::graph_catalog::pattern_schema::NodeAccessStrategy;
+
+        let ctx = plan_ctx?;
+
+        // Polymorphic `$any`: the concrete label is a runtime value, so there
+        // is no single node schema to read a property set from. Checked only
+        // when a strategy is actually available — a UNION arm's cloned PlanCtx
+        // carries no pattern contexts, and the schema lookup below is the
+        // authority in that case anyway.
+        let rel_alias = self
+            .find_graph_rel_for_alias(alias)
+            .map(|g| g.alias.clone());
+        if matches!(
+            ctx.get_node_strategy(alias, rel_alias.as_deref())
+                .or_else(|| ctx.get_node_strategy(alias, None)),
+            Some(NodeAccessStrategy::Virtual { .. })
+        ) {
+            return None;
+        }
+
+        // `__denorm_scan_` anchors (#582/#590) resolve through the anchor CTE,
+        // never a lazy own-table join.
+        if crate::render_plan::plan_builder_helpers::is_denorm_scan_anchor_alias(alias, self) {
+            return None;
+        }
+
+        // The pattern collapsed to a bare edge-table scan: the planner emitted
+        // NO join binding this endpoint's own table, so the own-table columns
+        // we would emit have nothing to reference (Code 47).
+        //
+        // `RETURN *` reaches here on a mixed-access edge because
+        // `plan_references_alias` has no `LogicalExpr::Star` arm — every alias
+        // reads as unreferenced, and the `SingleTableScan` collapse in
+        // `graph_join::inference` fires. That is a PRE-EXISTING analyzer
+        // defect (main drops the second endpoint from the projection outright,
+        // and discards an explicitly written `b.name` alongside `RETURN *`);
+        // fixing it belongs in the reference analysis, not here. Until then
+        // abstain, so those shapes keep main's exact behavior rather than
+        // trading a silent truncation for a loud error.
+        //
+        // Read off the PLAN, not `PatternSchemaContext.join_strategy`: the
+        // context is registered BEFORE the collapse is applied
+        // (`inference.rs`, register at ~3253 vs override at ~3334), so its
+        // stored strategy still says `MixedAccess` here. The planner's join
+        // list is the post-collapse truth.
+        //
+        // That list lives on `GraphJoins`, which is the plan ROOT and wraps the
+        // Projection this builder is invoked on — so `self` cannot see it.
+        // Consult the outermost plan recorded by `scoped_render_root_plan`
+        // (the same mechanism #1077 uses for path-node detection). When no root
+        // is recorded (a nested/standalone render), fall back to `self`.
+        let endpoints: Vec<String> = self
+            .find_graph_rel_for_alias(alias)
+            .map(|gr| vec![gr.left_connection.clone(), gr.right_connection.clone()])
+            .unwrap_or_else(|| vec![alias.to_string()]);
+        let root = crate::render_plan::cte_extraction::render_root_plan();
+        let join_source: &LogicalPlan = root.as_deref().unwrap_or(self);
+        if !join_source.pattern_binds_an_endpoint_table(&endpoints) {
+            return None;
+        }
+
+        let schema = crate::server::query_context::get_current_schema_with_fallback()?;
+        let label = crate::render_plan::cte_extraction::get_node_label_for_alias(alias, self)?;
+        let node_schema = schema.node_schema_opt(&label)?;
+
+        // What the structural walk believes this alias has — the caller uses
+        // exactly this, so it is the baseline we must strictly improve on.
+        let (structural, _) = self.get_properties_with_table_alias(lookup_alias).ok()?;
+
+        // AUTHORITY: the node's OWN `property_mappings` is what "this node's
+        // properties" means — see the doc comment for why the edge strategy
+        // is deliberately NOT the authority here.
+        //
+        // Gate: only act when the node schema declares a property the
+        // structural walk does not carry, i.e. we genuinely know more than the
+        // caller's existing path does. This also subsumes the empty-map case:
+        // a same-table denormalized node keeps all its properties on the edge
+        // under role-specific names, so it declares nothing extra and abstains.
+        //
+        // Verified by mutation, this gate changes NO output on the 2400-shape
+        // schema corpus — the endpoint-join gate below already excludes every
+        // shape it would catch. It is retained as the statement of intent
+        // ("never act without new information"), not as a load-bearing filter;
+        // do not read its presence as evidence that some shape needs it.
+        let id_columns = node_schema.node_id.columns();
+        let structural_names: std::collections::BTreeSet<&str> =
+            structural.iter().map(|(p, _)| p.as_str()).collect();
+        let declared_names: std::collections::BTreeSet<&str> = node_schema
+            .property_mappings
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        if !declared_names.iter().any(|p| !structural_names.contains(p)) {
+            return None;
+        }
+
+        // The full declared set, in a deterministic order (HashMap iteration
+        // order is not stable across runs and this drives SELECT column order).
+        let mut ordered: Vec<(String, String)> = node_schema
+            .property_mappings
+            .iter()
+            .map(|(k, v)| (k.clone(), v.raw().to_string()))
+            .collect();
+        ordered.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // `inject_own_table_joins` bails on a composite node id, so any column
+        // we emit under the node alias would be unbound. Abstain in step.
+        if id_columns.len() != 1 {
+            return None;
+        }
+        let id_name = id_columns[0].to_string();
+
+        // Resolve the FULL set against the node's own table. The embedded map
+        // still wins for a property it does carry — that column is on the edge
+        // table, already in scope, and joining for it would be wasteful.
+        let embedded: std::collections::BTreeMap<&str, &str> = structural
+            .iter()
+            .map(|(p, c)| (p.as_str(), c.as_str()))
+            .collect();
+
+        let mut resolved: Vec<(String, String, String)> = Vec::new(); // (prop, alias, column)
+        let mut own_table_props: Vec<String> = Vec::new();
+
+        for (prop, _) in &ordered {
+            if let Some(col) = embedded.get(prop.as_str()) {
+                resolved.push((
+                    prop.clone(),
+                    actual_table_alias.to_string(),
+                    (*col).to_string(),
+                ));
+                continue;
+            }
+            // The node id itself is resolvable from the own table under its
+            // own physical column; `own_table_property_column` deliberately
+            // returns None for it (the #1006 per-property path reaches ids
+            // through the embedded map), so resolve it directly here.
+            if prop == &id_name {
+                let physical = node_schema
+                    .property_mappings
+                    .get(prop)
+                    .map(|pv| pv.raw().to_string())
+                    .unwrap_or_else(|| prop.clone());
+                resolved.push((prop.clone(), alias.to_string(), physical));
+                own_table_props.push(prop.clone());
+                continue;
+            }
+            let physical = crate::render_plan::plan_builder_helpers::own_table_property_column(
+                node_schema,
+                prop,
+            )?; // unresolvable → abstain wholesale, never a partial projection
+            resolved.push((prop.clone(), alias.to_string(), physical));
+            own_table_props.push(prop.clone());
+        }
+
+        if own_table_props.is_empty() {
+            // Nothing actually needed the own table; the caller's path is
+            // already correct for this alias.
+            return None;
+        }
+
+        for prop in &own_table_props {
+            crate::server::query_context::register_own_table_join_request(alias, &label, prop);
+        }
+
+        log::info!(
+            "🔧 #1154: whole-node '{}' ({}) resolved to {} properties via own table '{}' ({} embedded, {} own)",
+            alias,
+            label,
+            resolved.len(),
+            node_schema.table_name,
+            resolved.len() - own_table_props.len(),
+            own_table_props.len()
+        );
+
+        Some(
+            resolved
+                .into_iter()
+                .map(|(prop, table, column)| SelectItem {
+                    expression: RenderExpr::PropertyAccessExp(PropertyAccess {
+                        table_alias: RenderTableAlias(table),
+                        column: PropertyValue::Column(column),
+                    }),
+                    col_alias: Some(ColumnAlias(format!("{}.{}", alias, prop))),
+                })
+                .collect(),
+        )
     }
 
     /// Expand a CTE-sourced entity (Node/Relationship from WITH)

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -730,6 +730,28 @@ async fn generate_sql_inline(schema: &GraphSchema, cypher: &str) -> String {
     .await
 }
 
+/// Like [`generate_sql_inline`] but surfaces planner/render errors as `Err`
+/// instead of panicking — for asserting clean-error behavior.
+async fn try_generate_sql_inline(schema: &GraphSchema, cypher: &str) -> Result<String, String> {
+    let schema = schema.clone();
+    let cypher = cypher.to_string();
+    let ctx = QueryContext::new(Some("default".to_string()));
+    with_query_context(ctx, async {
+        set_current_schema(Arc::new(schema.clone()));
+        let cleaned = strip_comments(&cypher);
+        let (_rem, statement) = clickgraph::open_cypher_parser::parse_cypher_statement(&cleaned)
+            .map_err(|e| format!("parse: {e:?}"))?;
+        let (logical_plan, plan_ctx) =
+            evaluate_read_statement(statement, &schema, None, None, None)
+                .map_err(|e| format!("plan: {e:?}"))?;
+        let render_plan =
+            logical_plan_to_render_plan_with_ctx(logical_plan, &schema, Some(&plan_ctx))
+                .map_err(|e| format!("render: {e:?}"))?;
+        Ok(render_plan.to_sql())
+    })
+    .await
+}
+
 /// #1100 sub-shape 1 (WITH barrier + re-MATCH): the re-matched endpoint's
 /// property must reference the WITH CTE alias, never the VLP FROM alias `t`
 /// with an `end_` prefix.
@@ -3641,5 +3663,116 @@ async fn ldbc_1154_collapsed_pattern_abstains_rather_than_dangling() {
     assert!(
         sql.contains("mgr_id"),
         "#1154: abstaining must reproduce main's spelling:\n{sql}"
+    );
+}
+
+/// #1154 review (CRITICAL): the endpoint-join gate is evaluated against the
+/// OUTERMOST plan, but a Cypher `UNION` renders each arm separately. A first cut
+/// disjoined across branches (`Union => inputs.iter().any(..)`), so a COLLAPSED
+/// arm — `RETURN *`, where `SingleTableScan` fires and nothing binds an endpoint
+/// table — passed the gate on its SIBLING's evidence and emitted exactly the
+/// dangling own-table columns the gate exists to prevent (Code 47 where main
+/// returned rows).
+///
+/// The fix requires EVERY branch that owns the relationship to bind an endpoint.
+/// Here the collapsed arm does not, so its own expansion abstains. What remains
+/// is a genuine Cypher arity mismatch, surfaced LOUDLY: main hid it by
+/// truncating BOTH arms to one column so they happened to line up.
+///
+/// Single-arm `RETURN *` cannot catch this — the leak needs a sibling to leak
+/// from, which is why the earlier sweep (single-clause queries only) missed it.
+#[tokio::test]
+async fn ldbc_1154_union_arm_gate_does_not_leak_across_branches() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let err = try_generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) RETURN * \
+         UNION MATCH (a:Person)-[:REPORTS_TO]->(b:Person) RETURN a, b",
+    )
+    .await
+    .expect_err("#1154: expected a loud arity error, not a dangling projection");
+    assert!(
+        err.contains("UnionColumnMismatch"),
+        "#1154: the collapsed arm must abstain, leaving a clean arity error — \
+         a rendered SQL with b.name and no b join means the gate leaked \
+         across branches:\n{err}"
+    );
+    // The collapsed arm keeps main's single column; the healthy arm keeps its
+    // full set. Both halves of that are the point: neither arm borrowed the
+    // other's evidence.
+    assert!(
+        err.contains("first_columns: \"a.pid\"") && err.contains("a.name, a.pid, b.name, b.pid"),
+        "#1154: expected the collapsed arm truncated and the healthy arm \
+         complete:\n{err}"
+    );
+}
+
+/// #1154 review: the undirected two-arm split reuses the SAME rel alias in both
+/// arms with swapped connections. It is a legitimate multi-owner case, so the
+/// branch-scoped gate must resolve it rather than abstain on ambiguity — an
+/// "exactly one owning branch" rule silently re-broke this (back to NULL
+/// padding) while every single-clause test still passed.
+#[tokio::test]
+async fn ldbc_1154_undirected_split_shares_rel_alias_across_arms() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]-(b:Person) RETURN a, b",
+    )
+    .await;
+    assert!(
+        !sql.contains("NULL AS"),
+        "#1154: both arms share rel alias `t1`; requiring a UNIQUE owning \
+         branch makes the gate abstain and restores the NULL padding:\n{sql}"
+    );
+    for want in ["\"a.name\"", "\"b.name\""] {
+        assert!(
+            sql.contains(want),
+            "#1154: undirected arms must still resolve {want}:\n{sql}"
+        );
+    }
+}
+
+/// #1154 review (HIGH): two independent `MATCH` clauses plan as a
+/// `CartesianProduct`, whose sides are also rendered separately. The gate
+/// judges each side on ITS OWN joins.
+///
+/// Here both sides DO bind their own-table endpoint (`b`, `d`), so both expand
+/// — while `a` and `c` stay embedded-only because nothing binds a table for
+/// them. The mixed result is not a "partial set": it is per-alias resolution
+/// doing exactly what the evidence supports, and it matches the per-property
+/// oracle on this build row-for-row (verified live). Main projected only
+/// `a.pid`/`c.pid`, dropping `b` and `d` entirely.
+///
+/// HONEST SCOPE: unlike its UNION sibling, this test is a BEHAVIOR pin, not a
+/// gate pin. Mutating the cartesian arm back to the leaky cross-side
+/// disjunction leaves this output byte-identical — on every available fixture
+/// the two sides agree about whether an endpoint is bound, so the leak has no
+/// observable effect. No schema in the repo produces a mixed-verdict cartesian.
+/// The scoping is still correct by construction (a side's joins say nothing
+/// about its sibling); it is simply not observable here, and this comment
+/// exists so nobody later reads a passing test as proof that it is.
+#[tokio::test]
+async fn ldbc_1154_cartesian_sides_are_scoped_independently() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) \
+         MATCH (c:Person)-[:REPORTS_TO]->(d:Person) RETURN *",
+    )
+    .await;
+    // Each own-table endpoint resolves against ITS OWN side's join.
+    assert!(
+        sql.contains("b.name") && sql.contains("d.name"),
+        "#1154: each cartesian side binds its own endpoint table, so both \
+         must expand:\n{sql}"
+    );
+    // Symmetry is the tell that neither side borrowed the other's evidence:
+    // an asymmetric result would mean one side passed on foreign joins.
+    assert_eq!(
+        sql.matches("\"b.").count(),
+        sql.matches("\"d.").count(),
+        "#1154: the two sides are structurally identical, so their projections \
+         must be too — asymmetry means the gate crossed sides:\n{sql}"
     );
 }

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -3776,3 +3776,86 @@ async fn ldbc_1154_cartesian_sides_are_scoped_independently() {
          must be too — asymmetry means the gate crossed sides:\n{sql}"
     );
 }
+
+/// #1154 follow-up review (MEDIUM): `pattern_binds_an_endpoint_table` must stop
+/// at a `Union` (or a branch borrows a sibling's joins), so a wrapper above the
+/// root — `ORDER BY`, `LIMIT`, `SKIP` — would hide the `Union` beneath it, the
+/// branch lookup would find nothing, and the gate would abstain.
+///
+/// That silently disabled the whole fix for the undirected shape the moment a
+/// sort or limit was added: back to `NULL AS "b.pid"` and wrong values, with
+/// every unsorted test still green. `union_branches_all_bind` now descends
+/// through those wrappers.
+#[tokio::test]
+async fn ldbc_1154_wrapper_above_union_does_not_disable_the_fix() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    for suffix in [
+        "",
+        " ORDER BY a.pid",
+        " LIMIT 3",
+        " SKIP 1",
+        " ORDER BY a.pid LIMIT 2",
+    ] {
+        let sql = generate_sql_inline(
+            &schema,
+            &format!("MATCH (a:Person)-[:REPORTS_TO]-(b:Person) RETURN a, b{suffix}"),
+        )
+        .await;
+        assert!(
+            !sql.contains("NULL AS"),
+            "#1154: `{suffix}` above the undirected UNION must not hide it from \
+             the branch lookup — a NULL literal here means the fix silently \
+             stopped applying:\n{sql}"
+        );
+        assert!(
+            sql.contains("\"a.name\"") && sql.contains("\"b.name\""),
+            "#1154: both endpoints must still resolve with `{suffix}`:\n{sql}"
+        );
+    }
+}
+
+/// #1154 follow-up review (HIGH): across a WITH barrier the planner binds a
+/// second pattern's own-table endpoint through the EDGE-side id column —
+/// `people AS d ON d.mgr_id = t2.emp_id`, and `people` has no `mgr_id` (#1160).
+///
+/// Main hides that by dropping the endpoint from the projection entirely.
+/// Projecting it correctly makes the broken join reachable, turning a silent
+/// truncation into a Code 47 — trading one wrong answer for another. The
+/// corruption happens in a render-stage rewrite AFTER this gate runs (at
+/// analyzer level the join is still the correct `d.pid = t2.emp_id`), so it
+/// cannot be detected by inspecting the join; the gate abstains across a
+/// barrier instead and reproduces main until #1160 lands.
+///
+/// A TRIVIAL `WITH a, b` is eliminated by the analyzer and never reaches here,
+/// so the abstain costs nothing on that shape — pinned below so the scope of
+/// this concession stays visible.
+#[tokio::test]
+async fn ldbc_1154_with_barrier_second_match_abstains_pending_1160() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+
+    // Real barrier + a second pattern: abstain, reproducing main.
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) WITH count(*) AS n \
+         MATCH (c:Person)-[:REPORTS_TO]->(d:Person) RETURN c, d, n",
+    )
+    .await;
+    assert!(
+        !sql.contains("d.name"),
+        "#1154/#1160: across a WITH barrier the endpoint's join is spelled with \
+         the edge-side id column, so projecting own-table columns yields a \
+         Code 47 — abstain until #1160 fixes the join:\n{sql}"
+    );
+
+    // Trivial WITH is eliminated upstream, so the fix still applies there.
+    let trivial = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) WITH a, b RETURN a, b",
+    )
+    .await;
+    assert!(
+        trivial.contains("\"a.name\"") && trivial.contains("\"b.name\""),
+        "#1154: a trivial WITH is eliminated by the analyzer and must NOT be \
+         caught by the barrier abstain:\n{trivial}"
+    );
+}

--- a/tests/rust/integration/ldbc_regression_tests.rs
+++ b/tests/rust/integration/ldbc_regression_tests.rs
@@ -3481,3 +3481,165 @@ async fn ldbc_1152_no_candidate_lookup_abstains_rather_than_guessing() {
         "#1152 M1: abstaining reproduces main's spelling for this item:\n{dup}"
     );
 }
+
+// ===========================================================================
+// #1154 — mixed-access whole-node endpoint resolution
+//
+// On a MIXED-access edge (`classify_edge_table_pattern` → `Mixed`: one endpoint
+// `EmbeddedInEdge`, the other `OwnTable`) a whole-node `RETURN a` / `RETURN a, b`
+// sourced its property set from the plan-walk, which returns the EDGE's embedded
+// map. That map is incomplete for both roles at once, so main:
+//   * lost the embedded endpoint's non-embedded properties (`a.name`), and
+//   * projected NOTHING for the own-table endpoint — the column vanished from
+//     the result with no error (undirected then NULL-padded it into
+//     right-count/wrong-value rows).
+// ===========================================================================
+
+/// #1154 behavior: a directed mixed-access single hop must project BOTH
+/// endpoints in full. On main this rendered a single column (`a.pid`) for two
+/// whole nodes.
+#[tokio::test]
+async fn ldbc_1154_mixed_access_whole_node_projects_both_endpoints() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) RETURN a, b",
+    )
+    .await;
+    for want in ["\"a.name\"", "\"a.pid\"", "\"b.name\"", "\"b.pid\""] {
+        assert!(
+            sql.contains(want),
+            "#1154: whole-node RETURN must project {want}; main dropped it:\n{sql}"
+        );
+    }
+    // The own-table endpoint's columns bind the NODE alias, not the edge alias.
+    assert!(
+        sql.contains("b.name") && sql.contains("b.pid"),
+        "#1154: own-table endpoint must resolve against its own table:\n{sql}"
+    );
+}
+
+/// #1154 role symmetry: the mirrored schema (`foreign_selfloop_end` embeds the
+/// TO role instead of the FROM role) must be repaired identically. A fix that
+/// keyed on one role would leave this one truncated.
+#[tokio::test]
+async fn ldbc_1154_mixed_access_whole_node_is_role_symmetric() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop_end.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) RETURN a, b",
+    )
+    .await;
+    for want in ["\"a.name\"", "\"a.pid\"", "\"b.name\"", "\"b.pid\""] {
+        assert!(
+            sql.contains(want),
+            "#1154: mirrored schema must project {want} too:\n{sql}"
+        );
+    }
+}
+
+/// #1154 undirected: each UNION arm must resolve BOTH endpoints. On main each
+/// arm projected one endpoint and let `normalize_branch` pad the other with a
+/// literal NULL — right row count, every value wrong, no error.
+#[tokio::test]
+async fn ldbc_1154_undirected_arms_resolve_both_endpoints_no_null_padding() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]-(b:Person) RETURN a, b",
+    )
+    .await;
+    assert!(
+        !sql.contains("NULL AS"),
+        "#1154: no arm may stand in a NULL literal for an unresolved endpoint \
+         — that is indistinguishable from a legitimately absent value:\n{sql}"
+    );
+    // Both arms present, and each names both endpoints.
+    assert_eq!(
+        sql.matches("UNION ALL").count(),
+        1,
+        "#1154: expected the two-arm undirected split:\n{sql}"
+    );
+    for want in ["\"a.name\"", "\"b.name\""] {
+        assert!(
+            sql.contains(want),
+            "#1154: undirected arms must project {want}:\n{sql}"
+        );
+    }
+}
+
+/// #1154 abstain: a same-table denormalized node (`flights_denorm`'s Airport
+/// declares `property_mappings: {}` — every property lives on the edge under a
+/// role-specific name) already renders correctly and must be left BYTE-identical.
+/// This is the gate that keeps the fix inert for every non-mixed schema.
+#[tokio::test]
+async fn ldbc_1154_same_table_denorm_whole_node_unchanged() {
+    let schema = load_schema_from("schemas/test/flights_denorm_test.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (o:Airport)-[:FLIGHT]->(d:Airport) RETURN o, d",
+    )
+    .await;
+    // Role-specific edge columns, NOT own-table columns.
+    for want in ["origin_city", "origin_code", "dest_city", "dest_code"] {
+        assert!(
+            sql.contains(want),
+            "#1154: same-table denorm must keep its per-role edge columns \
+             ({want} missing) — the fix must not fire here:\n{sql}"
+        );
+    }
+}
+
+/// #1154 abstain: a fully-denormalized schema must be left alone. Zeek's Domain
+/// declares `property_mappings: {}` in YAML but the catalog SYNTHESIZES an id
+/// entry (`{query → query}`), so the emptiness filter does NOT stop it — the
+/// endpoint-join gate does, because a fully-denormalized pattern never binds an
+/// endpoint's own table.
+///
+/// This distinction is load-bearing and was found by measurement: an earlier
+/// cut gated on "declares a property beyond its id" and, verified by mutation,
+/// that gate turned out to be masked by the join gate on all 2400 swept shapes
+/// (dead code), so it was removed rather than shipped unexercised. Without the
+/// join gate this query rebinds `b.name` → `b.query` against an unjoined table:
+/// a renamed output column AND a Code 47.
+#[tokio::test]
+async fn ldbc_1154_fully_denormalized_schema_abstains() {
+    let schema = load_schema_from("schemas/test/zeek_merged_collision.yaml");
+    let sql =
+        generate_sql_inline(&schema, "MATCH (a:IP)-[:REQUESTED]->(b:Domain) RETURN a, b").await;
+    assert!(
+        sql.contains("\"b.name\""),
+        "#1154: the node's declared Cypher property name must survive — \
+         rebinding to the synthesized id entry renames the output column:\n{sql}"
+    );
+    assert!(
+        !sql.contains("\"b.query\""),
+        "#1154: an id-only property map must NOT drive the own-table rebind:\n{sql}"
+    );
+}
+
+/// #1154 abstain: when the pattern collapses to a bare edge scan
+/// (`SingleTableScan`) no endpoint node table is joined, so own-table columns
+/// would dangle. `RETURN *` reaches that collapse on a mixed-access edge because
+/// `plan_references_alias` has no `Star` arm — a PRE-EXISTING analyzer defect
+/// (main also discards an explicitly written `b.name` next to `RETURN *`).
+/// Until that is fixed upstream this shape must keep main's exact output rather
+/// than trade a silent truncation for a Code 47.
+#[tokio::test]
+async fn ldbc_1154_collapsed_pattern_abstains_rather_than_dangling() {
+    let schema = load_schema_from("schemas/test/foreign_selfloop.yaml");
+    let sql = generate_sql_inline(
+        &schema,
+        "MATCH (a:Person)-[:REPORTS_TO]->(b:Person) RETURN *",
+    )
+    .await;
+    assert!(
+        !sql.contains("a.name"),
+        "#1154: with the pattern collapsed to a bare edge scan there is no \
+         own-table join to bind to — the fix must abstain here:\n{sql}"
+    );
+    assert!(
+        sql.contains("mgr_id"),
+        "#1154: abstaining must reproduce main's spelling:\n{sql}"
+    );
+}


### PR DESCRIPTION
Closes #1154 (fixed-hop half; VLP half filed as #1157).

## The defect

On a **mixed-access** edge (`classify_edge_table_pattern` → `Mixed`: one endpoint `EmbeddedInEdge`, the other `OwnTable`), whole-node expansion sourced its property set from the structural plan-walk, which returns the **edge's embedded map**. That map is incomplete for *both* roles at once:

| endpoint | plan-walk (what main used) | reality |
|---|---|---|
| `a` (embedded) | `[pid→mgr_id]` | + `name` on `people` |
| `b` (own-table) | `[]` → **node dropped entirely** | `[name, pid]` on `people` |

Directed, `RETURN a, b` returned **one column for two whole nodes**, no error. Undirected, each UNION arm projected one endpoint and `normalize_branch` padded the other with a literal NULL — right row count, every value wrong:

```
main                                oracle
| p1    | NULL  |                   | Alice p1 | Bob   p2 |
| p2    | NULL  |                   | Bob   p2 | Carol p3 |
| NULL  | p1    |                   | Bob   p2 | Alice p1 |
| NULL  | p2    |                   | Carol p3 | Bob   p2 |
```

Two corrections to the issue as I originally filed it, both verified: it is **not VLP-specific** (a plain single hop fails identically), and the undirected half is **not latent** — it is silently wrong on main today.

## The fix

The per-property path never had this bug: it resolves properties one at a time and falls through to the **#1006 own-table join request** when the embedded map lacks one. Whole-node is the one caller that asks for the *whole set* at once, so it must consult the same authority. `mixed_access_whole_node_items` resolves the declared property set against the node's own table and registers those requests, so `inject_own_table_joins` supplies the LEFT JOIN.

Wired at **both** whole-node sites: the `TableAlias` branch (`RETURN a`) and the `n.*` wildcard branch (undirected UNION arms land there instead).

**Authority is the node schema, not the edge access strategy.** On a mixed edge both roles' strategies are partial — that *is* the defect. Keying the gate on the strategy fixes only the own-table role and leaves the embedded role's `name` missing; an earlier cut did exactly that, caught by measurement. The strategy is still consulted for the one thing it alone knows: `Virtual`.

## The load-bearing gate, established by mutation

Four guards; I forced each open and measured. Only one changes output on the corpus: **the pattern must have bound some endpoint node table**. When the `SingleTableScan` collapse fires, nothing binds an endpoint's own table and the columns dangle.

Of the other three, one was **dead across all 2400 shapes and removed** rather than shipped unexercised; one is kept with an explicit comment that it is a statement of intent, not a filter — so nobody later reads its presence as evidence some shape needs it.

That check reads the **plan**, not `PatternSchemaContext.join_strategy`: the context is registered *before* the collapse is applied (`inference.rs` ~3253 vs ~3334), so its stored strategy still says `MixedAccess`. `GraphJoins` is the plan root wrapping the Projection the builder sees, so it is reached via `render_root_plan()` (the #1077 mechanism).

## Verification

Two independent sweeps against clean `main` in isolated target dirs.

| sweep | shapes | changed | live outcome |
|---|---|---|---|
| two-node × 10 patterns × 6 returns | 2400 | 109 | 10 ERROR→OK, 32 OK→OK, **0 regressions** |
| chained / comma / WITH / self-loop / OPTIONAL-chain / path-var / EXISTS, non-first edge types | 2940 | 68 | 7 ERROR→OK, 30 OK→OK, **0 regressions** |

The second sweep exists because my generator has twice before structurally omitted a whole shape family. Every change in both is strictly additive — no query loses a column or newly errors.

Values, not counts: every fixed-hop shape now matches an independent per-property oracle **row-for-row**, including per-arm role assignment on the undirected split (the #908 hazard — arm 1 binds `a` to `mgr_id`, arm 2 binds `b` to it, correctly swapped, same column order in both arms).

Suite green: 1738 unit + 725 integration + ratchet + clippy clean. Ratchet passing confirms the axis-dispatch rule is respected — resolution goes through `PlanCtx`/schema-catalog APIs, no raw denorm flags.

## Deliberately not fixed here — all pre-existing, all unregressed

- **VLP whole-node** still truncates (#1157). VLP endpoints resolve through CTE columns (`t.start_name`), a different mechanism; byte-identical to main.
- **`RETURN *`** on a mixed-access edge. `plan_references_alias` has no `LogicalExpr::Star` arm, so every alias reads unreferenced and the collapse fires — main drops the second endpoint outright and discards an explicitly written `b.name` beside `RETURN *`. Making the projection correct without fixing the collapse trades a silent truncation for a Code 47, so the fix abstains; the repair belongs in the reference analysis.
- **`*0..2`** is broken on this schema for per-property too (zero-hop seed reads `start_node.name` off the edge table).

Found while verifying, filed separately, **not** caused by this change: **#1158** — chained mixed-access patterns render `JOIN ... ON 1 = 1`, producing rows where the shared middle variable holds two values at once; the comma/disconnected form has the mirror defect (correlated where a cross product was required).

## Tests

6 regression tests, **each verified to fail when the gate it pins is forced open** — behavior tests and abstain guards alike. Two of the six pin abstain contracts that only fail once the overlapping join gate is also opened; that overlap is documented in the test bodies rather than left as a false sense of coverage.